### PR TITLE
feat: cloud push SDK (drives the ai-hist binary) + installer test fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,10 +253,14 @@ a separate step (`push`), which has its own background service using the same
 launchd/cron plumbing:
 
 ```bash
-ai-hist push --install-service      # schedule automatic cloud push (default: every 300s)
+ai-hist push --install-service      # schedule automatic cloud push (macOS: every 300s)
 ai-hist push --uninstall-service    # remove it
 ai-hist push                        # push new history now
 ```
+
+On macOS the launchd job honors `--interval` (default 300s). On Linux the job is
+a cron entry: whole-minute intervals become a step schedule (300s → `*/5`), and
+sub-minute intervals run every minute (cron's finest granularity).
 
 Running both services keeps local capture and cloud upload going end-to-end.
 The push job authenticates with the `rth_at_` token written by `ai-hist login`.

--- a/README.md
+++ b/README.md
@@ -258,10 +258,8 @@ ai-hist push --uninstall-service    # remove it
 ai-hist push                        # push new history now
 ```
 
-Enabling Reflex — `agent-relay reflex on` — installs both the `sync` and `push`
-services for you, so local capture and cloud upload run end-to-end automatically;
-`agent-relay reflex off` removes the push service again. The push job authenticates
-with the `rth_at_` token written by `ai-hist login` / `reflex on`.
+Running both services keeps local capture and cloud upload going end-to-end.
+The push job authenticates with the `rth_at_` token written by `ai-hist login`.
 
 ### Manual setup (macOS)
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,23 @@ cron runs at 1-minute granularity). Verify health with:
 launchctl list | grep ai-hist   # middle "last exit status" column should be 0
 ```
 
+### Continuous cloud push
+
+`sync` keeps the **local** database fresh. Uploading it to relayhistory-cloud is
+a separate step (`push`), which has its own background service using the same
+launchd/cron plumbing:
+
+```bash
+ai-hist push --install-service      # schedule automatic cloud push (default: every 300s)
+ai-hist push --uninstall-service    # remove it
+ai-hist push                        # push new history now
+```
+
+Enabling Reflex — `agent-relay reflex on` — installs both the `sync` and `push`
+services for you, so local capture and cloud upload run end-to-end automatically;
+`agent-relay reflex off` removes the push service again. The push job authenticates
+with the `rth_at_` token written by `ai-hist login` / `reflex on`.
+
 ### Manual setup (macOS)
 
 If you prefer to write the launchd plist by hand, sync every 60 seconds with:

--- a/crates/ai-hist/src/main.rs
+++ b/crates/ai-hist/src/main.rs
@@ -1714,24 +1714,41 @@ fn shell_single_quote(s: &str) -> String {
 }
 
 /// Translate a desired interval (seconds) into a cron schedule expression plus a
-/// human cadence. cron's finest granularity is one minute, so sub-minute or
-/// non-whole-minute intervals collapse to every minute.
-fn cron_schedule(interval: u64) -> (String, String) {
-    if interval < 60 || !interval.is_multiple_of(60) {
-        return ("* * * * *".to_string(), "every minute".to_string());
+/// human cadence. cron's finest granularity is one minute. When an interval
+/// isn't exactly expressible we round toward a *less* frequent cadence, never
+/// more — a scheduled cloud push should never fire more often than the user
+/// asked. Intervals of a day or longer collapse to a daily run (the coarsest
+/// simple cron cadence).
+/// Returns `(cron expression, human cadence, effective period in seconds)`. The
+/// effective period lets callers detect when the interval was rounded.
+fn cron_schedule(interval: u64) -> (String, String, u64) {
+    // Sub-two-minute intervals can only be "every minute".
+    if interval < 120 {
+        return ("* * * * *".to_string(), "every minute".to_string(), 60);
     }
-    let minutes = interval / 60;
-    if minutes == 1 {
-        ("* * * * *".to_string(), "every minute".to_string())
-    } else if minutes < 60 {
-        (format!("*/{minutes} * * * *"), format!("every {minutes} minutes"))
-    } else if minutes.is_multiple_of(60) && minutes / 60 < 24 {
-        let hours = minutes / 60;
-        (format!("0 */{hours} * * *"), format!("every {hours} hour(s)"))
+    let minutes = interval / 60; // floor; >= 2 here
+    if minutes < 60 {
+        return (
+            format!("*/{minutes} * * * *"),
+            format!("every {minutes} minutes"),
+            minutes * 60,
+        );
+    }
+    // Round up to whole hours so we don't over-run (e.g. 90 min -> every 2h).
+    let hours = if minutes.is_multiple_of(60) {
+        minutes / 60
     } else {
-        // Odd multi-hour cadence — fall back to hourly rather than mis-schedule.
-        ("0 * * * *".to_string(), "every hour".to_string())
+        minutes / 60 + 1
+    };
+    if hours < 24 {
+        return (
+            format!("0 */{hours} * * *"),
+            format!("every {hours} hour(s)"),
+            hours * 3600,
+        );
     }
+    // A day or longer: run once daily at midnight.
+    ("0 0 * * *".to_string(), "once a day".to_string(), 86_400)
 }
 
 fn install_launchd_service(spec: &ServiceSpec, bin: &str, interval: u64) -> Result<()> {
@@ -1824,14 +1841,13 @@ fn write_crontab(contents: &str) -> Result<()> {
 }
 
 fn install_cron_service(spec: &ServiceSpec, bin: &str, interval: u64) -> Result<()> {
-    let (schedule, cadence) = cron_schedule(interval);
-    if interval >= 60 && !interval.is_multiple_of(60) {
+    let (schedule, cadence, effective) = cron_schedule(interval);
+    // cron can't match every interval exactly; the confirmation below states the
+    // cadence actually scheduled. Only note a mismatch when it isn't exact, so a
+    // plain `--interval=300` install doesn't imply the user picked an odd value.
+    if effective != interval {
         eprintln!(
-            "Note: cron runs at 1-minute granularity; rounding --interval={interval}s to {cadence}."
-        );
-    } else if interval < 60 && interval != 60 {
-        eprintln!(
-            "Note: cron runs at 1-minute granularity; scheduling --interval={interval}s as {cadence}."
+            "Note: cron runs at 1-minute granularity; --interval={interval}s scheduled as {cadence}."
         );
     }
     let marker = cron_marker(spec);
@@ -4690,9 +4706,16 @@ mod tests {
         assert_eq!(cron_schedule(300).0, "*/5 * * * *"); // push default
         assert_eq!(cron_schedule(120).0, "*/2 * * * *");
         assert_eq!(cron_schedule(3600).0, "0 */1 * * *");
-        // Sub-minute and non-whole-minute intervals collapse to every minute.
+        // Sub-two-minute intervals collapse to every minute.
         assert_eq!(cron_schedule(30).0, "* * * * *");
         assert_eq!(cron_schedule(90).0, "* * * * *");
+        // Never run MORE often than requested: round toward a coarser cadence.
+        assert_eq!(cron_schedule(5400).0, "0 */2 * * *"); // 90 min -> every 2h, not hourly
+        assert_eq!(cron_schedule(86_400).0, "0 0 * * *"); // 1 day -> daily, not hourly
+        assert_eq!(cron_schedule(90_000).0, "0 0 * * *"); // 25h -> daily
+        // The effective period flags whether the interval was matched exactly.
+        assert_eq!(cron_schedule(300).2, 300);
+        assert_eq!(cron_schedule(5400).2, 7200);
     }
 
     #[test]

--- a/crates/ai-hist/src/main.rs
+++ b/crates/ai-hist/src/main.rs
@@ -271,6 +271,18 @@ enum Command {
         incognito: Vec<String>,
         #[arg(long)]
         json: bool,
+        /// Install a background service (launchd on macOS, cron on Linux) that
+        /// runs `push` on an interval so new history reaches the cloud
+        /// automatically. Enabling Reflex (`agent-relay reflex on`) does this.
+        #[arg(long)]
+        install_service: bool,
+        /// Remove the background push service installed by --install-service.
+        #[arg(long, conflicts_with = "install_service")]
+        uninstall_service: bool,
+        /// Seconds between pushes for the installed service (macOS only; cron
+        /// runs at 1-minute granularity).
+        #[arg(long, default_value_t = 300)]
+        interval: u64,
     },
     /// Pair (Agent Relay Loop, WS-6) — in-session warnings from your team's history.
     Pair {
@@ -596,9 +608,9 @@ fn main() -> Result<()> {
             interval,
         } => {
             if install_service {
-                install_sync_service(interval)
+                install_managed_service(&SYNC_SERVICE, interval)
             } else if uninstall_service {
-                uninstall_sync_service()
+                uninstall_managed_service(&SYNC_SERVICE)
             } else {
                 sync_basic(&conn, &db_path)
             }
@@ -721,7 +733,16 @@ fn main() -> Result<()> {
             limit,
             incognito,
             json,
+            install_service,
+            uninstall_service,
+            interval,
         } => {
+            if install_service {
+                return install_managed_service(&PUSH_SERVICE, interval);
+            }
+            if uninstall_service {
+                return uninstall_managed_service(&PUSH_SERVICE);
+            }
             let auth = cloud::load_auth()?
                 .context("not authenticated — run `ai-hist login` or `ai-hist admin-mint` first")?;
             let machine = MachineIdentity {
@@ -1608,11 +1629,41 @@ fn watch_loop(db_path: &Path, interval: u64) -> Result<()> {
     }
 }
 
-const SYNC_SERVICE_LABEL: &str = "com.ai-hist.sync";
-const CRON_MARKER: &str = "# ai-hist sync (managed)";
+/// A background service managed by ai-hist. Both the local `sync` job and the
+/// cloud `push` job share the same launchd/cron plumbing; only these fields
+/// differ.
+struct ServiceSpec {
+    /// launchd label and plist basename stem, e.g. "com.ai-hist.sync".
+    label: &'static str,
+    /// ai-hist subcommand the service runs, e.g. "sync" or "push".
+    subcommand: &'static str,
+    /// `/tmp/<log_stem>.log` and `.err` capture the service's output.
+    log_stem: &'static str,
+    /// Human-facing noun for messages, e.g. "sync" or "cloud push".
+    human: &'static str,
+}
 
-fn launchd_plist_path() -> PathBuf {
-    home_dir().join("Library/LaunchAgents/com.ai-hist.sync.plist")
+const SYNC_SERVICE: ServiceSpec = ServiceSpec {
+    label: "com.ai-hist.sync",
+    subcommand: "sync",
+    log_stem: "ai-hist-sync",
+    human: "sync",
+};
+
+const PUSH_SERVICE: ServiceSpec = ServiceSpec {
+    label: "com.ai-hist.push",
+    subcommand: "push",
+    log_stem: "ai-hist-push",
+    human: "cloud push",
+};
+
+/// The comment marker that identifies this service's managed crontab line.
+fn cron_marker(spec: &ServiceSpec) -> String {
+    format!("# ai-hist {} (managed)", spec.subcommand)
+}
+
+fn launchd_plist_path(spec: &ServiceSpec) -> PathBuf {
+    home_dir().join(format!("Library/LaunchAgents/{}.plist", spec.label))
 }
 
 /// Resolve the absolute path of the running ai-hist binary so the service
@@ -1628,23 +1679,24 @@ fn xml_escape(s: &str) -> String {
         .replace('>', "&gt;")
 }
 
-fn install_sync_service(interval: u64) -> Result<()> {
+fn install_managed_service(spec: &ServiceSpec, interval: u64) -> Result<()> {
     let bin = service_binary()?;
     let bin = bin.to_string_lossy();
     if cfg!(target_os = "macos") {
-        install_launchd_service(&bin, interval)
+        install_launchd_service(spec, &bin, interval)
     } else if cfg!(target_os = "linux") {
-        install_cron_service(&bin, interval)
+        install_cron_service(spec, &bin, interval)
     } else {
         anyhow::bail!(
-            "Automatic sync service install is only supported on macOS and Linux. \
-             Run `ai-hist watch` to keep syncing in the foreground instead."
+            "Automatic {} service install is only supported on macOS and Linux. \
+             Run `ai-hist watch` to keep syncing in the foreground instead.",
+            spec.human
         )
     }
 }
 
-fn install_launchd_service(bin: &str, interval: u64) -> Result<()> {
-    let plist_path = launchd_plist_path();
+fn install_launchd_service(spec: &ServiceSpec, bin: &str, interval: u64) -> Result<()> {
+    let plist_path = launchd_plist_path(spec);
     if let Some(dir) = plist_path.parent() {
         fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
     }
@@ -1658,22 +1710,24 @@ fn install_launchd_service(bin: &str, interval: u64) -> Result<()> {
     <key>ProgramArguments</key>
     <array>
         <string>{bin}</string>
-        <string>sync</string>
+        <string>{subcommand}</string>
     </array>
     <key>StartInterval</key>
     <integer>{interval}</integer>
     <key>RunAtLoad</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>/tmp/ai-hist-sync.log</string>
+    <string>/tmp/{log_stem}.log</string>
     <key>StandardErrorPath</key>
-    <string>/tmp/ai-hist-sync.err</string>
+    <string>/tmp/{log_stem}.err</string>
 </dict>
 </plist>
 "#,
-        label = SYNC_SERVICE_LABEL,
+        label = spec.label,
         bin = xml_escape(bin),
+        subcommand = spec.subcommand,
         interval = interval,
+        log_stem = spec.log_stem,
     );
     fs::write(&plist_path, plist).with_context(|| format!("writing {}", plist_path.display()))?;
 
@@ -1691,10 +1745,16 @@ fn install_launchd_service(bin: &str, interval: u64) -> Result<()> {
         anyhow::bail!("launchctl load failed for {}", plist_path.display());
     }
 
-    println!("Installed launchd sync service ({SYNC_SERVICE_LABEL}); syncing every {interval}s.");
+    println!(
+        "Installed launchd {} service ({}); running every {interval}s.",
+        spec.human, spec.label
+    );
     println!("  plist: {}", plist_path.display());
     println!("  check: launchctl list | grep ai-hist   (middle column 0 = healthy)");
-    println!("  remove: ai-hist sync --uninstall-service");
+    println!(
+        "  remove: ai-hist {} --uninstall-service",
+        spec.subcommand
+    );
     Ok(())
 }
 
@@ -1724,32 +1784,39 @@ fn write_crontab(contents: &str) -> Result<()> {
     Ok(())
 }
 
-fn install_cron_service(bin: &str, interval: u64) -> Result<()> {
+fn install_cron_service(spec: &ServiceSpec, bin: &str, interval: u64) -> Result<()> {
     if interval != 60 {
         eprintln!(
             "Note: cron runs at 1-minute granularity; ignoring --interval={interval} and \
              scheduling every minute."
         );
     }
-    let line = format!("* * * * * {bin} sync >> /tmp/ai-hist-sync.log 2>&1 {CRON_MARKER}");
+    let marker = cron_marker(spec);
+    let line = format!(
+        "* * * * * {bin} {} >> /tmp/{}.log 2>&1 {marker}",
+        spec.subcommand, spec.log_stem
+    );
     // Drop any previously managed line, then append the current one.
     let mut lines: Vec<String> = read_crontab()
         .lines()
-        .filter(|l| !l.contains(CRON_MARKER))
+        .filter(|l| !l.contains(&marker))
         .map(str::to_string)
         .collect();
     lines.push(line);
     write_crontab(&format!("{}\n", lines.join("\n")))?;
 
-    println!("Installed cron sync job; syncing every minute.");
+    println!("Installed cron {} job; running every minute.", spec.human);
     println!("  view:   crontab -l");
-    println!("  remove: ai-hist sync --uninstall-service");
+    println!(
+        "  remove: ai-hist {} --uninstall-service",
+        spec.subcommand
+    );
     Ok(())
 }
 
-fn uninstall_sync_service() -> Result<()> {
+fn uninstall_managed_service(spec: &ServiceSpec) -> Result<()> {
     if cfg!(target_os = "macos") {
-        let plist_path = launchd_plist_path();
+        let plist_path = launchd_plist_path(spec);
         let _ = std::process::Command::new("launchctl")
             .arg("unload")
             .arg(&plist_path)
@@ -1757,22 +1824,23 @@ fn uninstall_sync_service() -> Result<()> {
         if plist_path.exists() {
             fs::remove_file(&plist_path)
                 .with_context(|| format!("removing {}", plist_path.display()))?;
-            println!("Removed launchd sync service.");
+            println!("Removed launchd {} service.", spec.human);
         } else {
-            println!("No launchd sync service installed.");
+            println!("No launchd {} service installed.", spec.human);
         }
         Ok(())
     } else if cfg!(target_os = "linux") {
+        let marker = cron_marker(spec);
         let kept: Vec<String> = read_crontab()
             .lines()
-            .filter(|l| !l.contains(CRON_MARKER))
+            .filter(|l| !l.contains(&marker))
             .map(str::to_string)
             .collect();
         write_crontab(&format!("{}\n", kept.join("\n")))?;
-        println!("Removed cron sync job.");
+        println!("Removed cron {} job.", spec.human);
         Ok(())
     } else {
-        anyhow::bail!("No managed sync service exists on this platform.")
+        anyhow::bail!("No managed {} service exists on this platform.", spec.human)
     }
 }
 

--- a/crates/ai-hist/src/main.rs
+++ b/crates/ai-hist/src/main.rs
@@ -1719,8 +1719,17 @@ fn shell_single_quote(s: &str) -> String {
 /// more — a scheduled cloud push should never fire more often than the user
 /// asked. Intervals of a day or longer collapse to a daily run (the coarsest
 /// simple cron cadence).
+/// Smallest divisor of `base` that is `>= n`. Using a divisor keeps a `*/step`
+/// cron field uniform — a non-divisor step (e.g. `*/45`) fires a short interval
+/// at the field's rollover (`:00, :45, :00` → a 15-minute gap).
+fn round_up_to_divisor(n: u64, base: u64) -> u64 {
+    (n..=base).find(|d| base.is_multiple_of(*d)).unwrap_or(base)
+}
+
 /// Returns `(cron expression, human cadence, effective period in seconds)`. The
-/// effective period lets callers detect when the interval was rounded.
+/// effective period lets callers detect when the interval was rounded. cron
+/// can't match every interval exactly; we always round toward a *coarser*,
+/// uniform cadence so a scheduled push never fires more often than requested.
 fn cron_schedule(interval: u64) -> (String, String, u64) {
     // Sub-two-minute intervals can only be "every minute".
     if interval < 120 {
@@ -1728,24 +1737,29 @@ fn cron_schedule(interval: u64) -> (String, String, u64) {
     }
     let minutes = interval / 60; // floor; >= 2 here
     if minutes < 60 {
-        return (
-            format!("*/{minutes} * * * *"),
-            format!("every {minutes} minutes"),
-            minutes * 60,
-        );
+        // Uniform minute steps require a divisor of 60; round up to the next one.
+        let step = round_up_to_divisor(minutes, 60);
+        if step < 60 {
+            return (
+                format!("*/{step} * * * *"),
+                format!("every {step} minutes"),
+                step * 60,
+            );
+        }
+        return ("0 * * * *".to_string(), "every hour".to_string(), 3600);
     }
-    // Round up to whole hours so we don't over-run (e.g. 90 min -> every 2h).
-    let hours = if minutes.is_multiple_of(60) {
-        minutes / 60
-    } else {
-        minutes / 60 + 1
-    };
+    // Round up to whole hours (e.g. 90 min -> 2h), then to a uniform hour step.
+    let hours = minutes.div_ceil(60);
     if hours < 24 {
-        return (
-            format!("0 */{hours} * * *"),
-            format!("every {hours} hour(s)"),
-            hours * 3600,
-        );
+        let step = round_up_to_divisor(hours, 24);
+        if step < 24 {
+            return (
+                format!("0 */{step} * * *"),
+                format!("every {step} hour(s)"),
+                step * 3600,
+            );
+        }
+        return ("0 0 * * *".to_string(), "once a day".to_string(), 86_400);
     }
     // A day or longer: run once daily at midnight.
     ("0 0 * * *".to_string(), "once a day".to_string(), 86_400)
@@ -4713,9 +4727,14 @@ mod tests {
         assert_eq!(cron_schedule(5400).0, "0 */2 * * *"); // 90 min -> every 2h, not hourly
         assert_eq!(cron_schedule(86_400).0, "0 0 * * *"); // 1 day -> daily, not hourly
         assert_eq!(cron_schedule(90_000).0, "0 0 * * *"); // 25h -> daily
+        // Non-divisor steps round up to a uniform divisor (no short boundary gap).
+        assert_eq!(cron_schedule(420).0, "*/10 * * * *"); // 7 min -> */10 (not */7)
+        assert_eq!(cron_schedule(2700).0, "0 * * * *"); // 45 min -> hourly (60 is next divisor)
+        assert_eq!(cron_schedule(25_200).0, "0 */8 * * *"); // 7h -> */8 (uniform), not */7
         // The effective period flags whether the interval was matched exactly.
         assert_eq!(cron_schedule(300).2, 300);
         assert_eq!(cron_schedule(5400).2, 7200);
+        assert_eq!(cron_schedule(420).2, 600);
     }
 
     #[test]

--- a/crates/ai-hist/src/main.rs
+++ b/crates/ai-hist/src/main.rs
@@ -738,6 +738,17 @@ fn main() -> Result<()> {
             interval,
         } => {
             if install_service {
+                // `--incognito` is a per-run privacy filter; the scheduled job
+                // runs a plain `push`, so silently dropping it would give a
+                // false sense that it applies. Reject the combo. (`--limit` is
+                // only a batch-size knob and is harmless to ignore here.)
+                if !incognito.is_empty() {
+                    anyhow::bail!(
+                        "--incognito is a per-run privacy filter and is NOT applied to the scheduled \
+                         push service. Run `ai-hist push --incognito ...` for a one-off push, or omit \
+                         it when installing the service."
+                    );
+                }
                 return install_managed_service(&PUSH_SERVICE, interval);
             }
             if uninstall_service {
@@ -1689,9 +1700,37 @@ fn install_managed_service(spec: &ServiceSpec, interval: u64) -> Result<()> {
     } else {
         anyhow::bail!(
             "Automatic {} service install is only supported on macOS and Linux. \
-             Run `ai-hist watch` to keep syncing in the foreground instead.",
-            spec.human
+             Schedule `ai-hist {}` yourself (e.g. via your platform's task scheduler) instead.",
+            spec.human,
+            spec.subcommand
         )
+    }
+}
+
+/// Single-quote a path for a crontab line so spaces / shell metacharacters in
+/// the binary path don't break the scheduled command.
+fn shell_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Translate a desired interval (seconds) into a cron schedule expression plus a
+/// human cadence. cron's finest granularity is one minute, so sub-minute or
+/// non-whole-minute intervals collapse to every minute.
+fn cron_schedule(interval: u64) -> (String, String) {
+    if interval < 60 || !interval.is_multiple_of(60) {
+        return ("* * * * *".to_string(), "every minute".to_string());
+    }
+    let minutes = interval / 60;
+    if minutes == 1 {
+        ("* * * * *".to_string(), "every minute".to_string())
+    } else if minutes < 60 {
+        (format!("*/{minutes} * * * *"), format!("every {minutes} minutes"))
+    } else if minutes.is_multiple_of(60) && minutes / 60 < 24 {
+        let hours = minutes / 60;
+        (format!("0 */{hours} * * *"), format!("every {hours} hour(s)"))
+    } else {
+        // Odd multi-hour cadence — fall back to hourly rather than mis-schedule.
+        ("0 * * * *".to_string(), "every hour".to_string())
     }
 }
 
@@ -1785,16 +1824,22 @@ fn write_crontab(contents: &str) -> Result<()> {
 }
 
 fn install_cron_service(spec: &ServiceSpec, bin: &str, interval: u64) -> Result<()> {
-    if interval != 60 {
+    let (schedule, cadence) = cron_schedule(interval);
+    if interval >= 60 && !interval.is_multiple_of(60) {
         eprintln!(
-            "Note: cron runs at 1-minute granularity; ignoring --interval={interval} and \
-             scheduling every minute."
+            "Note: cron runs at 1-minute granularity; rounding --interval={interval}s to {cadence}."
+        );
+    } else if interval < 60 && interval != 60 {
+        eprintln!(
+            "Note: cron runs at 1-minute granularity; scheduling --interval={interval}s as {cadence}."
         );
     }
     let marker = cron_marker(spec);
     let line = format!(
-        "* * * * * {bin} {} >> /tmp/{}.log 2>&1 {marker}",
-        spec.subcommand, spec.log_stem
+        "{schedule} {} {} >> /tmp/{}.log 2>&1 {marker}",
+        shell_single_quote(bin),
+        spec.subcommand,
+        spec.log_stem
     );
     // Drop any previously managed line, then append the current one.
     let mut lines: Vec<String> = read_crontab()
@@ -1805,12 +1850,9 @@ fn install_cron_service(spec: &ServiceSpec, bin: &str, interval: u64) -> Result<
     lines.push(line);
     write_crontab(&format!("{}\n", lines.join("\n")))?;
 
-    println!("Installed cron {} job; running every minute.", spec.human);
+    println!("Installed cron {} job; running {cadence}.", spec.human);
     println!("  view:   crontab -l");
-    println!(
-        "  remove: ai-hist {} --uninstall-service",
-        spec.subcommand
-    );
+    println!("  remove: ai-hist {} --uninstall-service", spec.subcommand);
     Ok(())
 }
 
@@ -4633,14 +4675,31 @@ fn home_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::{
-        file_stamp, git_commit_time_ms, git_stdout, ingest_claude_transcript, link_git_commit,
-        parse_trajectory_file, paths_overlap, search_all, strip_url_credentials,
-        sync_claude_session_metadata, xml_escape, SearchRole,
+        cron_schedule, file_stamp, git_commit_time_ms, git_stdout, ingest_claude_transcript,
+        link_git_commit, parse_trajectory_file, paths_overlap, search_all, shell_single_quote,
+        strip_url_credentials, sync_claude_session_metadata, xml_escape, SearchRole,
     };
     use ai_hist_core::{init_db, QueryFilter};
     use rusqlite::Connection;
     use serde_json::{json, Map, Value};
     use std::fs;
+
+    #[test]
+    fn cron_schedule_maps_intervals_to_step_expressions() {
+        assert_eq!(cron_schedule(60).0, "* * * * *");
+        assert_eq!(cron_schedule(300).0, "*/5 * * * *"); // push default
+        assert_eq!(cron_schedule(120).0, "*/2 * * * *");
+        assert_eq!(cron_schedule(3600).0, "0 */1 * * *");
+        // Sub-minute and non-whole-minute intervals collapse to every minute.
+        assert_eq!(cron_schedule(30).0, "* * * * *");
+        assert_eq!(cron_schedule(90).0, "* * * * *");
+    }
+
+    #[test]
+    fn shell_single_quote_survives_spaces_and_quotes() {
+        assert_eq!(shell_single_quote("/opt/ai hist/bin"), "'/opt/ai hist/bin'");
+        assert_eq!(shell_single_quote("a'b"), "'a'\\''b'");
+    }
 
     #[test]
     fn xml_escape_protects_plist_path() {

--- a/crates/ai-hist/src/main.rs
+++ b/crates/ai-hist/src/main.rs
@@ -273,7 +273,7 @@ enum Command {
         json: bool,
         /// Install a background service (launchd on macOS, cron on Linux) that
         /// runs `push` on an interval so new history reaches the cloud
-        /// automatically. Enabling Reflex (`agent-relay reflex on`) does this.
+        /// automatically.
         #[arg(long)]
         install_service: bool,
         /// Remove the background push service installed by --install-service.

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **In-process cloud push (`ai-hist/cloud` → `pushToCloud`)** — a wire-compatible
+  TypeScript port of the Rust `ai-hist push`: reads new local history/trajectory
+  rows and POSTs them to relayhistory-cloud `/v1/ingest`. Enables hosts (e.g. the
+  Agent Relay runtime) to sync in-process without shelling out to the CLI. Also
+  exports the primitives `buildOutboxBatch`, `promptHash`, `batchId`, `machineId`,
+  `loadCursor`/`saveCursor`, and `normalizeHomePath`.
+
 ## [0.3.7] - 2026-06-27
 
 ### Added

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **In-process cloud push (`ai-hist/cloud` → `pushToCloud`)** — a wire-compatible
-  TypeScript port of the Rust `ai-hist push`: reads new local history/trajectory
-  rows and POSTs them to relayhistory-cloud `/v1/ingest`. Enables hosts (e.g. the
-  Agent Relay runtime) to sync in-process without shelling out to the CLI. Also
-  exports the primitives `buildOutboxBatch`, `promptHash`, `batchId`, `machineId`,
-  `loadCursor`/`saveCursor`, and `normalizeHomePath`.
+- **In-process cloud push (`ai-hist/cloud` → `pushToCloud`)** — a thin wrapper
+  that drives the real `ai-hist push --json` Rust binary and parses its result,
+  rather than re-implementing the push pipeline in TypeScript. The binary stays
+  the single source of truth for batching/cursor/dedup; the SDK just gives hosts
+  (e.g. the Agent Relay runtime) an ergonomic surface to sync in-process without
+  shelling out to a CLI by hand. Binary discovery: `$AI_HIST_RUST_BIN` → the
+  install.sh location → `ai-hist` on `PATH`. Also exports `resolveAiHistBinary`.
 
 ## [0.3.7] - 2026-06-27
 

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-hist",
-  "version": "0.3.7",
-  "description": "TypeScript SDK and MCP server for AI coding agent session history — Claude Code, Codex, Cursor, Grok, and Agent Relay in one searchable index. Works with or without ai-hist sync via automatic JSONL fallback.",
+  "version": "0.4.0",
+  "description": "TypeScript SDK and MCP server for AI coding agent session history \u2014 Claude Code, Codex, Cursor, Grok, and Agent Relay in one searchable index. Works with or without ai-hist sync via automatic JSONL fallback.",
   "license": "MIT",
   "private": false,
   "type": "module",

--- a/sdk-ts/src/cloud-client.ts
+++ b/sdk-ts/src/cloud-client.ts
@@ -3,23 +3,7 @@ import { homedir } from 'node:os';
 import { join, dirname } from 'node:path';
 
 // Re-export the in-process cloud push so `ai-hist/cloud` exposes auth + push.
-export {
-  pushToCloud,
-  buildOutboxBatch,
-  promptHash,
-  batchId,
-  machineId,
-  buildMachineIdentity,
-  loadCursor,
-  saveCursor,
-  normalizeHomePath,
-  type SyncCursor,
-  type MachineIdentity,
-  type ConvergenceEnvelope,
-  type PushReport,
-  type PushOptions,
-  type OutboxBatch,
-} from './cloud-push.js';
+export { pushToCloud, resolveAiHistBinary, type PushReport, type PushOptions } from './cloud-push.js';
 
 export interface RelayhistoryAuth {
   baseUrl: string;

--- a/sdk-ts/src/cloud-client.ts
+++ b/sdk-ts/src/cloud-client.ts
@@ -2,6 +2,25 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, dirname } from 'node:path';
 
+// Re-export the in-process cloud push so `ai-hist/cloud` exposes auth + push.
+export {
+  pushToCloud,
+  buildOutboxBatch,
+  promptHash,
+  batchId,
+  machineId,
+  buildMachineIdentity,
+  loadCursor,
+  saveCursor,
+  normalizeHomePath,
+  type SyncCursor,
+  type MachineIdentity,
+  type ConvergenceEnvelope,
+  type PushReport,
+  type PushOptions,
+  type OutboxBatch,
+} from './cloud-push.js';
+
 export interface RelayhistoryAuth {
   baseUrl: string;
   accessToken: string;

--- a/sdk-ts/src/cloud-push.test.ts
+++ b/sdk-ts/src/cloud-push.test.ts
@@ -66,3 +66,8 @@ test('pushToCloud treats empty stdout as a zero-record push', async () => {
   const report = await pushToCloud({ binPath: '/bin/echo', spawnFn });
   assert.deepEqual(report, { sent: 0, accepted: 0, batchId: null, cursor: undefined });
 });
+
+test('pushToCloud rejects when the binary prints malformed JSON', async () => {
+  const { spawnFn } = fakeSpawn({ code: 0, stdout: '{ truncated' });
+  await assert.rejects(pushToCloud({ binPath: '/bin/echo', spawnFn }), /could not parse ai-hist push output/);
+});

--- a/sdk-ts/src/cloud-push.test.ts
+++ b/sdk-ts/src/cloud-push.test.ts
@@ -1,0 +1,206 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import initSqlJs, { type Database } from 'sql.js';
+
+import {
+  promptHash,
+  batchId,
+  normalizeHomePath,
+  buildOutboxBatch,
+  type SyncCursor,
+} from './cloud-push.js';
+
+// ----- hashing (must match ai_hist_core::prompt_hash) -----
+
+test('promptHash is sha256 hex truncated to 16 chars', () => {
+  // sha256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+  assert.equal(promptHash('hello'), '2cf24dba5fb0a30e');
+  assert.equal(promptHash('hello').length, 16);
+});
+
+test('batchId hashes the exact cursor-span material with a b_ prefix', () => {
+  const from: SyncCursor = { history_id: 0, trajectory_rowid: 0 };
+  const to: SyncCursor = { history_id: 5, trajectory_rowid: 2 };
+  const expected = `b_${promptHash('m_abc:0:0:5:2:3')}`;
+  assert.equal(batchId('m_abc', from, to, 3), expected);
+});
+
+// ----- home-path scrub (must match convergence::normalize_home_path) -----
+
+test('normalizeHomePath replaces the username segment, preserving prefix case', () => {
+  assert.equal(normalizeHomePath('/Users/alice/foo'), '/Users/~/foo');
+  assert.equal(normalizeHomePath('/home/bob/x'), '/home/~/x');
+  assert.equal(normalizeHomePath('C:\\Users\\carol\\y'), 'C:\\Users\\~\\y');
+  // Prefix case is preserved; only the username becomes ~.
+  assert.equal(normalizeHomePath('/USERS/Dave/z'), '/USERS/~/z');
+  // Mid-string and multiple occurrences.
+  assert.equal(normalizeHomePath('see /Users/eve/a and /home/eve/b'), 'see /Users/~/a and /home/~/b');
+  // No trailing segment → unchanged.
+  assert.equal(normalizeHomePath('/Users/'), '/Users/');
+  assert.equal(normalizeHomePath('nothing here'), 'nothing here');
+});
+
+// ----- outbox builder against a real in-memory sql.js DB -----
+
+async function seedDb(): Promise<Database> {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  db.run(`CREATE TABLE history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL,
+    session_id TEXT,
+    project TEXT,
+    prompt TEXT NOT NULL,
+    prompt_hash TEXT,
+    timestamp_ms INTEGER NOT NULL
+  )`);
+  db.run(`CREATE TABLE trajectories (
+    id TEXT PRIMARY KEY,
+    persona_id TEXT,
+    project_id TEXT,
+    task_title TEXT,
+    task_description TEXT,
+    status TEXT,
+    decisions_json TEXT NOT NULL,
+    retrospective_json TEXT NOT NULL,
+    timestamp_ms INTEGER NOT NULL
+  )`);
+  return db;
+}
+
+test('buildOutboxBatch maps history rows and advances the cursor', async () => {
+  const db = await seedDb();
+  db.run(
+    "INSERT INTO history (source, session_id, prompt, prompt_hash, timestamp_ms) VALUES ('claude','s1','hi there','deadbeef0000cafe',1700000000000)",
+  );
+  db.run(
+    "INSERT INTO history (source, session_id, prompt, timestamp_ms) VALUES ('codex','s2','path /Users/me/x',1700000001000)",
+  );
+
+  const batch = buildOutboxBatch(db, { history_id: 0, trajectory_rowid: 0 }, 500, new Set());
+  db.close();
+
+  assert.equal(batch.records.length, 2);
+  assert.equal(batch.cursor.history_id, 2);
+
+  const first = batch.records[0];
+  assert.equal(first.kind, 'prompt');
+  assert.equal(first.source, 'claude');
+  assert.equal(first.lens, 'history');
+  assert.equal(first.sessionId, 's1');
+  assert.equal(first.eventId, 'prompt:1700000000000:deadbeef0000cafe');
+  assert.equal(first.ts, new Date(1700000000000).toISOString());
+  assert.equal(first.confidence, null);
+
+  // prompt_hash absent → derived from the prompt text.
+  const second = batch.records[1];
+  assert.equal(second.eventId, `prompt:1700000001000:${promptHash('path /Users/me/x')}`);
+  // content is home-path scrubbed.
+  assert.equal(second.content, 'path /Users/~/x');
+
+  // confidence must serialize as null (present), optional fields omitted.
+  const json = JSON.stringify(first);
+  assert.match(json, /"confidence":null/);
+  assert.doesNotMatch(json, /significance/);
+  assert.doesNotMatch(json, /actorName/);
+});
+
+test('buildOutboxBatch advances the cursor past incognito rows without emitting them', async () => {
+  const db = await seedDb();
+  db.run("INSERT INTO history (source, session_id, prompt, timestamp_ms) VALUES ('claude','secret','x',1700000000000)");
+  db.run("INSERT INTO history (source, session_id, prompt, timestamp_ms) VALUES ('claude','ok','y',1700000001000)");
+
+  const batch = buildOutboxBatch(db, { history_id: 0, trajectory_rowid: 0 }, 500, new Set(['secret']));
+  db.close();
+
+  assert.equal(batch.records.length, 1);
+  assert.equal(batch.records[0].sessionId, 'ok');
+  // Cursor still advances past the skipped row so it is never re-scanned.
+  assert.equal(batch.cursor.history_id, 2);
+});
+
+test('buildOutboxBatch fans a trajectory into decision + retrospective events in order', async () => {
+  const db = await seedDb();
+  const decisions = JSON.stringify([
+    { question: 'Use X or Y?', chosen: 'X', reasoning: 'faster', confidence: 0.8 },
+  ]);
+  const retro = JSON.stringify({
+    confidence: 0.5,
+    summary: 'went well',
+    learnings: ['learned a', 'learned b'],
+    challenges: ['hard c'],
+  });
+  db.run(
+    'INSERT INTO trajectories (id, persona_id, project_id, task_title, status, decisions_json, retrospective_json, timestamp_ms) VALUES ($id,$p,$pr,$t,$s,$d,$r,$ts)',
+    {
+      $id: 'traj-1',
+      $p: 'planner',
+      $pr: '/repo',
+      $t: 'Do the thing',
+      $s: 'completed',
+      $d: decisions,
+      $r: retro,
+      $ts: 1700000000000,
+    },
+  );
+
+  const batch = buildOutboxBatch(db, { history_id: 0, trajectory_rowid: 0 }, 500, new Set());
+  db.close();
+
+  const ids = batch.records.map((r) => r.eventId);
+  assert.deepEqual(ids, [
+    'decision:traj-1:0',
+    'reflection:traj-1:summary',
+    'finding:traj-1:learning:0',
+    'finding:traj-1:learning:1',
+    'finding:traj-1:challenge:0',
+  ]);
+
+  const decision = batch.records[0];
+  assert.equal(decision.kind, 'decision');
+  assert.equal(decision.source, 'trajectories');
+  assert.equal(decision.sessionId, 'traj-1');
+  assert.equal(decision.actorName, 'planner');
+  assert.equal(decision.projectId, '/repo');
+  assert.equal(decision.taskTitle, 'Do the thing');
+  assert.equal(decision.confidence, 0.8);
+  assert.match(decision.content, /Question: Use X or Y\?/);
+  assert.match(decision.content, /Chose: X/);
+  assert.deepEqual(decision.record, { chosen: 'X' });
+
+  // Retrospective summary inherits the retro-level confidence.
+  assert.equal(batch.records[1].confidence, 0.5);
+  // Array findings carry null confidence.
+  assert.equal(batch.records[2].confidence, null);
+
+  assert.equal(batch.cursor.trajectory_rowid, 1);
+});
+
+test('buildOutboxBatch handles compacted rollups with tag-derived source/lens', async () => {
+  const db = await seedDb();
+  const retro = JSON.stringify({
+    type: 'compacted',
+    sourceTrajectories: ['a', 'b'],
+    source: 'burn',
+    tags: ['learn'],
+    decisions: [{ chosen: 'go', impact: 'big' }],
+    keyLearnings: ['k1'],
+    narrative: 'should be dropped because is_learn',
+  });
+  db.run(
+    'INSERT INTO trajectories (id, decisions_json, retrospective_json, timestamp_ms) VALUES ($id,$d,$r,$ts)',
+    { $id: 'roll-1', $d: '[]', $r: retro, $ts: 1700000000000 },
+  );
+
+  const batch = buildOutboxBatch(db, { history_id: 0, trajectory_rowid: 0 }, 500, new Set());
+  db.close();
+
+  const ids = batch.records.map((r) => r.eventId);
+  // narrative omitted (is_learn), decisions + keyLearnings present.
+  assert.deepEqual(ids, ['decision:roll-1:0', 'finding:roll-1:learning:0']);
+  assert.equal(batch.records[0].source, 'burn');
+  assert.equal(batch.records[0].lens, 'burn');
+  assert.deepEqual(batch.records[0].tags, ['learn']);
+  assert.deepEqual(batch.records[0].record, { chosen: 'go', impact: 'big' });
+});

--- a/sdk-ts/src/cloud-push.test.ts
+++ b/sdk-ts/src/cloud-push.test.ts
@@ -1,206 +1,68 @@
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
 import { test } from 'node:test';
 
-import initSqlJs, { type Database } from 'sql.js';
+import { pushToCloud } from './cloud-push.js';
 
-import {
-  promptHash,
-  batchId,
-  normalizeHomePath,
-  buildOutboxBatch,
-  type SyncCursor,
-} from './cloud-push.js';
-
-// ----- hashing (must match ai_hist_core::prompt_hash) -----
-
-test('promptHash is sha256 hex truncated to 16 chars', () => {
-  // sha256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
-  assert.equal(promptHash('hello'), '2cf24dba5fb0a30e');
-  assert.equal(promptHash('hello').length, 16);
-});
-
-test('batchId hashes the exact cursor-span material with a b_ prefix', () => {
-  const from: SyncCursor = { history_id: 0, trajectory_rowid: 0 };
-  const to: SyncCursor = { history_id: 5, trajectory_rowid: 2 };
-  const expected = `b_${promptHash('m_abc:0:0:5:2:3')}`;
-  assert.equal(batchId('m_abc', from, to, 3), expected);
-});
-
-// ----- home-path scrub (must match convergence::normalize_home_path) -----
-
-test('normalizeHomePath replaces the username segment, preserving prefix case', () => {
-  assert.equal(normalizeHomePath('/Users/alice/foo'), '/Users/~/foo');
-  assert.equal(normalizeHomePath('/home/bob/x'), '/home/~/x');
-  assert.equal(normalizeHomePath('C:\\Users\\carol\\y'), 'C:\\Users\\~\\y');
-  // Prefix case is preserved; only the username becomes ~.
-  assert.equal(normalizeHomePath('/USERS/Dave/z'), '/USERS/~/z');
-  // Mid-string and multiple occurrences.
-  assert.equal(normalizeHomePath('see /Users/eve/a and /home/eve/b'), 'see /Users/~/a and /home/~/b');
-  // No trailing segment → unchanged.
-  assert.equal(normalizeHomePath('/Users/'), '/Users/');
-  assert.equal(normalizeHomePath('nothing here'), 'nothing here');
-});
-
-// ----- outbox builder against a real in-memory sql.js DB -----
-
-async function seedDb(): Promise<Database> {
-  const SQL = await initSqlJs();
-  const db = new SQL.Database();
-  db.run(`CREATE TABLE history (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    source TEXT NOT NULL,
-    session_id TEXT,
-    project TEXT,
-    prompt TEXT NOT NULL,
-    prompt_hash TEXT,
-    timestamp_ms INTEGER NOT NULL
-  )`);
-  db.run(`CREATE TABLE trajectories (
-    id TEXT PRIMARY KEY,
-    persona_id TEXT,
-    project_id TEXT,
-    task_title TEXT,
-    task_description TEXT,
-    status TEXT,
-    decisions_json TEXT NOT NULL,
-    retrospective_json TEXT NOT NULL,
-    timestamp_ms INTEGER NOT NULL
-  )`);
-  return db;
+/** Minimal fake child process that scripts stdout/stderr/exit for one run. */
+function fakeSpawn(script: { stdout?: string; stderr?: string; code?: number; errorCode?: string }) {
+  const calls: Array<{ bin: string; args: string[] }> = [];
+  const spawnFn = ((bin: string, args: string[]) => {
+    calls.push({ bin, args });
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    // Emit asynchronously so the caller has attached its listeners.
+    setImmediate(() => {
+      if (script.errorCode) {
+        const err = new Error('spawn failed') as NodeJS.ErrnoException;
+        err.code = script.errorCode;
+        child.emit('error', err);
+        return;
+      }
+      if (script.stdout) child.stdout.emit('data', script.stdout);
+      if (script.stderr) child.stderr.emit('data', script.stderr);
+      child.emit('close', script.code ?? 0);
+    });
+    return child;
+  }) as unknown as typeof import('node:child_process').spawn;
+  return { spawnFn, calls };
 }
 
-test('buildOutboxBatch maps history rows and advances the cursor', async () => {
-  const db = await seedDb();
-  db.run(
-    "INSERT INTO history (source, session_id, prompt, prompt_hash, timestamp_ms) VALUES ('claude','s1','hi there','deadbeef0000cafe',1700000000000)",
-  );
-  db.run(
-    "INSERT INTO history (source, session_id, prompt, timestamp_ms) VALUES ('codex','s2','path /Users/me/x',1700000001000)",
-  );
-
-  const batch = buildOutboxBatch(db, { history_id: 0, trajectory_rowid: 0 }, 500, new Set());
-  db.close();
-
-  assert.equal(batch.records.length, 2);
-  assert.equal(batch.cursor.history_id, 2);
-
-  const first = batch.records[0];
-  assert.equal(first.kind, 'prompt');
-  assert.equal(first.source, 'claude');
-  assert.equal(first.lens, 'history');
-  assert.equal(first.sessionId, 's1');
-  assert.equal(first.eventId, 'prompt:1700000000000:deadbeef0000cafe');
-  assert.equal(first.ts, new Date(1700000000000).toISOString());
-  assert.equal(first.confidence, null);
-
-  // prompt_hash absent → derived from the prompt text.
-  const second = batch.records[1];
-  assert.equal(second.eventId, `prompt:1700000001000:${promptHash('path /Users/me/x')}`);
-  // content is home-path scrubbed.
-  assert.equal(second.content, 'path /Users/~/x');
-
-  // confidence must serialize as null (present), optional fields omitted.
-  const json = JSON.stringify(first);
-  assert.match(json, /"confidence":null/);
-  assert.doesNotMatch(json, /significance/);
-  assert.doesNotMatch(json, /actorName/);
-});
-
-test('buildOutboxBatch advances the cursor past incognito rows without emitting them', async () => {
-  const db = await seedDb();
-  db.run("INSERT INTO history (source, session_id, prompt, timestamp_ms) VALUES ('claude','secret','x',1700000000000)");
-  db.run("INSERT INTO history (source, session_id, prompt, timestamp_ms) VALUES ('claude','ok','y',1700000001000)");
-
-  const batch = buildOutboxBatch(db, { history_id: 0, trajectory_rowid: 0 }, 500, new Set(['secret']));
-  db.close();
-
-  assert.equal(batch.records.length, 1);
-  assert.equal(batch.records[0].sessionId, 'ok');
-  // Cursor still advances past the skipped row so it is never re-scanned.
-  assert.equal(batch.cursor.history_id, 2);
-});
-
-test('buildOutboxBatch fans a trajectory into decision + retrospective events in order', async () => {
-  const db = await seedDb();
-  const decisions = JSON.stringify([
-    { question: 'Use X or Y?', chosen: 'X', reasoning: 'faster', confidence: 0.8 },
-  ]);
-  const retro = JSON.stringify({
-    confidence: 0.5,
-    summary: 'went well',
-    learnings: ['learned a', 'learned b'],
-    challenges: ['hard c'],
+test('pushToCloud parses ai-hist push --json output into a report', async () => {
+  const { spawnFn, calls } = fakeSpawn({
+    stdout: JSON.stringify({ sent: 3, accepted: 3, batchId: 'b_abc', cursor: { history_id: 9 } }),
   });
-  db.run(
-    'INSERT INTO trajectories (id, persona_id, project_id, task_title, status, decisions_json, retrospective_json, timestamp_ms) VALUES ($id,$p,$pr,$t,$s,$d,$r,$ts)',
-    {
-      $id: 'traj-1',
-      $p: 'planner',
-      $pr: '/repo',
-      $t: 'Do the thing',
-      $s: 'completed',
-      $d: decisions,
-      $r: retro,
-      $ts: 1700000000000,
-    },
-  );
 
-  const batch = buildOutboxBatch(db, { history_id: 0, trajectory_rowid: 0 }, 500, new Set());
-  db.close();
+  const report = await pushToCloud({ binPath: '/bin/echo', spawnFn, limit: 200, incognito: ['s1', 's2'] });
 
-  const ids = batch.records.map((r) => r.eventId);
-  assert.deepEqual(ids, [
-    'decision:traj-1:0',
-    'reflection:traj-1:summary',
-    'finding:traj-1:learning:0',
-    'finding:traj-1:learning:1',
-    'finding:traj-1:challenge:0',
-  ]);
-
-  const decision = batch.records[0];
-  assert.equal(decision.kind, 'decision');
-  assert.equal(decision.source, 'trajectories');
-  assert.equal(decision.sessionId, 'traj-1');
-  assert.equal(decision.actorName, 'planner');
-  assert.equal(decision.projectId, '/repo');
-  assert.equal(decision.taskTitle, 'Do the thing');
-  assert.equal(decision.confidence, 0.8);
-  assert.match(decision.content, /Question: Use X or Y\?/);
-  assert.match(decision.content, /Chose: X/);
-  assert.deepEqual(decision.record, { chosen: 'X' });
-
-  // Retrospective summary inherits the retro-level confidence.
-  assert.equal(batch.records[1].confidence, 0.5);
-  // Array findings carry null confidence.
-  assert.equal(batch.records[2].confidence, null);
-
-  assert.equal(batch.cursor.trajectory_rowid, 1);
+  assert.deepEqual(report, { sent: 3, accepted: 3, batchId: 'b_abc', cursor: { history_id: 9 } });
+  // Forwards the flags to the binary.
+  assert.deepEqual(calls[0].args, ['push', '--json', '--limit', '200', '--incognito', 's1', '--incognito', 's2']);
 });
 
-test('buildOutboxBatch handles compacted rollups with tag-derived source/lens', async () => {
-  const db = await seedDb();
-  const retro = JSON.stringify({
-    type: 'compacted',
-    sourceTrajectories: ['a', 'b'],
-    source: 'burn',
-    tags: ['learn'],
-    decisions: [{ chosen: 'go', impact: 'big' }],
-    keyLearnings: ['k1'],
-    narrative: 'should be dropped because is_learn',
-  });
-  db.run(
-    'INSERT INTO trajectories (id, decisions_json, retrospective_json, timestamp_ms) VALUES ($id,$d,$r,$ts)',
-    { $id: 'roll-1', $d: '[]', $r: retro, $ts: 1700000000000 },
-  );
+test('pushToCloud returns null when the binary is not installed (ENOENT)', async () => {
+  const { spawnFn } = fakeSpawn({ errorCode: 'ENOENT' });
+  const report = await pushToCloud({ binPath: '/bin/echo', spawnFn });
+  assert.equal(report, null);
+});
 
-  const batch = buildOutboxBatch(db, { history_id: 0, trajectory_rowid: 0 }, 500, new Set());
-  db.close();
+test('pushToCloud returns null when not authenticated', async () => {
+  const { spawnFn } = fakeSpawn({ code: 1, stderr: 'error: not authenticated — run `ai-hist login`' });
+  const report = await pushToCloud({ binPath: '/bin/echo', spawnFn });
+  assert.equal(report, null);
+});
 
-  const ids = batch.records.map((r) => r.eventId);
-  // narrative omitted (is_learn), decisions + keyLearnings present.
-  assert.deepEqual(ids, ['decision:roll-1:0', 'finding:roll-1:learning:0']);
-  assert.equal(batch.records[0].source, 'burn');
-  assert.equal(batch.records[0].lens, 'burn');
-  assert.deepEqual(batch.records[0].tags, ['learn']);
-  assert.deepEqual(batch.records[0].record, { chosen: 'go', impact: 'big' });
+test('pushToCloud rejects on other non-zero exits', async () => {
+  const { spawnFn } = fakeSpawn({ code: 2, stderr: 'boom: server exploded' });
+  await assert.rejects(pushToCloud({ binPath: '/bin/echo', spawnFn }), /ai-hist push failed \(exit 2\).*boom/);
+});
+
+test('pushToCloud treats empty stdout as a zero-record push', async () => {
+  const { spawnFn } = fakeSpawn({ stdout: '' });
+  const report = await pushToCloud({ binPath: '/bin/echo', spawnFn });
+  assert.deepEqual(report, { sent: 0, accepted: 0, batchId: null, cursor: undefined });
 });

--- a/sdk-ts/src/cloud-push.test.ts
+++ b/sdk-ts/src/cloud-push.test.ts
@@ -50,6 +50,12 @@ test('pushToCloud returns null when the binary is not installed (ENOENT)', async
   assert.equal(report, null);
 });
 
+test('pushToCloud returns null when the binary is not executable (EACCES)', async () => {
+  const { spawnFn } = fakeSpawn({ errorCode: 'EACCES' });
+  const report = await pushToCloud({ binPath: '/some/dir', spawnFn });
+  assert.equal(report, null);
+});
+
 test('pushToCloud returns null when not authenticated', async () => {
   const { spawnFn } = fakeSpawn({ code: 1, stderr: 'error: not authenticated — run `ai-hist login`' });
   const report = await pushToCloud({ binPath: '/bin/echo', spawnFn });

--- a/sdk-ts/src/cloud-push.ts
+++ b/sdk-ts/src/cloud-push.ts
@@ -48,10 +48,10 @@ function isExecutable(path: string): boolean {
 /**
  * Resolve the ai-hist binary. An explicit override is **authoritative** — it is
  * returned verbatim without falling through to discovery, so the caller always
- * runs the binary it asked for (a bad path surfaces later as ENOENT → a no-op
- * push, never a silent switch to a different binary). With no override:
- * `$AI_HIST_RUST_BIN` → the install.sh location → the `ai-hist` wrapper on
- * `PATH`. Always returns a string.
+ * runs the binary it asked for (an unusable path surfaces later in `pushToCloud`
+ * as a no-op push, never a silent switch to a different binary). With no
+ * override: `$AI_HIST_RUST_BIN` → the install.sh location → the `ai-hist`
+ * wrapper on `PATH`. Always returns a string.
  */
 export function resolveAiHistBinary(explicit?: string): string {
   if (typeof explicit === 'string' && explicit.length > 0) return explicit;
@@ -98,8 +98,10 @@ export function pushToCloud(opts: PushOptions = {}): Promise<PushReport | null> 
     });
 
     child.on('error', (err: NodeJS.ErrnoException) => {
-      // Binary not on PATH / not installed → treat as "nothing to do".
-      if (err.code === 'ENOENT') {
+      // Binary unavailable — missing (ENOENT), not executable (EACCES/EPERM), or
+      // a directory (ENOTDIR/EISDIR). All mean "nothing to sync", the same
+      // no-op contract a background loop relies on.
+      if (['ENOENT', 'EACCES', 'EPERM', 'ENOTDIR', 'EISDIR'].includes(err.code ?? '')) {
         resolve(null);
         return;
       }

--- a/sdk-ts/src/cloud-push.ts
+++ b/sdk-ts/src/cloud-push.ts
@@ -46,15 +46,19 @@ function isExecutable(path: string): boolean {
 }
 
 /**
- * Resolve the ai-hist binary: explicit override → `$AI_HIST_RUST_BIN` → the
- * install.sh location → the `ai-hist` wrapper on `PATH`. Returns `null` only if
- * an explicit/known path was given but isn't executable; otherwise falls back
- * to `'ai-hist'` and lets spawn surface ENOENT (handled as a no-op).
+ * Resolve the ai-hist binary. An explicit override is **authoritative** — it is
+ * returned verbatim without falling through to discovery, so the caller always
+ * runs the binary it asked for (a bad path surfaces later as ENOENT → a no-op
+ * push, never a silent switch to a different binary). With no override:
+ * `$AI_HIST_RUST_BIN` → the install.sh location → the `ai-hist` wrapper on
+ * `PATH`. Always returns a string.
  */
 export function resolveAiHistBinary(explicit?: string): string {
-  const known = [explicit, process.env[AI_HIST_RUST_BIN_ENV], join(homedir(), '.local', 'share', 'ai-hist', 'ai-hist-rust-bin')].filter(
-    (c): c is string => typeof c === 'string' && c.length > 0
-  );
+  if (typeof explicit === 'string' && explicit.length > 0) return explicit;
+  const known = [
+    process.env[AI_HIST_RUST_BIN_ENV],
+    join(homedir(), '.local', 'share', 'ai-hist', 'ai-hist-rust-bin'),
+  ].filter((c): c is string => typeof c === 'string' && c.length > 0);
   for (const candidate of known) {
     if (isExecutable(candidate)) return candidate;
   }

--- a/sdk-ts/src/cloud-push.ts
+++ b/sdk-ts/src/cloud-push.ts
@@ -1,0 +1,742 @@
+/**
+ * In-process cloud push: read new local history/trajectory rows from the
+ * ai-hist SQLite DB and POST them to relayhistory-cloud `/v1/ingest`.
+ *
+ * This is a wire-compatible TypeScript port of the Rust `ai-hist push`
+ * (`crates/ai-hist/src/cloud.rs` + `crates/ai-hist-core/src/{outbox,convergence}.rs`).
+ * The envelope shapes, `eventId` formats, `promptHash`, `batchId`, and cursor
+ * semantics MUST match the Rust client exactly so the server's
+ * `(orgId, machineId, batchId)` batch dedup and per-event upsert keys line up.
+ *
+ * Only one pusher should run per machine. In the Reflex flow that is this
+ * in-process pusher (the Rust CLI `push` service is not scheduled), so this
+ * module owns the cursor.
+ */
+import { createHash } from 'node:crypto';
+import { readFile, mkdir, writeFile } from 'node:fs/promises';
+import { homedir, hostname as osHostname } from 'node:os';
+import { join, dirname } from 'node:path';
+
+import initSqlJs, { type Database, type SqlJsStatic } from 'sql.js';
+
+import { loadStoredRelayhistoryAuth, type RelayhistoryAuth } from './cloud-client.js';
+
+/** Cap on rows scanned per source per batch (mirrors Rust `limit`). */
+const DEFAULT_LIMIT = 500;
+/** Cap on records emitted across the whole batch (mirrors Rust `MAX_RECORDS`). */
+const MAX_RECORDS = 900;
+
+export interface SyncCursor {
+  /** Highest `history.id` synced. */
+  history_id: number;
+  /** Highest `trajectories.rowid` synced. */
+  trajectory_rowid: number;
+}
+
+export interface MachineIdentity {
+  id: string;
+  hostname?: string;
+  label?: string;
+  os?: string;
+  cliVersion?: string;
+}
+
+/** A `/v1/ingest` record envelope. Optional fields are omitted from JSON when
+ * undefined; `confidence` is the sole exception — it is always present and is
+ * `null` when unknown (matching the Rust serializer). */
+export interface ConvergenceEnvelope {
+  v: number;
+  kind: string;
+  source: string;
+  lens?: string;
+  sessionId: string;
+  eventId: string;
+  ts: string;
+  type: string;
+  content: string;
+  significance?: string;
+  confidence: number | null;
+  tags?: string[];
+  actorName?: string;
+  projectId?: string;
+  taskTitle?: string;
+  taskDescription?: string;
+  taskStatus?: string;
+  taskRef?: { system?: string; id?: string };
+  record?: Record<string, unknown>;
+}
+
+export interface PushReport {
+  sent: number;
+  accepted: number;
+  cursor: SyncCursor;
+  batchId: string | null;
+}
+
+// ----- config dir / state files (kept alongside the TS auth.json) -----
+
+function configDir(): string {
+  return process.env.AI_HIST_CONFIG_DIR ?? join(homedir(), '.config', 'ai-hist');
+}
+function cursorPath(): string {
+  return join(configDir(), 'cursor.json');
+}
+function machineIdPath(): string {
+  return join(configDir(), 'machine-id');
+}
+
+function defaultDbPath(): string {
+  const fromEnv = process.env.AI_HIST_DB;
+  if (fromEnv && fromEnv.trim().length > 0) return fromEnv;
+  return join(homedir(), '.local', 'share', 'ai-hist', 'ai-history.db');
+}
+
+async function writePrivate(path: string, body: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, body, { mode: 0o600 });
+}
+
+// ----- hashing (must match ai_hist_core::prompt_hash) -----
+
+/** SHA-256 → lowercase hex → first 16 chars. Load-bearing: used for machine
+ * id, batch id, and prompt event ids. */
+export function promptHash(input: string): string {
+  return createHash('sha256').update(input, 'utf8').digest('hex').slice(0, 16);
+}
+
+/** Deterministic, retry-safe batch id (mirrors Rust `batch_id`). */
+export function batchId(machineId: string, from: SyncCursor, to: SyncCursor, count: number): string {
+  const material = `${machineId}:${from.history_id}:${from.trajectory_rowid}:${to.history_id}:${to.trajectory_rowid}:${count}`;
+  return `b_${promptHash(material)}`;
+}
+
+// ----- machine id + cursor persistence -----
+
+export async function loadCursor(): Promise<SyncCursor> {
+  try {
+    const body = await readFile(cursorPath(), 'utf-8');
+    const parsed = JSON.parse(body) as Partial<SyncCursor>;
+    return {
+      history_id: typeof parsed.history_id === 'number' ? parsed.history_id : 0,
+      trajectory_rowid: typeof parsed.trajectory_rowid === 'number' ? parsed.trajectory_rowid : 0,
+    };
+  } catch {
+    return { history_id: 0, trajectory_rowid: 0 };
+  }
+}
+
+export async function saveCursor(cursor: SyncCursor): Promise<void> {
+  await writePrivate(cursorPath(), JSON.stringify(cursor, null, 2));
+}
+
+function hostname(): string {
+  const fromEnv = process.env.HOSTNAME;
+  if (fromEnv && fromEnv.length > 0) return fromEnv;
+  const fromOs = osHostname();
+  return fromOs && fromOs.length > 0 ? fromOs : 'unknown-host';
+}
+
+/** Stable per-machine id, generated once and persisted (mirrors Rust `machine_id`). */
+export async function machineId(): Promise<string> {
+  try {
+    const existing = (await readFile(machineIdPath(), 'utf-8')).trim();
+    if (existing.length > 0) return existing;
+  } catch {
+    /* not generated yet */
+  }
+  // process.hrtime.bigint() is a monotonic nanosecond counter — a unique enough
+  // salt so two machines with the same hostname don't collide.
+  const nanos = process.hrtime.bigint().toString();
+  const id = `m_${promptHash(`${hostname()}:${nanos}`)}`;
+  await writePrivate(machineIdPath(), id);
+  return id;
+}
+
+function osName(): string {
+  switch (process.platform) {
+    case 'darwin':
+      return 'macos';
+    case 'win32':
+      return 'windows';
+    default:
+      return process.platform;
+  }
+}
+
+export async function buildMachineIdentity(cliVersion?: string): Promise<MachineIdentity> {
+  const envHost = process.env.HOSTNAME;
+  return {
+    id: await machineId(),
+    hostname: envHost && envHost.length > 0 ? envHost : undefined,
+    os: osName(),
+    cliVersion,
+  };
+}
+
+// ----- text normalization (must match convergence::normalize_home_path) -----
+
+const HOME_PREFIXES = ['/users/', '/home/', '\\users\\'];
+
+/** Replace the username segment in home-rooted paths with `~`, preserving the
+ * original prefix casing. Mirrors Rust `normalize_home_path`. */
+export function normalizeHomePath(input: string): string {
+  let out = '';
+  let i = 0;
+  const lower = input.toLowerCase();
+  while (i < input.length) {
+    let matched = false;
+    for (const prefix of HOME_PREFIXES) {
+      if (lower.startsWith(prefix, i)) {
+        // Find the end of the username segment (next '/' or '\\', or end).
+        const segStart = i + prefix.length;
+        let segEnd = segStart;
+        while (segEnd < input.length && input[segEnd] !== '/' && input[segEnd] !== '\\') {
+          segEnd += 1;
+        }
+        if (segEnd > segStart) {
+          // Keep the original-cased prefix, replace the username with '~'.
+          out += input.slice(i, i + prefix.length) + '~';
+          i = segEnd;
+          matched = true;
+          break;
+        }
+      }
+    }
+    if (!matched) {
+      out += input[i];
+      i += 1;
+    }
+  }
+  return out;
+}
+
+function epochMsToIso(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+// ----- small JSON helpers -----
+
+function trimmedOrUndef(v: unknown): string | undefined {
+  if (typeof v !== 'string') return undefined;
+  const t = v.trim();
+  return t.length > 0 ? t : undefined;
+}
+
+function asNumber(v: unknown): number | null {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+function asObject(v: unknown): Record<string, unknown> | null {
+  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
+}
+
+function asArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+
+function parseJson(text: unknown): unknown {
+  if (typeof text !== 'string' || text.trim().length === 0) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+// ----- history mapper (convergence::map_history_entry) -----
+
+interface HistoryRow {
+  id: number;
+  source: string;
+  session_id: string | null;
+  prompt: string;
+  prompt_hash: string | null;
+  timestamp_ms: number;
+}
+
+function mapHistoryEntry(row: HistoryRow): ConvergenceEnvelope {
+  const hash = row.prompt_hash && row.prompt_hash.length > 0 ? row.prompt_hash : promptHash(row.prompt);
+  return {
+    v: 1,
+    kind: 'prompt',
+    source: row.source,
+    lens: 'history',
+    sessionId: row.session_id ?? 'unsessioned',
+    eventId: `prompt:${row.timestamp_ms}:${hash}`,
+    ts: epochMsToIso(row.timestamp_ms),
+    type: 'prompt',
+    content: normalizeHomePath(row.prompt.trim()),
+    confidence: null,
+  };
+}
+
+// ----- trajectory mappers (convergence::map_trajectory / map_compacted_trajectory) -----
+
+interface TrajectoryRow {
+  id: string;
+  persona_id: string | null;
+  project_id: string | null;
+  task_title: string | null;
+  task_description: string | null;
+  status: string | null;
+  decisions_json: string;
+  retrospective_json: string;
+  timestamp_ms: number;
+}
+
+interface TrajContext {
+  sessionId: string;
+  tsIso: string;
+  actorName?: string;
+  projectId?: string;
+  taskTitle?: string;
+  taskDescription?: string;
+  taskStatus?: string;
+}
+
+function alternativesText(alts: unknown): string[] {
+  return asArray(alts)
+    .map((a) => {
+      if (typeof a === 'string') return a.trim();
+      const o = asObject(a);
+      if (!o) return '';
+      const option = trimmedOrUndef(o.option);
+      const reason = trimmedOrUndef(o.reason);
+      if (option && reason) return `${option} (${reason})`;
+      return option ?? reason ?? '';
+    })
+    .filter((s) => s.length > 0);
+}
+
+function decisionContent(d: Record<string, unknown>): string {
+  const parts: string[] = [];
+  const question = trimmedOrUndef(d.question);
+  const chosen = trimmedOrUndef(d.chosen);
+  const reasoning = trimmedOrUndef(d.reasoning);
+  const alts = alternativesText(d.alternatives);
+  if (question) parts.push(`Question: ${question}`);
+  if (chosen) parts.push(`Chose: ${chosen}`);
+  if (reasoning) parts.push(`Because: ${reasoning}`);
+  if (alts.length > 0) parts.push(`Alternatives: ${alts.join('; ')}`);
+  return normalizeHomePath(parts.join('\n').trim());
+}
+
+function decisionRecord(d: Record<string, unknown>): Record<string, unknown> | undefined {
+  const chosen = trimmedOrUndef(d.chosen);
+  const alts = alternativesText(d.alternatives).map(normalizeHomePath);
+  const rec: Record<string, unknown> = {};
+  if (chosen) rec.chosen = normalizeHomePath(chosen);
+  if (alts.length > 0) rec.alternatives = alts;
+  return Object.keys(rec).length > 0 ? rec : undefined;
+}
+
+/** Strings trimmed non-empty; objects → first of text/summary/description/value. */
+function stringArray(v: unknown): string[] {
+  return asArray(v)
+    .map((item) => {
+      if (typeof item === 'string') return item.trim();
+      const o = asObject(item);
+      if (!o) return '';
+      return (
+        trimmedOrUndef(o.text) ??
+        trimmedOrUndef(o.summary) ??
+        trimmedOrUndef(o.description) ??
+        trimmedOrUndef(o.value) ??
+        ''
+      );
+    })
+    .filter((s) => s.length > 0);
+}
+
+function labeledFields(o: Record<string, unknown>, fields: [string, string][]): string {
+  const parts: string[] = [];
+  for (const [label, key] of fields) {
+    const val = trimmedOrUndef(o[key]);
+    if (val) parts.push(`${label}: ${val}`);
+  }
+  return normalizeHomePath(parts.join('\n').trim());
+}
+
+function baseEnvelope(
+  ctx: TrajContext,
+  source: string,
+  lens: string,
+  kind: string,
+  eventId: string,
+  content: string,
+  confidence: number | null,
+  extra?: { tags?: string[]; record?: Record<string, unknown> },
+): ConvergenceEnvelope {
+  return {
+    v: 1,
+    kind,
+    source,
+    lens,
+    sessionId: ctx.sessionId,
+    eventId,
+    ts: ctx.tsIso,
+    type: kind,
+    content,
+    confidence,
+    tags: extra?.tags && extra.tags.length > 0 ? extra.tags : undefined,
+    actorName: ctx.actorName,
+    projectId: ctx.projectId,
+    taskTitle: ctx.taskTitle,
+    taskDescription: ctx.taskDescription,
+    taskStatus: ctx.taskStatus,
+    record: extra?.record,
+  };
+}
+
+function isCompactedRollup(retro: unknown): retro is Record<string, unknown> {
+  const o = asObject(retro);
+  return !!o && o.type === 'compacted' && Array.isArray(o.sourceTrajectories);
+}
+
+function mapCompacted(
+  trajId: string,
+  ctx: TrajContext,
+  compacted: Record<string, unknown>,
+): ConvergenceEnvelope[] {
+  const out: ConvergenceEnvelope[] = [];
+  const source = trimmedOrUndef(compacted.source) ?? 'trajectories';
+  const lens = trimmedOrUndef(compacted.lens) ?? source;
+  const tagList = asArray(compacted.tags)
+    .map((t) => (typeof t === 'string' ? t.trim() : ''))
+    .filter((s) => s.length > 0);
+  const tags = tagList.length > 0 ? tagList : ['compacted'];
+  const isLearn = tags.includes('learn');
+
+  const emit = (kind: string, eventId: string, content: string, record?: Record<string, unknown>) => {
+    const c = content.trim();
+    if (c.length === 0) return;
+    out.push(baseEnvelope(ctx, source, lens, kind, eventId, c, null, { tags, record }));
+  };
+
+  // decisions[]
+  asArray(compacted.decisions).forEach((d, i) => {
+    const o = asObject(d);
+    if (!o) return;
+    const parts: string[] = [];
+    const question = trimmedOrUndef(o.question);
+    const chosen = trimmedOrUndef(o.chosen);
+    const reasoning = trimmedOrUndef(o.reasoning);
+    const impact = trimmedOrUndef(o.impact);
+    if (question) parts.push(`Question: ${question}`);
+    if (chosen) parts.push(`Chose: ${chosen}`);
+    if (reasoning) parts.push(`Because: ${reasoning}`);
+    if (impact) parts.push(`Impact: ${impact}`);
+    const rec: Record<string, unknown> = {};
+    if (chosen) rec.chosen = normalizeHomePath(chosen);
+    if (impact) rec.impact = normalizeHomePath(impact);
+    emit(
+      'decision',
+      `decision:${trajId}:${i}`,
+      normalizeHomePath(parts.join('\n')),
+      Object.keys(rec).length > 0 ? rec : undefined,
+    );
+  });
+
+  // lessons[]
+  asArray(compacted.lessons).forEach((l, i) => {
+    const o = asObject(l);
+    if (!o) return;
+    emit(
+      'reflection',
+      `reflection:${trajId}:lesson:${i}`,
+      labeledFields(o, [
+        ['Context', 'context'],
+        ['Lesson', 'lesson'],
+        ['Recommendation', 'recommendation'],
+      ]),
+    );
+  });
+
+  // keyFindings[]
+  stringArray(compacted.keyFindings).forEach((f, i) => {
+    emit('finding', `finding:${trajId}:keyfinding:${i}`, normalizeHomePath(f));
+  });
+
+  // keyLearnings[]
+  stringArray(compacted.keyLearnings).forEach((f, i) => {
+    emit('finding', `finding:${trajId}:learning:${i}`, normalizeHomePath(f));
+  });
+
+  // conventions[]
+  asArray(compacted.conventions).forEach((c, i) => {
+    const o = asObject(c);
+    if (!o) return;
+    emit(
+      'reflection',
+      `reflection:${trajId}:convention:${i}`,
+      labeledFields(o, [
+        ['Pattern', 'pattern'],
+        ['Rationale', 'rationale'],
+        ['Scope', 'scope'],
+      ]),
+    );
+  });
+
+  // narrative (only when not a "learn" rollup)
+  if (!isLearn) {
+    const narrative = trimmedOrUndef(compacted.narrative);
+    if (narrative) emit('reflection', `reflection:${trajId}:summary`, normalizeHomePath(narrative));
+  }
+
+  // openQuestions[]
+  stringArray(compacted.openQuestions).forEach((q, i) => {
+    emit('finding', `finding:${trajId}:openquestion:${i}`, normalizeHomePath(q));
+  });
+
+  return out;
+}
+
+function mapTrajectory(row: TrajectoryRow): ConvergenceEnvelope[] {
+  const trajId = row.id.trim();
+  if (trajId.length === 0) return [];
+
+  const ctx: TrajContext = {
+    sessionId: trajId,
+    tsIso: epochMsToIso(row.timestamp_ms),
+    actorName: trimmedOrUndef(row.persona_id),
+    projectId: trimmedOrUndef(row.project_id),
+    taskTitle: trimmedOrUndef(row.task_title),
+    taskDescription: trimmedOrUndef(row.task_description),
+    taskStatus: trimmedOrUndef(row.status),
+  };
+
+  const retro = parseJson(row.retrospective_json);
+  if (isCompactedRollup(retro)) {
+    return mapCompacted(trajId, ctx, retro);
+  }
+
+  const out: ConvergenceEnvelope[] = [];
+  const source = 'trajectories';
+  const lens = 'trajectories';
+
+  // Decisions first.
+  asArray(parseJson(row.decisions_json)).forEach((d, i) => {
+    const o = asObject(d);
+    if (!o) return;
+    const content = decisionContent(o);
+    if (content.length === 0) return;
+    out.push(
+      baseEnvelope(ctx, source, lens, 'decision', `decision:${trajId}:${i}`, content, asNumber(o.confidence), {
+        record: decisionRecord(o),
+      }),
+    );
+  });
+
+  const retroObj = asObject(retro);
+  if (retroObj) {
+    const retroConf = asNumber(retroObj.confidence);
+    const pushRetro = (kind: string, eventId: string, raw: unknown, confidence: number | null) => {
+      const content = normalizeHomePath((trimmedOrUndef(raw) ?? '').trim());
+      if (content.length === 0) return;
+      out.push(baseEnvelope(ctx, source, lens, kind, eventId, content, confidence));
+    };
+    pushRetro('reflection', `reflection:${trajId}:summary`, retroObj.summary, retroConf);
+    pushRetro('reflection', `reflection:${trajId}:approach`, retroObj.approach, retroConf);
+    stringArray(retroObj.learnings).forEach((v, i) =>
+      out.push(baseEnvelope(ctx, source, lens, 'finding', `finding:${trajId}:learning:${i}`, normalizeHomePath(v), null)),
+    );
+    stringArray(retroObj.suggestions).forEach((v, i) =>
+      out.push(
+        baseEnvelope(ctx, source, lens, 'reflection', `reflection:${trajId}:suggestion:${i}`, normalizeHomePath(v), null),
+      ),
+    );
+    stringArray(retroObj.challenges).forEach((v, i) =>
+      out.push(baseEnvelope(ctx, source, lens, 'finding', `finding:${trajId}:challenge:${i}`, normalizeHomePath(v), null)),
+    );
+  }
+
+  return out;
+}
+
+// ----- outbox batch builder (outbox::build_outbox_batch) -----
+
+export interface OutboxBatch {
+  records: ConvergenceEnvelope[];
+  cursor: SyncCursor;
+}
+
+function queryAll(db: Database, sql: string, params: Record<string, number>): Record<string, unknown>[] {
+  const stmt = db.prepare(sql);
+  try {
+    stmt.bind(params);
+    const rows: Record<string, unknown>[] = [];
+    while (stmt.step()) rows.push(stmt.getAsObject());
+    return rows;
+  } finally {
+    stmt.free();
+  }
+}
+
+export function buildOutboxBatch(
+  db: Database,
+  cursor: SyncCursor,
+  limit: number,
+  incognito: Set<string>,
+): OutboxBatch {
+  const effLimit = Math.max(limit, 1);
+  const next: SyncCursor = { ...cursor };
+  const records: ConvergenceEnvelope[] = [];
+
+  // History.
+  const historyRows = queryAll(
+    db,
+    'SELECT id, source, session_id, project, prompt, prompt_hash, timestamp_ms FROM history WHERE id > $id ORDER BY id ASC LIMIT $limit',
+    { $id: cursor.history_id, $limit: effLimit },
+  );
+  for (const raw of historyRows) {
+    if (records.length >= MAX_RECORDS) break;
+    const row: HistoryRow = {
+      id: Number(raw.id),
+      source: String(raw.source),
+      session_id: raw.session_id == null ? null : String(raw.session_id),
+      prompt: String(raw.prompt ?? ''),
+      prompt_hash: raw.prompt_hash == null ? null : String(raw.prompt_hash),
+      timestamp_ms: Number(raw.timestamp_ms),
+    };
+    next.history_id = Math.max(next.history_id, row.id);
+    if (row.session_id && incognito.has(row.session_id)) continue;
+    records.push(mapHistoryEntry(row));
+  }
+
+  // Trajectories (rowid watermark; TEXT PK means rowid is separate).
+  let trajRows: Record<string, unknown>[] = [];
+  try {
+    trajRows = queryAll(
+      db,
+      'SELECT rowid, id, persona_id, project_id, task_title, task_description, status, decisions_json, retrospective_json, timestamp_ms FROM trajectories WHERE rowid > $id ORDER BY rowid ASC LIMIT $limit',
+      { $id: cursor.trajectory_rowid, $limit: effLimit },
+    );
+  } catch {
+    trajRows = [];
+  }
+  for (const raw of trajRows) {
+    const rowid = Number(raw.rowid);
+    const id = String(raw.id ?? '');
+    if (incognito.has(id)) {
+      next.trajectory_rowid = Math.max(next.trajectory_rowid, rowid);
+      continue;
+    }
+    const mapped = mapTrajectory({
+      id,
+      persona_id: raw.persona_id == null ? null : String(raw.persona_id),
+      project_id: raw.project_id == null ? null : String(raw.project_id),
+      task_title: raw.task_title == null ? null : String(raw.task_title),
+      task_description: raw.task_description == null ? null : String(raw.task_description),
+      status: raw.status == null ? null : String(raw.status),
+      decisions_json: String(raw.decisions_json ?? ''),
+      retrospective_json: String(raw.retrospective_json ?? ''),
+      timestamp_ms: Number(raw.timestamp_ms),
+    });
+    if (records.length > 0 && records.length + mapped.length > MAX_RECORDS) break;
+    next.trajectory_rowid = Math.max(next.trajectory_rowid, rowid);
+    records.push(...mapped);
+  }
+
+  return { records, cursor: next };
+}
+
+// ----- HTTP (POST /v1/ingest) -----
+
+interface IngestRequest {
+  machine: MachineIdentity;
+  batchId: string;
+  cursors?: { history_id: number; trajectory_rowid: number };
+  records: ConvergenceEnvelope[];
+}
+
+interface IngestResponse {
+  accepted: number;
+}
+
+async function ingest(auth: RelayhistoryAuth, req: IngestRequest): Promise<IngestResponse> {
+  const url = `${auth.baseUrl.replace(/\/$/, '')}/v1/ingest`;
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${auth.accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(req),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '');
+    throw new Error(`ingest failed: HTTP ${resp.status}: ${body.slice(0, 300)}`);
+  }
+  const payload = (await resp.json()) as Partial<IngestResponse>;
+  return { accepted: typeof payload.accepted === 'number' ? payload.accepted : 0 };
+}
+
+// ----- sql.js DB open -----
+
+let _sqlPromise: Promise<SqlJsStatic> | null = null;
+function getSqlJs(): Promise<SqlJsStatic> {
+  if (!_sqlPromise) _sqlPromise = initSqlJs();
+  return _sqlPromise;
+}
+
+export interface PushOptions {
+  /** Override the SQLite path (default `$AI_HIST_DB` or the standard location). */
+  dbPath?: string;
+  /** Pre-loaded auth; falls back to `loadStoredRelayhistoryAuth()`. */
+  auth?: RelayhistoryAuth | null;
+  /** Rows scanned per source (default 500). */
+  limit?: number;
+  /** Session/trajectory ids to exclude (incognito). */
+  incognito?: Iterable<string>;
+  /** Reported as `machine.cliVersion`. */
+  cliVersion?: string;
+}
+
+/**
+ * Build the next outbox batch from the local DB and push it to
+ * relayhistory-cloud. No-op (no HTTP) when there is nothing new. On success,
+ * persists the advanced cursor. Returns `{ ok: false }`-style errors as thrown
+ * exceptions; callers in a background loop should catch.
+ */
+export async function pushToCloud(opts: PushOptions = {}): Promise<PushReport> {
+  const auth = opts.auth ?? (await loadStoredRelayhistoryAuth());
+  if (!auth) {
+    throw new Error('not authenticated — no relayhistory auth found (run reflex on / ai-hist login)');
+  }
+
+  const dbPath = opts.dbPath ?? defaultDbPath();
+  let fileBuffer: Buffer;
+  try {
+    fileBuffer = await readFile(dbPath);
+  } catch {
+    // No local DB yet → nothing to push.
+    const cursor = await loadCursor();
+    return { sent: 0, accepted: 0, cursor, batchId: null };
+  }
+
+  const SQL = await getSqlJs();
+  const db = new SQL.Database(fileBuffer);
+  try {
+    const cursor = await loadCursor();
+    const incognito = new Set<string>(opts.incognito ?? []);
+    const batch = buildOutboxBatch(db, cursor, opts.limit ?? DEFAULT_LIMIT, incognito);
+    if (batch.records.length === 0) {
+      return { sent: 0, accepted: 0, cursor, batchId: null };
+    }
+
+    const machine = await buildMachineIdentity(opts.cliVersion);
+    const bid = batchId(machine.id, cursor, batch.cursor, batch.records.length);
+    const resp = await ingest(auth, {
+      machine,
+      batchId: bid,
+      cursors: { history_id: batch.cursor.history_id, trajectory_rowid: batch.cursor.trajectory_rowid },
+      records: batch.records,
+    });
+    // Advance the cursor only after the server accepts the batch.
+    await saveCursor(batch.cursor);
+    return { sent: batch.records.length, accepted: resp.accepted, cursor: batch.cursor, batchId: bid };
+  } finally {
+    db.close();
+  }
+}

--- a/sdk-ts/src/cloud-push.ts
+++ b/sdk-ts/src/cloud-push.ts
@@ -1,742 +1,130 @@
 /**
- * In-process cloud push: read new local history/trajectory rows from the
- * ai-hist SQLite DB and POST them to relayhistory-cloud `/v1/ingest`.
+ * In-process cloud push — a thin wrapper over the `ai-hist` Rust binary.
  *
- * This is a wire-compatible TypeScript port of the Rust `ai-hist push`
- * (`crates/ai-hist/src/cloud.rs` + `crates/ai-hist-core/src/{outbox,convergence}.rs`).
- * The envelope shapes, `eventId` formats, `promptHash`, `batchId`, and cursor
- * semantics MUST match the Rust client exactly so the server's
- * `(orgId, machineId, batchId)` batch dedup and per-event upsert keys line up.
- *
- * Only one pusher should run per machine. In the Reflex flow that is this
- * in-process pusher (the Rust CLI `push` service is not scheduled), so this
- * module owns the cursor.
+ * Rather than re-implement the push pipeline (outbox batching, cursor, wire
+ * envelopes, dedup hashing) in TypeScript — which would have to stay byte-for-
+ * byte compatible with the Rust client forever — this spawns the real
+ * `ai-hist push --json` and parses its result. The Rust binary is the single
+ * source of truth for the push logic; this is just an ergonomic SDK surface
+ * over it, so hosts (e.g. the Agent Relay runtime) can sync without shelling
+ * out to a CLI by hand.
  */
-import { createHash } from 'node:crypto';
-import { readFile, mkdir, writeFile } from 'node:fs/promises';
-import { homedir, hostname as osHostname } from 'node:os';
-import { join, dirname } from 'node:path';
-
-import initSqlJs, { type Database, type SqlJsStatic } from 'sql.js';
-
-import { loadStoredRelayhistoryAuth, type RelayhistoryAuth } from './cloud-client.js';
-
-/** Cap on rows scanned per source per batch (mirrors Rust `limit`). */
-const DEFAULT_LIMIT = 500;
-/** Cap on records emitted across the whole batch (mirrors Rust `MAX_RECORDS`). */
-const MAX_RECORDS = 900;
-
-export interface SyncCursor {
-  /** Highest `history.id` synced. */
-  history_id: number;
-  /** Highest `trajectories.rowid` synced. */
-  trajectory_rowid: number;
-}
-
-export interface MachineIdentity {
-  id: string;
-  hostname?: string;
-  label?: string;
-  os?: string;
-  cliVersion?: string;
-}
-
-/** A `/v1/ingest` record envelope. Optional fields are omitted from JSON when
- * undefined; `confidence` is the sole exception — it is always present and is
- * `null` when unknown (matching the Rust serializer). */
-export interface ConvergenceEnvelope {
-  v: number;
-  kind: string;
-  source: string;
-  lens?: string;
-  sessionId: string;
-  eventId: string;
-  ts: string;
-  type: string;
-  content: string;
-  significance?: string;
-  confidence: number | null;
-  tags?: string[];
-  actorName?: string;
-  projectId?: string;
-  taskTitle?: string;
-  taskDescription?: string;
-  taskStatus?: string;
-  taskRef?: { system?: string; id?: string };
-  record?: Record<string, unknown>;
-}
+import { spawn, type SpawnOptions } from 'node:child_process';
+import { accessSync, constants } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 export interface PushReport {
   sent: number;
   accepted: number;
-  cursor: SyncCursor;
   batchId: string | null;
-}
-
-// ----- config dir / state files (kept alongside the TS auth.json) -----
-
-function configDir(): string {
-  return process.env.AI_HIST_CONFIG_DIR ?? join(homedir(), '.config', 'ai-hist');
-}
-function cursorPath(): string {
-  return join(configDir(), 'cursor.json');
-}
-function machineIdPath(): string {
-  return join(configDir(), 'machine-id');
-}
-
-function defaultDbPath(): string {
-  const fromEnv = process.env.AI_HIST_DB;
-  if (fromEnv && fromEnv.trim().length > 0) return fromEnv;
-  return join(homedir(), '.local', 'share', 'ai-hist', 'ai-history.db');
-}
-
-async function writePrivate(path: string, body: string): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, body, { mode: 0o600 });
-}
-
-// ----- hashing (must match ai_hist_core::prompt_hash) -----
-
-/** SHA-256 → lowercase hex → first 16 chars. Load-bearing: used for machine
- * id, batch id, and prompt event ids. */
-export function promptHash(input: string): string {
-  return createHash('sha256').update(input, 'utf8').digest('hex').slice(0, 16);
-}
-
-/** Deterministic, retry-safe batch id (mirrors Rust `batch_id`). */
-export function batchId(machineId: string, from: SyncCursor, to: SyncCursor, count: number): string {
-  const material = `${machineId}:${from.history_id}:${from.trajectory_rowid}:${to.history_id}:${to.trajectory_rowid}:${count}`;
-  return `b_${promptHash(material)}`;
-}
-
-// ----- machine id + cursor persistence -----
-
-export async function loadCursor(): Promise<SyncCursor> {
-  try {
-    const body = await readFile(cursorPath(), 'utf-8');
-    const parsed = JSON.parse(body) as Partial<SyncCursor>;
-    return {
-      history_id: typeof parsed.history_id === 'number' ? parsed.history_id : 0,
-      trajectory_rowid: typeof parsed.trajectory_rowid === 'number' ? parsed.trajectory_rowid : 0,
-    };
-  } catch {
-    return { history_id: 0, trajectory_rowid: 0 };
-  }
-}
-
-export async function saveCursor(cursor: SyncCursor): Promise<void> {
-  await writePrivate(cursorPath(), JSON.stringify(cursor, null, 2));
-}
-
-function hostname(): string {
-  const fromEnv = process.env.HOSTNAME;
-  if (fromEnv && fromEnv.length > 0) return fromEnv;
-  const fromOs = osHostname();
-  return fromOs && fromOs.length > 0 ? fromOs : 'unknown-host';
-}
-
-/** Stable per-machine id, generated once and persisted (mirrors Rust `machine_id`). */
-export async function machineId(): Promise<string> {
-  try {
-    const existing = (await readFile(machineIdPath(), 'utf-8')).trim();
-    if (existing.length > 0) return existing;
-  } catch {
-    /* not generated yet */
-  }
-  // process.hrtime.bigint() is a monotonic nanosecond counter — a unique enough
-  // salt so two machines with the same hostname don't collide.
-  const nanos = process.hrtime.bigint().toString();
-  const id = `m_${promptHash(`${hostname()}:${nanos}`)}`;
-  await writePrivate(machineIdPath(), id);
-  return id;
-}
-
-function osName(): string {
-  switch (process.platform) {
-    case 'darwin':
-      return 'macos';
-    case 'win32':
-      return 'windows';
-    default:
-      return process.platform;
-  }
-}
-
-export async function buildMachineIdentity(cliVersion?: string): Promise<MachineIdentity> {
-  const envHost = process.env.HOSTNAME;
-  return {
-    id: await machineId(),
-    hostname: envHost && envHost.length > 0 ? envHost : undefined,
-    os: osName(),
-    cliVersion,
-  };
-}
-
-// ----- text normalization (must match convergence::normalize_home_path) -----
-
-const HOME_PREFIXES = ['/users/', '/home/', '\\users\\'];
-
-/** Replace the username segment in home-rooted paths with `~`, preserving the
- * original prefix casing. Mirrors Rust `normalize_home_path`. */
-export function normalizeHomePath(input: string): string {
-  let out = '';
-  let i = 0;
-  const lower = input.toLowerCase();
-  while (i < input.length) {
-    let matched = false;
-    for (const prefix of HOME_PREFIXES) {
-      if (lower.startsWith(prefix, i)) {
-        // Find the end of the username segment (next '/' or '\\', or end).
-        const segStart = i + prefix.length;
-        let segEnd = segStart;
-        while (segEnd < input.length && input[segEnd] !== '/' && input[segEnd] !== '\\') {
-          segEnd += 1;
-        }
-        if (segEnd > segStart) {
-          // Keep the original-cased prefix, replace the username with '~'.
-          out += input.slice(i, i + prefix.length) + '~';
-          i = segEnd;
-          matched = true;
-          break;
-        }
-      }
-    }
-    if (!matched) {
-      out += input[i];
-      i += 1;
-    }
-  }
-  return out;
-}
-
-function epochMsToIso(ms: number): string {
-  return new Date(ms).toISOString();
-}
-
-// ----- small JSON helpers -----
-
-function trimmedOrUndef(v: unknown): string | undefined {
-  if (typeof v !== 'string') return undefined;
-  const t = v.trim();
-  return t.length > 0 ? t : undefined;
-}
-
-function asNumber(v: unknown): number | null {
-  return typeof v === 'number' && Number.isFinite(v) ? v : null;
-}
-
-function asObject(v: unknown): Record<string, unknown> | null {
-  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null;
-}
-
-function asArray(v: unknown): unknown[] {
-  return Array.isArray(v) ? v : [];
-}
-
-function parseJson(text: unknown): unknown {
-  if (typeof text !== 'string' || text.trim().length === 0) return null;
-  try {
-    return JSON.parse(text);
-  } catch {
-    return null;
-  }
-}
-
-// ----- history mapper (convergence::map_history_entry) -----
-
-interface HistoryRow {
-  id: number;
-  source: string;
-  session_id: string | null;
-  prompt: string;
-  prompt_hash: string | null;
-  timestamp_ms: number;
-}
-
-function mapHistoryEntry(row: HistoryRow): ConvergenceEnvelope {
-  const hash = row.prompt_hash && row.prompt_hash.length > 0 ? row.prompt_hash : promptHash(row.prompt);
-  return {
-    v: 1,
-    kind: 'prompt',
-    source: row.source,
-    lens: 'history',
-    sessionId: row.session_id ?? 'unsessioned',
-    eventId: `prompt:${row.timestamp_ms}:${hash}`,
-    ts: epochMsToIso(row.timestamp_ms),
-    type: 'prompt',
-    content: normalizeHomePath(row.prompt.trim()),
-    confidence: null,
-  };
-}
-
-// ----- trajectory mappers (convergence::map_trajectory / map_compacted_trajectory) -----
-
-interface TrajectoryRow {
-  id: string;
-  persona_id: string | null;
-  project_id: string | null;
-  task_title: string | null;
-  task_description: string | null;
-  status: string | null;
-  decisions_json: string;
-  retrospective_json: string;
-  timestamp_ms: number;
-}
-
-interface TrajContext {
-  sessionId: string;
-  tsIso: string;
-  actorName?: string;
-  projectId?: string;
-  taskTitle?: string;
-  taskDescription?: string;
-  taskStatus?: string;
-}
-
-function alternativesText(alts: unknown): string[] {
-  return asArray(alts)
-    .map((a) => {
-      if (typeof a === 'string') return a.trim();
-      const o = asObject(a);
-      if (!o) return '';
-      const option = trimmedOrUndef(o.option);
-      const reason = trimmedOrUndef(o.reason);
-      if (option && reason) return `${option} (${reason})`;
-      return option ?? reason ?? '';
-    })
-    .filter((s) => s.length > 0);
-}
-
-function decisionContent(d: Record<string, unknown>): string {
-  const parts: string[] = [];
-  const question = trimmedOrUndef(d.question);
-  const chosen = trimmedOrUndef(d.chosen);
-  const reasoning = trimmedOrUndef(d.reasoning);
-  const alts = alternativesText(d.alternatives);
-  if (question) parts.push(`Question: ${question}`);
-  if (chosen) parts.push(`Chose: ${chosen}`);
-  if (reasoning) parts.push(`Because: ${reasoning}`);
-  if (alts.length > 0) parts.push(`Alternatives: ${alts.join('; ')}`);
-  return normalizeHomePath(parts.join('\n').trim());
-}
-
-function decisionRecord(d: Record<string, unknown>): Record<string, unknown> | undefined {
-  const chosen = trimmedOrUndef(d.chosen);
-  const alts = alternativesText(d.alternatives).map(normalizeHomePath);
-  const rec: Record<string, unknown> = {};
-  if (chosen) rec.chosen = normalizeHomePath(chosen);
-  if (alts.length > 0) rec.alternatives = alts;
-  return Object.keys(rec).length > 0 ? rec : undefined;
-}
-
-/** Strings trimmed non-empty; objects → first of text/summary/description/value. */
-function stringArray(v: unknown): string[] {
-  return asArray(v)
-    .map((item) => {
-      if (typeof item === 'string') return item.trim();
-      const o = asObject(item);
-      if (!o) return '';
-      return (
-        trimmedOrUndef(o.text) ??
-        trimmedOrUndef(o.summary) ??
-        trimmedOrUndef(o.description) ??
-        trimmedOrUndef(o.value) ??
-        ''
-      );
-    })
-    .filter((s) => s.length > 0);
-}
-
-function labeledFields(o: Record<string, unknown>, fields: [string, string][]): string {
-  const parts: string[] = [];
-  for (const [label, key] of fields) {
-    const val = trimmedOrUndef(o[key]);
-    if (val) parts.push(`${label}: ${val}`);
-  }
-  return normalizeHomePath(parts.join('\n').trim());
-}
-
-function baseEnvelope(
-  ctx: TrajContext,
-  source: string,
-  lens: string,
-  kind: string,
-  eventId: string,
-  content: string,
-  confidence: number | null,
-  extra?: { tags?: string[]; record?: Record<string, unknown> },
-): ConvergenceEnvelope {
-  return {
-    v: 1,
-    kind,
-    source,
-    lens,
-    sessionId: ctx.sessionId,
-    eventId,
-    ts: ctx.tsIso,
-    type: kind,
-    content,
-    confidence,
-    tags: extra?.tags && extra.tags.length > 0 ? extra.tags : undefined,
-    actorName: ctx.actorName,
-    projectId: ctx.projectId,
-    taskTitle: ctx.taskTitle,
-    taskDescription: ctx.taskDescription,
-    taskStatus: ctx.taskStatus,
-    record: extra?.record,
-  };
-}
-
-function isCompactedRollup(retro: unknown): retro is Record<string, unknown> {
-  const o = asObject(retro);
-  return !!o && o.type === 'compacted' && Array.isArray(o.sourceTrajectories);
-}
-
-function mapCompacted(
-  trajId: string,
-  ctx: TrajContext,
-  compacted: Record<string, unknown>,
-): ConvergenceEnvelope[] {
-  const out: ConvergenceEnvelope[] = [];
-  const source = trimmedOrUndef(compacted.source) ?? 'trajectories';
-  const lens = trimmedOrUndef(compacted.lens) ?? source;
-  const tagList = asArray(compacted.tags)
-    .map((t) => (typeof t === 'string' ? t.trim() : ''))
-    .filter((s) => s.length > 0);
-  const tags = tagList.length > 0 ? tagList : ['compacted'];
-  const isLearn = tags.includes('learn');
-
-  const emit = (kind: string, eventId: string, content: string, record?: Record<string, unknown>) => {
-    const c = content.trim();
-    if (c.length === 0) return;
-    out.push(baseEnvelope(ctx, source, lens, kind, eventId, c, null, { tags, record }));
-  };
-
-  // decisions[]
-  asArray(compacted.decisions).forEach((d, i) => {
-    const o = asObject(d);
-    if (!o) return;
-    const parts: string[] = [];
-    const question = trimmedOrUndef(o.question);
-    const chosen = trimmedOrUndef(o.chosen);
-    const reasoning = trimmedOrUndef(o.reasoning);
-    const impact = trimmedOrUndef(o.impact);
-    if (question) parts.push(`Question: ${question}`);
-    if (chosen) parts.push(`Chose: ${chosen}`);
-    if (reasoning) parts.push(`Because: ${reasoning}`);
-    if (impact) parts.push(`Impact: ${impact}`);
-    const rec: Record<string, unknown> = {};
-    if (chosen) rec.chosen = normalizeHomePath(chosen);
-    if (impact) rec.impact = normalizeHomePath(impact);
-    emit(
-      'decision',
-      `decision:${trajId}:${i}`,
-      normalizeHomePath(parts.join('\n')),
-      Object.keys(rec).length > 0 ? rec : undefined,
-    );
-  });
-
-  // lessons[]
-  asArray(compacted.lessons).forEach((l, i) => {
-    const o = asObject(l);
-    if (!o) return;
-    emit(
-      'reflection',
-      `reflection:${trajId}:lesson:${i}`,
-      labeledFields(o, [
-        ['Context', 'context'],
-        ['Lesson', 'lesson'],
-        ['Recommendation', 'recommendation'],
-      ]),
-    );
-  });
-
-  // keyFindings[]
-  stringArray(compacted.keyFindings).forEach((f, i) => {
-    emit('finding', `finding:${trajId}:keyfinding:${i}`, normalizeHomePath(f));
-  });
-
-  // keyLearnings[]
-  stringArray(compacted.keyLearnings).forEach((f, i) => {
-    emit('finding', `finding:${trajId}:learning:${i}`, normalizeHomePath(f));
-  });
-
-  // conventions[]
-  asArray(compacted.conventions).forEach((c, i) => {
-    const o = asObject(c);
-    if (!o) return;
-    emit(
-      'reflection',
-      `reflection:${trajId}:convention:${i}`,
-      labeledFields(o, [
-        ['Pattern', 'pattern'],
-        ['Rationale', 'rationale'],
-        ['Scope', 'scope'],
-      ]),
-    );
-  });
-
-  // narrative (only when not a "learn" rollup)
-  if (!isLearn) {
-    const narrative = trimmedOrUndef(compacted.narrative);
-    if (narrative) emit('reflection', `reflection:${trajId}:summary`, normalizeHomePath(narrative));
-  }
-
-  // openQuestions[]
-  stringArray(compacted.openQuestions).forEach((q, i) => {
-    emit('finding', `finding:${trajId}:openquestion:${i}`, normalizeHomePath(q));
-  });
-
-  return out;
-}
-
-function mapTrajectory(row: TrajectoryRow): ConvergenceEnvelope[] {
-  const trajId = row.id.trim();
-  if (trajId.length === 0) return [];
-
-  const ctx: TrajContext = {
-    sessionId: trajId,
-    tsIso: epochMsToIso(row.timestamp_ms),
-    actorName: trimmedOrUndef(row.persona_id),
-    projectId: trimmedOrUndef(row.project_id),
-    taskTitle: trimmedOrUndef(row.task_title),
-    taskDescription: trimmedOrUndef(row.task_description),
-    taskStatus: trimmedOrUndef(row.status),
-  };
-
-  const retro = parseJson(row.retrospective_json);
-  if (isCompactedRollup(retro)) {
-    return mapCompacted(trajId, ctx, retro);
-  }
-
-  const out: ConvergenceEnvelope[] = [];
-  const source = 'trajectories';
-  const lens = 'trajectories';
-
-  // Decisions first.
-  asArray(parseJson(row.decisions_json)).forEach((d, i) => {
-    const o = asObject(d);
-    if (!o) return;
-    const content = decisionContent(o);
-    if (content.length === 0) return;
-    out.push(
-      baseEnvelope(ctx, source, lens, 'decision', `decision:${trajId}:${i}`, content, asNumber(o.confidence), {
-        record: decisionRecord(o),
-      }),
-    );
-  });
-
-  const retroObj = asObject(retro);
-  if (retroObj) {
-    const retroConf = asNumber(retroObj.confidence);
-    const pushRetro = (kind: string, eventId: string, raw: unknown, confidence: number | null) => {
-      const content = normalizeHomePath((trimmedOrUndef(raw) ?? '').trim());
-      if (content.length === 0) return;
-      out.push(baseEnvelope(ctx, source, lens, kind, eventId, content, confidence));
-    };
-    pushRetro('reflection', `reflection:${trajId}:summary`, retroObj.summary, retroConf);
-    pushRetro('reflection', `reflection:${trajId}:approach`, retroObj.approach, retroConf);
-    stringArray(retroObj.learnings).forEach((v, i) =>
-      out.push(baseEnvelope(ctx, source, lens, 'finding', `finding:${trajId}:learning:${i}`, normalizeHomePath(v), null)),
-    );
-    stringArray(retroObj.suggestions).forEach((v, i) =>
-      out.push(
-        baseEnvelope(ctx, source, lens, 'reflection', `reflection:${trajId}:suggestion:${i}`, normalizeHomePath(v), null),
-      ),
-    );
-    stringArray(retroObj.challenges).forEach((v, i) =>
-      out.push(baseEnvelope(ctx, source, lens, 'finding', `finding:${trajId}:challenge:${i}`, normalizeHomePath(v), null)),
-    );
-  }
-
-  return out;
-}
-
-// ----- outbox batch builder (outbox::build_outbox_batch) -----
-
-export interface OutboxBatch {
-  records: ConvergenceEnvelope[];
-  cursor: SyncCursor;
-}
-
-function queryAll(db: Database, sql: string, params: Record<string, number>): Record<string, unknown>[] {
-  const stmt = db.prepare(sql);
-  try {
-    stmt.bind(params);
-    const rows: Record<string, unknown>[] = [];
-    while (stmt.step()) rows.push(stmt.getAsObject());
-    return rows;
-  } finally {
-    stmt.free();
-  }
-}
-
-export function buildOutboxBatch(
-  db: Database,
-  cursor: SyncCursor,
-  limit: number,
-  incognito: Set<string>,
-): OutboxBatch {
-  const effLimit = Math.max(limit, 1);
-  const next: SyncCursor = { ...cursor };
-  const records: ConvergenceEnvelope[] = [];
-
-  // History.
-  const historyRows = queryAll(
-    db,
-    'SELECT id, source, session_id, project, prompt, prompt_hash, timestamp_ms FROM history WHERE id > $id ORDER BY id ASC LIMIT $limit',
-    { $id: cursor.history_id, $limit: effLimit },
-  );
-  for (const raw of historyRows) {
-    if (records.length >= MAX_RECORDS) break;
-    const row: HistoryRow = {
-      id: Number(raw.id),
-      source: String(raw.source),
-      session_id: raw.session_id == null ? null : String(raw.session_id),
-      prompt: String(raw.prompt ?? ''),
-      prompt_hash: raw.prompt_hash == null ? null : String(raw.prompt_hash),
-      timestamp_ms: Number(raw.timestamp_ms),
-    };
-    next.history_id = Math.max(next.history_id, row.id);
-    if (row.session_id && incognito.has(row.session_id)) continue;
-    records.push(mapHistoryEntry(row));
-  }
-
-  // Trajectories (rowid watermark; TEXT PK means rowid is separate).
-  let trajRows: Record<string, unknown>[] = [];
-  try {
-    trajRows = queryAll(
-      db,
-      'SELECT rowid, id, persona_id, project_id, task_title, task_description, status, decisions_json, retrospective_json, timestamp_ms FROM trajectories WHERE rowid > $id ORDER BY rowid ASC LIMIT $limit',
-      { $id: cursor.trajectory_rowid, $limit: effLimit },
-    );
-  } catch {
-    trajRows = [];
-  }
-  for (const raw of trajRows) {
-    const rowid = Number(raw.rowid);
-    const id = String(raw.id ?? '');
-    if (incognito.has(id)) {
-      next.trajectory_rowid = Math.max(next.trajectory_rowid, rowid);
-      continue;
-    }
-    const mapped = mapTrajectory({
-      id,
-      persona_id: raw.persona_id == null ? null : String(raw.persona_id),
-      project_id: raw.project_id == null ? null : String(raw.project_id),
-      task_title: raw.task_title == null ? null : String(raw.task_title),
-      task_description: raw.task_description == null ? null : String(raw.task_description),
-      status: raw.status == null ? null : String(raw.status),
-      decisions_json: String(raw.decisions_json ?? ''),
-      retrospective_json: String(raw.retrospective_json ?? ''),
-      timestamp_ms: Number(raw.timestamp_ms),
-    });
-    if (records.length > 0 && records.length + mapped.length > MAX_RECORDS) break;
-    next.trajectory_rowid = Math.max(next.trajectory_rowid, rowid);
-    records.push(...mapped);
-  }
-
-  return { records, cursor: next };
-}
-
-// ----- HTTP (POST /v1/ingest) -----
-
-interface IngestRequest {
-  machine: MachineIdentity;
-  batchId: string;
-  cursors?: { history_id: number; trajectory_rowid: number };
-  records: ConvergenceEnvelope[];
-}
-
-interface IngestResponse {
-  accepted: number;
-}
-
-async function ingest(auth: RelayhistoryAuth, req: IngestRequest): Promise<IngestResponse> {
-  const url = `${auth.baseUrl.replace(/\/$/, '')}/v1/ingest`;
-  const resp = await fetch(url, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${auth.accessToken}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(req),
-    signal: AbortSignal.timeout(30_000),
-  });
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
-    throw new Error(`ingest failed: HTTP ${resp.status}: ${body.slice(0, 300)}`);
-  }
-  const payload = (await resp.json()) as Partial<IngestResponse>;
-  return { accepted: typeof payload.accepted === 'number' ? payload.accepted : 0 };
-}
-
-// ----- sql.js DB open -----
-
-let _sqlPromise: Promise<SqlJsStatic> | null = null;
-function getSqlJs(): Promise<SqlJsStatic> {
-  if (!_sqlPromise) _sqlPromise = initSqlJs();
-  return _sqlPromise;
+  cursor?: unknown;
 }
 
 export interface PushOptions {
-  /** Override the SQLite path (default `$AI_HIST_DB` or the standard location). */
-  dbPath?: string;
-  /** Pre-loaded auth; falls back to `loadStoredRelayhistoryAuth()`. */
-  auth?: RelayhistoryAuth | null;
-  /** Rows scanned per source (default 500). */
+  /** Explicit path to the ai-hist binary (overrides discovery). */
+  binPath?: string;
+  /** Rows scanned per source (forwarded as `--limit`). */
   limit?: number;
-  /** Session/trajectory ids to exclude (incognito). */
+  /** Session/trajectory ids to exclude (forwarded as repeated `--incognito`). */
   incognito?: Iterable<string>;
-  /** Reported as `machine.cliVersion`. */
-  cliVersion?: string;
+  /** Extra environment for the spawned binary (merged over `process.env`). */
+  env?: NodeJS.ProcessEnv;
+  /** Injectable spawn for testing. */
+  spawnFn?: typeof spawn;
+}
+
+const AI_HIST_RUST_BIN_ENV = 'AI_HIST_RUST_BIN';
+
+function isExecutable(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
- * Build the next outbox batch from the local DB and push it to
- * relayhistory-cloud. No-op (no HTTP) when there is nothing new. On success,
- * persists the advanced cursor. Returns `{ ok: false }`-style errors as thrown
- * exceptions; callers in a background loop should catch.
+ * Resolve the ai-hist binary: explicit override → `$AI_HIST_RUST_BIN` → the
+ * install.sh location → the `ai-hist` wrapper on `PATH`. Returns `null` only if
+ * an explicit/known path was given but isn't executable; otherwise falls back
+ * to `'ai-hist'` and lets spawn surface ENOENT (handled as a no-op).
  */
-export async function pushToCloud(opts: PushOptions = {}): Promise<PushReport> {
-  const auth = opts.auth ?? (await loadStoredRelayhistoryAuth());
-  if (!auth) {
-    throw new Error('not authenticated — no relayhistory auth found (run reflex on / ai-hist login)');
+export function resolveAiHistBinary(explicit?: string): string {
+  const known = [explicit, process.env[AI_HIST_RUST_BIN_ENV], join(homedir(), '.local', 'share', 'ai-hist', 'ai-hist-rust-bin')].filter(
+    (c): c is string => typeof c === 'string' && c.length > 0
+  );
+  for (const candidate of known) {
+    if (isExecutable(candidate)) return candidate;
   }
+  // Let PATH resolution (and ENOENT handling) take over.
+  return 'ai-hist';
+}
 
-  const dbPath = opts.dbPath ?? defaultDbPath();
-  let fileBuffer: Buffer;
-  try {
-    fileBuffer = await readFile(dbPath);
-  } catch {
-    // No local DB yet → nothing to push.
-    const cursor = await loadCursor();
-    return { sent: 0, accepted: 0, cursor, batchId: null };
-  }
+/**
+ * Push new local history to relayhistory-cloud by driving `ai-hist push --json`.
+ * Resolves `null` when the binary isn't installed or the user isn't
+ * authenticated (both non-fatal for a background loop); rejects on other
+ * non-zero exits or unparseable output.
+ */
+export function pushToCloud(opts: PushOptions = {}): Promise<PushReport | null> {
+  const spawnFn = opts.spawnFn ?? spawn;
+  const bin = resolveAiHistBinary(opts.binPath);
 
-  const SQL = await getSqlJs();
-  const db = new SQL.Database(fileBuffer);
-  try {
-    const cursor = await loadCursor();
-    const incognito = new Set<string>(opts.incognito ?? []);
-    const batch = buildOutboxBatch(db, cursor, opts.limit ?? DEFAULT_LIMIT, incognito);
-    if (batch.records.length === 0) {
-      return { sent: 0, accepted: 0, cursor, batchId: null };
-    }
+  const args = ['push', '--json'];
+  if (opts.limit != null) args.push('--limit', String(opts.limit));
+  for (const id of opts.incognito ?? []) args.push('--incognito', id);
 
-    const machine = await buildMachineIdentity(opts.cliVersion);
-    const bid = batchId(machine.id, cursor, batch.cursor, batch.records.length);
-    const resp = await ingest(auth, {
-      machine,
-      batchId: bid,
-      cursors: { history_id: batch.cursor.history_id, trajectory_rowid: batch.cursor.trajectory_rowid },
-      records: batch.records,
+  const spawnOpts: SpawnOptions = {
+    env: { ...process.env, ...opts.env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  };
+
+  return new Promise((resolve, reject) => {
+    const child = spawnFn(bin, args, spawnOpts);
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk) => {
+      stdout += String(chunk);
     });
-    // Advance the cursor only after the server accepts the batch.
-    await saveCursor(batch.cursor);
-    return { sent: batch.records.length, accepted: resp.accepted, cursor: batch.cursor, batchId: bid };
-  } finally {
-    db.close();
-  }
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      // Binary not on PATH / not installed → treat as "nothing to do".
+      if (err.code === 'ENOENT') {
+        resolve(null);
+        return;
+      }
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        // Not logged in yet is expected before `reflex on` completes.
+        if (/not authenticated|no relayhistory auth|run `?ai-hist login/i.test(stderr)) {
+          resolve(null);
+          return;
+        }
+        reject(new Error(`ai-hist push failed (exit ${code}): ${stderr.trim().slice(0, 300)}`));
+        return;
+      }
+      try {
+        const parsed = (stdout.trim() ? JSON.parse(stdout) : {}) as Partial<PushReport>;
+        resolve({
+          sent: typeof parsed.sent === 'number' ? parsed.sent : 0,
+          accepted: typeof parsed.accepted === 'number' ? parsed.accepted : 0,
+          batchId: typeof parsed.batchId === 'string' ? parsed.batchId : null,
+          cursor: parsed.cursor,
+        });
+      } catch (err) {
+        reject(
+          new Error(`could not parse ai-hist push output: ${err instanceof Error ? err.message : String(err)}`)
+        );
+      }
+    });
+  });
 }

--- a/test_install.py
+++ b/test_install.py
@@ -219,9 +219,9 @@ def test_install_script_autosync_opt_out_leaves_launchd_untouched(tmp_path):
     bin_dir = tmp_path / "bin"
     install_dir = tmp_path / "share" / "ai-hist"
     sandbox_home = tmp_path / "home"
-    fake_tools = tmp_path / "fake-tools"
-    fake_tools.mkdir()
 
+    # Binary mode installs a prebuilt binary (no cargo), so no fake toolchain on
+    # PATH is needed here — the inherited PATH covers install.sh's own tools.
     fake_binary = tmp_path / "ai-hist-darwin-arm64"
     fake_binary.write_text(
         "#!/bin/sh\n"
@@ -239,7 +239,6 @@ def test_install_script_autosync_opt_out_leaves_launchd_untouched(tmp_path):
             "AI_HIST_BIN_DIR": str(bin_dir),
             "AI_HIST_INSTALL_DIR": str(install_dir),
             "AI_HIST_WRAPPER_SOURCE_DIR": str(ROOT),
-            "PATH": f"{fake_tools}:{os.environ.get('PATH', '')}",
             "AI_HIST_NO_AUTOSYNC": "1",
             "HOME": str(sandbox_home),
         }

--- a/test_install.py
+++ b/test_install.py
@@ -18,6 +18,12 @@ def test_install_script_installs_working_launchers_from_source(tmp_path):
             "AI_HIST_BIN_DIR": str(bin_dir),
             "AI_HIST_INSTALL_DIR": str(install_dir),
             "AI_HIST_BUILD_PROFILE": "debug",
+            # Never let the installer's auto-sync step touch the developer's real
+            # launchd session: it would overwrite ~/Library/LaunchAgents with a
+            # plist pointing at this throwaway tmp binary. Sandbox HOME too as
+            # defense in depth.
+            "AI_HIST_NO_AUTOSYNC": "1",
+            "HOME": str(tmp_path / "install-home"),
         }
     )
 
@@ -150,6 +156,10 @@ def test_install_script_binary_mode_does_not_require_cargo(tmp_path):
             "AI_HIST_INSTALL_DIR": str(install_dir),
             "AI_HIST_WRAPPER_SOURCE_DIR": str(ROOT),
             "PATH": f"{fake_tools}:{os.environ.get('PATH', '')}",
+            # See note above: keep the installer's auto-sync out of the real
+            # launchd session during tests.
+            "AI_HIST_NO_AUTOSYNC": "1",
+            "HOME": str(tmp_path / "install-home"),
         }
     )
 
@@ -195,3 +205,55 @@ def test_install_script_binary_mode_does_not_require_cargo(tmp_path):
     )
     assert rust_result.returncode == 0, rust_result.stderr
     assert rust_result.stdout.strip() == "[]"
+
+
+def test_install_script_autosync_opt_out_leaves_launchd_untouched(tmp_path):
+    """AI_HIST_NO_AUTOSYNC=1 must skip the launchd/cron install entirely.
+
+    Regression guard: the installer's auto-sync step resolves the launchd plist
+    against $HOME, so an un-sandboxed install (as the test suite once did) would
+    clobber the real ~/Library/LaunchAgents job with a pointer to a throwaway
+    binary. The opt-out must write no plist at all.
+    """
+    bin_dir = tmp_path / "bin"
+    install_dir = tmp_path / "share" / "ai-hist"
+    sandbox_home = tmp_path / "home"
+    fake_tools = tmp_path / "fake-tools"
+    fake_tools.mkdir()
+
+    fake_binary = tmp_path / "ai-hist-darwin-arm64"
+    fake_binary.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"--version\" ]; then echo 'ai-hist 9.9.9'; exit 0; fi\n"
+        "if [ \"$1\" = \"recent\" ]; then echo '[]'; exit 0; fi\n"
+        "echo \"fake ai-hist: $*\"\n"
+    )
+    fake_binary.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "AI_HIST_INSTALL_METHOD": "binary",
+            "AI_HIST_BINARY_URL": fake_binary.as_uri(),
+            "AI_HIST_BIN_DIR": str(bin_dir),
+            "AI_HIST_INSTALL_DIR": str(install_dir),
+            "AI_HIST_WRAPPER_SOURCE_DIR": str(ROOT),
+            "PATH": f"{fake_tools}:{os.environ.get('PATH', '')}",
+            "AI_HIST_NO_AUTOSYNC": "1",
+            "HOME": str(sandbox_home),
+        }
+    )
+
+    result = subprocess.run(
+        ["sh", str(ROOT / "install.sh")],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "skipping auto-sync" in (result.stdout + result.stderr)
+    assert not sandbox_home.joinpath(
+        "Library", "LaunchAgents", "com.ai-hist.sync.plist"
+    ).exists()

--- a/test_install.py
+++ b/test_install.py
@@ -20,10 +20,11 @@ def test_install_script_installs_working_launchers_from_source(tmp_path):
             "AI_HIST_BUILD_PROFILE": "debug",
             # Never let the installer's auto-sync step touch the developer's real
             # launchd session: it would overwrite ~/Library/LaunchAgents with a
-            # plist pointing at this throwaway tmp binary. Sandbox HOME too as
-            # defense in depth.
+            # plist pointing at this throwaway tmp binary. AI_HIST_NO_AUTOSYNC
+            # skips the launchctl step entirely, which is the real fix. We do NOT
+            # override HOME here: this path runs `cargo build`, and an empty HOME
+            # blinds rustup (it resolves the toolchain via ~/.rustup / ~/.cargo).
             "AI_HIST_NO_AUTOSYNC": "1",
-            "HOME": str(tmp_path / "install-home"),
         }
     )
 


### PR DESCRIPTION
Makes relayhistory cloud sync automatic and available as an SDK, without re-implementing the push logic.

## 1. `sdk-ts`: cloud push that drives the Rust binary

`ai-hist/cloud` exports `pushToCloud`, a **thin wrapper over the real `ai-hist push --json` binary** — it resolves the binary (`$AI_HIST_RUST_BIN` → install.sh location → `ai-hist` on `PATH`), spawns it, and parses `{sent, accepted, batchId, cursor}`. 

This replaces an earlier ~500-line TypeScript **port** of the Rust push pipeline. Per review discussion, a port was the wrong call: it duplicated batching/cursor/dedup logic that must stay byte-for-byte wire-compatible with the Rust client forever. Driving the binary keeps **one source of truth** (the Rust `ai-hist push`) and drops the `sql.js` DB reading entirely. `pushToCloud` resolves `null` (no-op) when the binary is missing or the user isn't authenticated; rejects on other failures. Net −900 lines.

## 2. Installer test fix (was breaking CI `verify`)

The from-source install test sandboxed `$HOME`, which blinds rustup (it resolves the toolchain via `~/.rustup` / `~/.cargo`) during `cargo build` → `rustup could not choose a version of cargo`. `AI_HIST_NO_AUTOSYNC=1` alone is the real launchd-pollution fix; the `HOME` override is removed from the cargo path (kept on binary-mode tests, which don't compile).

## 3. `ai-hist push --install-service` (CLI parity)

Standalone launchd/cron push service (`com.ai-hist.push`), independent of the SDK path above.

## Testing

- `cargo build`/`cargo test --no-run` ✅
- sdk-ts `npm test` ✅ (wrapper tests: arg forwarding, JSON parse, ENOENT→null, not-authed→null, error→reject)
- `pytest test_install.py` / `test_cli_dispatch.py` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)