### PR TITLE
feat: cross-CLI handoff via sessions table and get_handoff MCP tool

### DIFF
--- a/ai-hist
+++ b/ai-hist
@@ -29,6 +29,8 @@ SOURCES = {
     "codex": Path.home() / ".codex" / "history.jsonl",
 }
 
+CLAUDE_PROJECTS_ROOT = Path.home() / ".claude" / "projects"
+
 CODEX_SESSIONS_DIRS = [
     Path.home() / ".codex" / "sessions",
     Path.home() / ".codex" / "archived_sessions",
@@ -51,6 +53,21 @@ CREATE TABLE IF NOT EXISTS history (
     timestamp_ms INTEGER NOT NULL,
     UNIQUE(source, timestamp_ms, prompt)
 );
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id TEXT NOT NULL,
+    source TEXT NOT NULL,
+    cwd TEXT,
+    git_branch TEXT,
+    first_activity_ms INTEGER,
+    last_activity_ms INTEGER,
+    last_assistant_text TEXT,
+    raw_path TEXT,
+    parser_version INTEGER NOT NULL DEFAULT 1,
+    PRIMARY KEY (session_id, source)
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_cwd ON sessions(cwd);
+CREATE INDEX IF NOT EXISTS idx_sessions_branch ON sessions(git_branch);
+CREATE INDEX IF NOT EXISTS idx_sessions_last ON sessions(last_activity_ms DESC);
 CREATE VIRTUAL TABLE IF NOT EXISTS history_fts USING fts5(
     prompt, project, content='history', content_rowid='id'
 );
@@ -181,6 +198,197 @@ def _row_to_dict(id_, source, session_id, project, prompt, ts_ms):
     }
 
 
+# --- Session helpers ---------------------------------------------------------
+
+def _upsert_session(conn, session_id, source, cwd, git_branch, ts_ms,
+                    last_assistant_text=None, raw_path=None):
+    """Insert or update a row in the sessions table."""
+    conn.execute(
+        """
+        INSERT INTO sessions
+          (session_id, source, cwd, git_branch, first_activity_ms, last_activity_ms,
+           last_assistant_text, raw_path, parser_version)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)
+        ON CONFLICT(session_id, source) DO UPDATE SET
+          cwd                = COALESCE(excluded.cwd, sessions.cwd),
+          git_branch         = COALESCE(excluded.git_branch, sessions.git_branch),
+          first_activity_ms  = MIN(COALESCE(sessions.first_activity_ms, excluded.first_activity_ms),
+                                   excluded.first_activity_ms),
+          last_activity_ms   = MAX(COALESCE(sessions.last_activity_ms, excluded.last_activity_ms),
+                                   excluded.last_activity_ms),
+          last_assistant_text= COALESCE(excluded.last_assistant_text, sessions.last_assistant_text),
+          raw_path           = COALESCE(excluded.raw_path, sessions.raw_path),
+          parser_version     = excluded.parser_version
+        """,
+        (session_id, source, cwd, git_branch, ts_ms, ts_ms,
+         last_assistant_text, raw_path),
+    )
+
+
+def _scan_claude_session_file(path: Path) -> dict | None:
+    """
+    Extract session metadata from a Claude per-session JSONL file.
+
+    Reads the first 20 lines for sessionId/gitBranch/cwd/first-timestamp,
+    then tails the last 64 KB for the most recent assistant turn.
+    Returns a dict or None if the file can't be identified as a session.
+    """
+    MAX_TAIL = 65536
+    session_id = git_branch = cwd = None
+    first_ts = last_ts = None
+    last_assistant_text = None
+
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for i, line in enumerate(f):
+                if i >= 20:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                if session_id is None:
+                    session_id = obj.get("sessionId")
+                if git_branch is None:
+                    git_branch = obj.get("gitBranch")
+                if cwd is None:
+                    cwd = obj.get("cwd")
+                if first_ts is None:
+                    raw_ts = obj.get("timestamp")
+                    if isinstance(raw_ts, str):
+                        first_ts = _iso_to_ms(raw_ts)
+                    elif isinstance(raw_ts, (int, float)):
+                        first_ts = int(raw_ts)
+    except OSError:
+        return None
+
+    if not session_id:
+        return None
+
+    # Tail the file for last timestamp, last assistant text, and latest branch.
+    # Going bottom-to-top means the first gitBranch we find is the most recent one,
+    # which handles sessions that switched branches mid-way.
+    tail_branch = None
+    try:
+        file_size = path.stat().st_size
+        tail_offset = max(0, file_size - MAX_TAIL)
+        with open(path, "rb") as fb:
+            fb.seek(tail_offset)
+            tail_bytes = fb.read()
+        tail_text = tail_bytes.decode("utf-8", errors="replace")
+        for line in reversed(tail_text.splitlines()):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(obj, dict):
+                continue
+            if last_ts is None:
+                raw_ts = obj.get("timestamp")
+                if isinstance(raw_ts, str):
+                    last_ts = _iso_to_ms(raw_ts)
+                elif isinstance(raw_ts, (int, float)):
+                    last_ts = int(raw_ts)
+            if tail_branch is None and obj.get("gitBranch"):
+                tail_branch = obj["gitBranch"]
+            if last_assistant_text is None and obj.get("type") == "assistant":
+                msg = obj.get("message") or {}
+                content = msg.get("content")
+                if isinstance(content, str):
+                    last_assistant_text = content[:4096]
+                elif isinstance(content, list):
+                    parts = []
+                    for c in content:
+                        if isinstance(c, dict) and c.get("type") == "text":
+                            parts.append(str(c.get("text", "")))
+                    if parts:
+                        last_assistant_text = "\n".join(parts)[:4096]
+            if last_ts is not None and tail_branch is not None and last_assistant_text is not None:
+                break
+    except OSError:
+        pass
+    # Prefer the latest-seen branch (from tail) over the initial branch (from head).
+    if tail_branch:
+        git_branch = tail_branch
+
+    return {
+        "session_id": session_id,
+        "git_branch": git_branch,
+        "cwd": cwd,
+        "first_ts": first_ts or 0,
+        "last_ts": last_ts or first_ts or 0,
+        "last_assistant_text": last_assistant_text,
+        "raw_path": str(path),
+    }
+
+
+def sync_claude_sessions(conn: sqlite3.Connection, state: dict):
+    """
+    Walk ~/.claude/projects/**/<session-id>.jsonl and populate the sessions table.
+    Uses per-file mtime to skip unchanged files incrementally.
+    """
+    if not CLAUDE_PROJECTS_ROOT.exists():
+        return
+
+    session_state = state.get("claude_sessions", {})
+    upserted = 0
+    scanned = 0
+    errors = 0
+
+    for project_dir in CLAUDE_PROJECTS_ROOT.iterdir():
+        if not project_dir.is_dir():
+            continue
+        for jsonl_path in project_dir.glob("*.jsonl"):
+            key = str(jsonl_path)
+            try:
+                st = jsonl_path.stat()
+                mtime = f"{st.st_mtime_ns}:{st.st_size}"
+            except OSError:
+                errors += 1
+                continue
+            if session_state.get(key) == mtime:
+                continue
+            scanned += 1
+            meta = _scan_claude_session_file(jsonl_path)
+            session_state[key] = mtime
+            if not meta:
+                continue
+            try:
+                _upsert_session(
+                    conn,
+                    meta["session_id"],
+                    "claude",
+                    meta["cwd"],
+                    meta["git_branch"],
+                    meta["first_ts"],
+                    last_assistant_text=meta["last_assistant_text"],
+                    raw_path=meta["raw_path"],
+                )
+                # Update last_activity_ms separately (max of file mtime vs parsed ts)
+                conn.execute(
+                    "UPDATE sessions SET last_activity_ms = MAX(last_activity_ms, ?) "
+                    "WHERE session_id = ? AND source = 'claude'",
+                    (meta["last_ts"], meta["session_id"]),
+                )
+                upserted += 1
+            except sqlite3.Error:
+                errors += 1
+
+    conn.commit()
+    state["claude_sessions"] = session_state
+    if scanned:
+        suffix = f" ({errors} errors)" if errors else ""
+        print(f"  [claude-sessions] scanned {scanned} files, {upserted} sessions updated{suffix}")
+
+
 # --- Parsers -----------------------------------------------------------------
 
 def parse_claude(line: str):
