### PR TITLE
ci: publish Rust installer binaries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -368,28 +368,28 @@ jobs:
         if: ${{ steps.published.outputs.sdk_published != 'true' }}
         run: |
           set -euo pipefail
-          FLAGS="--access public --tag ${{ github.event.inputs.tag }}"
+          FLAGS=(--access public --tag "${{ github.event.inputs.tag }}")
           if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
-            FLAGS+=" --dry-run"
+            FLAGS+=(--dry-run)
           else
-            FLAGS+=" --provenance"
+            FLAGS+=(--provenance)
           fi
-          echo "==> npm publish $FLAGS"
-          npm publish $FLAGS
+          echo "==> npm publish ${FLAGS[*]}"
+          npm publish "${FLAGS[@]}"
 
       - name: Publish MCP wrapper to npm
         if: ${{ steps.published.outputs.mcp_published != 'true' }}
         working-directory: ${{ github.workspace }}/mcp-package
         run: |
           set -euo pipefail
-          FLAGS="--access public --tag ${{ github.event.inputs.tag }}"
+          FLAGS=(--access public --tag "${{ github.event.inputs.tag }}")
           if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
-            FLAGS+=" --dry-run"
+            FLAGS+=(--dry-run)
           else
-            FLAGS+=" --provenance"
+            FLAGS+=(--provenance)
           fi
-          echo "==> npm publish ai-hist-mcp $FLAGS"
-          npm publish $FLAGS
+          echo "==> npm publish ai-hist-mcp ${FLAGS[*]}"
+          npm publish "${FLAGS[@]}"
 
       # Annotated tag (-a) so `git push --follow-tags` actually pushes it.
       - name: Tag + push
@@ -406,15 +406,100 @@ jobs:
             echo ""
             echo "- \`${{ steps.bump.outputs.npm_name }}@${{ steps.bump.outputs.version }}\`"
             echo "- \`ai-hist-mcp@${{ steps.bump.outputs.version }}\`"
+            echo "- Rust installer binaries attached to \`sdk-ts-v${{ steps.bump.outputs.version }}\`"
             echo "- **dist-tag**: \`${{ github.event.inputs.tag }}\`"
             echo "- **dry run**: \`${{ github.event.inputs.dry_run }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  build-binaries:
+    name: Build binary (${{ matrix.asset }})
+    needs: publish
+    if: ${{ github.event.inputs.dry_run != 'true' && (github.event.inputs.version != 'none' || github.event.inputs.custom_version != '') }}
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            asset: ai-hist-darwin-arm64
+            binary: ai-hist
+            run_binary: false
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            asset: ai-hist-darwin-x64
+            binary: ai-hist
+            run_binary: false
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            asset: ai-hist-linux-x64
+            binary: ai-hist
+            run_binary: true
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            asset: ai-hist-linux-arm64
+            binary: ai-hist
+            run_binary: false
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: sdk-ts-v${{ needs.publish.outputs.version }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ai-hist-${{ matrix.target }}
+          cache-bin: false
+
+      - name: Install musl tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Install cross
+        if: matrix.target == 'aarch64-unknown-linux-musl'
+        uses: taiki-e/install-action@cross
+
+      - name: Build binary
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
+            RUSTFLAGS="-C target-feature=+crt-static" cross build --release --target "${{ matrix.target }}" -p ai-hist-cli
+          else
+            RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target "${{ matrix.target }}" -p ai-hist-cli
+          fi
+          strip "target/${{ matrix.target }}/release/${{ matrix.binary }}" 2>/dev/null || true
+          cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" "${{ matrix.asset }}"
+          chmod 755 "${{ matrix.asset }}"
+
+      - name: Verify binary
+        if: matrix.run_binary
+        run: "./${{ matrix.asset }} --version"
+
+      - name: Inspect binary
+        if: ${{ !matrix.run_binary }}
+        run: file "${{ matrix.asset }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: ${{ matrix.asset }}
+          retention-days: 7
+
   # One GitHub Release per publish run. The release body inlines the
-  # CHANGELOG block for this version.
+  # CHANGELOG block for this version and includes the Rust installer binaries.
   create-release:
     name: Create GitHub Release
-    needs: publish
+    needs:
+      - publish
+      - build-binaries
     if: ${{ github.event.inputs.dry_run != 'true' && (github.event.inputs.version != 'none' || github.event.inputs.custom_version != '') }}
     runs-on: ubuntu-latest
     permissions:
@@ -443,6 +528,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.release.outputs.tag_name }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: release-binaries
+          merge-multiple: true
 
       - name: Build release notes
         env:
@@ -486,4 +576,5 @@ jobs:
           tag_name: ${{ steps.release.outputs.tag_name }}
           name: ${{ needs.publish.outputs.npm_name }}@${{ steps.release.outputs.version }}
           body_path: /tmp/release-notes.md
+          files: release-binaries/*
           prerelease: ${{ steps.release.outputs.prerelease }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,13 +1,10 @@
 name: Build ai-hist release binaries
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag to attach binaries to, for example v0.3.5'
+        description: 'Release tag to attach binaries to, for example sdk-ts-v0.3.5'
         required: true
         type: string
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ AI_HIST_INSTALL_METHOD=source sh install.sh   # from a local checkout
 AI_HIST_SOURCE_REF=my-branch sh install.sh    # override source fallback ref
 ```
 
+The publish workflow creates the npm packages, the `sdk-ts-v<version>` GitHub
+Release, and the prebuilt Rust assets consumed by the installer.
+
 Escape hatches:
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -84,11 +84,20 @@ release_download_url() {
     return 0
   fi
 
-  case "$VERSION" in
-    v*) tag="$VERSION" ;;
-    *) tag="v$VERSION" ;;
-  esac
-  echo "https://github.com/$REPO_SLUG/releases/download/$tag/$asset"
+  echo "https://github.com/$REPO_SLUG/releases/download/$(version_tag)/$asset"
+}
+
+version_tag() {
+  if [ "$VERSION" != "latest" ]; then
+    case "$VERSION" in
+      sdk-ts-v*) echo "$VERSION" ;;
+      v*) echo "sdk-ts-$VERSION" ;;
+      *) echo "sdk-ts-v$VERSION" ;;
+    esac
+    return 0
+  fi
+
+  echo "$REF"
 }
 
 raw_ref() {
@@ -97,15 +106,7 @@ raw_ref() {
     return 0
   fi
 
-  if [ "$VERSION" != "latest" ]; then
-    case "$VERSION" in
-      v*) echo "$VERSION" ;;
-      *) echo "v$VERSION" ;;
-    esac
-    return 0
-  fi
-
-  echo "$REF"
+  version_tag
 }
 
 source_ref() {


### PR DESCRIPTION
## Summary
- make publish.yml build macOS/Linux Rust ai-hist binaries after npm publish
- attach those binaries to the sdk-ts-v<version> GitHub Release created by publish.yml
- align install.sh pinned versions with sdk-ts-v<version> release tags
- keep release-binaries.yml as manual-only backfill to avoid racing publish.yml
- tighten npm publish shell quoting and document that publish now owns binary assets

## Tests
- actionlint .github/workflows/publish.yml .github/workflows/release-binaries.yml
- sh -n install.sh
- AI_HIST_RUST_BIN="/Users/khaliqgant/Projects/AgentWorkforce/relayhistory/target/debug/ai-hist" pytest -q test_install.py

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

