### PR TITLE
fix: clarify raw FTS query errors

### DIFF
--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -471,8 +471,28 @@ fn quote_fts_term(term: &str) -> String {
     format!("\"{}\"", term.replace('"', "\"\""))
 }
 
+/// True when a SQLite error is FTS5 rejecting the MATCH expression itself.
+///
+/// FTS5 surfaces a malformed expression as a `SqliteFailure` whose message names
+/// the fts5 parser, or -- when a bareword is parsed as a column reference -- as
+/// `no such column: <term>`. Anything else (I/O, decoding, a genuine schema
+/// mismatch) is a real failure and must not be relabelled.
+fn is_fts5_syntax_error(error: &rusqlite::Error) -> bool {
+    let rusqlite::Error::SqliteFailure(_, Some(message)) = error else {
+        return false;
+    };
+    let m = message.to_ascii_lowercase();
+    m.contains("fts5")
+        || m.contains("malformed match")
+        || m.contains("unterminated string")
+        || m.starts_with("no such column")
+}
+
+/// Map an FTS5 expression error to actionable guidance, leaving every other
+/// error untouched. Only applies in raw mode, where the caller supplied the
+/// MATCH expression verbatim.
 pub fn raw_fts_query_error(raw: bool, error: rusqlite::Error) -> anyhow::Error {
-    if raw {
+    if raw && is_fts5_syntax_error(&error) {
         anyhow::anyhow!(
             "Invalid raw FTS5 MATCH expression. Quote literal terms (for example, \"parity-check\") or remove --fts to use the default search."
         )

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -471,6 +471,16 @@ fn quote_fts_term(term: &str) -> String {
     format!("\"{}\"", term.replace('"', "\"\""))
 }
 
+pub fn raw_fts_query_error(raw: bool, error: rusqlite::Error) -> anyhow::Error {
+    if raw {
+        anyhow::anyhow!(
+            "Invalid raw FTS5 MATCH expression. Quote literal terms (for example, \"parity-check\") or remove --fts to use the default search."
+        )
+    } else {
+        error.into()
+    }
+}
+
 fn row_to_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<HistoryEntry> {
     Ok(HistoryEntry {
         id: row.get(0)?,
@@ -534,8 +544,12 @@ pub fn search(
     sql.push_str(" ORDER BY h.timestamp_ms DESC LIMIT ?");
     params_vec.push(filter.limit.max(1).to_string());
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), row_to_entry)?;
-    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+    let rows = stmt
+        .query_map(rusqlite::params_from_iter(params_vec), row_to_entry)
+        .map_err(|error| raw_fts_query_error(raw_fts, error))?;
+    Ok(rows
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| raw_fts_query_error(raw_fts, error))?)
 }
 
 pub fn recent(conn: &Connection, filter: &QueryFilter) -> Result<Vec<HistoryEntry>> {
@@ -870,6 +884,10 @@ mod tests {
         assert_eq!(
             build_fts_query(&["deploy".into(), "-relay".into()], false),
             "\"deploy\" NOT \"relay\""
+        );
+        assert_eq!(
+            build_fts_query(&["parity-check".into()], false),
+            "\"parity-check\""
         );
         assert_eq!(build_fts_query(&["foo*".into()], false), "foo*");
     }

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -4996,12 +4996,41 @@ mod tests {
             SearchRole::All,
         )
         .expect_err("malformed raw FTS query should fail");
-        let message = error.to_string();
+        assert_friendly_fts_error(&error.to_string());
 
-        assert!(message.contains("Invalid raw FTS5 MATCH expression"));
-        assert!(message.contains("Quote literal terms"));
-        assert!(!message.contains("no such column"));
-        assert!(!message.contains("SQL error or missing database"));
+        // event-row branch: history lookup succeeds, the event search still parses raw
+        let assistant_error = search_all(
+            &conn,
+            &["parity-check".to_string()],
+            true,
+            &QueryFilter {
+                limit: 10,
+                ..Default::default()
+            },
+            SearchRole::Assistant,
+        )
+        .expect_err("malformed raw FTS query should fail for assistant role");
+        assert_friendly_fts_error(&assistant_error.to_string());
+
+        // core search invoked directly with raw_fts enabled
+        let core_error = ai_hist_core::search(
+            &conn,
+            &["parity-check".to_string()],
+            true,
+            &QueryFilter {
+                limit: 10,
+                ..Default::default()
+            },
+        )
+        .expect_err("malformed raw FTS query should fail in core search");
+        assert_friendly_fts_error(&core_error.to_string());
+    }
+
+    fn assert_friendly_fts_error(message: &str) {
+        assert!(message.contains("Invalid raw FTS5 MATCH expression"), "got: {message}");
+        assert!(message.contains("Quote literal terms"), "got: {message}");
+        assert!(!message.contains("no such column"), "got: {message}");
+        assert!(!message.contains("SQL error or missing database"), "got: {message}");
     }
 
     #[test]

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -1,8 +1,8 @@
 use ai_hist_core::convergence::MachineIdentity;
 use ai_hist_core::{
     default_db_path, import_json, insert_history, normalize_tag_name, open_db, parse_cursor_text,
-    prompt_hash, recent, resume_command, search, session, sync_opencode_db, untag_session,
-    HistoryEntry, QueryFilter, SOURCE_CHOICES,
+    prompt_hash, raw_fts_query_error, recent, resume_command, search, session, sync_opencode_db,
+    untag_session, HistoryEntry, QueryFilter, SOURCE_CHOICES,
 };
 use anyhow::{Context, Result};
 use chrono::{Local, TimeZone};
@@ -125,6 +125,8 @@ enum Command {
         human: bool,
         #[arg(long, default_value_t = 20)]
         limit: i64,
+        /// Pass the query through as a raw FTS5 MATCH expression. Operators such as
+        /// `-`, `*`, `AND`, `OR`, and `NOT` are interpreted; quote literal terms yourself.
         #[arg(long)]
         fts: bool,
         #[arg(long)]
@@ -207,6 +209,8 @@ enum Command {
     Resume {
         #[arg(required = true)]
         query: Vec<String>,
+        /// Pass the query through as a raw FTS5 MATCH expression. Operators such as
+        /// `-`, `*`, `AND`, `OR`, and `NOT` are interpreted; quote literal terms yourself.
         #[arg(long)]
         fts: bool,
         #[arg(long)]
@@ -2587,8 +2591,10 @@ fn search_history_rows(
                 kind: "history".to_string(),
                 match_source: "history".to_string(),
             })
-        })?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
+        })
+        .map_err(|error| raw_fts_query_error(raw_fts, error))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| raw_fts_query_error(raw_fts, error))?;
     Ok(rows)
 }
 
