### PR TITLE
Fix Rust CLI help and default Cloud login

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Escape hatches:
 ```bash
 AI_HIST_CLI=rust ai-hist search deploy
 AI_HIST_CLI=python ai-hist sync   # explicit legacy compatibility path
-AI_HIST_RUST_BIN=/absolute/path/to/ai-hist-rust-bin ai-hist search deploy
 ai-hist-rust search deploy
 ai-hist-python sync
 ```
@@ -223,11 +222,6 @@ cat > ~/Library/LaunchAgents/com.ai-hist.sync.plist << 'EOF'
         <string>${HOME}/.local/bin/ai-hist</string>
         <string>sync</string>
     </array>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>AI_HIST_RUST_BIN</key>
-        <string>${HOME}/.local/share/ai-hist/ai-hist-rust-bin</string>
-    </dict>
     <key>StartInterval</key>
     <integer>60</integer>
     <key>RunAtLoad</key>

--- a/ai-hist
+++ b/ai-hist
@@ -33,6 +33,11 @@ RUST_COMMANDS = {
     "untag",
     "tags",
     "sync",
+    "login",
+    "admin-mint",
+    "push",
+    "pair",
+    "learn",
 }
 
 PYTHON_COMMANDS = set()
@@ -112,6 +117,11 @@ Rust-default commands:
   tag            Tag a session
   untag          Remove a tag from a session
   tags           List tags and tagged sessions
+  login          Authenticate through Agent Relay Cloud
+  admin-mint     Dev-only local relayhistory token mint
+  push           Push new local history to relayhistory-cloud
+  pair           Ask relayhistory-cloud for in-session warnings
+  learn          Distill history into Pair signal
 
 Python fallback commands:
   (none in auto mode; use the explicit escape hatches for legacy compatibility)

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -21,6 +21,8 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 
+const DEFAULT_BASE_URL: &str = "https://history.agentrelay.com";
+
 /// Locally stored service-local session (never the RelayAuth JWT). Written `0600`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StoredAuth {
@@ -46,6 +48,15 @@ pub fn config_dir() -> PathBuf {
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."));
     home.join(".agentworkforce/relayhistory")
+}
+
+pub fn default_base_url() -> String {
+    std::env::var("RELAYHISTORY_BASE_URL")
+        .or_else(|_| std::env::var("AI_HIST_BASE_URL"))
+        .ok()
+        .map(|s| s.trim_end_matches('/').to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_BASE_URL.to_string())
 }
 
 fn auth_path() -> PathBuf {
@@ -276,64 +287,123 @@ pub fn login(base_url: &str, agent_relay_token: &str, label: &str) -> Result<Sto
     })
 }
 
-/// The relayhistory session JSON returned by `agent-relay cloud relayhistory-session --json`.
-/// Only the final session is parsed — no upstream Cloud/RelayAuth token is present in this shape.
-#[derive(serde::Deserialize)]
-struct CloudSessionResponse {
-    #[serde(rename = "baseUrl")]
-    base_url: String,
+/// The canonical Agent Relay Cloud session returned by `agent-relay cloud session --json`.
+/// This is the same credential source used by relayfile/workforce. It is captured only long
+/// enough to exchange it for a service-local relayhistory session.
+#[derive(Debug, serde::Deserialize)]
+struct AgentRelayCloudSession {
+    #[serde(rename = "apiUrl")]
+    _api_url: Option<String>,
     #[serde(rename = "accessToken")]
     access_token: String,
-    #[serde(rename = "refreshToken")]
-    refresh_token: Option<String>,
-    #[serde(rename = "orgId")]
-    org_id: Option<String>,
-    #[serde(rename = "workspaceId")]
-    workspace_id: Option<String>,
 }
 
-/// Cloud-bridge login: shell to the already-authenticated Agent Relay Cloud CLI, which performs
-/// the **server-to-server** exchange (Cloud mints a short-lived `aud=relayhistory` assertion and
-/// calls `/v1/cli/login` itself) and returns ONLY the final `rth_*` session. The client never
-/// handles a Cloud or RelayAuth token — it consumes the session JSON on stdout and stores it 0600.
-/// `mode` is a least-privilege *ceiling request* (`read` | `sync`); Cloud authorizes the actual
-/// scope it signs. The relayhistory target is **server-configured by Cloud**, never client-supplied
-/// — a client-chosen URL would let Cloud send a signed `aud=relayhistory` assertion to an arbitrary
-/// host (SSRF / token exfil). The returned `baseUrl` tells the client where the session belongs.
-pub fn login_via_cloud(mode: &str, workspace: Option<&str>) -> Result<StoredAuth> {
-    if mode != "read" && mode != "sync" {
-        anyhow::bail!("invalid --mode '{mode}' (expected `read` or `sync`)");
-    }
-    // Allow overriding the binary for tests / non-standard installs; default to PATH lookup.
-    let bin = std::env::var("AGENT_RELAY_BIN").unwrap_or_else(|_| "agent-relay".to_string());
-    let mut cmd = std::process::Command::new(&bin);
-    cmd.args(["cloud", "relayhistory-session", "--json", "--mode", mode]);
-    if let Some(ws) = workspace {
-        cmd.args(["--workspace", ws]);
-    }
-    let output = cmd.output().with_context(|| {
-        format!("failed to run `{bin} cloud relayhistory-session` — is the Agent Relay CLI installed and logged in? (`agent-relay login`)")
-    })?;
+fn env_agent_relay_session() -> Option<AgentRelayCloudSession> {
+    std::env::var("CLOUD_API_ACCESS_TOKEN")
+        .ok()
+        .map(|token| token.trim().to_string())
+        .filter(|token| !token.is_empty())
+        .map(|access_token| AgentRelayCloudSession {
+            _api_url: std::env::var("CLOUD_API_URL").ok(),
+            access_token,
+        })
+}
+
+fn agent_relay_bin() -> String {
+    std::env::var("AGENT_RELAY_BIN").unwrap_or_else(|_| "agent-relay".to_string())
+}
+
+fn switch_agent_relay_workspace(bin: &str, workspace: &str) -> Result<()> {
+    let output = std::process::Command::new(bin)
+        .args(["workspace", "switch", workspace])
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to run `{bin} workspace switch {workspace}` — is the Agent Relay CLI installed?"
+            )
+        })?;
     if !output.status.success() {
-        // Surface stderr (user-facing auth prompts/errors) but NEVER stdout — stdout may carry a
-        // partial/!-redacted session.
         let stderr = String::from_utf8_lossy(&output.stderr);
         anyhow::bail!(
-            "Agent Relay Cloud login failed ({}). {}",
+            "Agent Relay workspace switch failed ({}). {}",
             output.status,
             stderr.trim()
         );
     }