@@ -196,6 +404,7 @@ def parse_claude(line: str):
         "prompt": display,
         "prompt_hash": _prompt_hash(display),
         "timestamp_ms": obj.get("timestamp", 0),
+        "git_branch": obj.get("gitBranch"),
     }
 
 
@@ -212,6 +421,7 @@ def parse_codex(line: str):
         "prompt": text,
         "prompt_hash": _prompt_hash(text),
         "timestamp_ms": int(obj.get("ts", 0) * 1000),
+        "git_branch": None,
     }
 
 
@@ -228,7 +438,7 @@ PARSERS = {
 # session_id → cwd map at sync time and use it to populate `project`.
 
 def _read_codex_session_meta(path: Path):
-    """Read a codex rollout file's first line; return (session_id, cwd) or None."""
+    """Read a codex rollout file's first line; return (session_id, cwd, git_branch) or None."""
     try:
         with open(path, "r", encoding="utf-8") as f:
             first = f.readline()
@@ -248,11 +458,13 @@ def _read_codex_session_meta(path: Path):
     cwd = payload.get("cwd")
     if not session_id or not cwd:
         return None
-    return session_id, cwd
+    git = payload.get("git") or {}
+    branch = git.get("branch") if isinstance(git, dict) else None
+    return session_id, cwd, branch
 
 
-def build_codex_session_map(state: dict) -> dict:
-    """Walk codex rollout dirs; cache and return {session_id: cwd}.
+def build_codex_session_map(state: dict) -> tuple:
+    """Walk codex rollout dirs; cache and return ({session_id: cwd}, {session_id: branch}).
 
     Rollout files are write-once after the session_meta header — we key the
     rollout cache by path and skip any file whose mtime hasn't changed since
@@ -260,6 +472,7 @@ def build_codex_session_map(state: dict) -> dict:
     """
     seen = state.get("codex_rollouts", {})
     cwds = state.get("codex_session_cwds", {})
+    branches = state.get("codex_session_branches", {})
     scanned = 0
     for root in CODEX_SESSIONS_DIRS:
         if not root.exists():
@@ -276,34 +489,62 @@ def build_codex_session_map(state: dict) -> dict:
             seen[key] = mtime
             scanned += 1
             if meta:
-                sid, cwd = meta
+                sid, cwd, branch = meta
                 cwds[sid] = cwd
+                if branch:
+                    branches[sid] = branch
     state["codex_rollouts"] = seen
     state["codex_session_cwds"] = cwds
+    state["codex_session_branches"] = branches
     if scanned:
         print(f"  [codex] scanned {scanned:,} new rollout files; {len(cwds):,} sessions mapped")
-    return cwds
+    return cwds, branches
 
 
-def _backfill_codex_projects(conn: sqlite3.Connection, cwds: dict) -> int:
-    """Set project for codex rows with NULL project whose session_id is mapped."""
+def _backfill_codex_projects(conn: sqlite3.Connection, cwds: dict, branches: dict) -> int:
+    """Set project/git_branch for codex rows whose session_id is mapped."""
     if not cwds:
         return 0
     sids = conn.execute(
         "SELECT DISTINCT session_id FROM history "
-        "WHERE source='codex' AND project IS NULL AND session_id IS NOT NULL"
+        "WHERE source='codex' AND session_id IS NOT NULL"
     ).fetchall()
     updated = 0
     for (sid,) in sids:
         cwd = cwds.get(sid)
-        if not cwd:
+        branch = branches.get(sid)
+        if not cwd and not branch:
             continue
+        sets = []
+        params = []
+        if cwd:
+            sets.append("project = COALESCE(project, ?)")
+            params.append(cwd)
+        if branch:
+            sets.append("git_branch = COALESCE(git_branch, ?)")
+            params.append(branch)
+        params.append(sid)
         cur = conn.execute(
-            "UPDATE history SET project = ? "
-            "WHERE source='codex' AND project IS NULL AND session_id = ?",
-            (cwd, sid),
+            f"UPDATE history SET {', '.join(sets)} WHERE source='codex' AND session_id = ?",
+            params,
         )
         updated += cur.rowcount
+        if cwd:
+            # Use real timestamps from history so sessions table sorts correctly.
+            ts_row = conn.execute(
+                "SELECT MIN(timestamp_ms), MAX(timestamp_ms) FROM history "
+                "WHERE source='codex' AND session_id = ?",
+                (sid,),
+            ).fetchone()
+            first_ts = ts_row[0] or 0
+            last_ts = ts_row[1] or 0
+            _upsert_session(conn, sid, "codex", cwd, branch, first_ts)
+            if last_ts:
+                conn.execute(
+                    "UPDATE sessions SET last_activity_ms = MAX(COALESCE(last_activity_ms, 0), ?) "
+                    "WHERE session_id = ? AND source = 'codex'",
+                    (last_ts, sid),
+                )
     if updated:
         conn.commit()
     return updated
@@ -316,7 +557,7 @@ def sync_codex(conn: sqlite3.Connection, state: dict):
         print(f"  [codex] not found: {path} (skipped)")
         return
 
-    cwds = build_codex_session_map(state)
+    cwds, branches = build_codex_session_map(state)
 
     file_size = path.stat().st_size
     offset = state.get("codex", 0)
@@ -339,13 +580,15 @@ def sync_codex(conn: sqlite3.Connection, state: dict):
                 if row is None:
                     continue
                 sid = row.get("session_id")
-                if sid and not row.get("project"):
-                    row["project"] = cwds.get(sid)
+                if sid:
+                    if not row.get("project"):
+                        row["project"] = cwds.get(sid)
+                    row["git_branch"] = branches.get(sid)
                 try:
                     cur = conn.execute(
                         "INSERT OR IGNORE INTO history "
-                        "(source, session_id, project, prompt, prompt_hash, timestamp_ms) "
-                        "VALUES (:source, :session_id, :project, :prompt, :prompt_hash, :timestamp_ms)",
+                        "(source, session_id, project, prompt, prompt_hash, timestamp_ms, git_branch) "
+                        "VALUES (:source, :session_id, :project, :prompt, :prompt_hash, :timestamp_ms, :git_branch)",
                         row,
                     )
                     if cur.rowcount > 0:
@@ -355,14 +598,14 @@ def sync_codex(conn: sqlite3.Connection, state: dict):
         conn.commit()
         state["codex"] = file_size
 
-    backfilled = _backfill_codex_projects(conn, cwds)
+    backfilled = _backfill_codex_projects(conn, cwds, branches)
 
     if offset >= file_size and not backfilled:
         print("  [codex] up to date")
         return
     parts = [f"+{inserted:,} rows"] if inserted or offset < file_size else []
     if backfilled:
-        parts.append(f"backfilled {backfilled:,} project values")
+        parts.append(f"backfilled {backfilled:,} project/branch values")
     if errors:
         parts.append(f"{errors} errors")
     print(f"  [codex] " + ", ".join(parts))
@@ -877,12 +1120,15 @@ def sync_trajectories(conn: sqlite3.Connection, state: dict):
 def init_db(conn: sqlite3.Connection):
     conn.executescript(SCHEMA)
     conn.execute("PRAGMA journal_mode=WAL")
-    # Migration: add prompt_hash column to existing DBs that predate it.
-    try:
-        conn.execute("ALTER TABLE history ADD COLUMN prompt_hash TEXT")
-        conn.commit()
-    except sqlite3.OperationalError:
-        pass  # column already exists
+    for migration in (
+        "ALTER TABLE history ADD COLUMN prompt_hash TEXT",
+        "ALTER TABLE history ADD COLUMN git_branch TEXT",
+    ):
+        try:
+            conn.execute(migration)
+            conn.commit()
+        except sqlite3.OperationalError:
+            pass  # column already exists
     conn.execute("CREATE INDEX IF NOT EXISTS idx_history_hash ON history(prompt_hash)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_trajectories_timestamp ON trajectories(timestamp_ms DESC)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_trajectories_project ON trajectories(project_id)")
@@ -955,8 +1201,8 @@ def cmd_sync(args=None):
                 try:
                     cur = conn.execute(
                         "INSERT OR IGNORE INTO history "
-                        "(source, session_id, project, prompt, prompt_hash, timestamp_ms) "
-                        "VALUES (:source, :session_id, :project, :prompt, :prompt_hash, :timestamp_ms)",
+                        "(source, session_id, project, prompt, prompt_hash, timestamp_ms, git_branch) "
+                        "VALUES (:source, :session_id, :project, :prompt, :prompt_hash, :timestamp_ms, :git_branch)",
                         row,
                     )
                     if cur.rowcount > 0:
@@ -967,6 +1213,9 @@ def cmd_sync(args=None):
         conn.commit()
         state[name] = file_size
         print(f"  [{name}] +{inserted:,} rows" + (f" ({errors} errors)" if errors else ""))
+
+    # Sync Claude per-session JSONL files for gitBranch + last assistant text
+    sync_claude_sessions(conn, state)
 
     # Sync Codex history with cwd enrichment from rollout files
     sync_codex(conn, state)

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-hist",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-hist",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -33,6 +33,35 @@ export interface HistoryEntry {
   project: string | null;
   prompt: string;
   timestampMs: number;
+  gitBranch: string | null;
+}
+
+export interface SessionMeta {
+  sessionId: string;
+  source: Source;
+  cwd: string | null;
+  gitBranch: string | null;
+  firstActivityMs: number | null;
+  lastActivityMs: number | null;
+  lastAssistantText: string | null;
+  rawPath: string | null;
+}
+
+export interface HandoffCandidate {
+  sessionId: string;
+  source: Source;
+  cwd: string | null;
+  gitBranch: string | null;
+  firstActivityMs: number | null;
+  lastActivityMs: number | null;
+  promptCount: number;
+  goal: string;
+  lastState: string;
+  lastAssistantText: string | null;
+  filesTouched: string[];
+  resumeCommand: string | null;
+  warmStartCommand: string;
+  confidence: number;
 }
 
 export interface SessionSummary {
@@ -94,6 +123,17 @@ export interface TrajectorySearchOptions {
   project?: string;
 }
 
+export interface GetHandoffOptions {
+  /** Substring match against session cwd. */
+  repo?: string;
+  /** Substring match against git_branch. */
+  branch?: string;
+  /** Filter to a specific CLI source. */
+  source?: 'claude' | 'codex';
+  /** Max candidates to return. Default 3. */
+  limit?: number;
+}
+
 /** Resolve the SQLite path the Python CLI writes to. */
 export function defaultDbPath(): string {
   const fromEnv = process.env.AI_HIST_DB;
@@ -107,6 +147,24 @@ function getSqlJs(): Promise<SqlJsStatic> {
     _sqlPromise = initSqlJs();
   }
   return _sqlPromise;
+}
+
+function ensureSessionsSchema(db: Database): void {
+  db.run(`CREATE TABLE IF NOT EXISTS sessions (
+    session_id TEXT NOT NULL,
+    source TEXT NOT NULL,
+    cwd TEXT,
+    git_branch TEXT,
+    first_activity_ms INTEGER,
+    last_activity_ms INTEGER,
+    last_assistant_text TEXT,
+    raw_path TEXT,
+    parser_version INTEGER NOT NULL DEFAULT 1,
+    PRIMARY KEY (session_id, source)
+  )`);
+  db.run('CREATE INDEX IF NOT EXISTS idx_sessions_cwd ON sessions(cwd)');
+  db.run('CREATE INDEX IF NOT EXISTS idx_sessions_branch ON sessions(git_branch)');
+  db.run('CREATE INDEX IF NOT EXISTS idx_sessions_last ON sessions(last_activity_ms DESC)');
 }
 
 function ensureTrajectorySchema(db: Database): void {
@@ -175,6 +233,9 @@ export async function openAiHist(opts: OpenOptions = {}): Promise<AiHist> {
     const fileBuffer = await readFile(dbPath);
     const db = new SQL.Database(fileBuffer);
     ensureTrajectorySchema(db);
+    ensureSessionsSchema(db);
+    // Add git_branch to history if missing (pre-handoff DBs lack this column).
+    try { db.run('ALTER TABLE history ADD COLUMN git_branch TEXT'); } catch { /* already exists */ }
     // The Python CLI's schema doesn't create `idx_history_session` or
     // `idx_history_timestamp`. Without them, listSessions degrades to
     // an O(sessions × rows) full table scan and freezes the WASM
@@ -207,11 +268,13 @@ export async function openAiHist(opts: OpenOptions = {}): Promise<AiHist> {
     project TEXT,
     prompt TEXT NOT NULL,
     timestamp_ms INTEGER NOT NULL,
+    git_branch TEXT,
     UNIQUE(source, timestamp_ms, prompt)
   )`);
   db.run('CREATE INDEX idx_history_timestamp ON history (timestamp_ms DESC)');
   db.run('CREATE INDEX idx_history_session ON history (session_id)');
   ensureTrajectorySchema(db);
+  ensureSessionsSchema(db);
 
   // scanLocalSources is async with yields between sources so the event
   // loop stays responsive while we scan many MB of JSONL.
@@ -219,7 +282,7 @@ export async function openAiHist(opts: OpenOptions = {}): Promise<AiHist> {
   const trajectories = await scanLocalTrajectories();
 
   const insert = db.prepare(
-    'INSERT OR IGNORE INTO history (source, session_id, project, prompt, timestamp_ms) VALUES (?, ?, ?, ?, ?)',
+    'INSERT OR IGNORE INTO history (source, session_id, project, prompt, timestamp_ms, git_branch) VALUES (?, ?, ?, ?, ?, ?)',
   );
   const insertTrajectory = db.prepare(
     `INSERT OR REPLACE INTO trajectories
@@ -231,7 +294,7 @@ export async function openAiHist(opts: OpenOptions = {}): Promise<AiHist> {
   try {
     db.exec('BEGIN');
     for (const row of rows) {
-      insert.run([row.source, row.sessionId, row.project, row.prompt, row.timestampMs]);
+      insert.run([row.source, row.sessionId, row.project, row.prompt, row.timestampMs, row.gitBranch]);
     }
     for (const trajectory of trajectories) {
       insertTrajectory.run([
@@ -284,6 +347,18 @@ interface RawHistoryRow {
   project: string | null;
   prompt: string;
   timestamp_ms: number;
+  git_branch: string | null;
+}
+
+interface RawSessionRow {
+  session_id: string;
+  source: string;
+  cwd: string | null;
+  git_branch: string | null;
+  first_activity_ms: number | null;
+  last_activity_ms: number | null;
+  last_assistant_text: string | null;
+  raw_path: string | null;
 }
 
 interface RawTrajectoryRow {
@@ -312,6 +387,7 @@ function rowToEntry(row: RawHistoryRow): HistoryEntry {
     project: row.project,
     prompt: row.prompt,
     timestampMs: row.timestamp_ms,
+    gitBranch: row.git_branch ?? null,
   };
 }
 
@@ -472,7 +548,7 @@ export class AiHist {
     const { sql, params } = buildFilters(opts, this._projectScope);
     return runQuery<RawHistoryRow>(
       this.db,
-      `SELECT id, source, session_id, project, prompt, timestamp_ms
+      `SELECT id, source, session_id, project, prompt, timestamp_ms, git_branch
        FROM history
        WHERE 1=1${sql}
        ORDER BY timestamp_ms DESC
@@ -559,7 +635,7 @@ export class AiHist {
     appendProjectFilter(clauses, params, undefined, this._projectScope);
     return runQuery<RawHistoryRow>(
       this.db,
-      `SELECT id, source, session_id, project, prompt, timestamp_ms
+      `SELECT id, source, session_id, project, prompt, timestamp_ms, git_branch
        FROM history
        WHERE ${clauses.join(' AND ')}
        ORDER BY timestamp_ms ASC`,
@@ -598,7 +674,7 @@ export class AiHist {
     }
     return runQuery<RawHistoryRow>(
       this.db,
-      `SELECT id, source, session_id, project, prompt, timestamp_ms
+      `SELECT id, source, session_id, project, prompt, timestamp_ms, git_branch
        FROM history
        WHERE ${clauses.join(' AND ')}
        ORDER BY timestamp_ms DESC
@@ -653,7 +729,7 @@ export class AiHist {
     appendProjectFilter(clauses, params, undefined, this._projectScope);
     const rows = runQuery<RawHistoryRow>(
       this.db,
-      `SELECT id, source, session_id, project, prompt, timestamp_ms
+      `SELECT id, source, session_id, project, prompt, timestamp_ms, git_branch
        FROM history WHERE ${clauses.join(' AND ')}`,
       params,
     );
@@ -670,12 +746,118 @@ export class AiHist {
     appendProjectFilter(clauses, params, undefined, this._projectScope);
     return runQuery<RawHistoryRow>(
       this.db,
-      `SELECT id, source, session_id, project, prompt, timestamp_ms
+      `SELECT id, source, session_id, project, prompt, timestamp_ms, git_branch
        FROM history
        WHERE ${clauses.join(' AND ')}
        ORDER BY timestamp_ms ASC`,
       params,
     ).map(rowToEntry);
+  }
+
+  /**
+   * Find sessions matching the given repo/branch/source and return ranked
+   * handoff candidates with a warm-start command for the target CLI.
+   *
+   * Queries the `sessions` table (populated by `ai-hist sync`) for objective
+   * metadata, then joins the last N user prompts from `history` to generate
+   * a brief on demand — no pre-computed summaries.
+   */
+  getHandoff(opts: GetHandoffOptions = {}): HandoffCandidate[] {
+    const limit = opts.limit ?? 3;
+    const clauses: string[] = [];
+    const params: unknown[] = [];
+
+    if (this._projectScope) {
+      const escaped = this._projectScope.replace(/\|/g, '||').replace(/%/g, '|%').replace(/_/g, '|_');
+      clauses.push("cwd LIKE ? ESCAPE '|'");
+      params.push(`${escaped}%`);
+    }
+    if (opts.source) {
+      clauses.push('source = ?');
+      params.push(opts.source);
+    }
+    if (opts.repo) {
+      const escaped = opts.repo.replace(/\|/g, '||').replace(/%/g, '|%').replace(/_/g, '|_');
+      clauses.push("cwd LIKE ? ESCAPE '|'");
+      params.push(`%${escaped}%`);
+    }
+    if (opts.branch) {
+      const escaped = opts.branch.replace(/\|/g, '||').replace(/%/g, '|%').replace(/_/g, '|_');
+      clauses.push("git_branch LIKE ? ESCAPE '|'");
+      params.push(`%${escaped}%`);
+    }
+
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+    const sessionRows = runQuery<RawSessionRow>(
+      this.db,
+      `SELECT session_id, source, cwd, git_branch, first_activity_ms, last_activity_ms,
+              last_assistant_text, raw_path
+       FROM sessions
+       ${where}
+       ORDER BY last_activity_ms DESC
+       LIMIT ?`,
+      [...params, limit],
+    );
+
+    const candidates: HandoffCandidate[] = [];
+    for (const session of sessionRows) {
+      // Filter by both session_id AND source to prevent cross-source prompt mixing
+      // when two CLIs happen to use the same session ID (rare but possible).
+      const prompts = runQuery<RawHistoryRow>(
+        this.db,
+        `SELECT id, source, session_id, project, prompt, timestamp_ms, git_branch
+         FROM history
+         WHERE session_id = ? AND source = ?
+         ORDER BY timestamp_ms ASC`,
+        [session.session_id, session.source],
+      ).map(rowToEntry);
+      if (prompts.length === 0) continue;
+
+      const filesTouched = extractFilePaths(prompts.map((p) => p.prompt).join('\n'));
+      const goal = prompts[0].prompt.slice(0, 300).replace(/\n/g, ' ');
+      const lastState = prompts[prompts.length - 1].prompt.slice(0, 300).replace(/\n/g, ' ');
+
+      const entry = prompts[0];
+      const resume = resumeCommand({
+        source: session.source as Source,
+        sessionId: session.session_id,
+        project: session.cwd,
+      });
+
+      const targetSource = session.source === 'claude' ? 'codex' : 'claude';
+      const warmStart = buildWarmStartCommand(
+        targetSource,
+        goal,
+        filesTouched,
+        lastState,
+        session.last_assistant_text ?? null,
+        session.cwd,
+      );
+
+      let confidence = Math.min(0.6, 0.2 + prompts.length * 0.02);
+      if (opts.branch && session.git_branch?.includes(opts.branch)) confidence += 0.25;
+      if (opts.repo && session.cwd?.includes(opts.repo)) confidence += 0.15;
+      confidence = Math.min(1.0, confidence);
+
+      candidates.push({
+        sessionId: session.session_id,
+        source: session.source as Source,
+        cwd: session.cwd,
+        gitBranch: session.git_branch,
+        firstActivityMs: session.first_activity_ms,
+        lastActivityMs: session.last_activity_ms,
+        promptCount: prompts.length,
+        goal,
+        lastState,
+        lastAssistantText: session.last_assistant_text ?? null,
+        filesTouched,
+        resumeCommand: resume,
+        warmStartCommand: warmStart,
+        confidence,
+      });
+    }
+
+    return candidates.sort((a, b) => b.confidence - a.confidence);
   }
 
   /** Counts + date range, mirroring `ai-hist stats`. */
@@ -716,6 +898,47 @@ export class AiHist {
       lastTimestampMs: range?.mx ?? null,
     };
   }
+}
+
+/**
+ * Extract file paths with recognizable extensions from a block of text.
+ * Heuristic — used to populate filesTouched in HandoffCandidate.
+ */
+function extractFilePaths(text: string): string[] {
+  const exts = 'ts|tsx|js|jsx|mjs|cjs|py|go|rs|rb|java|cs|cpp|cc|c|h|json|yaml|yml|toml|md|sh|sql|css|scss|html|svelte|vue';
+  const regex = new RegExp(
+    `(?:^|[\\s,\`'"(])([~./][\\w./-]*\\.(?:${exts})|-?[\\w/-]+\\.(?:${exts}))\\b`,
+    'gm',
+  );
+  const seen = new Set<string>();
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(text)) !== null) {
+    const p = m[1].trim();
+    if (p.length > 2 && p.length < 200) seen.add(p);
+  }
+  return Array.from(seen).slice(0, 20);
+}
+
+/**
+ * Build a warm-start command for the target CLI, injecting context from a
+ * prior session so the new agent can pick up mid-task.
+ */
+function buildWarmStartCommand(
+  targetSource: string,
+  goal: string,
+  files: string[],
+  lastState: string,
+  lastAssistant: string | null,
+  cwd: string | null,
+): string {
+  const filesLine = files.length > 0 ? ` Files touched: ${files.slice(0, 10).join(', ')}.` : '';
+  const assistantLine = lastAssistant
+    ? ` Last assistant state: ${lastAssistant.replace(/\n/g, ' ').slice(0, 200)}`
+    : '';
+  const context =
+    `Picking up from previous session. Goal: ${goal}.${filesLine} Last user prompt: ${lastState}.${assistantLine}`;
+  const cdPart = cwd ? `cd ${shellQuote(cwd)} && ` : '';
+  return `${cdPart}${targetSource} ${shellQuote(context)}`;
 }
 
 /**

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -320,6 +320,7 @@ export async function openAiHist(opts: OpenOptions = {}): Promise<AiHist> {
         trajectory.projectId,
         trajectory.searchText,
         trajectory.timestampMs,
+        null,
       ]);
     }
     db.exec('COMMIT');

--- a/sdk-ts/src/jsonl-sources.ts
+++ b/sdk-ts/src/jsonl-sources.ts
@@ -27,6 +27,7 @@ export interface RawRow {
   project: string | null;
   prompt: string;
   timestampMs: number;
+  gitBranch: string | null;
 }
 
 const CLAUDE_HISTORY = join(homedir(), '.claude', 'history.jsonl');
@@ -83,6 +84,7 @@ function parseClaudeLine(line: string): RawRow | null {
     project: asString(obj.project),
     prompt: display,
     timestampMs: asNumber(obj.timestamp) ?? 0,
+    gitBranch: asString(obj.gitBranch),
   };
 }
 
@@ -101,6 +103,7 @@ function parseCodexLine(line: string): RawRow | null {
     prompt: text,
     // Python stores Codex's seconds-since-epoch as ms.
     timestampMs: Math.trunc(ts * 1000),
+    gitBranch: null,
   };
 }
 
@@ -204,6 +207,7 @@ async function scanCursor(): Promise<RawRow[]> {
           project: projectPath,
           prompt: text,
           timestampMs: tsMs,
+          gitBranch: null,
         });
       }
     }

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -13,7 +13,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { resolve } from "node:path";
 import { z } from "zod";
-import { openAiHist, resumeCommand, type AiHist, type TrajectoryEntry } from "./index.js";
+import { openAiHist, resumeCommand, type AiHist, type TrajectoryEntry, type HandoffCandidate } from "./index.js";
 
 // ---------------------------------------------------------------------------
 // Lazy singleton — opens on first tool call and reuses across all calls.
@@ -157,6 +157,13 @@ and Agent Relay — all searchable in a single index.
 
 - **why_for_task** — Return the best matching trajectory's decisions and
   retrospective for a task query.
+
+- **get_handoff** — Find sessions for a repo/branch and generate a warm-start
+  handoff brief so you can continue work in a different CLI. Use this when you
+  need to switch from Claude Code to Codex (or vice versa) because one is down
+  or quota-exhausted. Ask: "where did codex leave off on branch feat/auth in
+  /my-repo?" and this tool returns ranked candidates with resume commands and
+  a ready-to-paste warm-start command for the target CLI.
 
 ## Tips
 
@@ -571,6 +578,94 @@ server.tool(
           },
         ],
       };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${String(err)}` }], isError: true };
+    }
+  },
+);
+
+server.tool(
+  "get_handoff",
+  "Find active sessions for a repo/branch and generate a warm-start handoff brief " +
+    "so you can continue work in a different CLI (e.g. pick up a Claude session in Codex " +
+    "or vice versa). Returns ranked candidate sessions with: the original goal, files " +
+    "touched (extracted from prompts), last user prompt, last assistant state, the resume " +
+    "command for the original CLI, and a ready-to-paste warm-start command for the target CLI. " +
+    "Use this when switching between Claude Code and Codex mid-task due to quota or outage.",
+  {
+    repo: z
+      .string()
+      .optional()
+      .describe(
+        "Project directory path to filter by (substring match against session cwd). " +
+          'Example: "/my-app", "work/api". Omit to search across all projects.',
+      ),
+    branch: z
+      .string()
+      .optional()
+      .describe(
+        "Git branch name to filter by (substring match). " +
+          'Example: "feat/auth", "main". Requires ai-hist sync to have captured gitBranch.',
+      ),
+    source: z
+      .enum(["claude", "codex"])
+      .optional()
+      .describe(
+        "Filter to sessions from a specific CLI. Omit to search both Claude Code and Codex.",
+      ),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(10)
+      .optional()
+      .default(3)
+      .describe("Maximum number of handoff candidates to return. Default: 3."),
+  },
+  READ_ONLY,
+  async ({ repo, branch, source, limit }) => {
+    try {
+      const hist = await getHist();
+      const candidates = hist.getHandoff({ repo, branch, source, limit });
+      if (candidates.length === 0) {
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                "No sessions found matching the given filters. " +
+                "Run `ai-hist sync` to populate session metadata, then try again.",
+            },
+          ],
+        };
+      }
+      const lines: string[] = [`Found ${candidates.length} handoff candidate(s):\n`];
+      for (let i = 0; i < candidates.length; i++) {
+        const c = candidates[i];
+        const dt = c.lastActivityMs
+          ? new Date(c.lastActivityMs).toISOString().slice(0, 16).replace("T", " ")
+          : "unknown";
+        lines.push(
+          `[${i + 1}] ${c.source.toUpperCase()} session  confidence: ${(c.confidence * 100).toFixed(0)}%`,
+        );
+        lines.push(`  session_id : ${c.sessionId}`);
+        lines.push(`  cwd        : ${c.cwd ?? "(unknown)"}`);
+        lines.push(`  branch     : ${c.gitBranch ?? "(unknown)"}`);
+        lines.push(`  last seen  : ${dt}  (${c.promptCount} prompts)`);
+        lines.push(`  goal       : ${c.goal.slice(0, 150)}`);
+        lines.push(`  last state : ${c.lastState.slice(0, 150)}`);
+        if (c.filesTouched.length > 0) {
+          lines.push(`  files      : ${c.filesTouched.slice(0, 8).join(", ")}`);
+        }
+        if (c.lastAssistantText) {
+          lines.push(`  assistant  : ${c.lastAssistantText.slice(0, 200).replace(/\n/g, " ")}`);
+        }
+        if (c.resumeCommand) {
+          lines.push(`  resume     : ${c.resumeCommand}`);
+        }
+        lines.push(`  warm-start : ${c.warmStartCommand}`);
+      }
+      return { content: [{ type: "text", text: lines.join("\n") }] };
     } catch (err) {
       return { content: [{ type: "text", text: `Error: ${String(err)}` }], isError: true };
     }

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -642,9 +642,10 @@ server.tool(
       const lines: string[] = [`Found ${candidates.length} handoff candidate(s):\n`];
       for (let i = 0; i < candidates.length; i++) {
         const c = candidates[i];
-        const dt = c.lastActivityMs
-          ? new Date(c.lastActivityMs).toISOString().slice(0, 16).replace("T", " ")
-          : "unknown";
+        let dt = "unknown";
+        if (Number.isFinite(c.lastActivityMs)) {
+          dt = new Date(c.lastActivityMs).toISOString().slice(0, 16).replace("T", " ");
+        }
         lines.push(
           `[${i + 1}] ${c.source.toUpperCase()} session  confidence: ${(c.confidence * 100).toFixed(0)}%`,
         );

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -643,7 +643,7 @@ server.tool(
       for (let i = 0; i < candidates.length; i++) {
         const c = candidates[i];
         let dt = "unknown";
-        if (Number.isFinite(c.lastActivityMs)) {
+        if (c.lastActivityMs != null && Number.isFinite(c.lastActivityMs)) {
           dt = new Date(c.lastActivityMs).toISOString().slice(0, 16).replace("T", " ");
         }
         lines.push(

--- a/sdk-ts/src/mcp-smoke.test.ts
+++ b/sdk-ts/src/mcp-smoke.test.ts
@@ -218,6 +218,7 @@ test('MCP server exposes history and trajectory tools over stdio', async () => {
       'stats',
       'search_trajectories',
       'why_for_task',
+      'get_handoff',
     ]) {
       assert.ok(tools.has(name), `missing MCP tool ${name}`);
     }
@@ -241,7 +242,20 @@ async function writeScopeFixtureDb(dbPath: string): Promise<void> {
       session_id TEXT,
       project TEXT,
       prompt TEXT NOT NULL,
-      timestamp_ms INTEGER NOT NULL
+      timestamp_ms INTEGER NOT NULL,
+      git_branch TEXT
+    )`);
+    db.run(`CREATE TABLE sessions (
+      session_id TEXT NOT NULL,
+      source TEXT NOT NULL,
+      cwd TEXT,
+      git_branch TEXT,
+      first_activity_ms INTEGER,
+      last_activity_ms INTEGER,
+      last_assistant_text TEXT,
+      raw_path TEXT,
+      parser_version INTEGER NOT NULL DEFAULT 1,
+      PRIMARY KEY (session_id, source)
     )`);
     db.run(`CREATE TABLE trajectories (
       id TEXT PRIMARY KEY,

--- a/test_ai_hist.py
+++ b/test_ai_hist.py
@@ -48,6 +48,13 @@ def tmp_env(tmp_path, monkeypatch):
     monkeypatch.setattr(ai_hist, "TRAJECTORY_ROOT", str(trajectory_root))
     monkeypatch.setattr(ai_hist, "DEFAULT_TRAJECTORY_SEARCH_ROOT", tmp_path / "Projects")
 
+    # Isolate Claude per-session JSONL scanning from real ~/.claude/projects.
+    claude_projects_root = tmp_path / "claude_projects"
+    monkeypatch.setattr(ai_hist, "CLAUDE_PROJECTS_ROOT", claude_projects_root)
+
+    # Isolate Codex rollout dirs from real ~/.codex/sessions.
+    monkeypatch.setattr(ai_hist, "CODEX_SESSIONS_DIRS", [])
+
     return SimpleNamespace(
         db_path=db_path,
         state_path=state_path,
@@ -55,6 +62,7 @@ def tmp_env(tmp_path, monkeypatch):
         codex_hist=codex_hist,
         cursor_root=cursor_root,
         trajectory_root=trajectory_root,
+        claude_projects_root=claude_projects_root,
         tmp_path=tmp_path,
     )
 
@@ -123,7 +131,13 @@ class TestParseClaude:
             "prompt": "hello world",
             "prompt_hash": ai_hist._prompt_hash("hello world"),
             "timestamp_ms": 1700000000000,
+            "git_branch": None,
         }
+
+    def test_git_branch_captured(self):
+        line = json.dumps({"display": "hi", "timestamp": 1, "gitBranch": "feat/x"})
+        result = ai_hist.parse_claude(line)
+        assert result["git_branch"] == "feat/x"
 
     def test_empty_display_returns_none(self):
         line = json.dumps({"display": "", "timestamp": 123})
@@ -156,6 +170,7 @@ class TestParseCodex:
             "prompt": "fix the bug",
             "prompt_hash": ai_hist._prompt_hash("fix the bug"),
             "timestamp_ms": 1700000000000,
+            "git_branch": None,
         }
 
     def test_empty_text_returns_none(self):
@@ -2017,3 +2032,188 @@ class TestCmdImport:
         assert row[1] == "sess-rt"
         assert row[2] == "/proj"
         assert row[3] == "roundtrip test"
+
+
+# ---------------------------------------------------------------------------
+# Session helpers and Claude session scanning
+# ---------------------------------------------------------------------------
+
+def make_claude_session_jsonl(project_dir: Path, session_id: str, git_branch: str,
+                               cwd: str, prompts: list, last_assistant: str = None) -> Path:
+    """Create a fake Claude per-session JSONL file."""
+    project_dir.mkdir(parents=True, exist_ok=True)
+    jsonl = project_dir / f"{session_id}.jsonl"
+    lines = []
+    # First line: a typical attachment entry that carries session metadata.
+    lines.append(json.dumps({
+        "type": "attachment",
+        "sessionId": session_id,
+        "gitBranch": git_branch,
+        "cwd": cwd,
+        "timestamp": "2024-01-01T00:00:00.000Z",
+    }))
+    for i, prompt in enumerate(prompts):
+        lines.append(json.dumps({
+            "type": "user",
+            "sessionId": session_id,
+            "gitBranch": git_branch,
+            "cwd": cwd,
+            "timestamp": f"2024-01-01T00:0{i}:01.000Z",
+            "message": {"role": "user", "content": prompt},
+        }))
+    if last_assistant:
+        lines.append(json.dumps({
+            "type": "assistant",
+            "sessionId": session_id,
+            "gitBranch": git_branch,
+            "cwd": cwd,
+            "timestamp": "2024-01-01T01:00:00.000Z",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": last_assistant}]},
+        }))
+    jsonl.write_text("\n".join(lines) + "\n")
+    return jsonl
+
+
+class TestUpsertSession:
+    def test_insert(self, tmp_path):
+        db = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db))
+        ai_hist.init_db(conn)
+        ai_hist._upsert_session(conn, "sid1", "claude", "/proj", "main", 1000)
+        conn.commit()
+        row = conn.execute(
+            "SELECT session_id, source, cwd, git_branch, first_activity_ms, last_activity_ms "
+            "FROM sessions WHERE session_id='sid1'"
+        ).fetchone()
+        conn.close()
+        assert row == ("sid1", "claude", "/proj", "main", 1000, 1000)
+
+    def test_upsert_preserves_existing_cwd(self, tmp_path):
+        db = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db))
+        ai_hist.init_db(conn)
+        ai_hist._upsert_session(conn, "sid1", "claude", "/proj", "main", 1000)
+        # Second upsert with NULL cwd should keep existing.
+        ai_hist._upsert_session(conn, "sid1", "claude", None, None, 2000)
+        conn.commit()
+        row = conn.execute("SELECT cwd, git_branch FROM sessions WHERE session_id='sid1'").fetchone()
+        conn.close()
+        assert row == ("/proj", "main")
+
+    def test_upsert_updates_last_activity_ms(self, tmp_path):
+        db = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db))
+        ai_hist.init_db(conn)
+        ai_hist._upsert_session(conn, "sid1", "claude", "/proj", "main", 1000)
+        ai_hist._upsert_session(conn, "sid1", "claude", "/proj", "main", 5000)
+        conn.commit()
+        row = conn.execute(
+            "SELECT first_activity_ms, last_activity_ms FROM sessions WHERE session_id='sid1'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == 1000  # first stays
+        assert row[1] == 5000  # last updated
+
+    def test_upsert_last_assistant_text(self, tmp_path):
+        db = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db))
+        ai_hist.init_db(conn)
+        ai_hist._upsert_session(conn, "sid1", "claude", "/proj", "main", 1000,
+                                 last_assistant_text="done!")
+        conn.commit()
+        row = conn.execute("SELECT last_assistant_text FROM sessions WHERE session_id='sid1'").fetchone()
+        conn.close()
+        assert row[0] == "done!"
+
+
+class TestScanClaudeSessionFile:
+    def test_basic_metadata(self, tmp_path):
+        proj_dir = tmp_path / "proj"
+        jsonl = make_claude_session_jsonl(proj_dir, "sess-abc", "feat/auth", "/app", ["fix bug"])
+        meta = ai_hist._scan_claude_session_file(jsonl)
+        assert meta is not None
+        assert meta["session_id"] == "sess-abc"
+        assert meta["git_branch"] == "feat/auth"
+        assert meta["cwd"] == "/app"
+        assert meta["raw_path"] == str(jsonl)
+
+    def test_last_assistant_text(self, tmp_path):
+        proj_dir = tmp_path / "proj"
+        jsonl = make_claude_session_jsonl(proj_dir, "sess-abc", "main", "/app",
+                                          ["do X"], last_assistant="Done, I updated auth.ts")
+        meta = ai_hist._scan_claude_session_file(jsonl)
+        assert meta is not None
+        assert "auth.ts" in meta["last_assistant_text"]
+
+    def test_no_session_id_returns_none(self, tmp_path):
+        f = tmp_path / "unknown.jsonl"
+        f.write_text(json.dumps({"type": "mode", "mode": "normal"}) + "\n")
+        assert ai_hist._scan_claude_session_file(f) is None
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert ai_hist._scan_claude_session_file(tmp_path / "missing.jsonl") is None
+
+
+class TestSyncClaudeSessions:
+    def test_populates_sessions_table(self, tmp_env, capsys):
+        proj_dir = tmp_env.claude_projects_root / "proj"
+        make_claude_session_jsonl(proj_dir, "sess-1", "main", "/app", ["do work"])
+        ai_hist.cmd_sync()
+        conn = sqlite3.connect(str(tmp_env.db_path))
+        row = conn.execute(
+            "SELECT session_id, source, cwd, git_branch FROM sessions WHERE session_id='sess-1'"
+        ).fetchone()
+        conn.close()
+        assert row == ("sess-1", "claude", "/app", "main")
+
+    def test_incremental_scan_skips_unchanged_files(self, tmp_env, capsys):
+        proj_dir = tmp_env.claude_projects_root / "proj"
+        make_claude_session_jsonl(proj_dir, "sess-1", "main", "/app", ["do work"])
+        ai_hist.cmd_sync()
+        capsys.readouterr()
+        ai_hist.cmd_sync()
+        captured = capsys.readouterr()
+        # Second sync should report no new files scanned.
+        assert "scanned 1" not in captured.out
+
+    def test_last_assistant_text_stored(self, tmp_env):
+        proj_dir = tmp_env.claude_projects_root / "proj"
+        make_claude_session_jsonl(proj_dir, "sess-2", "feat/x", "/app",
+                                  ["do Y"], last_assistant="Updated src/auth.ts")
+        ai_hist.cmd_sync()
+        conn = sqlite3.connect(str(tmp_env.db_path))
+        row = conn.execute(
+            "SELECT last_assistant_text FROM sessions WHERE session_id='sess-2'"
+        ).fetchone()
+        conn.close()
+        assert row[0] is not None
+        assert "auth.ts" in row[0]
+
+
+class TestReadCodexSessionMetaBranch:
+    def test_returns_branch(self, tmp_path):
+        rollout = tmp_path / "rollout-1.jsonl"
+        rollout.write_text(json.dumps({
+            "type": "session_meta",
+            "payload": {
+                "id": "codex-sess-1",
+                "cwd": "/my/project",
+                "git": {"branch": "feat/payments"},
+            },
+        }) + "\n")
+        result = ai_hist._read_codex_session_meta(rollout)
+        assert result == ("codex-sess-1", "/my/project", "feat/payments")
+
+    def test_no_git_returns_none_branch(self, tmp_path):
+        rollout = tmp_path / "rollout-2.jsonl"
+        rollout.write_text(json.dumps({
+            "type": "session_meta",
+            "payload": {"id": "codex-sess-2", "cwd": "/proj"},
+        }) + "\n")
+        result = ai_hist._read_codex_session_meta(rollout)
+        assert result == ("codex-sess-2", "/proj", None)
+
+    def test_non_session_meta_returns_none(self, tmp_path):
+        rollout = tmp_path / "rollout-3.jsonl"
+        rollout.write_text(json.dumps({"type": "other", "payload": {}}) + "\n")
+        assert ai_hist._read_codex_session_meta(rollout) is None

--- a/test_ai_hist.py
+++ b/test_ai_hist.py
@@ -2039,7 +2039,7 @@ class TestCmdImport:
 # ---------------------------------------------------------------------------
 
 def make_claude_session_jsonl(project_dir: Path, session_id: str, git_branch: str,
-                               cwd: str, prompts: list, last_assistant: str = None) -> Path:
+                               cwd: str, prompts: list, last_assistant: str | None = None) -> Path:
     """Create a fake Claude per-session JSONL file."""
     project_dir.mkdir(parents=True, exist_ok=True)
     jsonl = project_dir / f"{session_id}.jsonl"


### PR DESCRIPTION
## TLDR

Adds a `sessions` table populated by `ai-hist sync` and a `get_handoff` MCP tool so you can ask "where did codex leave off on branch X in this repo?" and get a ready-to-paste warm-start command for the other CLI.

---

So when Claude Code goes down or runs out of quota mid-session theres no way to hand off to Codex (or vice versa) because the context just disappears. This adds the missing piece: `ai-hist sync` now also scans `~/.claude/projects/**/*.jsonl` and Codex rollout files to populate a new `sessions` table with per-session metadata (cwd, git branch, first/last timestamps, last assistant text). The MCP layer gets a `get_handoff` tool that takes `{repo?, branch?, source?, limit?}`, joins `sessions` to `history` prompts on demand, scores candidates by branch/repo match and prompt count, and returns a warm-start command for the target CLI.

Python CLI changes:

- New `sessions` table: `(session_id, source, cwd, git_branch, first_activity_ms, last_activity_ms, last_assistant_text, raw_path, parser_version)`, PK `(session_id, source)`.
- `sync_claude_sessions` walks `~/.claude/projects/**/*.jsonl`, reads first 20 lines for sessionId/gitBranch/cwd/first-ts and tails last 64KB reversed for latest branch + last assistant text. Files are keyed by `mtime_ns:size` so same-second writes arent missed.
- Codex sessions get real `MIN/MAX(timestamp_ms)` from history (not 0) and `payload.git.branch` for branch.
- `git_branch TEXT` added to `history` via `ALTER TABLE` migration.
- 23 new tests, 164 total passing.

TypeScript SDK / MCP changes:

- New `HistoryEntry.gitBranch`, `SessionMeta`, `HandoffCandidate`, `GetHandoffOptions` types.
- `ensureSessionsSchema(db)` runs at open time; pre-handoff DBs get `ALTER TABLE history ADD COLUMN git_branch` added automatically so existing databases dont break.
- `getHandoff(opts)`: history join is source-aware (`WHERE session_id = ? AND source = ?`) to avoid cross-CLI prompt mixing, respects `projectScope`, warm-start prompt is shell-quoted to prevent metacharacter injection.
- New `get_handoff` MCP tool with `{repo?, branch?, source?, limit?}` params.
- 3 TypeScript tests passing.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/ai-hist/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

