### PR TITLE
fix(publish): tolerate missing CHANGELOG on first publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -309,7 +309,12 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add sdk-ts/package.json sdk-ts/CHANGELOG.md
+          git add sdk-ts/package.json
+          # CHANGELOG only exists once there's been at least one release with
+          # Unreleased content or a prior tag — skip silently on first publish.
+          if [ -f sdk-ts/CHANGELOG.md ]; then
+            git add sdk-ts/CHANGELOG.md
+          fi
           if git diff --cached --quiet; then
             echo "No version changes to commit."
           else


### PR DESCRIPTION
The publish workflow [failed on the first dispatch](https://github.com/AgentWorkforce/ai-hist/actions/runs/26280453039/job/77355046575) at the **Commit version bump** step:

\`\`\`
fatal: pathspec 'sdk-ts/CHANGELOG.md' did not match any files
\`\`\`

The changelog generator skips silently when there's no \`[Unreleased]\` content **and** no prior \`sdk-ts-v*\` tag (the first-publish case), so the file never gets written. Then \`git add sdk-ts/CHANGELOG.md\` aborts the whole step before \`npm publish\` runs.

Fix: stage \`sdk-ts/package.json\` unconditionally, and only stage the CHANGELOG if it actually exists. The Unreleased-promotion path still picks it up on every subsequent release once the first publish lands.

Origin/main was not advanced by the failed run (the bump and CHANGELOG steps run in the workflow's working tree, never get pushed), and the workflow failed before \`npm publish\`, so npm wasn't bumped either. After merging this, re-dispatch \`Publish ai-hist (TS SDK)\` with the same inputs (e.g. \`version: patch\`) — the first publish will land at 0.1.1 and CHANGELOG will start populating from the next release.

## Test plan

- [ ] Merge.
- [ ] Re-run \`Publish ai-hist (TS SDK)\` workflow with \`version: patch\` (or \`custom_version: 0.1.0\`).
- [ ] Verify the run gets past **Commit version bump** → npm publish → tag + GitHub Release succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)