-    let session: CloudSessionResponse = serde_json::from_slice(&output.stdout).context(
-        "parsing relayhistory session JSON from `agent-relay cloud relayhistory-session`",
-    )?;
-    Ok(StoredAuth {
-        base_url: session.base_url.trim_end_matches('/').to_string(),
-        access_token: session.access_token,
-        refresh_token: session.refresh_token,
-        org_id: session.org_id,
-        workspace_id: session.workspace_id,
-    })
+    Ok(())
+}
+
+fn read_agent_relay_session(bin: &str) -> Result<AgentRelayCloudSession> {
+    let output = std::process::Command::new(bin)
+        .args(["cloud", "session", "--json"])
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to run `{bin} cloud session --json` — install Agent Relay and run `agent-relay login`"
+            )
+        })?;
+    if !output.status.success() {
+        // Surface stderr (user-facing auth prompts/errors) but NEVER stdout — stdout contains the
+        // bearer token when this command succeeds or partially succeeds.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "Agent Relay Cloud session lookup failed ({}). {}",
+            output.status,
+            stderr.trim()
+        );
+    }
+    serde_json::from_slice(&output.stdout)
+        .context("parsing Agent Relay Cloud session JSON from `agent-relay cloud session --json`")
+}
+
+fn ensure_agent_relay_session(
+    bin: &str,
+    workspace: Option<&str>,
+) -> Result<AgentRelayCloudSession> {
+    if let Some(session) = env_agent_relay_session() {
+        return Ok(session);
+    }
+
+    if let Some(ws) = workspace {
+        switch_agent_relay_workspace(bin, ws)?;
+    }
+
+    match read_agent_relay_session(bin) {
+        Ok(session) => Ok(session),
+        Err(first_error) => {
+            eprintln!("Agent Relay Cloud login required; starting `agent-relay cloud login`.");
+            let status = std::process::Command::new(bin)
+                .args(["cloud", "login"])
+                .status()
+                .with_context(|| {
+                    format!(
+                        "failed to run `{bin} cloud login` — install Agent Relay and run `agent-relay login`"
+                    )
+                })?;
+            if !status.success() {
+                anyhow::bail!(
+                    "Agent Relay Cloud login failed ({status}). Previous session lookup error: {first_error}"
+                );
+            }
+            read_agent_relay_session(bin)
+        }
+    }
+}
+
+/// Cloud login: use the canonical Agent Relay Cloud session, then exchange that bearer for a
+/// service-local `rth_*` relayhistory session via `/v1/cli/login`.
+pub fn login_via_cloud(
+    base_url: &str,
+    mode: &str,
+    workspace: Option<&str>,
+    label: &str,
+) -> Result<StoredAuth> {
+    if mode != "read" && mode != "sync" {
+        anyhow::bail!("invalid --mode '{mode}' (expected `read` or `sync`)");
+    }
+    let bin = agent_relay_bin();
+    let session = ensure_agent_relay_session(&bin, workspace)?;
+    login(base_url, &session.access_token, label)
 }
 
 fn field(v: &serde_json::Value, key: &str) -> Result<String> {
@@ -709,19 +779,70 @@ mod tests {
         (dir, path)
     }
 
+    fn one_shot_login_server(
+        expected_agent_relay_token: &'static str,
+    ) -> (String, std::thread::JoinHandle<()>) {
+        use std::io::{BufRead, BufReader, Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+                .unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut content_length = 0usize;
+            let mut first_line = String::new();
+            reader.read_line(&mut first_line).unwrap();
+            assert!(first_line.starts_with("POST /v1/cli/login "));
+            loop {
+                let mut line = String::new();
+                reader.read_line(&mut line).unwrap();
+                let trimmed = line.trim_end();
+                if trimmed.is_empty() {
+                    break;
+                }
+                if let Some((name, value)) = trimmed.split_once(':') {
+                    if name.eq_ignore_ascii_case("content-length") {
+                        content_length = value.trim().parse().unwrap();
+                    }
+                }
+            }
+            let mut body = vec![0; content_length];
+            reader.read_exact(&mut body).unwrap();
+            let body = String::from_utf8(body).unwrap();
+            assert!(body.contains(expected_agent_relay_token), "{body}");
+            let response_body = r#"{"accessToken":"rth_at_abc","refreshToken":"rth_rt_def","orgId":"org_dev","workspaceId":"ws_dev","tokenType":"Bearer"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        (format!("http://{addr}"), handle)
+    }
+
     #[cfg(unix)]
     #[test]
-    fn login_via_cloud_parses_and_maps_session() {
+    fn login_via_cloud_exchanges_agent_relay_session() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        // The fake Cloud CLI emits ONLY the final relayhistory session JSON on stdout.
+        let (base_url, server) = one_shot_login_server("relay_at_abc");
         let (_dir, bin) = fake_agent_relay(
-            r#"echo '{"baseUrl":"https://history.agentrelay.com/","accessToken":"rth_at_abc","refreshToken":"rth_rt_def","orgId":"org_dev","workspaceId":"ws_dev","tokenType":"Bearer"}'"#,
+            r#"if [ "$1 $2 $3" = "cloud session --json" ]; then
+  echo '{"apiUrl":"https://agentrelay.com/cloud","accessToken":"relay_at_abc","accessTokenExpiresAt":"2999-01-01T00:00:00.000Z"}'
+  exit 0
+fi
+echo "unexpected args: $*" 1>&2
+exit 42"#,
         );
         std::env::set_var("AGENT_RELAY_BIN", &bin);
-        let auth = login_via_cloud("sync", None).unwrap();
+        std::env::remove_var("CLOUD_API_ACCESS_TOKEN");
+        let auth = login_via_cloud(&base_url, "sync", None, "test-label").unwrap();
         std::env::remove_var("AGENT_RELAY_BIN");
+        server.join().unwrap();
 
-        assert_eq!(auth.base_url, "https://history.agentrelay.com"); // trailing slash trimmed
+        assert_eq!(auth.base_url, base_url);
         assert_eq!(auth.access_token, "rth_at_abc");
         assert_eq!(auth.refresh_token.as_deref(), Some("rth_rt_def"));
         assert_eq!(auth.org_id.as_deref(), Some("org_dev"));
@@ -730,15 +851,15 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn login_via_cloud_surfaces_stderr_never_stdout_on_failure() {
+    fn cloud_session_failure_surfaces_stderr_never_stdout() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Failing exit: stdout carries a (would-be) secret; stderr carries the user-facing reason.
         let (_dir, bin) = fake_agent_relay(
             "echo 'rth_at_LEAKED_TOKEN_SHOULD_NOT_SURFACE'; echo 'not logged in: run agent-relay login' 1>&2; exit 1",
         );
-        std::env::set_var("AGENT_RELAY_BIN", &bin);
-        let err = login_via_cloud("sync", None).unwrap_err().to_string();
-        std::env::remove_var("AGENT_RELAY_BIN");
+        let err = read_agent_relay_session(bin.to_str().unwrap())
+            .unwrap_err()
+            .to_string();
 
         assert!(
             err.contains("not logged in"),
@@ -753,7 +874,17 @@ mod tests {
 
     #[test]
     fn login_via_cloud_rejects_invalid_mode() {
-        let err = login_via_cloud("admin", None).unwrap_err().to_string();
+        let err = login_via_cloud("https://history.agentrelay.com", "admin", None, "test")
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("invalid --mode"), "{err}");
+    }
+
+    #[test]
+    fn default_base_url_honors_env_override() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("RELAYHISTORY_BASE_URL", "http://localhost:8787/");
+        assert_eq!(default_base_url(), "http://localhost:8787");
+        std::env::remove_var("RELAYHISTORY_BASE_URL");
     }
 }

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -51,12 +51,20 @@ pub fn config_dir() -> PathBuf {
 }
 
 pub fn default_base_url() -> String {
-    std::env::var("RELAYHISTORY_BASE_URL")
-        .or_else(|_| std::env::var("AI_HIST_BASE_URL"))
-        .ok()
-        .map(|s| s.trim_end_matches('/').to_string())
-        .filter(|s| !s.is_empty())
+    ["RELAYHISTORY_BASE_URL", "AI_HIST_BASE_URL"]
+        .into_iter()
+        .filter_map(|key| std::env::var(key).ok())
+        .find_map(|value| normalize_base_url(&value))
         .unwrap_or_else(|| DEFAULT_BASE_URL.to_string())
+}
+
+fn normalize_base_url(value: &str) -> Option<String> {
+    let normalized = value.trim().trim_end_matches('/').to_string();
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
 }
 
 fn auth_path() -> PathBuf {
@@ -265,11 +273,20 @@ pub fn admin_mint(
 }
 
 /// `POST /v1/cli/login` (RelayAuth JWT → `rth_at_`/`rth_rt_`) — the real-use bootstrap.
-pub fn login(base_url: &str, agent_relay_token: &str, label: &str) -> Result<StoredAuth> {
+pub fn login(
+    base_url: &str,
+    agent_relay_token: &str,
+    label: &str,
+    mode: Option<&str>,
+) -> Result<StoredAuth> {
     let url = format!("{}/v1/cli/login", base_url.trim_end_matches('/'));
+    let mut body = serde_json::json!({ "agentRelayToken": agent_relay_token, "label": label });
+    if let Some(mode) = mode {
+        body["mode"] = serde_json::json!(mode);
+    }
     let resp = ureq::post(&url)
         .set("Content-Type", "application/json")
-        .send_json(serde_json::json!({ "agentRelayToken": agent_relay_token, "label": label }))
+        .send_json(body)
         .map_err(map_http_err)?;
     let v: serde_json::Value = resp.into_json()?;
     Ok(StoredAuth {
@@ -313,26 +330,6 @@ fn agent_relay_bin() -> String {
     std::env::var("AGENT_RELAY_BIN").unwrap_or_else(|_| "agent-relay".to_string())
 }
 
-fn switch_agent_relay_workspace(bin: &str, workspace: &str) -> Result<()> {
-    let output = std::process::Command::new(bin)
-        .args(["workspace", "switch", workspace])
-        .output()
-        .with_context(|| {
-            format!(
-                "failed to run `{bin} workspace switch {workspace}` — is the Agent Relay CLI installed?"
-            )
-        })?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!(
-            "Agent Relay workspace switch failed ({}). {}",
-            output.status,
-            stderr.trim()
-        );
-    }
-    Ok(())
-}
-
 fn read_agent_relay_session(bin: &str) -> Result<AgentRelayCloudSession> {
     let output = std::process::Command::new(bin)
         .args(["cloud", "session", "--json"])
@@ -360,12 +357,14 @@ fn ensure_agent_relay_session(
     bin: &str,
     workspace: Option<&str>,
 ) -> Result<AgentRelayCloudSession> {
-    if let Some(session) = env_agent_relay_session() {
-        return Ok(session);
+    if let Some(ws) = workspace {
+        anyhow::bail!(
+            "`--workspace {ws}` is not supported for Cloud login yet because `agent-relay cloud session` has no non-mutating workspace-scoped mode; switch the active workspace with Agent Relay first, then rerun without `--workspace`"
+        );
     }
 
-    if let Some(ws) = workspace {
-        switch_agent_relay_workspace(bin, ws)?;
+    if let Some(session) = env_agent_relay_session() {
+        return Ok(session);
     }
 
     match read_agent_relay_session(bin) {
@@ -401,9 +400,26 @@ pub fn login_via_cloud(
     if mode != "read" && mode != "sync" {
         anyhow::bail!("invalid --mode '{mode}' (expected `read` or `sync`)");
     }
+    validate_cloud_exchange_base_url(base_url)?;
     let bin = agent_relay_bin();
     let session = ensure_agent_relay_session(&bin, workspace)?;
-    login(base_url, &session.access_token, label)
+    login(base_url, &session.access_token, label, Some(mode))
+}
+
+fn validate_cloud_exchange_base_url(base_url: &str) -> Result<()> {
+    let normalized = normalize_base_url(base_url).context("relayhistory base URL is empty")?;
+    if normalized == DEFAULT_BASE_URL {
+        return Ok(());
+    }
+    let allowed = std::env::var("RELAYHISTORY_ALLOW_UNTRUSTED_CLOUD_BASE_URL")
+        .ok()
+        .is_some_and(|value| value == "1" || value.eq_ignore_ascii_case("true"));
+    if allowed {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "refusing to send the Agent Relay Cloud bearer to non-default relayhistory URL `{normalized}`; use manual `--token` login or set RELAYHISTORY_ALLOW_UNTRUSTED_CLOUD_BASE_URL=1 for a trusted dev endpoint"
+    )
 }
 
 fn field(v: &serde_json::Value, key: &str) -> Result<String> {
@@ -583,13 +599,40 @@ mod tests {
     // runner can't clobber it across tests.
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.previous {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
     fn with_temp_home<T>(f: impl FnOnce() -> T) -> T {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
-        std::env::set_var("RELAYHISTORY_HOME", dir.path());
-        let out = f();
-        std::env::remove_var("RELAYHISTORY_HOME");
-        out
+        let _relayhistory_home = EnvVarGuard::set("RELAYHISTORY_HOME", dir.path());
+        f()
     }
 
     #[test]
@@ -781,6 +824,7 @@ mod tests {
 
     fn one_shot_login_server(
         expected_agent_relay_token: &'static str,
+        expected_mode: Option<&'static str>,
     ) -> (String, std::thread::JoinHandle<()>) {
         use std::io::{BufRead, BufReader, Read, Write};
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -811,7 +855,13 @@ mod tests {
             let mut body = vec![0; content_length];
             reader.read_exact(&mut body).unwrap();
             let body = String::from_utf8(body).unwrap();
-            assert!(body.contains(expected_agent_relay_token), "{body}");
+            let payload: serde_json::Value = serde_json::from_str(&body).unwrap();
+            assert_eq!(payload["agentRelayToken"], expected_agent_relay_token);
+            if let Some(mode) = expected_mode {
+                assert_eq!(payload["mode"], mode);
+            } else {
+                assert!(payload.get("mode").is_none());
+            }
             let response_body = r#"{"accessToken":"rth_at_abc","refreshToken":"rth_rt_def","orgId":"org_dev","workspaceId":"ws_dev","tokenType":"Bearer"}"#;
             let response = format!(
                 "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
@@ -827,7 +877,7 @@ mod tests {
     #[test]
     fn login_via_cloud_exchanges_agent_relay_session() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let (base_url, server) = one_shot_login_server("relay_at_abc");
+        let (base_url, server) = one_shot_login_server("relay_at_abc", Some("sync"));
         let (_dir, bin) = fake_agent_relay(
             r#"if [ "$1 $2 $3" = "cloud session --json" ]; then
   echo '{"apiUrl":"https://agentrelay.com/cloud","accessToken":"relay_at_abc","accessTokenExpiresAt":"2999-01-01T00:00:00.000Z"}'
@@ -836,10 +886,11 @@ fi
 echo "unexpected args: $*" 1>&2
 exit 42"#,
         );
-        std::env::set_var("AGENT_RELAY_BIN", &bin);
-        std::env::remove_var("CLOUD_API_ACCESS_TOKEN");
+        let _agent_relay_bin = EnvVarGuard::set("AGENT_RELAY_BIN", bin.as_os_str());
+        let _cloud_token = EnvVarGuard::remove("CLOUD_API_ACCESS_TOKEN");
+        let _allow_dev_base_url =
+            EnvVarGuard::set("RELAYHISTORY_ALLOW_UNTRUSTED_CLOUD_BASE_URL", "1");
         let auth = login_via_cloud(&base_url, "sync", None, "test-label").unwrap();
-        std::env::remove_var("AGENT_RELAY_BIN");
         server.join().unwrap();
 
         assert_eq!(auth.base_url, base_url);
@@ -881,10 +932,42 @@ exit 42"#,
     }
 
     #[test]
+    fn login_via_cloud_rejects_workspace_without_mutating_global_agent_relay_state() {
+        let err = login_via_cloud(
+            "https://history.agentrelay.com",
+            "sync",
+            Some("workspace-a"),
+            "test",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("not supported for Cloud login"), "{err}");
+        assert!(err.contains("non-mutating"), "{err}");
+    }
+
+    #[test]
+    fn login_via_cloud_rejects_non_default_base_url_without_explicit_dev_opt_in() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _allow = EnvVarGuard::remove("RELAYHISTORY_ALLOW_UNTRUSTED_CLOUD_BASE_URL");
+        let err = login_via_cloud("http://localhost:8787", "sync", None, "test")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("refusing to send"), "{err}");
+    }
+
+    #[test]
     fn default_base_url_honors_env_override() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        std::env::set_var("RELAYHISTORY_BASE_URL", "http://localhost:8787/");
+        let _relayhistory_base_url =
+            EnvVarGuard::set("RELAYHISTORY_BASE_URL", "http://localhost:8787/");
         assert_eq!(default_base_url(), "http://localhost:8787");
-        std::env::remove_var("RELAYHISTORY_BASE_URL");
+    }
+
+    #[test]
+    fn default_base_url_falls_through_empty_primary_env() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _relayhistory_base_url = EnvVarGuard::set("RELAYHISTORY_BASE_URL", "///");
+        let _ai_hist_base_url = EnvVarGuard::set("AI_HIST_BASE_URL", "http://localhost:8787/");
+        assert_eq!(default_base_url(), "http://localhost:8787");
     }
 }

--- a/crates/ai-hist/src/main.rs
+++ b/crates/ai-hist/src/main.rs
@@ -24,8 +24,9 @@ mod learn;
 #[derive(Parser)]
 #[command(
     name = "ai-hist",
+    bin_name = "ai-hist",
     version,
-    about = "Rust ai-hist CLI, parallel to the Python CLI"
+    about = "Sync, search, tag, and relay AI coding agent history"
 )]
 struct Cli {
     #[arg(long)]
@@ -36,6 +37,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// Search prompts and sessions.
     Search {
         query: Vec<String>,
         #[arg(long)]
@@ -51,6 +53,7 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Show recent history entries.
     Recent {
         #[arg(default_value_t = 20)]
         n: i64,
@@ -63,6 +66,7 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Show all entries for a session.
     Session {
         session_id: String,
         #[arg(long)]
@@ -74,22 +78,26 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Show one history entry by id.
     Show {
         id: i64,
         #[arg(long)]
         json: bool,
     },
+    /// Show neighboring entries around an id.
     Context {
         id: i64,
         #[arg(long, default_value_t = 5)]
         window: i64,
     },
+    /// Show local history statistics.
     Stats {
         #[arg(long)]
         tag: Option<String>,
         #[arg(long)]
         json: bool,
     },
+    /// Add a tag to a session.
     Tag {
         session_id: String,
         tag_name: String,
@@ -100,6 +108,7 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Remove a tag from a session.
     Untag {
         session_id: String,
         tag_name: String,
@@ -108,6 +117,7 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// List tags, optionally with tagged sessions.
     Tags {
         #[arg(long)]
         tag: Option<String>,
@@ -116,6 +126,7 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Print a resume command for the best matching session.
     Resume {
         #[arg(required = true)]
         query: Vec<String>,
@@ -124,15 +135,19 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Import history from an opencode SQLite database.
     SyncOpencode {
         #[arg(long)]
         opencode_db: Option<PathBuf>,
     },
+    /// Sync local agent history into the relayhistory database.
     Sync,
+    /// Repeatedly sync local agent history.
     Watch {
         #[arg(long, default_value_t = 60)]
         interval: u64,
     },
+    /// Build a compact context pack from matching history.
     Pack {
         #[arg(required = true)]
         query: Vec<String>,
@@ -151,6 +166,7 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Export local history.
     Export {
         output: Option<PathBuf>,
         #[arg(long, default_value = "jsonl")]
@@ -162,6 +178,7 @@ enum Command {
         #[arg(long)]
         since: Option<String>,
     },
+    /// Import exported history.
     Import {
         file: PathBuf,
         #[arg(long)]
@@ -169,22 +186,21 @@ enum Command {
     },
     /// Authenticate to relayhistory-cloud (Agent Relay Loop).
     ///
-    /// `--cloud` uses Agent Relay Cloud — you never handle a token: it shells to the already-
-    /// authenticated `agent-relay` CLI, which performs the server-to-server exchange and returns
-    /// only the relayhistory session. (Cloud will become the default once the bridge is live.)
-    /// Otherwise pass `--base-url` + `--token` for manual/dev login.
+    /// Defaults to Agent Relay Cloud auth, matching relayfile/workforce. The CLI reads the
+    /// canonical `agent-relay` session and exchanges it for a relayhistory session. Pass
+    /// `--base-url` + `--token` only for manual/dev login.
     Login {
-        /// Use Agent Relay Cloud (no token handling).
+        /// Use Agent Relay Cloud auth. This is now the default and is kept for compatibility.
         #[arg(long)]
         cloud: bool,
         /// Least-privilege ceiling: `read` (Pair-only) or `sync` (Learn/push). Cloud authorizes
         /// the actual scope it grants. Cloud mode only.
         #[arg(long, default_value = "sync")]
         mode: String,
-        /// Optional workspace id for the Cloud session.
+        /// Optional Agent Relay workspace name/id to switch before reading the Cloud session.
         #[arg(long)]
         workspace: Option<String>,
-        /// Legacy/manual: relayhistory-cloud base URL (required with `--token`).
+        /// relayhistory-cloud base URL. Defaults to https://history.agentrelay.com for Cloud login.
         #[arg(long)]
         base_url: Option<String>,
         /// Legacy/manual: RelayAuth/Agent Relay token (device-flow JWT). Prefer Cloud login.
@@ -522,26 +538,20 @@ fn main() -> Result<()> {
         }
         Command::Import { file, dry_run } => import_history(&conn, &file, dry_run),
         Command::Login {
-            cloud: use_cloud,
+            cloud: _use_cloud,
             mode,
             workspace,
             base_url,
             token,
             label,
         } => {
-            // Cloud login is opt-in via --cloud until the Cloud `relayhistory-session` command +
-            // RelayAuth org-claim land end-to-end; legacy --token + --base-url is the current
-            // default so this can ship without a broken-by-default `login`. (Flip to Cloud-default
-            // once the bridge is live.)
-            let auth = if use_cloud {
-                cloud::login_via_cloud(&mode, workspace.as_deref())?
-            } else {
-                let base_url = base_url.context(
-                    "use `--cloud` for Agent Relay Cloud login, or pass `--base-url` + `--token` for manual login",
-                )?;
-                let token =
-                    token.context("`--token` is required for manual login (or use `--cloud`)")?;
+            let auth = if let Some(token) = token {
+                let base_url =
+                    base_url.context("`--base-url` is required with manual `--token` login")?;
                 cloud::login(&base_url, &token, &label)?
+            } else {
+                let base_url = base_url.unwrap_or_else(cloud::default_base_url);
+                cloud::login_via_cloud(&base_url, &mode, workspace.as_deref(), &label)?
             };
             cloud::save_auth(&auth)?;
             // Never print the session/token — only where it landed.

--- a/crates/ai-hist/src/main.rs
+++ b/crates/ai-hist/src/main.rs
@@ -197,10 +197,11 @@ enum Command {
         /// the actual scope it grants. Cloud mode only.
         #[arg(long, default_value = "sync")]
         mode: String,
-        /// Optional Agent Relay workspace name/id to switch before reading the Cloud session.
+        /// Reserved for future non-mutating workspace-scoped Cloud sessions.
         #[arg(long)]
         workspace: Option<String>,
-        /// relayhistory-cloud base URL. Defaults to https://history.agentrelay.com for Cloud login.
+        /// relayhistory-cloud base URL. Cloud login defaults to https://history.agentrelay.com;
+        /// non-default Cloud exchanges require RELAYHISTORY_ALLOW_UNTRUSTED_CLOUD_BASE_URL=1.
         #[arg(long)]
         base_url: Option<String>,
         /// Legacy/manual: RelayAuth/Agent Relay token (device-flow JWT). Prefer Cloud login.
@@ -548,7 +549,7 @@ fn main() -> Result<()> {
             let auth = if let Some(token) = token {
                 let base_url =
                     base_url.context("`--base-url` is required with manual `--token` login")?;
-                cloud::login(&base_url, &token, &label)?
+                cloud::login(&base_url, &token, &label, None)?
             } else {
                 let base_url = base_url.unwrap_or_else(cloud::default_base_url);
                 cloud::login_via_cloud(&base_url, &mode, workspace.as_deref(), &label)?

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -108,7 +108,7 @@ Empty result → `{"decision":"allow","warnings":[]}` → the hook no-ops cleanl
 
 ```bash
 # one-time: build + authenticate (see docs/cloud-sync.md)
-npx agent-relay cloud login                                # prod; hides auth/token plumbing
+ai-hist login                                             # prod; uses canonical Agent Relay Cloud auth
 ai-hist admin-mint --base-url <dev-url> --org <org> --user "$USER"   # dev only; reads $ADMIN_MINT_SECRET from env (never pass via --flag → argv/ps exposure)
 
 # every session

--- a/docs/cloud-sync.md
+++ b/docs/cloud-sync.md
@@ -83,18 +83,18 @@ Prod auth goes through **Agent Relay Cloud**. End users should not mint tokens, 
 internal auth services, or handle internal API keys.
 
 ```bash
-# 1. Sign in to Agent Relay Cloud. Cloud provisions the relayhistory session.
-npx agent-relay cloud login
+export RELAYHISTORY_HOME="$HOME/.agentworkforce/relayhistory-prod"
+
+# 1. Sign in to Agent Relay Cloud and exchange that session for relayhistory auth.
+ai-hist login
 
 # 2. Push with the stored prod relayhistory session.
-RELAYHISTORY_HOME="$HOME/.agentworkforce/relayhistory-prod" \
-  ai-hist push --json
+ai-hist push --json
 ```
 
-Current implementation note: older `ai-hist` builds may still expose a manual auth handoff.
-That handoff value is internal Cloud/relayhistory plumbing, not something a user should
-mint manually. If your build still requires it, ask your Agent Relay Cloud admin for the
-Cloud-provisioned handoff or wait for the first-class browser/device login flow.
+`ai-hist login` uses the same canonical Agent Relay Cloud login as relayfile/workforce. If
+you are not already signed in, it will start `agent-relay cloud login`; for dev/local
+targets, pass `--base-url` or set `RELAYHISTORY_BASE_URL`.
 
 ---
 

--- a/docs/cloud-sync.md
+++ b/docs/cloud-sync.md
@@ -93,8 +93,11 @@ ai-hist push --json
 ```
 
 `ai-hist login` uses the same canonical Agent Relay Cloud login as relayfile/workforce. If
-you are not already signed in, it will start `agent-relay cloud login`; for dev/local
-targets, pass `--base-url` or set `RELAYHISTORY_BASE_URL`.
+you are not already signed in, it will start `agent-relay cloud login`. Cloud login
+defaults to prod; for dev/local targets use `admin-mint` or explicit manual `--token`
+login. To test Cloud exchange against a trusted non-prod endpoint, set
+`RELAYHISTORY_ALLOW_UNTRUSTED_CLOUD_BASE_URL=1` with `--base-url` or
+`RELAYHISTORY_BASE_URL`.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,22 +93,22 @@ RELAYHISTORY_HOME="$HOME/.agentworkforce/relayhistory-dev" ai-hist push --json
 
 Prod auth is owned by **Agent Relay Cloud**. End users should not mint auth tokens, call
 internal auth services directly, or handle internal API keys. Sign in through Agent Relay
-Cloud, then let the Cloud/relayhistory login handoff populate the `ai-hist` prod session:
+Cloud, then let `ai-hist login` populate the relayhistory prod session from the same
+canonical Agent Relay auth:
 
 ```bash
-# 1. Sign in to Agent Relay Cloud in the browser / Cloud CLI.
-#    Your org/workspace and relayhistory session are provisioned by Cloud.
-npx agent-relay cloud login
+export RELAYHISTORY_HOME="$HOME/.agentworkforce/relayhistory-prod"
+
+# 1. Sign in to Agent Relay Cloud and exchange that session for relayhistory auth.
+ai-hist login
 
 # 2. Push uses the stored prod relayhistory session.
-RELAYHISTORY_HOME="$HOME/.agentworkforce/relayhistory-prod" \
-  ai-hist push --json
+ai-hist push --json
 ```
 
-If your local build still asks for a manual auth handoff, treat that as a temporary
-Cloud-login gap, not as an instruction to mint anything yourself. Ask your Agent Relay
-Cloud admin to provision the relayhistory session, or wait for the first-class Cloud login
-handoff in the CLI. Internal auth details belong in operator runbooks, not human setup.
+If you are not already signed in to Agent Relay Cloud, `ai-hist login` will start
+`agent-relay cloud login`. Internal auth details belong in operator runbooks, not human
+setup.
 
 `push` is incremental + idempotent: it only sends new rows past the cursor, dedupes
 server-side, and advances the cursor only after the server accepts the batch. Re-run it (or

--- a/test_cli_dispatch.py
+++ b/test_cli_dispatch.py
@@ -79,7 +79,16 @@ def seed_via_wrapper(tmp_path):
 
 
 def ensure_rust_binary():
-    built = ROOT / "target" / "debug" / "ai-hist"
+    metadata = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    target_dir = Path(json.loads(metadata.stdout)["target_directory"])
+    built = target_dir / "debug" / ("ai-hist.exe" if os.name == "nt" else "ai-hist")
     if not built.exists():
         subprocess.run(["cargo", "build", "-q", "-p", "ai-hist-cli"], cwd=ROOT, check=True)
     return built

--- a/test_cli_dispatch.py
+++ b/test_cli_dispatch.py
@@ -78,6 +78,13 @@ def seed_via_wrapper(tmp_path):
     return env, db
 
 
+def ensure_rust_binary():
+    built = ROOT / "target" / "debug" / "ai-hist"
+    if not built.exists():
+        subprocess.run(["cargo", "build", "-q", "-p", "ai-hist-cli"], cwd=ROOT, check=True)
+    return built
+
+
 def test_sync_routes_to_rust_and_preserves_db(tmp_path):
     env, db = seed_via_wrapper(tmp_path)
     conn = sqlite3.connect(db)
@@ -175,9 +182,7 @@ def test_escape_hatches_force_python_or_rust(tmp_path):
 
 def test_explicit_rust_binary_escape_hatch(tmp_path):
     env, _db = seed_via_wrapper(tmp_path)
-    built = ROOT / "target" / "debug" / "ai-hist"
-    if not built.exists():
-        subprocess.run(["cargo", "build", "-q", "-p", "ai-hist-cli"], cwd=ROOT, check=True)
+    built = ensure_rust_binary()
     result = run_cli(
         ["search", "dispatch", "--json"],
         env | {"AI_HIST_RUST_BIN": str(built)},
@@ -195,7 +200,70 @@ def test_top_level_help_lists_rust_and_fallback_commands(tmp_path):
     assert "search" in result.stdout
     assert "sync" in result.stdout
     assert "show" in result.stdout
+    assert "login" in result.stdout
+    assert "pair" in result.stdout
+    assert "learn" in result.stdout
     assert "DISPATCH_MATRIX.md" in result.stdout
+
+
+def test_rust_binary_help_uses_public_name_and_describes_commands(tmp_path):
+    env, _db, _home = isolated_env(tmp_path)
+    built = ensure_rust_binary()
+    result = subprocess.run(
+        [str(built), "--help"],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Usage: ai-hist [OPTIONS] <COMMAND>" in result.stdout
+    assert "ai-hist-rust-bin" not in result.stdout
+    assert "Search prompts and sessions" in result.stdout
+    assert "Authenticate to relayhistory-cloud" in result.stdout
+
+
+def test_all_rust_command_help_forms_work(tmp_path):
+    env, _db, _home = isolated_env(tmp_path)
+    built = ensure_rust_binary()
+    commands = [
+        ["search"],
+        ["recent"],
+        ["session"],
+        ["show"],
+        ["context"],
+        ["stats"],
+        ["tag"],
+        ["untag"],
+        ["tags"],
+        ["resume"],
+        ["sync-opencode"],
+        ["sync"],
+        ["watch"],
+        ["pack"],
+        ["export"],
+        ["import"],
+        ["login"],
+        ["admin-mint"],
+        ["push"],
+        ["pair"],
+        ["pair", "check"],
+        ["learn"],
+        ["learn", "distill"],
+    ]
+    for command in commands:
+        result = subprocess.run(
+            [str(built), *command, "--help"],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert result.returncode == 0, (command, result.stderr)
+        assert "ai-hist-rust-bin" not in result.stdout
+        assert "Usage: ai-hist" in result.stdout
 
 
 def test_rust_default_validates_source_choices(tmp_path):


### PR DESCRIPTION
## Summary
- make the Rust CLI render as `ai-hist` instead of leaking `ai-hist-rust-bin`, and fill in command descriptions
- make bare `ai-hist login` use the canonical Agent Relay Cloud session, then exchange it with relayhistory `/v1/cli/login`
- update wrapper help/docs and add command-help coverage for every Rust command, including nested Pair/Learn commands

## Validation
- `cargo fmt --check`
- `cargo test -p ai-hist-cli`
- `cargo test -p ai-hist-core`
- `python -m pytest -q`
- manual smoke: every Rust command `--help`, nested `pair check` / `learn distill`, safe local DB commands, and `search --tag <tag> --json` without a query

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

