### PR TITLE
docs: add "Why ai-hist" positioning section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,33 @@ Sync and search your [Claude Code](https://docs.anthropic.com/en/docs/claude-cod
 `ai-hist` is a Rust CLI. New commands and integrations should land in the Rust
 SDK/CLI surfaces.
 
+## Why ai-hist
+
+Coding agents start every session from zero — they can't see the decisions you
+made yesterday, the approach that already failed, or the reasoning behind the
+architecture they're editing. Local transcript search recovers *what* you typed.
+ai-hist also captures *why*.
+
+- **HOW + WHY, not just HOW.** Most history tools index raw prompts and
+  transcripts (the *how*). ai-hist indexes those **and** distilled
+  **trajectories** — the `decisions` (question → chosen → reasoning →
+  alternatives) and `retrospectives` (learnings, confidence) behind each run.
+  Ask `why_for_task` and get the reasoning, not just the keystrokes.
+- **Local-first, team-optional.** Everything lands in local SQLite with FTS5 —
+  no keys, no network required. When you want it, opt into **cloud sync** to
+  feed a shared team memory with server-side secret/PII scrubbing and a
+  self-host Enterprise tier.
+- **It talks back.** Pushed history powers **Pair**: before a risky action, your
+  agent queries the store and gets *cited warnings drawn from your team's own
+  prior work* — so nobody repeats a mistake that's already in the record.
+- **Built for agents.** A stdio **MCP server** (`npx -y ai-hist-mcp`) exposes
+  `search_history`, `get_context`, `search_trajectories`, and `why_for_task` so
+  the agent can pull its own context mid-session, scoped to one project.
+
+If you only want fast local grep over your own agent history, ai-hist does that
+in one command. The trajectory + Pair loop is there when you're ready for team
+memory that prevents repeat mistakes.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
Adds a **Why ai-hist** section to the top of the README, right after the intro.

## What
Surfaces the core value proposition up front instead of leaving it buried in the cloud-sync docs:

- **HOW + WHY** — we index prompts *and* distilled trajectories (decisions + retrospectives), exposed via `why_for_task`.
- **Local-first, team-optional** — local SQLite/FTS5 with no keys or network; cloud sync is opt-in.
- **Pair loop** — pushed history feeds cited in-session warnings so mistakes aren't repeated.
- **MCP server** — agents can pull their own context mid-session.

Closes with reassurance for the "just want fast local grep" user so we don't scare off the individual-dev case.

## Scope
README only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

