### PR TITLE
perf(sdk): rewrite listSessions to use window functions (~68x faster) — 0.2.2

### DIFF
--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-hist",
-  "version": "0.2.1",
-  "description": "TypeScript SDK for reading the ai-hist SQLite database (recent prompts, sessions, search).",
+  "version": "0.2.2",
+  "description": "TypeScript SDK for browsing your Claude / Codex / Cursor history — reads the ai-hist SQLite DB when present, falls back to scanning the local JSONL files directly when not.",
   "license": "MIT",
   "private": false,
   "type": "module",

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -114,6 +114,16 @@ export async function openAiHist(opts: OpenOptions = {}): Promise<AiHist> {
   if (await pathExists(dbPath)) {
     const fileBuffer = await readFile(dbPath);
     const db = new SQL.Database(fileBuffer);
+    // The Python CLI's schema doesn't create `idx_history_session` or
+    // `idx_history_timestamp`. Without them, listSessions degrades to
+    // an O(sessions × rows) full table scan and freezes the WASM
+    // single-threaded JS engine for tens of seconds on real-sized DBs.
+    // The DB is opened read-only over a buffer, but sql.js still lets
+    // us run `CREATE INDEX` against the in-memory copy — the index
+    // lives only for this session's lifetime and is rebuilt each
+    // `openAiHist` call. Fast (~30ms on 35K rows).
+    db.run('CREATE INDEX IF NOT EXISTS idx_history_session ON history(session_id)');
+    db.run('CREATE INDEX IF NOT EXISTS idx_history_timestamp ON history(timestamp_ms DESC)');
     return new AiHist(db, { kind: 'sqlite', path: dbPath });
   }
 
@@ -273,6 +283,14 @@ export class AiHist {
   /**
    * Group history into sessions, ordered by last activity (newest first).
    * Sessions without a `session_id` are skipped.
+   *
+   * Implementation note: this used to use a correlated scalar subquery
+   * to pick `first_prompt`, which ran in O(sessions × rows) — ~19s on a
+   * 35K-row DB. Switched to `ROW_NUMBER() OVER (PARTITION BY session_id
+   * ORDER BY timestamp_ms)` so first-prompt picking is a single pass
+   * over the table (~300ms on the same DB). Plus the index ensure step
+   * in `openAiHist` keeps it fast even when the DB was written by the
+   * older Python CLI that didn't create `idx_history_session`.
    */
   listSessions(opts: ListOptions = {}): SessionSummary[] {
     const limit = opts.limit ?? 50;
@@ -291,28 +309,33 @@ export class AiHist {
         SELECT id, source, session_id, project, prompt, timestamp_ms
         FROM history
         WHERE session_id IS NOT NULL AND session_id != ''${sql}
+      ),
+      ranked AS (
+        SELECT
+          session_id,
+          source,
+          project,
+          prompt,
+          timestamp_ms,
+          ROW_NUMBER() OVER (
+            PARTITION BY session_id, source, project
+            ORDER BY timestamp_ms ASC, id ASC
+          ) AS rn_first,
+          COUNT(*) OVER (PARTITION BY session_id, source, project) AS prompt_count,
+          MIN(timestamp_ms) OVER (PARTITION BY session_id, source, project) AS first_activity_ms,
+          MAX(timestamp_ms) OVER (PARTITION BY session_id, source, project) AS last_activity_ms
+        FROM filtered
       )
       SELECT
         session_id,
         source,
         project,
-        prompt_count,
+        prompt AS first_prompt,
         first_activity_ms,
         last_activity_ms,
-        (SELECT prompt FROM filtered f2
-         WHERE f2.session_id = grouped.session_id
-         ORDER BY f2.timestamp_ms ASC LIMIT 1) AS first_prompt
-      FROM (
-        SELECT
-          session_id,
-          source,
-          project,
-          COUNT(*) AS prompt_count,
-          MIN(timestamp_ms) AS first_activity_ms,
-          MAX(timestamp_ms) AS last_activity_ms
-        FROM filtered
-        GROUP BY session_id, source, project
-      ) AS grouped
+        prompt_count
+      FROM ranked
+      WHERE rn_first = 1
       ORDER BY last_activity_ms DESC
       LIMIT ?`,
       [...params, limit],


### PR DESCRIPTION
The Conversations tab in the [pear](https://github.com/AgentWorkforce/pear) desktop app was freezing the UI for several seconds even after 0.2.0's async file-read changes. Deep investigation showed the freeze wasn't I/O — it was the \`listSessions\` SQL doing a correlated scalar subquery (one full table scan per session) on every call.

## Measured on a 91 MB / 35,857-row local DB

| Op | Before | After |
|---|---|---|
| \`listSessions({ limit: 500 })\` | **19,083 ms** | **278 ms** |
| \`listSessions({ limit: 50 })\` | ~16,000 ms | 226 ms |
| \`listSessions({ source: 'claude', limit: 200 })\` | several seconds | 156 ms |
| Open (DB read + WASM init + index creation) | ~60 ms | ~120 ms |

~68× faster on the path that hot reloads when the user clicks "Conversations".

## Why it was slow

sql.js is single-threaded WASM SQLite running on the JS thread. Any query that touches every row blocks the host's event loop (Electron's main process → renderer can't get IPC responses → app feels frozen).

The old query was a correlated scalar subquery:
\`\`\`sql
SELECT ..., (SELECT prompt FROM filtered f2 WHERE f2.session_id = grouped.session_id ORDER BY ts ASC LIMIT 1) AS first_prompt
FROM (SELECT session_id, source, project, COUNT(*), MIN, MAX FROM filtered GROUP BY ...)
\`\`\`

The subquery runs once per output row, and \`EXPLAIN QUERY PLAN\` showed it as \`SCAN filtered\` — there's no \`session_id\` index in the schema the Python CLI writes.

## The fix

1. **Window functions instead of a correlated subquery.** \`ROW_NUMBER() OVER (PARTITION BY session_id, source, project ORDER BY timestamp_ms ASC)\` picks the first prompt per session in a single pass; \`COUNT/MIN/MAX OVER (...)\` give the aggregates in the same pass.

2. **\`CREATE INDEX IF NOT EXISTS\` after opening SQLite.** The Python CLI's schema doesn't create \`idx_history_session\` or \`idx_history_timestamp\`. Adding them in the SDK after \`new SQL.Database(buffer)\` means the index lives for the in-memory session's lifetime and costs ~30 ms once on a 35K-row DB. Pays for itself on every subsequent query.

## Test plan

- [x] \`listSessions({ limit: 500 })\` returns the same shape + row count as 0.2.1.
- [x] Source filter still works.
- [x] Index creation works against the Python-CLI-written DB (read from disk, mutated in the in-memory copy).
- [ ] Publish 0.2.2 via the existing workflow; pear bumps its dep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)