### PR TITLE
fix+feat: make ai-hist sync run automatically (managed service + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,33 @@ npx -y ai-hist-mcp --project .
 npx -y ai-hist-mcp --project /path/to/project
 ```
 
-## Continuous sync (macOS)
+## Continuous sync
 
-Create a launchd plist to sync every 60 seconds:
+The installer sets up a background sync service automatically, so history stays
+fresh without any manual step. To opt out at install time, set
+`AI_HIST_NO_AUTOSYNC=1`.
+
+To manage it yourself at any time:
+
+```bash
+ai-hist sync --install-service    # launchd on macOS, cron on Linux
+ai-hist sync --uninstall-service  # remove it
+ai-hist sync                      # run a one-off sync now
+```
+
+`--install-service` points the scheduler directly at the resolved `ai-hist`
+binary (no shell wrapper, no `python3`) and reloads idempotently, so it can't
+fall into the stale-interpreter trap the hand-written plist below historically
+hit. On macOS, pass `--interval <seconds>` to change the cadence (default 60;
+cron runs at 1-minute granularity). Verify health with:
+
+```bash
+launchctl list | grep ai-hist   # middle "last exit status" column should be 0
+```
+
+### Manual setup (macOS)
+
+If you prefer to write the launchd plist by hand, sync every 60 seconds with:
 
 The unquoted heredoc (`<< EOF`) expands `$HOME` to an absolute path as the
 file is written — launchd does **not** expand `${HOME}` in `ProgramArguments`,
@@ -249,7 +273,7 @@ launchctl load ~/Library/LaunchAgents/com.ai-hist.sync.plist
 > `launchctl list | grep ai-hist` (the middle "last exit status" column should
 > be `0`, not `1`).
 
-### Linux (cron)
+### Manual setup (Linux, cron)
 
 ```bash
 # Sync every minute

--- a/README.md
+++ b/README.md
@@ -209,8 +209,13 @@ npx -y ai-hist-mcp --project /path/to/project
 
 Create a launchd plist to sync every 60 seconds:
 
+The unquoted heredoc (`<< EOF`) expands `$HOME` to an absolute path as the
+file is written — launchd does **not** expand `${HOME}` in `ProgramArguments`,
+so the path must be literal. Point it directly at the `ai-hist` wrapper; do not
+prefix it with `python3` (the wrapper dispatches to the Rust binary itself).
+
 ```bash
-cat > ~/Library/LaunchAgents/com.ai-hist.sync.plist << 'EOF'
+cat > ~/Library/LaunchAgents/com.ai-hist.sync.plist << EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -219,7 +224,7 @@ cat > ~/Library/LaunchAgents/com.ai-hist.sync.plist << 'EOF'
     <string>com.ai-hist.sync</string>
     <key>ProgramArguments</key>
     <array>
-        <string>${HOME}/.local/bin/ai-hist</string>
+        <string>$HOME/.local/bin/ai-hist</string>
         <string>sync</string>
     </array>
     <key>StartInterval</key>
@@ -234,10 +239,15 @@ cat > ~/Library/LaunchAgents/com.ai-hist.sync.plist << 'EOF'
 </plist>
 EOF
 
+# Reload (idempotent — unload any previous version first)
+launchctl unload ~/Library/LaunchAgents/com.ai-hist.sync.plist 2>/dev/null
 launchctl load ~/Library/LaunchAgents/com.ai-hist.sync.plist
 ```
 
-> Replace `${HOME}/.local/bin/ai-hist` with the wrapper path you installed if needed.
+> Replace `$HOME/.local/bin/ai-hist` with the wrapper path you installed if
+> needed, then confirm the job is healthy with
+> `launchctl list | grep ai-hist` (the middle "last exit status" column should
+> be `0`, not `1`).
 
 ### Linux (cron)
 

--- a/crates/ai-hist/src/main.rs
+++ b/crates/ai-hist/src/main.rs
@@ -141,7 +141,19 @@ enum Command {
         opencode_db: Option<PathBuf>,
     },
     /// Sync local agent history into the relayhistory database.
-    Sync,
+    Sync {
+        /// Install a background service (launchd on macOS, cron on Linux) that
+        /// runs `sync` on an interval so the database stays fresh automatically.
+        #[arg(long)]
+        install_service: bool,
+        /// Remove the background sync service installed by --install-service.
+        #[arg(long, conflicts_with = "install_service")]
+        uninstall_service: bool,
+        /// Seconds between syncs for the installed service (macOS only; cron
+        /// runs at 1-minute granularity).
+        #[arg(long, default_value_t = 60)]
+        interval: u64,
+    },
     /// Repeatedly sync local agent history.
     Watch {
         #[arg(long, default_value_t = 60)]
@@ -518,7 +530,19 @@ fn main() -> Result<()> {
             println!("  [opencode] +{inserted} rows");
             Ok(())
         }
-        Command::Sync => sync_basic(&conn, &db_path),
+        Command::Sync {
+            install_service,
+            uninstall_service,
+            interval,
+        } => {
+            if install_service {
+                install_sync_service(interval)
+            } else if uninstall_service {
+                uninstall_sync_service()
+            } else {
+                sync_basic(&conn, &db_path)
+            }
+        }
         Command::Watch { interval } => watch_loop(&db_path, interval),
         Command::Export {
             output,
@@ -1371,6 +1395,174 @@ fn watch_loop(db_path: &Path, interval: u64) -> Result<()> {
             Err(err) => eprintln!("Error: {err}"),
         }
         std::thread::sleep(Duration::from_secs(interval));
+    }
+}
+
+const SYNC_SERVICE_LABEL: &str = "com.ai-hist.sync";
+const CRON_MARKER: &str = "# ai-hist sync (managed)";
+
+fn launchd_plist_path() -> PathBuf {
+    home_dir().join("Library/LaunchAgents/com.ai-hist.sync.plist")
+}
+
+/// Resolve the absolute path of the running ai-hist binary so the service
+/// invokes it directly — never through a shell wrapper or `python3`, which is
+/// what historically broke the launchd job.
+fn service_binary() -> Result<PathBuf> {
+    std::env::current_exe().context("could not resolve the ai-hist binary path for the service")
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn install_sync_service(interval: u64) -> Result<()> {
+    let bin = service_binary()?;
+    let bin = bin.to_string_lossy();
+    if cfg!(target_os = "macos") {
+        install_launchd_service(&bin, interval)
+    } else if cfg!(target_os = "linux") {
+        install_cron_service(&bin, interval)
+    } else {
+        anyhow::bail!(
+            "Automatic sync service install is only supported on macOS and Linux. \
+             Run `ai-hist watch` to keep syncing in the foreground instead."
+        )
+    }
+}
+
+fn install_launchd_service(bin: &str, interval: u64) -> Result<()> {
+    let plist_path = launchd_plist_path();
+    if let Some(dir) = plist_path.parent() {
+        fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
+    }
+    let plist = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{label}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{bin}</string>
+        <string>sync</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>{interval}</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/tmp/ai-hist-sync.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/ai-hist-sync.err</string>
+</dict>
+</plist>
+"#,
+        label = SYNC_SERVICE_LABEL,
+        bin = xml_escape(bin),
+        interval = interval,
+    );
+    fs::write(&plist_path, plist).with_context(|| format!("writing {}", plist_path.display()))?;
+
+    // Reload idempotently: unload any previous version (ignoring errors), then load.
+    let _ = std::process::Command::new("launchctl")
+        .arg("unload")
+        .arg(&plist_path)
+        .status();
+    let status = std::process::Command::new("launchctl")
+        .arg("load")
+        .arg(&plist_path)
+        .status()
+        .context("running launchctl load")?;
+    if !status.success() {
+        anyhow::bail!("launchctl load failed for {}", plist_path.display());
+    }
+
+    println!("Installed launchd sync service ({SYNC_SERVICE_LABEL}); syncing every {interval}s.");
+    println!("  plist: {}", plist_path.display());
+    println!("  check: launchctl list | grep ai-hist   (middle column 0 = healthy)");
+    println!("  remove: ai-hist sync --uninstall-service");
+    Ok(())
+}
+
+fn read_crontab() -> String {
+    match std::process::Command::new("crontab").arg("-l").output() {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).into_owned(),
+        // No crontab yet (or `crontab -l` errors on an empty table) — start fresh.
+        _ => String::new(),
+    }
+}
+
+fn write_crontab(contents: &str) -> Result<()> {
+    let mut child = std::process::Command::new("crontab")
+        .arg("-")
+        .stdin(std::process::Stdio::piped())
+        .spawn()
+        .context("running `crontab -` (is cron installed?)")?;
+    child
+        .stdin
+        .take()
+        .context("failed to open crontab stdin")?
+        .write_all(contents.as_bytes())?;
+    let status = child.wait()?;
+    if !status.success() {
+        anyhow::bail!("crontab update failed");
+    }
+    Ok(())
+}
+
+fn install_cron_service(bin: &str, interval: u64) -> Result<()> {
+    if interval != 60 {
+        eprintln!(
+            "Note: cron runs at 1-minute granularity; ignoring --interval={interval} and \
+             scheduling every minute."
+        );
+    }
+    let line = format!("* * * * * {bin} sync >> /tmp/ai-hist-sync.log 2>&1 {CRON_MARKER}");
+    // Drop any previously managed line, then append the current one.
+    let mut lines: Vec<String> = read_crontab()
+        .lines()
+        .filter(|l| !l.contains(CRON_MARKER))
+        .map(str::to_string)
+        .collect();
+    lines.push(line);
+    write_crontab(&format!("{}\n", lines.join("\n")))?;
+
+    println!("Installed cron sync job; syncing every minute.");
+    println!("  view:   crontab -l");
+    println!("  remove: ai-hist sync --uninstall-service");
+    Ok(())
+}
+
+fn uninstall_sync_service() -> Result<()> {
+    if cfg!(target_os = "macos") {
+        let plist_path = launchd_plist_path();
+        let _ = std::process::Command::new("launchctl")
+            .arg("unload")
+            .arg(&plist_path)
+            .status();
+        if plist_path.exists() {
+            fs::remove_file(&plist_path)
+                .with_context(|| format!("removing {}", plist_path.display()))?;
+            println!("Removed launchd sync service.");
+        } else {
+            println!("No launchd sync service installed.");
+        }
+        Ok(())
+    } else if cfg!(target_os = "linux") {
+        let kept: Vec<String> = read_crontab()
+            .lines()
+            .filter(|l| !l.contains(CRON_MARKER))
+            .map(str::to_string)
+            .collect();
+        write_crontab(&format!("{}\n", kept.join("\n")))?;
+        println!("Removed cron sync job.");
+        Ok(())
+    } else {
+        anyhow::bail!("No managed sync service exists on this platform.")
     }
 }
 
