### PR TITLE
Use 'codex resume <id>' instead of 'codex --resume <id>'

### DIFF
--- a/ai-hist
+++ b/ai-hist
@@ -539,7 +539,7 @@ def cmd_show(args):
         if source == "claude" and project:
             print(f"  Resume:  cd {project} && claude --resume {session_id}")
         elif source == "codex" and session_id:
-            print(f"  Resume:  codex --resume {session_id}")
+            print(f"  Resume:  codex resume {session_id}")
         elif source == "cursor":
             cmd = f"cursor-agent --resume={session_id}"
             if project:

--- a/test_ai_hist.py
+++ b/test_ai_hist.py
@@ -582,7 +582,7 @@ class TestCmdShow:
         args = SimpleNamespace(id=1)
         ai_hist.cmd_show(args)
         captured = capsys.readouterr()
-        assert "codex --resume cx-sess" in captured.out
+        assert "codex resume cx-sess" in captured.out
 
     def test_show_nonexistent_entry(self, tmp_env, capsys):
         seed_db(tmp_env)


### PR DESCRIPTION
## Summary
The codex CLI resume is invoked as `codex resume <session_id>`, not `codex --resume <session_id>`. This fixes the resume hint printed by `ai-hist show`.

## Changes
- `ai-hist`: emit `codex resume <session_id>` in the resume hint
- `test_ai_hist.py`: update assertion to match

## Test plan
- `python -m pytest test_ai_hist.py -k codex_resume -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)