### PR TITLE
feat: add Grok history source

### DIFF
--- a/DISPATCH_MATRIX.md
+++ b/DISPATCH_MATRIX.md
@@ -17,8 +17,8 @@ Escape hatches:
 
 | Surface | Default route | Parity evidence |
 | --- | --- | --- |
-| `sync` | Rust | Full-source sync covers Claude, Codex, Cursor, OpenCode, Agent Relay when configured, and trajectories. Local E2E verifies Claude/Codex/Cursor/OpenCode/trajectory ingestion, `.sync-state.json`, WAL-safe OpenCode reads, and shared DB compatibility. |
-| `search QUERY [--source --project --tag --limit --fts --json]` | Rust | Wrapper tests cover JSON shape, source validation, no-result exit status, tag/project/source filters, and FTS behavior through the shared Rust core. |
+| `sync` | Rust | Full-source sync covers Claude, Codex, Cursor, Grok, OpenCode, Agent Relay when configured, and trajectories. Local E2E verifies Claude/Codex/Cursor/Grok/OpenCode/trajectory ingestion, `.sync-state.json`, WAL-safe OpenCode reads, and shared DB compatibility. |
+| `search [QUERY] [--source --project --tag --limit --fts --json]` | Rust | Wrapper tests cover JSON shape, source validation, no-result exit status, tag/project/source filters, filter-only search, and FTS behavior through the shared Rust core. |
 | `recent [n] [--source --project --tag --json]` | Rust | Uses the same row JSON fields and timestamp formatting contract as the legacy CLI. |
 | `show ID [--json]` | Rust | Includes full prompt, tags, session count, resume command, and context hint. |
 | `session SESSION_ID [--source --tag --full --json]` | Rust | `--full` and JSON output are Rust-default; missing sessions exit non-zero. |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ai-hist
 
