### PR TITLE
fix: harden get_handoff selection and codex backfill (follow-ups to #12)

### DIFF
--- a/ai-hist
+++ b/ai-hist
@@ -502,50 +502,70 @@ def build_codex_session_map(state: dict) -> tuple:
 
 
 def _backfill_codex_projects(conn: sqlite3.Connection, cwds: dict, branches: dict) -> int:
-    """Set project/git_branch for codex rows whose session_id is mapped."""
-    if not cwds:
+    """Set project/git_branch for codex rows whose session_id is mapped and keep
+    the sessions table in sync.
+
+    Only sessions that still need work are touched — those with a NULL
+    project/branch on some row, not yet recorded in `sessions`, or with newer
+    history activity than `sessions.last_activity_ms`. Fully-synced sessions are
+    skipped, so repeat syncs stay cheap regardless of total history size. The
+    per-session MIN/MAX timestamps come from the same aggregate query.
+    """
+    if not cwds and not branches:
         return 0
-    sids = conn.execute(
-        "SELECT DISTINCT session_id FROM history "
-        "WHERE source='codex' AND session_id IS NOT NULL"
+    rows = conn.execute(
+        """
+        SELECT h.session_id,
+               MIN(h.timestamp_ms), MAX(h.timestamp_ms),
+               SUM(CASE WHEN h.project IS NULL THEN 1 ELSE 0 END),
+               SUM(CASE WHEN h.git_branch IS NULL THEN 1 ELSE 0 END)
+        FROM history h
+        LEFT JOIN sessions s
+          ON s.session_id = h.session_id AND s.source = 'codex'
+        WHERE h.source = 'codex' AND h.session_id IS NOT NULL
+        GROUP BY h.session_id
+        HAVING SUM(CASE WHEN h.project IS NULL THEN 1 ELSE 0 END) > 0
+            OR SUM(CASE WHEN h.git_branch IS NULL THEN 1 ELSE 0 END) > 0
+            OR MAX(s.session_id) IS NULL
+            OR MAX(h.timestamp_ms) > COALESCE(MAX(s.last_activity_ms), -1)
+        """
     ).fetchall()
     updated = 0
-    for (sid,) in sids:
+    dirty = False
+    for sid, first_ts, last_ts, null_proj, null_branch in rows:
         cwd = cwds.get(sid)
         branch = branches.get(sid)
         if not cwd and not branch:
             continue
+        # Only write columns that are actually missing, so rowcount reflects
+        # genuine changes rather than COALESCE no-ops.
         sets = []
         params = []
-        if cwd:
+        if cwd and null_proj:
             sets.append("project = COALESCE(project, ?)")
             params.append(cwd)
-        if branch:
+        if branch and null_branch:
             sets.append("git_branch = COALESCE(git_branch, ?)")
             params.append(branch)
-        params.append(sid)
-        cur = conn.execute(
-            f"UPDATE history SET {', '.join(sets)} WHERE source='codex' AND session_id = ?",
-            params,
-        )
-        updated += cur.rowcount
+        if sets:
+            params.append(sid)
+            cur = conn.execute(
+                f"UPDATE history SET {', '.join(sets)} WHERE source='codex' AND session_id = ?",
+                params,
+            )
+            updated += cur.rowcount
+            dirty = True
         if cwd:
             # Use real timestamps from history so sessions table sorts correctly.
-            ts_row = conn.execute(
-                "SELECT MIN(timestamp_ms), MAX(timestamp_ms) FROM history "
-                "WHERE source='codex' AND session_id = ?",
-                (sid,),
-            ).fetchone()
-            first_ts = ts_row[0] or 0
-            last_ts = ts_row[1] or 0
-            _upsert_session(conn, sid, "codex", cwd, branch, first_ts)
+            _upsert_session(conn, sid, "codex", cwd, branch, first_ts or 0)
             if last_ts:
                 conn.execute(
                     "UPDATE sessions SET last_activity_ms = MAX(COALESCE(last_activity_ms, 0), ?) "
                     "WHERE session_id = ? AND source = 'codex'",
                     (last_ts, sid),
                 )
-    if updated:
+            dirty = True
+    if dirty:
         conn.commit()
     return updated
 

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -789,6 +789,11 @@ export class AiHist {
     }
 
     const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+    // Over-fetch sessions because many (old or sub-agent) sessions have no
+    // matching `history` prompts and get skipped below. Fetching exactly
+    // `limit` could starve the result to empty even when good candidates exist
+    // just past the cutoff. We stop scanning once we've collected `limit`.
+    const fetchCount = Math.min(Math.max(limit * 5, limit), 100);
     const sessionRows = runQuery<RawSessionRow>(
       this.db,
       `SELECT session_id, source, cwd, git_branch, first_activity_ms, last_activity_ms,
@@ -797,11 +802,12 @@ export class AiHist {
        ${where}
        ORDER BY last_activity_ms DESC
        LIMIT ?`,
-      [...params, limit],
+      [...params, fetchCount],
     );
 
     const candidates: HandoffCandidate[] = [];
     for (const session of sessionRows) {
+      if (candidates.length >= limit) break;
       // Filter by both session_id AND source to prevent cross-source prompt mixing
       // when two CLIs happen to use the same session ID (rare but possible).
       const prompts = runQuery<RawHistoryRow>(
@@ -815,10 +821,13 @@ export class AiHist {
       if (prompts.length === 0) continue;
 
       const filesTouched = extractFilePaths(prompts.map((p) => p.prompt).join('\n'));
-      const goal = prompts[0].prompt.slice(0, 300).replace(/\n/g, ' ');
+      // The first prompt is often injected boilerplate (system-reminder /
+      // command wrappers), especially for relay-driven sessions. Prefer the
+      // first prompt that looks like a real user instruction for the goal.
+      const goalPrompt = prompts.find((p) => !isBoilerplatePrompt(p.prompt)) ?? prompts[0];
+      const goal = goalPrompt.prompt.slice(0, 300).replace(/\n/g, ' ');
       const lastState = prompts[prompts.length - 1].prompt.slice(0, 300).replace(/\n/g, ' ');
 
-      const entry = prompts[0];
       const resume = resumeCommand({
         source: session.source as Source,
         sessionId: session.session_id,
@@ -899,6 +908,21 @@ export class AiHist {
       lastTimestampMs: range?.mx ?? null,
     };
   }
+}
+
+/**
+ * Heuristic: does a prompt look like injected boilerplate rather than a real
+ * user instruction? Relay/agent sessions often open with a system-reminder or
+ * command wrapper that makes a poor "goal" summary.
+ */
+function isBoilerplatePrompt(prompt: string): boolean {
+  const t = prompt.trimStart();
+  return (
+    t.startsWith('<system-reminder') ||
+    t.startsWith('<command-') ||
+    t.startsWith('Caveat:') ||
+    t.startsWith('[Request interrupted')
+  );
 }
 
 /**

--- a/test_ai_hist.py
+++ b/test_ai_hist.py
@@ -2217,3 +2217,57 @@ class TestReadCodexSessionMetaBranch:
         rollout = tmp_path / "rollout-3.jsonl"
         rollout.write_text(json.dumps({"type": "other", "payload": {}}) + "\n")
         assert ai_hist._read_codex_session_meta(rollout) is None
+
+
+class TestBackfillCodexProjects:
+    def _seed(self, tmp_path):
+        conn = sqlite3.connect(str(tmp_path / "test.db"))
+        ai_hist.init_db(conn)
+        for i, ts in enumerate((1000, 2000)):
+            conn.execute(
+                "INSERT INTO history (source, session_id, project, prompt, prompt_hash, timestamp_ms, git_branch) "
+                "VALUES ('codex', 'cx1', NULL, ?, ?, ?, NULL)",
+                (f"p{i}", ai_hist._prompt_hash(f"p{i}"), ts),
+            )
+        conn.commit()
+        return conn
+
+    def test_backfills_columns_and_session(self, tmp_path):
+        conn = self._seed(tmp_path)
+        updated = ai_hist._backfill_codex_projects(conn, {"cx1": "/proj"}, {"cx1": "main"})
+        assert updated == 2  # both rows had NULL project/branch
+        proj, branch = conn.execute(
+            "SELECT project, git_branch FROM history WHERE session_id='cx1' LIMIT 1"
+        ).fetchone()
+        assert (proj, branch) == ("/proj", "main")
+        srow = conn.execute(
+            "SELECT cwd, git_branch, first_activity_ms, last_activity_ms "
+            "FROM sessions WHERE session_id='cx1' AND source='codex'"
+        ).fetchone()
+        conn.close()
+        assert srow == ("/proj", "main", 1000, 2000)
+
+    def test_repeat_call_is_cheap_noop(self, tmp_path):
+        conn = self._seed(tmp_path)
+        ai_hist._backfill_codex_projects(conn, {"cx1": "/proj"}, {"cx1": "main"})
+        # Nothing changed since last sync: no history rows re-written.
+        updated = ai_hist._backfill_codex_projects(conn, {"cx1": "/proj"}, {"cx1": "main"})
+        conn.close()
+        assert updated == 0
+
+    def test_new_activity_bumps_last_activity(self, tmp_path):
+        conn = self._seed(tmp_path)
+        ai_hist._backfill_codex_projects(conn, {"cx1": "/proj"}, {"cx1": "main"})
+        # A newer codex row arrives (already enriched at insert time).
+        conn.execute(
+            "INSERT INTO history (source, session_id, project, prompt, prompt_hash, timestamp_ms, git_branch) "
+            "VALUES ('codex', 'cx1', '/proj', 'p2', ?, 9000, 'main')",
+            (ai_hist._prompt_hash("p2"),),
+        )
+        conn.commit()
+        ai_hist._backfill_codex_projects(conn, {"cx1": "/proj"}, {"cx1": "main"})
+        last = conn.execute(
+            "SELECT last_activity_ms FROM sessions WHERE session_id='cx1' AND source='codex'"
+        ).fetchone()[0]
+        conn.close()
+        assert last == 9000


### PR DESCRIPTION
Fast follow-ups to the cross-CLI handoff feature merged in #12.

## Changes

**1. `getHandoff` starvation fix (functional)**
Sessions with no matching `history` prompts are skipped. The old query fetched exactly `limit` sessions *before* that filter, so the most-recently-active sessions lacking prompts (old/sub-agent sessions) could starve the result to empty even when good candidates existed just past the cutoff. Now over-fetches (`limit*5`, capped at 100) and stops once `limit` valid candidates are collected.

**2. `getHandoff` goal-noise fix (quality)**
The `goal` field used `prompts[0]`, which for relay/agent sessions is an injected `<system-reminder>`/command wrapper. Now picks the first non-boilerplate prompt, falling back to `prompts[0]` when every turn is boilerplate. Verified: goals now read like `"what is the impact of this change?"` instead of `"<system-reminder> Agent Relay MCP tools..."`.

**3. Codex backfill cost (perf)**
`_backfill_codex_projects` dropped the `project IS NULL` filter in #12, so every sync re-scanned *all* codex sessions (UPDATE + MIN/MAX + upsert each) and cosmetically over-reported `backfilled N`. Now a single aggregate query returns only sessions that still need work (missing column, not yet in `sessions`, or newer activity than recorded `last_activity_ms`), and `updated` reflects genuine row changes.

## Tests
- 3 new Python regression tests (backfill idempotency, column backfill, activity bump). 167 Python tests pass (was 164).
- `sdk-ts` build + 3 TS tests pass.
- Verified end-to-end against a real ~316 MB DB: filtered/unfiltered candidates, goal quality, and confidence bonuses all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