@@ -2627,8 +2633,10 @@ fn search_event_rows(
                 kind: row.get(7)?,
                 match_source: "session_event".to_string(),
             })
-        })?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
+        })
+        .map_err(|error| raw_fts_query_error(raw_fts, error))?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| raw_fts_query_error(raw_fts, error))?;
     Ok(rows)
 }
 
@@ -4970,6 +4978,30 @@ mod tests {
                 && row.role == "assistant"
                 && row.text.contains("I will update auth.ts")
         }));
+    }
+
+    #[test]
+    fn malformed_raw_fts_query_has_a_friendly_error() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+
+        let error = search_all(
+            &conn,
+            &["parity-check".to_string()],
+            true,
+            &QueryFilter {
+                limit: 10,
+                ..Default::default()
+            },
+            SearchRole::All,
+        )
+        .expect_err("malformed raw FTS query should fail");
+        let message = error.to_string();
+
+        assert!(message.contains("Invalid raw FTS5 MATCH expression"));
+        assert!(message.contains("Quote literal terms"));
+        assert!(!message.contains("no such column"));
+        assert!(!message.contains("SQL error or missing database"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

FTS escaping was **not** broken: `quote_fts_term` already quotes and escapes non-raw terms, including hyphenated input. The actual issue was that `--fts` explicitly passes its input through as a raw FTS5 `MATCH` expression, where FTS5 interprets operators such as `-`.

This documents that raw-mode contract and maps malformed raw FTS5 expressions to an actionable error. Raw mode remains unescaped and unchanged.

## Verification

- `. "$HOME/.cargo/env" && cargo build` — passed
- `. "$HOME/.cargo/env" && cargo test --workspace` — passed (58 unit tests)
- Manual checks used an isolated temporary database seeded with `GATE_FAIL parity`:

```text
$ ai-hist search --fts "parity-check"
Error: Invalid raw FTS5 MATCH expression. Quote literal terms (for example, "parity-check") or remove --fts to use the default search.

$ ai-hist search --fts GATE_FAIL
  #1     1970-01-01 01:00  (claude) [/tmp/fts-manual]  GATE_FAIL parity

$ ai-hist search parity
  #1     1970-01-01 01:00  (claude) [/tmp/fts-manual]  GATE_FAIL parity

$ ai-hist search --help
Search prompts and sessions

Usage: ai-hist search [OPTIONS] [QUERY]...

Arguments:
  [QUERY]...

Options:
      --source <SOURCE>
      --project <PROJECT>
      --tag <TAG>
      --role <ROLE>        [default: all]
      --agent
      --human
      --limit <LIMIT>      [default: 20]
      --fts                Pass the query through as a raw FTS5 MATCH expression. Operators such as `-`, `*`, `AND`, `OR`, and `NOT` are interpreted; quote literal terms yourself
      --json
  -h, --help               Print help
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)