### PR TITLE
feat: install prebuilt Rust binaries

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,120 @@
+name: Build ai-hist release binaries
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attach binaries to, for example v0.3.5'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.asset }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            asset: ai-hist-darwin-arm64
+            binary: ai-hist
+            run_binary: false
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            asset: ai-hist-darwin-x64
+            binary: ai-hist
+            run_binary: false
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            asset: ai-hist-linux-x64
+            binary: ai-hist
+            run_binary: true
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            asset: ai-hist-linux-arm64
+            binary: ai-hist
+            run_binary: false
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ai-hist-${{ matrix.target }}
+          cache-bin: false
+
+      - name: Install musl tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Install cross
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        uses: taiki-e/install-action@cross
+
+      - name: Build binary
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
+            RUSTFLAGS="-C target-feature=+crt-static" cross build --release --target "${{ matrix.target }}" -p ai-hist-cli
+          else
+            RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target "${{ matrix.target }}" -p ai-hist-cli
+          fi
+          strip "target/${{ matrix.target }}/release/${{ matrix.binary }}" 2>/dev/null || true
+          cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" "${{ matrix.asset }}"
+          chmod 755 "${{ matrix.asset }}"
+
+      - name: Verify binary
+        if: matrix.run_binary
+        run: "./${{ matrix.asset }} --version"
+
+      - name: Inspect binary
+        if: ${{ !matrix.run_binary }}
+        run: file "${{ matrix.asset }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: ${{ matrix.asset }}
+          retention-days: 7
+
+  release:
+    name: Attach binaries to release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ai-hist ${{ steps.tag.outputs.tag }}
+          files: artifacts/*
+          make_latest: true

--- a/README.md
+++ b/README.md
@@ -19,14 +19,22 @@ Make sure `~/.local/bin` is in your `PATH`:
 export PATH="$HOME/.local/bin:$PATH"  # add to .zshrc / .bashrc
 ```
 
-The installer owns the Rust build and installs deterministic launchers for
-`ai-hist`, `ai-hist-python`, and `ai-hist-rust`. It requires `cargo` and
-`python3`; if Rust is missing, install it from <https://rustup.rs/> and rerun
-the script.
+The installer installs deterministic launchers for `ai-hist`, `ai-hist-python`,
+and `ai-hist-rust`. For normal installs it downloads a prebuilt Rust binary from
+GitHub Releases, so users do not need a local Rust toolchain.
 
-Normal use does not require manually running Cargo commands. The install script
-builds the Rust binary, places it under the ai-hist install directory, and
-writes launchers that point the wrapper at that exact binary.
+If no prebuilt binary is available for your platform, the installer falls back
+to building from source. That fallback requires `cargo` and `python3`; install
+Rust from <https://rustup.rs/> if you intentionally use the source path.
+
+Installer controls:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/AgentWorkforce/relayhistory/main/install.sh | AI_HIST_INSTALL_METHOD=binary sh
+curl -fsSL https://raw.githubusercontent.com/AgentWorkforce/relayhistory/main/install.sh | AI_HIST_VERSION=0.3.5 sh
+AI_HIST_INSTALL_METHOD=source sh install.sh   # from a local checkout
+AI_HIST_SOURCE_REF=my-branch sh install.sh    # override source fallback ref
+```
 
 Escape hatches:
 

--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,29 @@
 #!/usr/bin/env sh
 set -eu
 
-REPO_URL="${AI_HIST_REPO_URL:-https://github.com/AgentWorkforce/relayhistory.git}"
+REPO_SLUG="${AI_HIST_REPO_SLUG:-AgentWorkforce/relayhistory}"
+REPO_URL="${AI_HIST_REPO_URL:-https://github.com/$REPO_SLUG.git}"
 REF="${AI_HIST_REF:-main}"
+VERSION="${AI_HIST_VERSION:-latest}"
 PREFIX="${AI_HIST_PREFIX:-$HOME/.local}"
 BIN_DIR="${AI_HIST_BIN_DIR:-$PREFIX/bin}"
 INSTALL_DIR="${AI_HIST_INSTALL_DIR:-$PREFIX/share/ai-hist}"
 BUILD_PROFILE="${AI_HIST_BUILD_PROFILE:-release}"
+INSTALL_METHOD="${AI_HIST_INSTALL_METHOD:-auto}"
 
 need() {
   if ! command -v "$1" >/dev/null 2>&1; then
     echo "ai-hist installer: missing required command: $1" >&2
     return 1
   fi
+}
+
+info() {
+  echo "ai-hist installer: $*"
+}
+
+warn() {
+  echo "ai-hist installer: $*" >&2
 }
 
 script_dir() {
@@ -28,63 +39,255 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
-if [ -n "${AI_HIST_SOURCE_DIR:-}" ]; then
-  src_dir="$AI_HIST_SOURCE_DIR"
-elif [ -f "$(script_dir)/Cargo.toml" ] && [ -f "$(script_dir)/ai-hist" ]; then
-  src_dir="$(script_dir)"
-else
+case "$INSTALL_METHOD" in
+  auto | binary | source) ;;
+  *)
+    echo "ai-hist installer: AI_HIST_INSTALL_METHOD must be auto, binary, or source" >&2
+    exit 2
+    ;;
+esac
+
+platform_asset() {
+  os="$(uname -s 2>/dev/null || echo unknown)"
+  arch="$(uname -m 2>/dev/null || echo unknown)"
+
+  case "$os" in
+    Darwin) os_part="darwin" ;;
+    Linux) os_part="linux" ;;
+    *)
+      warn "unsupported OS for prebuilt binary: $os"
+      return 1
+      ;;
+  esac
+
+  case "$arch" in
+    arm64 | aarch64) arch_part="arm64" ;;
+    x86_64 | amd64) arch_part="x64" ;;
+    *)
+      warn "unsupported architecture for prebuilt binary: $arch"
+      return 1
+      ;;
+  esac
+
+  echo "ai-hist-$os_part-$arch_part"
+}
+
+release_download_url() {
+  asset="$1"
+  if [ -n "${AI_HIST_BINARY_URL:-}" ]; then
+    echo "$AI_HIST_BINARY_URL"
+    return 0
+  fi
+
+  if [ "$VERSION" = "latest" ]; then
+    echo "https://github.com/$REPO_SLUG/releases/latest/download/$asset"
+    return 0
+  fi
+
+  case "$VERSION" in
+    v*) tag="$VERSION" ;;
+    *) tag="v$VERSION" ;;
+  esac
+  echo "https://github.com/$REPO_SLUG/releases/download/$tag/$asset"
+}
+
+raw_ref() {
+  if [ -n "${AI_HIST_RAW_REF:-}" ]; then
+    echo "$AI_HIST_RAW_REF"
+    return 0
+  fi
+
+  if [ "$VERSION" != "latest" ]; then
+    case "$VERSION" in
+      v*) echo "$VERSION" ;;
+      *) echo "v$VERSION" ;;
+    esac
+    return 0
+  fi
+
+  echo "$REF"
+}
+
+source_ref() {
+  if [ -n "${AI_HIST_SOURCE_REF:-}" ]; then
+    echo "$AI_HIST_SOURCE_REF"
+    return 0
+  fi
+
+  raw_ref
+}
+
+install_binary_launchers() {
+  rust_bin="$1"
+
+  mkdir -p "$BIN_DIR" "$INSTALL_DIR"
+
+  cat > "$BIN_DIR/ai-hist" <<EOF
+#!/usr/bin/env sh
+if [ "\${AI_HIST_CLI:-auto}" = "python" ]; then
+  exec "$BIN_DIR/ai-hist-python" "\$@"
+fi
+exec "\${AI_HIST_RUST_BIN:-$rust_bin}" "\$@"
+EOF
+
+  cat > "$BIN_DIR/ai-hist-rust" <<EOF
+#!/usr/bin/env sh
+exec "\${AI_HIST_RUST_BIN:-$rust_bin}" "\$@"
+EOF
+
+  cat > "$BIN_DIR/ai-hist-python" <<EOF
+#!/usr/bin/env sh
+if [ ! -f "$INSTALL_DIR/ai-hist-python" ]; then
+  echo "ai-hist-python was not installed with this ai-hist binary install." >&2
+  exit 127
+fi
+exec python3 "$INSTALL_DIR/ai-hist-python" "\$@"
+EOF
+
+  chmod 755 "$BIN_DIR/ai-hist" "$BIN_DIR/ai-hist-rust" "$BIN_DIR/ai-hist-python"
+}
+
+install_python_fallback() {
+  mkdir -p "$INSTALL_DIR"
+
+  if [ -n "${AI_HIST_WRAPPER_SOURCE_DIR:-}" ] && [ -f "$AI_HIST_WRAPPER_SOURCE_DIR/ai-hist-python" ]; then
+    cp "$AI_HIST_WRAPPER_SOURCE_DIR/ai-hist-python" "$INSTALL_DIR/ai-hist-python"
+    chmod 755 "$INSTALL_DIR/ai-hist-python"
+    return 0
+  fi
+
+  if [ -f "$(script_dir)/ai-hist-python" ]; then
+    cp "$(script_dir)/ai-hist-python" "$INSTALL_DIR/ai-hist-python"
+    chmod 755 "$INSTALL_DIR/ai-hist-python"
+    return 0
+  fi
+
+  need curl || return 1
+  ref="$(raw_ref)"
+  url="https://raw.githubusercontent.com/$REPO_SLUG/$ref/ai-hist-python"
+  if curl -fsSL "$url" -o "$INSTALL_DIR/ai-hist-python" 2>/dev/null; then
+    chmod 755 "$INSTALL_DIR/ai-hist-python"
+    return 0
+  fi
+
+  warn "could not install ai-hist-python fallback from $url"
+  return 1
+}
+
+install_prebuilt() {
+  need curl || return 1
+
+  if [ -n "${AI_HIST_BINARY_URL:-}" ]; then
+    asset="ai-hist-custom"
+    url="$AI_HIST_BINARY_URL"
+  else
+    asset="$(platform_asset)" || return 1
+    url="$(release_download_url "$asset")"
+  fi
+  rust_bin="$INSTALL_DIR/ai-hist-rust-bin"
+  download="$tmp_dir/$asset"
+
+  info "downloading prebuilt $asset"
+  mkdir -p "$INSTALL_DIR"
+  if ! curl -fsSL "$url" -o "$download"; then
+    warn "prebuilt binary not available at $url"
+    return 1
+  fi
+
+  cp "$download" "$rust_bin"
+  chmod 755 "$rust_bin"
+
+  if ! "$rust_bin" --version >/dev/null 2>&1; then
+    warn "downloaded binary failed verification"
+    rm -f "$rust_bin"
+    return 1
+  fi
+
+  install_binary_launchers "$rust_bin"
+  install_python_fallback || true
+  info "installed prebuilt binary"
+  return 0
+}
+
+resolve_source_dir() {
+  if [ -n "${AI_HIST_SOURCE_DIR:-}" ]; then
+    echo "$AI_HIST_SOURCE_DIR"
+    return 0
+  fi
+
+  if [ -f "$(script_dir)/Cargo.toml" ] && [ -f "$(script_dir)/ai-hist" ]; then
+    echo "$(script_dir)"
+    return 0
+  fi
+
   need git || {
     echo "Install git or run from a cloned ai-hist checkout." >&2
-    exit 1
+    return 1
   }
   src_dir="$tmp_dir/ai-hist"
-  git clone --depth 1 --branch "$REF" "$REPO_URL" "$src_dir"
-fi
-
-need cargo || {
-  echo "Install Rust from https://rustup.rs/ and rerun this script." >&2
-  exit 1
-}
-need python3 || {
-  echo "Install Python 3 and rerun this script." >&2
-  exit 1
+  git clone --depth 1 --branch "$(source_ref)" "$REPO_URL" "$src_dir"
+  echo "$src_dir"
 }
 
-if [ "$BUILD_PROFILE" = "release" ]; then
-  (cd "$src_dir" && cargo build --release -q -p ai-hist-cli)
-else
-  (cd "$src_dir" && cargo build -q -p ai-hist-cli)
-fi
+install_from_source() {
+  src_dir="$(resolve_source_dir)" || exit 1
 
-rust_bin="$src_dir/target/$BUILD_PROFILE/ai-hist"
-if [ ! -x "$rust_bin" ]; then
-  echo "ai-hist installer: Rust binary was not built at $rust_bin" >&2
-  exit 1
-fi
+  need cargo || {
+    echo "Install Rust from https://rustup.rs/ and rerun this script, or use AI_HIST_INSTALL_METHOD=binary with a published prebuilt binary." >&2
+    exit 1
+  }
+  need python3 || {
+    echo "Install Python 3 and rerun this script." >&2
+    exit 1
+  }
 
-mkdir -p "$BIN_DIR" "$INSTALL_DIR"
-cp "$src_dir/ai-hist" "$INSTALL_DIR/ai-hist-wrapper"
-cp "$src_dir/ai-hist-python" "$INSTALL_DIR/ai-hist-python"
-cp "$rust_bin" "$INSTALL_DIR/ai-hist-rust-bin"
-chmod 755 "$INSTALL_DIR/ai-hist-wrapper" "$INSTALL_DIR/ai-hist-python" "$INSTALL_DIR/ai-hist-rust-bin"
+  if [ "$BUILD_PROFILE" = "release" ]; then
+    (cd "$src_dir" && cargo build --release -q -p ai-hist-cli)
+  else
+    (cd "$src_dir" && cargo build -q -p ai-hist-cli)
+  fi
 
-cat > "$BIN_DIR/ai-hist" <<EOF
+  rust_bin="$src_dir/target/$BUILD_PROFILE/ai-hist"
+  if [ ! -x "$rust_bin" ]; then
+    echo "ai-hist installer: Rust binary was not built at $rust_bin" >&2
+    exit 1
+  fi
+
+  mkdir -p "$BIN_DIR" "$INSTALL_DIR"
+  cp "$src_dir/ai-hist" "$INSTALL_DIR/ai-hist-wrapper"
+  cp "$src_dir/ai-hist-python" "$INSTALL_DIR/ai-hist-python"
+  cp "$rust_bin" "$INSTALL_DIR/ai-hist-rust-bin"
+  chmod 755 "$INSTALL_DIR/ai-hist-wrapper" "$INSTALL_DIR/ai-hist-python" "$INSTALL_DIR/ai-hist-rust-bin"
+
+  cat > "$BIN_DIR/ai-hist" <<EOF
 #!/usr/bin/env sh
 export AI_HIST_RUST_BIN="\${AI_HIST_RUST_BIN:-$INSTALL_DIR/ai-hist-rust-bin}"
 exec "$INSTALL_DIR/ai-hist-wrapper" "\$@"
 EOF
 
-cat > "$BIN_DIR/ai-hist-python" <<EOF
+  cat > "$BIN_DIR/ai-hist-python" <<EOF
 #!/usr/bin/env sh
 exec python3 "$INSTALL_DIR/ai-hist-python" "\$@"
 EOF
 
-cat > "$BIN_DIR/ai-hist-rust" <<EOF
+  cat > "$BIN_DIR/ai-hist-rust" <<EOF
 #!/usr/bin/env sh
 exec "$INSTALL_DIR/ai-hist-rust-bin" "\$@"
 EOF
 
-chmod 755 "$BIN_DIR/ai-hist" "$BIN_DIR/ai-hist-python" "$BIN_DIR/ai-hist-rust"
+  chmod 755 "$BIN_DIR/ai-hist" "$BIN_DIR/ai-hist-python" "$BIN_DIR/ai-hist-rust"
+  info "installed from source"
+}
+
+if [ "$INSTALL_METHOD" = "binary" ]; then
+  install_prebuilt || exit 1
+elif [ "$INSTALL_METHOD" = "source" ]; then
+  install_from_source
+elif [ -z "${AI_HIST_SOURCE_DIR:-}" ] && ! { [ -f "$(script_dir)/Cargo.toml" ] && [ -f "$(script_dir)/ai-hist" ]; }; then
+  install_prebuilt || install_from_source
+else
+  install_from_source
+fi
 
 cat <<EOF
 ai-hist installed.

--- a/test_install.py
+++ b/test_install.py
@@ -8,7 +8,7 @@ from pathlib import Path
 ROOT = Path(__file__).parent
 
 
-def test_install_script_installs_working_launchers(tmp_path):
+def test_install_script_installs_working_launchers_from_source(tmp_path):
     bin_dir = tmp_path / "bin"
     install_dir = tmp_path / "share" / "ai-hist"
     env = os.environ.copy()
@@ -121,3 +121,77 @@ def test_install_script_installs_working_launchers(tmp_path):
         assert conn.execute("SELECT COUNT(*) FROM history").fetchone()[0] == 2
     finally:
         conn.close()
+
+
+def test_install_script_binary_mode_does_not_require_cargo(tmp_path):
+    bin_dir = tmp_path / "bin"
+    install_dir = tmp_path / "share" / "ai-hist"
+    fake_tools = tmp_path / "fake-tools"
+    fake_tools.mkdir()
+    fake_cargo = fake_tools / "cargo"
+    fake_cargo.write_text("#!/bin/sh\necho cargo should not run >&2\nexit 99\n")
+    fake_cargo.chmod(0o755)
+
+    fake_binary = tmp_path / "ai-hist-darwin-arm64"
+    fake_binary.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"--version\" ]; then echo 'ai-hist 9.9.9'; exit 0; fi\n"
+        "if [ \"$1\" = \"recent\" ]; then echo '[]'; exit 0; fi\n"
+        "echo \"fake ai-hist: $*\"\n"
+    )
+    fake_binary.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "AI_HIST_INSTALL_METHOD": "binary",
+            "AI_HIST_BINARY_URL": fake_binary.as_uri(),
+            "AI_HIST_BIN_DIR": str(bin_dir),
+            "AI_HIST_INSTALL_DIR": str(install_dir),
+            "AI_HIST_WRAPPER_SOURCE_DIR": str(ROOT),
+            "PATH": f"{fake_tools}:{os.environ.get('PATH', '')}",
+        }
+    )
+
+    result = subprocess.run(
+        ["sh", str(ROOT / "install.sh")],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "cargo should not run" not in result.stderr
+
+    ai_hist = bin_dir / "ai-hist"
+    ai_hist_python = bin_dir / "ai-hist-python"
+    ai_hist_rust = bin_dir / "ai-hist-rust"
+    assert ai_hist.exists()
+    assert ai_hist_python.exists()
+    assert ai_hist_rust.exists()
+    assert install_dir.joinpath("ai-hist-rust-bin").exists()
+    assert install_dir.joinpath("ai-hist-python").exists()
+
+    run_env = os.environ.copy()
+    run_env.pop("AI_HIST_RUST_BIN", None)
+
+    version_result = subprocess.run(
+        [str(ai_hist), "--version"],
+        env=run_env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert version_result.returncode == 0, version_result.stderr
+    assert version_result.stdout.strip() == "ai-hist 9.9.9"
+
+    rust_result = subprocess.run(
+        [str(ai_hist_rust), "recent"],
+        env=run_env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert rust_result.returncode == 0, rust_result.stderr
+    assert rust_result.stdout.strip() == "[]"


### PR DESCRIPTION
## Summary
- add a release-binary workflow that builds macOS and Linux ai-hist Rust binaries for GitHub Releases
- update install.sh to prefer prebuilt binaries and only require cargo for source fallback
- add installer coverage proving binary mode does not call cargo
- document binary/source install controls

## Tests
- sh -n install.sh
- cargo test --workspace
- python3 -m py_compile ai-hist ai-hist-python
- pytest -q test_ai_hist.py test_cli_dispatch.py test_install.py
- npm test (sdk-ts)
- scripts/verify-e2e.sh

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