@@ -3004,8 +3196,18 @@ fn home_dir() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_trajectory_file, strip_url_credentials};
+    use super::{parse_trajectory_file, strip_url_credentials, xml_escape};
     use std::fs;
+
+    #[test]
+    fn xml_escape_protects_plist_path() {
+        // A binary path with shell/XML metacharacters must not break the plist.
+        assert_eq!(
+            xml_escape("/home/a&b/<bin>/ai-hist"),
+            "/home/a&amp;b/&lt;bin&gt;/ai-hist"
+        );
+        assert_eq!(xml_escape("/usr/local/bin/ai-hist"), "/usr/local/bin/ai-hist");
+    }
 
     #[test]
     fn strips_embedded_token_from_https_remote() {

--- a/install.sh
+++ b/install.sh
@@ -290,6 +290,17 @@ else
   install_from_source
 fi
 
+# Register the background sync service so history stays fresh automatically.
+# Opt out with AI_HIST_NO_AUTOSYNC=1 (e.g. CI, or to manage scheduling yourself).
+if [ "${AI_HIST_NO_AUTOSYNC:-0}" = "1" ]; then
+  info "skipping auto-sync service install (AI_HIST_NO_AUTOSYNC=1)"
+elif "$BIN_DIR/ai-hist" sync --install-service; then
+  info "background sync service installed; history will sync automatically"
+else
+  warn "could not install the background sync service automatically"
+  warn "run '$BIN_DIR/ai-hist sync --install-service' yourself, or see the README"
+fi
+
 cat <<EOF
 ai-hist installed.
 


### PR DESCRIPTION
## Background

A user's `ai-hist recent` silently went ~2 days stale. Root cause: continuous sync was **opt-in and manual** — the installer only dropped the binary + wrapper, and users had to hand-copy a launchd plist from the README. Their on-disk plist was a stale version that ran `/usr/bin/python3 ~/.local/bin/ai-hist sync`; after the CLI became a shell wrapper, that crashed every interval with `SyntaxError` (`last exit status = 1`) and sync never ran.

This PR makes auto-sync the default and removes the copy-paste footguns.

## Changes

### 1. Managed sync service — `ai-hist sync --install-service`
- New flags on `sync`: `--install-service`, `--uninstall-service`, `--interval <s>` (default 60).
- macOS → writes/loads a launchd job; Linux → installs a cron entry.
- Points the scheduler **directly at the resolved binary** (`current_exe()`) — no shell wrapper, no `python3` — and reloads idempotently, so it can't regress into the stale-interpreter failure that caused this bug.
- Symmetric uninstall; both operations are idempotent.

### 2. Installer auto-registers it (`install.sh`)
- After install, runs `ai-hist sync --install-service` so history syncs automatically out of the box.
- Opt out with `AI_HIST_NO_AUTOSYNC=1`. A failed install degrades to a warning, not a hard error.

### 3. README
- Lead the "Continuous sync" section with the managed subcommand and note the installer sets it up automatically.
- Keep a corrected hand-written plist as a fallback: switched the snippet from a quoted heredoc (which wrote `${HOME}` verbatim — launchd doesn't expand it, so the job pointed at a nonexistent path) to an unquoted heredoc with `$HOME`, made the reload idempotent, and added a `launchctl list` health-check note.

### Tests
- Unit test for plist-path XML escaping.
- Manually verified install/uninstall against a fake `launchctl` + temp `HOME` (no impact on the real session): valid plist (`plutil -lint` OK), correct binary path, honored `--interval`, idempotent unload→load and remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)