-Sync and search your [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), [Cursor](https://cursor.com), [Agent Relay](https://github.com/AgentWorkforce/relay), and compacted persona trajectory history into a local SQLite database with full-text search.
+Sync and search your [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), [Cursor](https://cursor.com), Grok, [Agent Relay](https://github.com/AgentWorkforce/relay), and compacted persona trajectory history into a local SQLite database with full-text search.
 
 `ai-hist` is now a Rust-default CLI. The public `ai-hist` command dispatches
 the user-facing command surface through Rust, while the legacy Python CLI
@@ -50,6 +50,7 @@ ai-hist search "refactor" --source claude --limit 10
 ai-hist search "deploy" --source relay
 ai-hist search "retry policy" --source trajectory
 ai-hist search "deploy" --project relay
+ai-hist search --tag relayfile-migration
 
 # Recent prompts
 ai-hist recent                             # last 20
@@ -112,11 +113,12 @@ ai-hist supports these sources:
 | Claude Code | Local JSONL (`~/.claude/history.jsonl`) | `display`, `timestamp`, `project`, `sessionId` |
 | Codex CLI | Local JSONL (`~/.codex/history.jsonl`) | `text`, `ts`, `session_id` |
 | Cursor | Per-session JSONL (`~/.cursor/projects/<encoded-path>/agent-transcripts/<uuid>/<uuid>.jsonl`) | `role`, `message.content[].text` (user prompts wrapped in `<user_query>...`) |
+| Grok | Per-session JSONL (`~/.grok/sessions/<encoded-path>/<session-id>/chat_history.jsonl`) plus `summary.json` | `type`, `content[].text`, `info.cwd`, `head_branch` |
 | [Agent Relay](https://github.com/AgentWorkforce/relay) | API (`https://api.relaycast.dev/v1`) | `sender`, `content`, `channel`, `timestamp` |
 | Trajectories | Compacted per-run JSON (`$TRAJECTORY_ROOT/**/compacted/*.json`) | `personaId`, `projectId`, `task`, `decisions`, `retrospective` |
 | OpenCode | Local SQLite (`$OPENCODE_DB` or `~/.local/share/opencode/opencode.db`) | user text parts joined to sessions |
 
-**Claude Code, Codex & Cursor** are synced from local JSONL files incrementally (byte-offset tracking in `.sync-state.json`). Cursor lines have no per-line timestamp, so the file mtime at sync time is used.
+**Claude Code, Codex, Cursor & Grok** are synced from local JSONL files incrementally. Grok user prompts are read from `chat_history.jsonl`; synthetic reminders are skipped and session metadata comes from `summary.json`.
 
 **Agent Relay** is synced via the [Relaycast API](https://github.com/AgentWorkforce/relaycast), pulling workspace messages with cursor-based pagination. Configure with:
 
@@ -251,7 +253,7 @@ ai-hist watch --interval 30  # syncs every 30s
 ```sql
 CREATE TABLE history (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    source TEXT NOT NULL,          -- 'claude', 'codex', 'cursor', 'relay', 'trajectory', or 'opencode'
+    source TEXT NOT NULL,          -- 'claude', 'codex', 'cursor', 'grok', 'relay', 'trajectory', or 'opencode'
     session_id TEXT,
     project TEXT,
     prompt TEXT NOT NULL,

--- a/ai-hist-python
+++ b/ai-hist-python
@@ -7,10 +7,12 @@ Zero dependencies — Python standard library only.
 """
 
 import argparse
+import datetime
 import gzip
 import hashlib
 import json
 import os
+import re
 import sqlite3
 import sys
 import tempfile
@@ -19,6 +21,7 @@ import urllib.request
 import urllib.error
 import urllib.parse
 from pathlib import Path
+from typing import Optional
 
 # --- Configuration -----------------------------------------------------------
 
@@ -868,7 +871,6 @@ def sync_grok(conn: sqlite3.Connection, state: dict):
         if grok_state.get(key) == stamp:
             continue
         scanned += 1
-        grok_state[key] = stamp
 
         summary = {}
         try:
@@ -882,8 +884,8 @@ def sync_grok(conn: sqlite3.Connection, state: dict):
         session_id = info.get("id") or chat_path.parent.name
         cwd = info.get("cwd") or summary.get("git_root_dir") or _grok_project_from_path(chat_path)
         git_branch = summary.get("head_branch")
-        created_ms = _iso_to_ms(summary.get("created_at")) if summary.get("created_at") else int(chat_stat.st_mtime * 1000)
-        updated_ms = _iso_to_ms(summary.get("updated_at")) if summary.get("updated_at") else created_ms
+        created_ms = _iso_to_ms(summary.get("created_at")) or int(chat_stat.st_mtime * 1000)
+        updated_ms = _iso_to_ms(summary.get("updated_at")) or created_ms
         prompts = []
         last_assistant_text = None
         try:
@@ -920,6 +922,7 @@ def sync_grok(conn: sqlite3.Connection, state: dict):
             if cur.rowcount > 0:
                 inserted += 1
         sessions += 1
+        grok_state[key] = stamp
 
     conn.commit()
     state["grok_sessions"] = grok_state
@@ -1148,7 +1151,7 @@ def _relay_msg_to_row(msg: dict, channel: str):
         return None
     sender = msg.get("from_name") or msg.get("from_id") or ""
     created_at = msg.get("created_at", "")
-    ts_ms = _iso_to_ms(created_at) if created_at else 0
+    ts_ms = _iso_to_ms(created_at) or 0
     prompt = f"[{sender}] {text}" if sender else text
     return {
         "source": "relay",
@@ -1160,19 +1163,31 @@ def _relay_msg_to_row(msg: dict, channel: str):
     }
 
 
-def _iso_to_ms(iso_str: str) -> int:
+def _iso_to_ms(iso_str) -> Optional[int]:
     """Parse ISO 8601 datetime string to milliseconds since epoch."""
-    iso_str = iso_str.rstrip("Z").split("+")[0]
-    frac = 0
-    if "." in iso_str:
-        base, frac_str = iso_str.rsplit(".", 1)
-        frac = int(frac_str.ljust(3, "0")[:3])
-        iso_str = base
+    if not isinstance(iso_str, str) or not iso_str:
+        return None
+    normalized = f"{iso_str[:-1]}+00:00" if iso_str.endswith("Z") else iso_str
+    match = re.fullmatch(
+        r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d+))?([+-]\d{2}:?\d{2})?",
+        normalized,
+    )
+    if not match:
+        return None
+    base, frac, offset = match.groups()
     try:
-        t = time.strptime(iso_str, "%Y-%m-%dT%H:%M:%S")
+        dt = datetime.datetime.strptime(base, "%Y-%m-%dT%H:%M:%S")
     except ValueError:
-        return 0
-    return int(time.mktime(t)) * 1000 + frac
+        return None
+    if frac:
+        dt = dt.replace(microsecond=int(frac.ljust(6, "0")[:6]))
+    if offset:
+        sign = 1 if offset[0] == "+" else -1
+        hours = int(offset[1:3])
+        minutes = int(offset[-2:])
+        tz = datetime.timezone(sign * datetime.timedelta(hours=hours, minutes=minutes))
+        dt = dt.replace(tzinfo=tz)
+    return int(dt.timestamp() * 1000)
 
 
 # --- Trajectories ------------------------------------------------------------

--- a/ai-hist-python
+++ b/ai-hist-python
@@ -17,6 +17,7 @@ import tempfile
 import time
 import urllib.request
 import urllib.error
+import urllib.parse
 from pathlib import Path
 
 # --- Configuration -----------------------------------------------------------
@@ -38,10 +39,11 @@ CODEX_SESSIONS_DIRS = [
 ]
 
 CURSOR_ROOT = Path.home() / ".cursor" / "projects"
+GROK_SESSIONS_ROOT = Path.home() / ".grok" / "sessions"
 OPENCODE_DB = Path(os.environ.get("OPENCODE_DB", str(Path.home() / ".local" / "share" / "opencode" / "opencode.db")))
 TRAJECTORY_ROOT = os.environ.get("TRAJECTORY_ROOT", "")
 DEFAULT_TRAJECTORY_SEARCH_ROOT = Path.home() / "Projects"
-SOURCE_CHOICES = ["claude", "codex", "cursor", "relay", "trajectory", "opencode"]
+SOURCE_CHOICES = ["claude", "codex", "cursor", "grok", "relay", "trajectory", "opencode"]
 
 # --- Schema ------------------------------------------------------------------
 
@@ -167,6 +169,11 @@ def _resume_cmd(source, session_id, project):
         return f"codex resume {_shell_quote(session_id)}"
     if source == "cursor":
         cmd = f"cursor-agent --resume={_shell_quote(session_id)}"
+        if project:
+            return f"cd {_shell_quote(project)} && {cmd}"
+        return cmd
+    if source == "grok":
+        cmd = f"grok resume {_shell_quote(session_id)}"
         if project:
             return f"cd {_shell_quote(project)} && {cmd}"
         return cmd
@@ -812,6 +819,115 @@ def sync_cursor(conn: sqlite3.Connection, state: dict):
         print(f"  [cursor] +{inserted:,} rows from {files_seen} files{suffix}")
 
 
+def _grok_chat_text(obj: dict, role: str):
+    if obj.get("type") != role:
+        return None
+    if role == "user" and obj.get("synthetic_reason"):
+        return None
+    content = obj.get("content")
+    parts = []
+    if isinstance(content, str):
+        parts.append(content)
+    elif isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text" and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+    elif isinstance(content, dict) and isinstance(content.get("text"), str):
+        parts.append(content["text"])
+    text = "\n".join(p.strip() for p in parts if p.strip())
+    return text or None
+
+
+def _grok_project_from_path(chat_path: Path):
+    try:
+        return urllib.parse.unquote(chat_path.parent.parent.name)
+    except Exception:
+        return None
+
+
+def sync_grok(conn: sqlite3.Connection, state: dict):
+    """Sync user prompts from ~/.grok/sessions/**/chat_history.jsonl."""
+    if not GROK_SESSIONS_ROOT.exists():
+        print(f"  [grok] not found: {GROK_SESSIONS_ROOT} (skipped)")
+        return
+
+    grok_state = state.get("grok_sessions", {})
+    inserted = scanned = sessions = errors = 0
+    for chat_path in sorted(GROK_SESSIONS_ROOT.rglob("chat_history.jsonl")):
+        key = str(chat_path)
+        try:
+            chat_stat = chat_path.stat()
+            stamp = f"{chat_stat.st_mtime_ns}:{chat_stat.st_size}"
+            summary_path = chat_path.with_name("summary.json")
+            if summary_path.exists():
+                summary_stat = summary_path.stat()
+                stamp += f"|{summary_stat.st_mtime_ns}:{summary_stat.st_size}"
+        except OSError:
+            errors += 1
+            continue
+        if grok_state.get(key) == stamp:
+            continue
+        scanned += 1
+        grok_state[key] = stamp
+
+        summary = {}
+        try:
+            summary_path = chat_path.with_name("summary.json")
+            if summary_path.exists():
+                summary = json.loads(summary_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            summary = {}
+
+        info = summary.get("info") if isinstance(summary.get("info"), dict) else {}
+        session_id = info.get("id") or chat_path.parent.name
+        cwd = info.get("cwd") or summary.get("git_root_dir") or _grok_project_from_path(chat_path)
+        git_branch = summary.get("head_branch")
+        created_ms = _iso_to_ms(summary.get("created_at")) if summary.get("created_at") else int(chat_stat.st_mtime * 1000)
+        updated_ms = _iso_to_ms(summary.get("updated_at")) if summary.get("updated_at") else created_ms
+        prompts = []
+        last_assistant_text = None
+        try:
+            with open(chat_path, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    try:
+                        obj = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(obj, dict):
+                        continue
+                    prompt = _grok_chat_text(obj, "user")
+                    if prompt:
+                        prompts.append(prompt)
+                    assistant_text = _grok_chat_text(obj, "assistant")
+                    if assistant_text:
+                        last_assistant_text = assistant_text[:4096]
+        except OSError:
+            errors += 1
+            continue
+
+        _upsert_session(conn, session_id, "grok", cwd, git_branch, created_ms, last_assistant_text, str(chat_path))
+        conn.execute(
+            "UPDATE sessions SET last_activity_ms = MAX(last_activity_ms, ?) WHERE session_id = ? AND source = 'grok'",
+            (updated_ms if not prompts else created_ms + len(prompts) - 1, session_id),
+        )
+        for idx, prompt in enumerate(prompts):
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO history "
+                "(source, session_id, project, prompt, prompt_hash, timestamp_ms, git_branch) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("grok", session_id, cwd, prompt, _prompt_hash(prompt), created_ms + idx, git_branch),
+            )
+            if cur.rowcount > 0:
+                inserted += 1
+        sessions += 1
+
+    conn.commit()
+    state["grok_sessions"] = grok_state
+    if scanned:
+        suffix = f" ({errors} errors)" if errors else ""
+        print(f"  [grok] +{inserted:,} rows from {sessions} sessions{suffix}")
+
+
 def _opencode_part_text(data: str) -> str:
     try:
         obj = json.loads(data)
@@ -1407,6 +1523,9 @@ def cmd_sync(args=None):
     # Sync Cursor agent transcripts (auto-discovered, no config needed)
     sync_cursor(conn, state)
 
+    # Sync Grok per-session chat histories (auto-discovered, no config needed)
+    sync_grok(conn, state)
+
     # Sync OpenCode SQLite history (auto-discovered, no config needed)
     sync_opencode(conn, state)
 
@@ -1426,14 +1545,17 @@ def cmd_search(args):
     """Full-text search across prompts."""
     conn = sqlite3.connect(str(DB_PATH))
     init_db(conn)
-    query = _build_fts_query(args.query, getattr(args, "fts", False))
-
-    sql = (
-        "SELECT h.id, h.source, h.session_id, h.project, h.prompt, h.timestamp_ms "
-        "FROM history_fts f JOIN history h ON f.rowid = h.id "
-        "WHERE history_fts MATCH ? "
-    )
-    params = [query]
+    if args.query:
+        query = _build_fts_query(args.query, getattr(args, "fts", False))
+        sql = (
+            "SELECT h.id, h.source, h.session_id, h.project, h.prompt, h.timestamp_ms "
+            "FROM history_fts f JOIN history h ON f.rowid = h.id "
+            "WHERE history_fts MATCH ? "
+        )
+        params = [query]
+    else:
+        sql = "SELECT h.id, h.source, h.session_id, h.project, h.prompt, h.timestamp_ms FROM history h WHERE 1=1 "
+        params = []
     if args.source:
         sql += "AND h.source = ? "
         params.append(args.source)
@@ -2227,7 +2349,7 @@ def main():
     sub.add_parser("sync", help="Import new entries from history files")
 
     s = sub.add_parser("search", help="Full-text search prompts")
-    s.add_argument("query", nargs="+", help="Search terms (FTS5: AND/OR/NOT auto-detected; use --fts for raw)")
+    s.add_argument("query", nargs="*", help="Search terms (FTS5: AND/OR/NOT auto-detected; use --fts for raw)")
     s.add_argument("--source", choices=SOURCE_CHOICES, help="Filter by source")
     s.add_argument("--project", help="Filter by project path (substring match)")
     s.add_argument("--tag", help="Filter by session tag")

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -14,6 +14,7 @@ pub const SOURCE_CHOICES: &[&str] = &[
     "claude",
     "codex",
     "cursor",
+    "grok",
     "relay",
     "trajectory",
     "opencode",
@@ -406,6 +407,9 @@ pub fn search(
     raw_fts: bool,
     filter: &QueryFilter,
 ) -> Result<Vec<HistoryEntry>> {
+    if terms.is_empty() {
+        return recent(conn, filter);
+    }
     let query = build_fts_query(terms, raw_fts);
     let mut sql = "SELECT h.id, h.source, h.session_id, h.project, h.prompt, h.timestamp_ms FROM history_fts f JOIN history h ON f.rowid = h.id WHERE history_fts MATCH ?".to_string();
     let mut params_vec = vec![query];
@@ -633,6 +637,10 @@ pub fn resume_command(entry: &HistoryEntry) -> Option<String> {
                 )
             },
         )),
+        "grok" => Some(entry.project.as_ref().map_or_else(
+            || format!("grok resume {}", shell_quote(sid)),
+            |p| format!("cd {} && grok resume {}", shell_quote(p), shell_quote(sid)),
+        )),
         _ => None,
     }
 }
@@ -784,6 +792,39 @@ mod tests {
             untag_session(&conn, "s1", "release", Some("claude")).unwrap(),
             1
         );
+    }
+
+    #[test]
+    fn empty_search_returns_recent_filtered_entries() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        insert_history(
+            &conn,
+            &HistoryEntry {
+                id: 0,
+                source: "grok".into(),
+                session_id: Some("g1".into()),
+                project: Some("/p".into()),
+                prompt: "relayfile migration".into(),
+                prompt_hash: Some(prompt_hash("relayfile migration")),
+                timestamp_ms: 2,
+            },
+        )
+        .unwrap();
+        tag_session(&conn, "g1", "Relayfile Migration", Some("grok"), None).unwrap();
+        let rows = search(
+            &conn,
+            &[],
+            false,
+            &QueryFilter {
+                tag: Some("relayfile migration".into()),
+                limit: 10,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].source, "grok");
     }
 
     #[test]

--- a/crates/ai-hist/src/main.rs
+++ b/crates/ai-hist/src/main.rs
@@ -37,7 +37,6 @@ struct Cli {
 #[derive(Subcommand)]
 enum Command {
     Search {
-        #[arg(required = true)]
         query: Vec<String>,
         #[arg(long)]
         source: Option<String>,
@@ -264,7 +263,7 @@ enum PairAction {
 enum LearnAction {
     /// Distill local session history into decision/finding/reflection events.
     Distill {
-        /// Only distill sessions from this source (claude, codex, cursor, relay, opencode).
+        /// Only distill sessions from this source (claude, codex, cursor, grok, relay, opencode).
         #[arg(long)]
         source: Option<String>,
         /// Distill one session id.
@@ -1333,6 +1332,7 @@ fn sync_basic(conn: &Connection, db_path: &Path) -> Result<()> {
     sync_claude_session_metadata(conn, &mut state, &home.join(".claude/projects"))?;
     total_inserted += sync_codex(conn, &mut state, &home)?;
     total_inserted += sync_cursor(conn, &mut state, &home.join(".cursor/projects"))?;
+    total_inserted += sync_grok(conn, &mut state, &home.join(".grok/sessions"))?;
     total_inserted += sync_trajectories(conn, &mut state)?;
     let opencode = std::env::var_os("OPENCODE_DB")
         .map(PathBuf::from)
@@ -2162,6 +2162,231 @@ fn sorted_dirs(root: &Path) -> Result<Vec<PathBuf>> {
 
 fn decode_cursor_project(name: &str) -> String {
     format!("/{}", name.replace('-', "/"))
+}
+
+fn sync_grok(conn: &Connection, state: &mut Map<String, Value>, root: &Path) -> Result<usize> {
+    if !root.exists() {
+        println!("  [grok] not found: {} (skipped)", root.display());
+        return Ok(0);
+    }
+    let mut grok_state = state
+        .get("grok_sessions")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let mut inserted = 0;
+    let mut scanned = 0;
+    let mut sessions = 0;
+    let mut errors = 0;
+    for chat in collect_matching_files(root, "chat_history", "jsonl")? {
+        let key = chat.to_string_lossy().to_string();
+        let stamp = grok_session_stamp(&chat)?;
+        if grok_state.get(&key).and_then(Value::as_str) == Some(stamp.as_str()) {
+            continue;
+        }
+        scanned += 1;
+        grok_state.insert(key, json!(stamp));
+        match scan_grok_session_file(&chat) {
+            Ok(Some(session)) => {
+                let raw_path = chat.to_string_lossy().to_string();
+                upsert_session(
+                    conn,
+                    &session.session_id,
+                    "grok",
+                    session.cwd.as_deref(),
+                    session.git_branch.as_deref(),
+                    session.first_ts,
+                    session.last_ts,
+                    session.last_assistant_text.as_deref(),
+                    Some(&raw_path),
+                )?;
+                for (idx, prompt) in session.prompts.iter().enumerate() {
+                    inserted += insert_history(
+                        conn,
+                        &HistoryEntry {
+                            id: 0,
+                            source: "grok".into(),
+                            session_id: Some(session.session_id.clone()),
+                            project: session.cwd.clone(),
+                            prompt_hash: Some(prompt_hash(prompt)),
+                            prompt: prompt.clone(),
+                            timestamp_ms: session.first_ts + idx as i64,
+                        },
+                    )?;
+                }
+                sessions += 1;
+            }
+            Ok(None) => {}
+            Err(_) => errors += 1,
+        }
+    }
+    state.insert("grok_sessions".to_string(), Value::Object(grok_state));
+    if scanned > 0 {
+        let suffix = if errors > 0 {
+            format!(" ({errors} errors)")
+        } else {
+            String::new()
+        };
+        println!("  [grok] +{inserted} rows from {sessions} sessions{suffix}");
+    }
+    Ok(inserted)
+}
+
+fn grok_session_stamp(chat: &Path) -> Result<String> {
+    let mut stamp = file_stamp(chat)?;
+    let summary = chat.with_file_name("summary.json");
+    if summary.exists() {
+        stamp.push('|');
+        stamp.push_str(&file_stamp(&summary)?);
+    }
+    Ok(stamp)
+}
+
+struct GrokSession {
+    session_id: String,
+    cwd: Option<String>,
+    git_branch: Option<String>,
+    first_ts: i64,
+    last_ts: i64,
+    last_assistant_text: Option<String>,
+    prompts: Vec<String>,
+}
+
+fn scan_grok_session_file(chat: &Path) -> Result<Option<GrokSession>> {
+    let summary = read_grok_summary(&chat.with_file_name("summary.json"));
+    let fallback_session = chat
+        .parent()
+        .and_then(|p| p.file_name())
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown");
+    let session_id = summary
+        .as_ref()
+        .and_then(|s| s.pointer("/info/id"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(fallback_session)
+        .to_string();
+    let cwd = summary
+        .as_ref()
+        .and_then(|s| s.pointer("/info/cwd").or_else(|| s.get("git_root_dir")))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| grok_project_from_path(chat));
+    let git_branch = summary
+        .as_ref()
+        .and_then(|s| s.get("head_branch"))
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let created_ms = summary
+        .as_ref()
+        .and_then(|s| s.get("created_at").and_then(Value::as_str))
+        .and_then(parse_iso_ms)
+        .or_else(|| file_modified_ms(chat))
+        .unwrap_or(0);
+    let updated_ms = summary
+        .as_ref()
+        .and_then(|s| s.get("updated_at").and_then(Value::as_str))
+        .and_then(parse_iso_ms)
+        .unwrap_or(created_ms);
+
+    let mut prompts = Vec::new();
+    let mut last_assistant_text = None;
+    for line in fs::read_to_string(chat).unwrap_or_default().lines() {
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if let Some(text) = grok_chat_text(&value, "user") {
+            prompts.push(text);
+        }
+        if let Some(text) = grok_chat_text(&value, "assistant") {
+            last_assistant_text = Some(text.chars().take(4096).collect());
+        }
+    }
+    if session_id.is_empty() {
+        return Ok(None);
+    }
+    let last_ts = if prompts.is_empty() {
+        updated_ms
+    } else {
+        created_ms + prompts.len() as i64 - 1
+    };
+    Ok(Some(GrokSession {
+        session_id,
+        cwd,
+        git_branch,
+        first_ts: created_ms,
+        last_ts,
+        last_assistant_text,
+        prompts,
+    }))
+}
+
+fn read_grok_summary(path: &Path) -> Option<Value> {
+    serde_json::from_str(&fs::read_to_string(path).ok()?).ok()
+}
+
+fn grok_project_from_path(chat: &Path) -> Option<String> {
+    let project_dir = chat.parent()?.parent()?.file_name()?.to_str()?;
+    percent_decode_path(project_dir)
+}
+
+fn percent_decode_path(raw: &str) -> Option<String> {
+    let bytes = raw.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(hex) = u8::from_str_radix(&raw[i + 1..i + 3], 16) {
+                out.push(hex);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).ok().filter(|s| !s.is_empty())
+}
+
+fn file_modified_ms(path: &Path) -> Option<i64> {
+    path.metadata()
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as i64)
+}
+
+fn grok_chat_text(value: &Value, role: &str) -> Option<String> {
+    if value.get("type").and_then(Value::as_str) != Some(role) {
+        return None;
+    }
+    if role == "user" && value.get("synthetic_reason").is_some() {
+        return None;
+    }
+    let content = value.get("content")?;
+    let mut parts = Vec::new();
+    if let Some(text) = content.as_str() {
+        parts.push(text);
+    } else if let Some(items) = content.as_array() {
+        for item in items {
+            if item.get("type").and_then(Value::as_str) == Some("text") {
+                if let Some(text) = item.get("text").and_then(Value::as_str) {
+                    parts.push(text);
+                }
+            }
+        }
+    } else if let Some(text) = content.get("text").and_then(Value::as_str) {
+        parts.push(text);
+    }
+    let text = parts
+        .into_iter()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!text.is_empty()).then_some(text)
 }
 
 fn sync_trajectories(conn: &Connection, state: &mut Map<String, Value>) -> Result<usize> {

--- a/crates/ai-hist/src/main.rs
+++ b/crates/ai-hist/src/main.rs
@@ -2185,7 +2185,6 @@ fn sync_grok(conn: &Connection, state: &mut Map<String, Value>, root: &Path) -> 
             continue;
         }
         scanned += 1;
-        grok_state.insert(key, json!(stamp));
         match scan_grok_session_file(&chat) {
             Ok(Some(session)) => {
                 let raw_path = chat.to_string_lossy().to_string();
@@ -2215,8 +2214,11 @@ fn sync_grok(conn: &Connection, state: &mut Map<String, Value>, root: &Path) -> 
                     )?;
                 }
                 sessions += 1;
+                grok_state.insert(key, json!(stamp));
             }
-            Ok(None) => {}
+            Ok(None) => {
+                grok_state.insert(key, json!(stamp));
+            }
             Err(_) => errors += 1,
         }
     }
@@ -2293,7 +2295,9 @@ fn scan_grok_session_file(chat: &Path) -> Result<Option<GrokSession>> {
 
     let mut prompts = Vec::new();
     let mut last_assistant_text = None;
-    for line in fs::read_to_string(chat).unwrap_or_default().lines() {
+    let contents = fs::read_to_string(chat)
+        .with_context(|| format!("read Grok chat history {}", chat.display()))?;
+    for line in contents.lines() {
         let Ok(value) = serde_json::from_str::<Value>(line) else {
             continue;
         };
@@ -2338,7 +2342,11 @@ fn percent_decode_path(raw: &str) -> Option<String> {
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'%' && i + 2 < bytes.len() {
-            if let Ok(hex) = u8::from_str_radix(&raw[i + 1..i + 3], 16) {
+            if let Some(hex) = bytes
+                .get(i + 1..i + 3)
+                .and_then(|hex| std::str::from_utf8(hex).ok())
+                .and_then(|hex| u8::from_str_radix(hex, 16).ok())
+            {
                 out.push(hex);
                 i += 3;
                 continue;

--- a/docs/cloud-sync.md
+++ b/docs/cloud-sync.md
@@ -1,7 +1,7 @@
 # Cloud Sync — push your local history to Agent Relay Loop
 
-`ai-hist` captures your AI-agent history **locally** (Claude Code, Codex, Cursor, Agent
-Relay, Trajectories) into a SQLite database. **Cloud sync** pushes that history to your
+`ai-hist` captures your AI-agent history **locally** (Claude Code, Codex, Cursor, Grok,
+Agent Relay, Trajectories) into a SQLite database. **Cloud sync** pushes that history to your
 team's **Agent Relay Loop** service (`relayhistory-cloud`) so it feeds the shared
 Capture → Learn → Plan → Pair loop.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,8 +9,8 @@ Code / Codex so your agents get advisory nudges from your team's own past work.
 
 The loop has three stages:
 
-1. **Capture** — `ai-hist` records your AI history (Claude Code, Codex, Cursor, Agent Relay,
-   Trajectories) into a local SQLite DB.
+1. **Capture** — `ai-hist` records your AI history (Claude Code, Codex, Cursor, Grok,
+   Agent Relay, Trajectories) into a local SQLite DB.
 2. **Cloud sync** — `ai-hist push` maps that history into normalized **convergence events**
    and POSTs them to your team's relayhistory-cloud service (`/v1/ingest`).
 3. **Pair** — before a risky action, a hook/MCP tool asks `/v1/pair/check` for advisory

--- a/scripts/verify-e2e.sh
+++ b/scripts/verify-e2e.sh
@@ -10,6 +10,7 @@ export TRAJECTORY_ROOT="$TMP/trajectories"
 export OPENCODE_DB="$TMP/opencode.db"
 export HOME="$TMP/home"
 mkdir -p "$HOME/.claude/projects/e2e-project" "$HOME/.codex/sessions/2026/06/20" "$TRAJECTORY_ROOT/planner/compacted"
+mkdir -p "$HOME/.grok/sessions/%2Ftmp%2Fe2e%2Fgrok/grok-e2e"
 mkdir -p "$HOME/.cursor/projects/tmp-e2e-cursor/agent-transcripts/cursor-e2e"
 
 rust_ai_hist() {
@@ -30,6 +31,15 @@ JSONL
 
 cat > "$HOME/.codex/sessions/2026/06/20/rollout-codex-e2e.jsonl" <<'JSONL'
 {"type":"session_meta","payload":{"id":"codex-e2e","cwd":"/tmp/e2e/codex","git":{"branch":"main"}}}
+JSONL
+
+cat > "$HOME/.grok/sessions/%2Ftmp%2Fe2e%2Fgrok/grok-e2e/summary.json" <<'JSON'
+{"info":{"id":"grok-e2e","cwd":"/tmp/e2e/grok"},"created_at":"2026-06-20T10:02:00.000Z","updated_at":"2026-06-20T10:03:00.000Z","head_branch":"main"}
+JSON
+cat > "$HOME/.grok/sessions/%2Ftmp%2Fe2e%2Fgrok/grok-e2e/chat_history.jsonl" <<'JSONL'
+{"type":"user","content":[{"type":"text","text":"e2e grok release tagging prompt"}]}
+{"type":"user","synthetic_reason":"system_reminder","content":[{"type":"text","text":"do not import this synthetic prompt"}]}
+{"type":"assistant","content":[{"type":"text","text":"grok assistant summary"}]}
 JSONL
 
 cat > "$HOME/.claude/projects/e2e-project/claude-e2e.jsonl" <<'JSONL'
@@ -87,9 +97,11 @@ PY
 "$ROOT/ai-hist" sync
 "$ROOT/ai-hist" tag claude-e2e release-e2e --source claude
 "$ROOT/ai-hist" tag opencode-e2e release-e2e --source opencode
+"$ROOT/ai-hist" tag grok-e2e release-e2e --source grok
 "$ROOT/ai-hist" tag cursor-e2e release-e2e --source cursor
 "$ROOT/ai-hist" tag trajectory-e2e release-e2e --source trajectory
 "$ROOT/ai-hist" search release --tag release-e2e --json
+"$ROOT/ai-hist" search --tag release-e2e >/dev/null
 "$ROOT/ai-hist" session claude-e2e --full >/dev/null
 "$ROOT/ai-hist" show 1 --json >/dev/null
 "$ROOT/ai-hist" context 1 >/dev/null
@@ -101,7 +113,7 @@ python3 - <<'PY'
 import os, sqlite3
 conn = sqlite3.connect(os.environ["AI_HIST_DB"])
 sources = {row[0] for row in conn.execute("SELECT DISTINCT source FROM history")}
-expected = {"claude", "codex", "cursor", "opencode", "trajectory"}
+expected = {"claude", "codex", "cursor", "grok", "opencode", "trajectory"}
 missing = expected - sources
 if missing:
     raise SystemExit(f"missing sources from Rust sync: {sorted(missing)}")
@@ -111,6 +123,12 @@ if codex_project != "/tmp/e2e/codex":
 claude_session = conn.execute("SELECT cwd, git_branch, last_assistant_text FROM sessions WHERE source='claude' AND session_id='claude-e2e'").fetchone()
 if not claude_session or claude_session[0] != "/tmp/e2e/project" or claude_session[1] != "main" or "assistant summary" not in (claude_session[2] or ""):
     raise SystemExit(f"claude session metadata missing: {claude_session!r}")
+grok_session = conn.execute("SELECT cwd, git_branch, last_assistant_text FROM sessions WHERE source='grok' AND session_id='grok-e2e'").fetchone()
+if not grok_session or grok_session[0] != "/tmp/e2e/grok" or grok_session[1] != "main" or "grok assistant summary" not in (grok_session[2] or ""):
+    raise SystemExit(f"grok session metadata missing: {grok_session!r}")
+synthetic = conn.execute("SELECT COUNT(*) FROM history WHERE source='grok' AND prompt LIKE '%synthetic prompt%'").fetchone()[0]
+if synthetic:
+    raise SystemExit("grok synthetic prompt was imported")
 conn.close()
 PY
 

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -1,8 +1,8 @@
 # ai-hist (TypeScript SDK and MCP server)
 
-TypeScript reader for the [ai-hist](../README.md) history database, plus an MCP server for searching local AI coding-agent history from Claude Code, Codex, Cursor, and Agent Relay.
+TypeScript reader for the [ai-hist](../README.md) history database, plus an MCP server for searching local AI coding-agent history from Claude Code, Codex, Cursor, Grok, and Agent Relay.
 
-The SDK uses `sql.js`, so it has no native build step. It reads the same SQLite file that `ai-hist sync` writes, or falls back to scanning local Claude/Codex/Cursor JSONL files and compacted trajectory JSON when the database is missing.
+The SDK uses `sql.js`, so it has no native build step. It reads the same SQLite file that `ai-hist sync` writes, or falls back to scanning local Claude/Codex/Cursor/Grok JSONL files and compacted trajectory JSON when the database is missing.
 
 ## Install
 

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-hist",
   "version": "0.3.4",
-  "description": "TypeScript SDK and MCP server for AI coding agent session history — Claude Code, Codex, Cursor, and Agent Relay in one searchable index. Works with or without ai-hist sync via automatic JSONL fallback.",
+  "description": "TypeScript SDK and MCP server for AI coding agent session history — Claude Code, Codex, Cursor, Grok, and Agent Relay in one searchable index. Works with or without ai-hist sync via automatic JSONL fallback.",
   "license": "MIT",
   "private": false,
   "type": "module",

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -30,7 +30,7 @@ import {
 
 const execFileAsync = promisify(execFile);
 
-export type Source = 'claude' | 'codex' | 'cursor' | 'relay' | 'trajectory' | 'opencode';
+export type Source = 'claude' | 'codex' | 'cursor' | 'grok' | 'relay' | 'trajectory' | 'opencode';
 
 export interface HistoryEntry {
   id: number;
@@ -251,7 +251,7 @@ export interface OpenOptions {
   projectScope?: string;
   /**
    * What to do when the SQLite DB is missing:
-   *   - `'jsonl'` (default): scan local Claude/Codex/Cursor history files
+   *   - `'jsonl'` (default): scan local Claude/Codex/Cursor/Grok history files
    *     directly into an in-memory SQLite — works without the Python
    *     `ai-hist sync` tool installed.
    *   - `'error'`: throw with an install hint (legacy 0.1.x behavior).
@@ -309,7 +309,7 @@ export async function openAiHist(opts: OpenOptions = {}): Promise<AiHist> {
     );
   }
 
-  // Fallback: scan local source files (Claude/Codex/Cursor) directly.
+  // Fallback: scan local source files (Claude/Codex/Cursor/Grok) directly.
   // No Python dependency; uses the same parsers documented in the Python
   // CLI's source. Yields control to the event loop between sources so a
   // large local history doesn't freeze the host.
@@ -386,7 +386,7 @@ export async function openAiHist(opts: OpenOptions = {}): Promise<AiHist> {
     insert.free();
     insertTrajectory.free();
   }
-  const scannedPaths = `${LOCAL_SOURCE_PATHS.claude}, ${LOCAL_SOURCE_PATHS.codex}, ${LOCAL_SOURCE_PATHS.cursorRoot}, ${trajectoryRootDescription()}`;
+  const scannedPaths = `${LOCAL_SOURCE_PATHS.claude}, ${LOCAL_SOURCE_PATHS.codex}, ${LOCAL_SOURCE_PATHS.cursorRoot}, ${LOCAL_SOURCE_PATHS.grokSessionsRoot}, ${trajectoryRootDescription()}`;
   return new AiHist(db, { kind: 'jsonl', path: scannedPaths }, { projectScope: opts.projectScope });
 }
 
@@ -990,18 +990,19 @@ export class AiHist {
    * future consumer needs phrase/boolean queries.
    *
    * The query is matched literally — `%` and `_` are escaped so users can
-   * search for them. Empty queries return an empty array.
+   * search for them. Empty queries return recent entries matching the filters.
    */
   search(query: string, opts: SearchOptions = {}): HistoryEntry[] {
     const trimmed = query.trim();
-    if (!trimmed) return [];
     const limit = opts.limit ?? 50;
-    const escaped = trimmed.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
-    const pattern = `%${escaped}%`;
-    const clauses: string[] = [
-      `(LOWER(prompt) LIKE LOWER(?) ESCAPE '\\' OR LOWER(COALESCE(project, '')) LIKE LOWER(?) ESCAPE '\\')`,
-    ];
-    const params: unknown[] = [pattern, pattern];
+    const clauses: string[] = [];
+    const params: unknown[] = [];
+    if (trimmed) {
+      const escaped = trimmed.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+      const pattern = `%${escaped}%`;
+      clauses.push(`(LOWER(prompt) LIKE LOWER(?) ESCAPE '\\' OR LOWER(COALESCE(project, '')) LIKE LOWER(?) ESCAPE '\\')`);
+      params.push(pattern, pattern);
+    }
     if (opts.source) {
       clauses.push('source = ?');
       params.push(opts.source);
@@ -1016,7 +1017,7 @@ export class AiHist {
       this.db,
       `SELECT id, source, session_id, project, prompt, timestamp_ms, git_branch
        FROM history
-       WHERE ${clauses.join(' AND ')}
+       WHERE ${clauses.length > 0 ? clauses.join(' AND ') : '1=1'}
        ORDER BY timestamp_ms DESC
        LIMIT ?`,
       [...params, limit],

--- a/sdk-ts/src/jsonl-sources.ts
+++ b/sdk-ts/src/jsonl-sources.ts
@@ -35,10 +35,10 @@ const CODEX_HISTORY = join(homedir(), '.codex', 'history.jsonl');
 const CURSOR_ROOT = join(homedir(), '.cursor', 'projects');
 const GROK_SESSIONS_ROOT = join(homedir(), '.grok', 'sessions');
 
-async function safeStat(path: string): Promise<{ size: number; mtimeMs: number } | null> {
+async function safeStat(path: string): Promise<{ isDirectory: boolean; isFile: boolean; size: number; mtimeMs: number } | null> {
   try {
     const s = await stat(path);
-    return { size: s.size, mtimeMs: s.mtimeMs };
+    return { isDirectory: s.isDirectory(), isFile: s.isFile(), size: s.size, mtimeMs: s.mtimeMs };
   } catch {
     return null;
   }
@@ -166,9 +166,9 @@ async function collectMatchingFiles(root: string, filename: string, out: string[
     const full = join(root, name);
     const child = await safeStat(full);
     if (!child) continue;
-    if (name === filename) {
+    if (name === filename && child.isFile) {
       out.push(full);
-    } else {
+    } else if (child.isDirectory) {
       await collectMatchingFiles(full, filename, out);
     }
   }

--- a/sdk-ts/src/jsonl-sources.ts
+++ b/sdk-ts/src/jsonl-sources.ts
@@ -13,13 +13,13 @@
 
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 function yieldToEventLoop(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
-export type Source = 'claude' | 'codex' | 'cursor';
+export type Source = 'claude' | 'codex' | 'cursor' | 'grok';
 
 export interface RawRow {
   source: Source;
@@ -33,6 +33,7 @@ export interface RawRow {
 const CLAUDE_HISTORY = join(homedir(), '.claude', 'history.jsonl');
 const CODEX_HISTORY = join(homedir(), '.codex', 'history.jsonl');
 const CURSOR_ROOT = join(homedir(), '.cursor', 'projects');
+const GROK_SESSIONS_ROOT = join(homedir(), '.grok', 'sessions');
 
 async function safeStat(path: string): Promise<{ size: number; mtimeMs: number } | null> {
   try {
@@ -158,6 +159,22 @@ async function readDirSafe(path: string): Promise<string[]> {
   }
 }
 
+async function collectMatchingFiles(root: string, filename: string, out: string[] = []): Promise<string[]> {
+  const rootStat = await safeStat(root);
+  if (!rootStat) return out;
+  for (const name of await readDirSafe(root)) {
+    const full = join(root, name);
+    const child = await safeStat(full);
+    if (!child) continue;
+    if (name === filename) {
+      out.push(full);
+    } else {
+      await collectMatchingFiles(full, filename, out);
+    }
+  }
+  return out;
+}
+
 async function scanClaude(): Promise<RawRow[]> {
   const lines = await readLines(CLAUDE_HISTORY);
   const rows: RawRow[] = [];
@@ -218,6 +235,94 @@ async function scanCursor(): Promise<RawRow[]> {
   return rows;
 }
 
+function parseIsoMs(value: unknown, fallbackMs: number): number {
+  if (typeof value !== 'string' || value.length === 0) return fallbackMs;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : fallbackMs;
+}
+
+function grokText(obj: Record<string, unknown>, role: 'user' | 'assistant'): string | null {
+  if (obj.type !== role) return null;
+  if (role === 'user' && obj.synthetic_reason) return null;
+  const content = obj.content;
+  const parts: string[] = [];
+  if (typeof content === 'string') {
+    parts.push(content);
+  } else if (Array.isArray(content)) {
+    for (const item of content) {
+      if (!item || typeof item !== 'object') continue;
+      const record = item as Record<string, unknown>;
+      if (record.type === 'text' && typeof record.text === 'string') parts.push(record.text);
+    }
+  } else if (content && typeof content === 'object') {
+    const record = content as Record<string, unknown>;
+    if (typeof record.text === 'string') parts.push(record.text);
+  }
+  const text = parts.map((part) => part.trim()).filter(Boolean).join('\n');
+  return text || null;
+}
+
+function grokProjectFromPath(chatPath: string): string | null {
+  const encodedProject = basename(dirname(dirname(chatPath)));
+  try {
+    const decoded = decodeURIComponent(encodedProject);
+    return decoded.length > 0 ? decoded : null;
+  } catch {
+    return null;
+  }
+}
+
+async function readGrokSummary(chatPath: string): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed = JSON.parse(await readFile(join(dirname(chatPath), 'summary.json'), 'utf8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
+function nestedString(obj: Record<string, unknown> | null, path: string[]): string | null {
+  let current: unknown = obj;
+  for (const part of path) {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) return null;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return asString(current);
+}
+
+async function scanGrok(): Promise<RawRow[]> {
+  const root = await safeStat(GROK_SESSIONS_ROOT);
+  if (!root) return [];
+  const rows: RawRow[] = [];
+  for (const chatPath of await collectMatchingFiles(GROK_SESSIONS_ROOT, 'chat_history.jsonl')) {
+    const summary = await readGrokSummary(chatPath);
+    const fileStat = await safeStat(chatPath);
+    const fallbackMs = Math.trunc(fileStat?.mtimeMs ?? 0);
+    const sessionId = nestedString(summary, ['info', 'id']) ?? basename(dirname(chatPath));
+    const project = nestedString(summary, ['info', 'cwd']) ?? asString(summary?.git_root_dir) ?? grokProjectFromPath(chatPath);
+    const gitBranch = asString(summary?.head_branch);
+    const baseMs = parseIsoMs(summary?.created_at, fallbackMs);
+    let idx = 0;
+    for (const line of await readLines(chatPath)) {
+      const obj = readJsonRecord(line);
+      if (!obj) continue;
+      const prompt = grokText(obj, 'user');
+      if (!prompt) continue;
+      rows.push({
+        source: 'grok',
+        sessionId,
+        project,
+        prompt,
+        timestampMs: baseMs + idx,
+        gitBranch,
+      });
+      idx += 1;
+    }
+    await yieldToEventLoop();
+  }
+  return rows;
+}
+
 /**
  * Scan all available local source files. Async + yields between sources
  * so a host event loop (e.g. Electron's main process) stays responsive.
@@ -230,11 +335,14 @@ export async function scanLocalSources(): Promise<RawRow[]> {
   const codexRows = await scanCodex();
   await yieldToEventLoop();
   const cursorRows = await scanCursor();
-  return [...claudeRows, ...codexRows, ...cursorRows];
+  await yieldToEventLoop();
+  const grokRows = await scanGrok();
+  return [...claudeRows, ...codexRows, ...cursorRows, ...grokRows];
 }
 
 export const LOCAL_SOURCE_PATHS = {
   claude: CLAUDE_HISTORY,
   codex: CODEX_HISTORY,
   cursorRoot: CURSOR_ROOT,
+  grokSessionsRoot: GROK_SESSIONS_ROOT,
 };

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -2,7 +2,7 @@
 /**
  * ai-hist MCP server — exposes AI coding agent history as MCP tools.
  *
- * Covers Claude Code, Codex, Cursor, and Agent Relay in a single index.
+ * Covers Claude Code, Codex, Cursor, Grok, and Agent Relay in a single index.
  * Uses the ai-hist SQLite database when present ($AI_HIST_DB or the
  * default ~/.local/share/ai-hist/ai-history.db), falling back to
  * scanning local JSONL source files directly so the server works without
@@ -104,7 +104,7 @@ function fmtTrajectory(t: TrajectoryEntry, maxChars = 500): string {
 const READ_ONLY = { readOnlyHint: true, idempotentHint: true, openWorldHint: false } as const;
 const WRITE_LOCAL = { readOnlyHint: false, idempotentHint: true, openWorldHint: false } as const;
 const REMOTE_READ_ONLY = { readOnlyHint: true, idempotentHint: true, openWorldHint: true } as const;
-const SOURCE_SCHEMA = z.enum(["claude", "codex", "cursor", "relay", "trajectory", "opencode"]);
+const SOURCE_SCHEMA = z.enum(["claude", "codex", "cursor", "grok", "relay", "trajectory", "opencode"]);
 
 // ---------------------------------------------------------------------------
 // Server
@@ -130,7 +130,7 @@ server.prompt(
           type: "text" as const,
           text: `You are connected to the ai-hist MCP server, which gives you access to a
 unified history of AI coding agent sessions across Claude Code, Codex, Cursor,
-and Agent Relay — all searchable in a single index.
+Grok, OpenCode, Agent Relay, and trajectories — all searchable in a single index.
 
 ## Available tools
 
@@ -230,7 +230,7 @@ server.tool(
 server.tool(
   "search_history",
   "Search your AI coding agent history using full-text search across all prompts " +
-    "from Claude Code, Codex, Cursor, and Agent Relay. Returns matching entries with " +
+    "from Claude Code, Codex, Cursor, Grok, and Agent Relay. Returns matching entries with " +
     "source, project path, session ID, and timestamp ordered by most recent first. " +
     "Supports FTS5 boolean operators (AND, OR, NOT), leading - to exclude a term, and " +
     "trailing * for prefix matching. Use get_session with a returned session_id to read " +

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -2,7 +2,7 @@
 /**
  * ai-hist MCP server — exposes AI coding agent history as MCP tools.
  *
- * Covers Claude Code, Codex, Cursor, Grok, and Agent Relay in a single index.
+ * Covers Claude Code, Codex, Cursor, Grok, OpenCode, Agent Relay, and trajectories in a single index.
  * Uses the ai-hist SQLite database when present ($AI_HIST_DB or the
  * default ~/.local/share/ai-hist/ai-history.db), falling back to
  * scanning local JSONL source files directly so the server works without
@@ -230,7 +230,7 @@ server.tool(
 server.tool(
   "search_history",
   "Search your AI coding agent history using full-text search across all prompts " +
-    "from Claude Code, Codex, Cursor, Grok, and Agent Relay. Returns matching entries with " +
+    "from Claude Code, Codex, Cursor, Grok, OpenCode, Agent Relay, and trajectories. Returns matching entries with " +
     "source, project path, session ID, and timestamp ordered by most recent first. " +
     "Supports FTS5 boolean operators (AND, OR, NOT), leading - to exclude a term, and " +
     "trailing * for prefix matching. Use get_session with a returned session_id to read " +

--- a/sdk-ts/src/mcp-smoke.test.ts
+++ b/sdk-ts/src/mcp-smoke.test.ts
@@ -74,6 +74,10 @@ test('SDK tags sessions, filters reads by tag, and persists SQLite writes', asyn
       hist.search('prompt', { tag: 'release work', limit: 10 }).map((entry) => entry.prompt),
       ['scoped root prompt'],
     );
+    assert.deepEqual(
+      hist.search('', { tag: 'release work', limit: 10 }).map((entry) => entry.prompt),
+      ['scoped root prompt'],
+    );
     assert.equal(hist.listTags({ includeSessions: true })[0].sessions?.[0].sessionId, 'shared');
   } finally {
     hist.close();

--- a/test_ai_hist.py
+++ b/test_ai_hist.py
@@ -44,6 +44,8 @@ def tmp_env(tmp_path, monkeypatch):
     # Point cursor at an empty tmp dir so it never reads real ~/.cursor.
     cursor_root = tmp_path / "cursor_projects"
     monkeypatch.setattr(ai_hist, "CURSOR_ROOT", cursor_root)
+    grok_sessions_root = tmp_path / "grok_sessions"
+    monkeypatch.setattr(ai_hist, "GROK_SESSIONS_ROOT", grok_sessions_root)
     monkeypatch.setattr(ai_hist, "OPENCODE_DB", tmp_path / "missing-opencode.db")
     trajectory_root = tmp_path / ".trajectories"
     monkeypatch.setattr(ai_hist, "TRAJECTORY_ROOT", str(trajectory_root))
@@ -62,6 +64,7 @@ def tmp_env(tmp_path, monkeypatch):
         claude_hist=claude_hist,
         codex_hist=codex_hist,
         cursor_root=cursor_root,
+        grok_sessions_root=grok_sessions_root,
         trajectory_root=trajectory_root,
         claude_projects_root=claude_projects_root,
         tmp_path=tmp_path,
@@ -88,6 +91,36 @@ def make_cursor_session(cursor_root: Path, project: str, session_id: str, prompt
         }))
     jsonl.write_text("\n".join(lines) + "\n")
     return jsonl
+
+
+def make_grok_session(grok_root: Path, project: str, session_id: str, prompts: list,
+                      synthetic_prompt: str = "synthetic reminder") -> Path:
+    """Create a fake Grok per-session chat_history.jsonl. Returns the session dir."""
+    session_dir = grok_root / project / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / "summary.json").write_text(json.dumps({
+        "info": {"id": session_id, "cwd": "/tmp/grok/project"},
+        "created_at": "2026-06-20T10:02:00.000Z",
+        "updated_at": "2026-06-20T10:03:00.000Z",
+        "head_branch": "main",
+    }))
+    lines = []
+    for prompt in prompts:
+        lines.append(json.dumps({
+            "type": "user",
+            "content": [{"type": "text", "text": prompt}],
+        }))
+    lines.append(json.dumps({
+        "type": "user",
+        "synthetic_reason": "system_reminder",
+        "content": [{"type": "text", "text": synthetic_prompt}],
+    }))
+    lines.append(json.dumps({
+        "type": "assistant",
+        "content": [{"type": "text", "text": "grok assistant state"}],
+    }))
+    (session_dir / "chat_history.jsonl").write_text("\n".join(lines) + "\n")
+    return session_dir
 
 
 def make_claude_entry(display, timestamp=1700000000000, project="/proj", session_id="s1"):
@@ -615,6 +648,11 @@ class TestTags:
         assert "Tagged 1 session" in captured.out
 
         ai_hist.cmd_search(SimpleNamespace(query=["auth"], source=None, project=None, tag="release", limit=20, fts=False, json=False))
+        captured = capsys.readouterr()
+        assert "taggable auth prompt" in captured.out
+        assert "other auth prompt" not in captured.out
+
+        ai_hist.cmd_search(SimpleNamespace(query=[], source=None, project=None, tag="release", limit=20, fts=False, json=False))
         captured = capsys.readouterr()
         assert "taggable auth prompt" in captured.out
         assert "other auth prompt" not in captured.out
@@ -1622,6 +1660,30 @@ class TestDecodeCursorProject:
         assert ai_hist._decode_cursor_project(
             "Users-khaliq-Projects-AgentWorkforce"
         ) == "/Users/khaliq/Projects/AgentWorkforce"
+
+
+class TestSyncGrok:
+    def test_imports_prompts_and_session_metadata(self, tmp_env, capsys):
+        make_grok_session(
+            tmp_env.grok_sessions_root,
+            "%2Ftmp%2Fgrok%2Fproject",
+            "grok-sess-1",
+            ["grok migration prompt"],
+            synthetic_prompt="synthetic should not import",
+        )
+        ai_hist.cmd_sync()
+        conn = sqlite3.connect(str(tmp_env.db_path))
+        prompts = conn.execute(
+            "SELECT prompt FROM history WHERE source='grok' ORDER BY timestamp_ms"
+        ).fetchall()
+        session = conn.execute(
+            "SELECT cwd, git_branch, last_assistant_text FROM sessions WHERE source='grok' AND session_id='grok-sess-1'"
+        ).fetchone()
+        conn.close()
+        assert prompts == [("grok migration prompt",)]
+        assert session[0] == "/tmp/grok/project"
+        assert session[1] == "main"
+        assert "grok assistant state" in session[2]
 
 
 class TestSyncTrajectories:

--- a/test_ai_hist.py
+++ b/test_ai_hist.py
@@ -1194,11 +1194,14 @@ class TestIsoToMs:
         ms = ai_hist._iso_to_ms("2026-03-07T20:13:00+00:00")
         assert ms > 0
 
+    def test_iso_z_is_utc(self):
+        assert ai_hist._iso_to_ms("1970-01-01T00:00:01Z") == 1000
+
     def test_iso_invalid(self):
-        assert ai_hist._iso_to_ms("not a date") == 0
+        assert ai_hist._iso_to_ms("not a date") is None
 
     def test_iso_empty(self):
-        assert ai_hist._iso_to_ms("") == 0
+        assert ai_hist._iso_to_ms("") is None
 
 
 class TestRelayMsgToRow:

--- a/test_cli_dispatch.py
+++ b/test_cli_dispatch.py
@@ -114,6 +114,7 @@ def test_search_tag_without_query_routes_to_rust(tmp_path):
     assert tag.returncode == 0, tag.stderr
     result = run_cli(["search", "--tag", "relayfile-migration", "--json"], env)
     assert result.returncode == 0, result.stderr
+    assert "deprecated Python fallback" not in result.stderr
     rows = json.loads(result.stdout)
     assert [row["session_id"] for row in rows] == ["claude-dispatch"]
 

--- a/test_cli_dispatch.py
+++ b/test_cli_dispatch.py
@@ -108,6 +108,16 @@ def test_search_json_routes_to_rust_with_python_compatible_shape(tmp_path):
     }
 
 
+def test_search_tag_without_query_routes_to_rust(tmp_path):
+    env, _db = seed_via_wrapper(tmp_path)
+    tag = run_cli(["tag", "claude-dispatch", "relayfile-migration", "--source", "claude"], env)
+    assert tag.returncode == 0, tag.stderr
+    result = run_cli(["search", "--tag", "relayfile-migration", "--json"], env)
+    assert result.returncode == 0, result.stderr
+    rows = json.loads(result.stdout)
+    assert [row["session_id"] for row in rows] == ["claude-dispatch"]
+
+
 def test_session_full_routes_to_rust(tmp_path):
     env, _db = seed_via_wrapper(tmp_path)
     result = run_cli(["session", "claude-dispatch", "--full"], env)


### PR DESCRIPTION
## Summary
- add Grok as a local history source from `~/.grok/sessions/**/chat_history.jsonl` with `summary.json` metadata
- allow filter-only searches such as `ai-hist search --tag relayfile-migration`
- update Rust, Python fallback, TypeScript SDK/MCP fallback, docs, and E2E coverage

## relayhistory-cloud compatibility
- checked `../relayhistory-cloud` after latest pull
- no code change or package bump needed: `/v1/ingest` validates `source` only as a non-empty string, stores it as `TEXT`, and has no dependency on this repo

## Tests
- `cargo test`
- `pytest -q test_cli_dispatch.py test_ai_hist.py`
- `npm test` in `sdk-ts`
- `scripts/verify-e2e.sh`

Note: E2E `npm ci` reported an existing high-severity npm audit advisory, but tests passed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

