### PR TITLE
fix(ai-hist): survive a truncated .sync-state.json instead of wedging sync

### DIFF
--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 mod cloud;
 mod learn;
 
-use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering as AtomicOrdering};
 
 /// When set, sync progress lines (`[claude] +N rows`, …) are suppressed. The
 /// in-process library API ([`sync_and_push`]) sets this so an embedding host's
@@ -2911,16 +2911,34 @@ fn load_sync_state(path: &Path) -> Result<Map<String, Value>> {
 
 /// Writes via a temp file + rename so an interrupted or out-of-space write
 /// leaves the previous state intact rather than a truncated file.
+///
+/// The temp name is unique per writer, not just per destination: `sync_basic`
+/// runs from the CLI, from `watch_loop`, and from the in-process napi binding,
+/// so two saves can overlap. Sharing one temp path would let them interleave
+/// writes and rename a torn blend into place, or leave the slower writer's
+/// rename failing on a path the faster one already moved — reintroducing the
+/// class of failure this function exists to prevent.
 fn save_sync_state(path: &Path, state: &Map<String, Value>) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let tmp_path = path.with_extension("json.tmp");
-    fs::write(&tmp_path, serde_json::to_string_pretty(state)? + "\n")
-        .with_context(|| format!("writing sync state to {}", tmp_path.display()))?;
-    fs::rename(&tmp_path, path)
-        .with_context(|| format!("replacing sync state at {}", path.display()))?;
-    Ok(())
+    static NEXT_TMP_ID: AtomicU64 = AtomicU64::new(0);
+    let tmp_path = path.with_extension(format!(
+        "json.tmp.{}.{}",
+        std::process::id(),
+        NEXT_TMP_ID.fetch_add(1, AtomicOrdering::Relaxed)
+    ));
+    let saved = fs::write(&tmp_path, serde_json::to_string_pretty(state)? + "\n")
+        .with_context(|| format!("writing sync state to {}", tmp_path.display()))
+        .and_then(|()| {
+            fs::rename(&tmp_path, path)
+                .with_context(|| format!("replacing sync state at {}", path.display()))
+        });
+    if saved.is_err() {
+        // Best effort: don't leave a stray temp file behind on a failed save.
+        let _ = fs::remove_file(&tmp_path);
+    }
+    saved
 }
 
 fn sync_jsonl_incremental(
@@ -4863,7 +4881,53 @@ mod tests {
         assert_eq!(load_sync_state(&path).unwrap(), state);
 
         // The temp file is renamed away, never left beside the real one.
-        assert!(!dir.join(".sync-state.json.tmp").exists());
+        assert_eq!(leftover_tmp_files(&dir), Vec::<String>::new());
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    /// Temp files staged by `save_sync_state`, which should never outlive a save.
+    fn leftover_tmp_files(dir: &std::path::Path) -> Vec<String> {
+        let mut found: Vec<String> = fs::read_dir(dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| name.starts_with(".sync-state.json.tmp"))
+            .collect();
+        found.sort();
+        found
+    }
+
+    #[test]
+    fn concurrent_saves_never_publish_a_torn_state_file() {
+        let dir =
+            std::env::temp_dir().join(format!("ai-hist-state-concurrent-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".sync-state.json");
+
+        // Each writer stages a differently-sized payload, so a shared temp path
+        // would interleave into something that either fails to parse or blends
+        // two writers' bytes. Every save must publish exactly one writer's state.
+        let threads: Vec<_> = (0..8)
+            .map(|i| {
+                let path = path.clone();
+                std::thread::spawn(move || {
+                    let mut state = Map::new();
+                    state.insert("writer".into(), json!(i));
+                    state.insert("padding".into(), json!("x".repeat(i * 4096)));
+                    save_sync_state(&path, &state).unwrap();
+                })
+            })
+            .collect();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        // Whoever renamed last wins, but the winner must be intact and whole.
+        let published = load_sync_state(&path).unwrap();
+        let writer = published.get("writer").and_then(Value::as_u64).unwrap();
+        let padding = published.get("padding").and_then(Value::as_str).unwrap();
+        assert_eq!(padding.len(), writer as usize * 4096);
+        assert_eq!(leftover_tmp_files(&dir), Vec::<String>::new());
 
         fs::remove_dir_all(&dir).ok();
     }

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -2880,19 +2880,46 @@ fn load_sqlite_entries(path: &Path) -> Result<Vec<HistoryEntry>> {
     Ok(entries)
 }
 
+/// Sync state is an optimization, not a source of truth: an unreadable file
+/// costs a full re-scan (every insert path upserts) but must never wedge sync.
+/// A disk-full write used to leave this file empty and abort every later run.
 fn load_sync_state(path: &Path) -> Result<Map<String, Value>> {
     if !path.exists() {
         return Ok(Map::new());
     }
-    let value: Value = serde_json::from_str(&fs::read_to_string(path)?)?;
-    Ok(value.as_object().cloned().unwrap_or_default())
+    let text = match fs::read_to_string(path) {
+        Ok(text) => text,
+        Err(err) => {
+            eprintln!(
+                "ai-hist: could not read {} ({err}); starting from empty sync state",
+                path.display()
+            );
+            return Ok(Map::new());
+        }
+    };
+    match serde_json::from_str::<Value>(&text) {
+        Ok(value) => Ok(value.as_object().cloned().unwrap_or_default()),
+        Err(err) => {
+            eprintln!(
+                "ai-hist: {} is corrupt ({err}); starting from empty sync state",
+                path.display()
+            );
+            Ok(Map::new())
+        }
+    }
 }
 
+/// Writes via a temp file + rename so an interrupted or out-of-space write
+/// leaves the previous state intact rather than a truncated file.
 fn save_sync_state(path: &Path, state: &Map<String, Value>) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::write(path, serde_json::to_string_pretty(state)? + "\n")?;
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, serde_json::to_string_pretty(state)? + "\n")
+        .with_context(|| format!("writing sync state to {}", tmp_path.display()))?;
+    fs::rename(&tmp_path, path)
+        .with_context(|| format!("replacing sync state at {}", path.display()))?;
     Ok(())
 }
 
@@ -4779,8 +4806,9 @@ fn home_dir() -> PathBuf {
 mod tests {
     use super::{
         cron_schedule, file_stamp, git_commit_time_ms, git_stdout, ingest_claude_transcript,
-        link_git_commit, parse_trajectory_file, paths_overlap, search_all, shell_single_quote,
-        strip_url_credentials, sync_claude_session_metadata, xml_escape, SearchRole,
+        link_git_commit, load_sync_state, parse_trajectory_file, paths_overlap, save_sync_state,
+        search_all, shell_single_quote, strip_url_credentials, sync_claude_session_metadata,
+        xml_escape, SearchRole,
     };
     use ai_hist_core::{init_db, QueryFilter};
     use rusqlite::Connection;
@@ -4808,6 +4836,36 @@ mod tests {
         assert_eq!(cron_schedule(300).2, 300);
         assert_eq!(cron_schedule(5400).2, 7200);
         assert_eq!(cron_schedule(420).2, 600);
+    }
+
+    #[test]
+    fn load_sync_state_recovers_from_empty_or_corrupt_file() {
+        let dir = std::env::temp_dir().join(format!("ai-hist-state-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".sync-state.json");
+
+        // Missing file: nothing synced yet.
+        assert!(load_sync_state(&path).unwrap().is_empty());
+
+        // Empty file — what an ENOSPC-truncated write leaves behind. Used to
+        // abort every sync with "EOF while parsing a value at line 1 column 0".
+        fs::write(&path, "").unwrap();
+        assert!(load_sync_state(&path).unwrap().is_empty());
+
+        // Partially written / otherwise corrupt JSON.
+        fs::write(&path, "{\"claude\": ").unwrap();
+        assert!(load_sync_state(&path).unwrap().is_empty());
+
+        // Valid state still round-trips.
+        let mut state = Map::new();
+        state.insert("claude".into(), json!({"offset": 42}));
+        save_sync_state(&path, &state).unwrap();
+        assert_eq!(load_sync_state(&path).unwrap(), state);
+
+        // The temp file is renamed away, never left beside the real one.
+        assert!(!dir.join(".sync-state.json.tmp").exists());
+
+        fs::remove_dir_all(&dir).ok();
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`ai-hist sync` had been failing on every run for three days with:

```
Error: EOF while parsing a value at line 1 column 0
```

`~/.local/share/ai-hist/.sync-state.json` was **0 bytes**. `serde_json::from_str("")` produces exactly that message, and `load_sync_state` propagated it — aborting `sync_basic` before any work happened.

### How it got truncated

The disk filled up. From `/tmp/ai-hist-sync.err`:

```
Error code 13: Insertion failed because database is full
Error code 261: Another process is recovering a WAL mode database file
Error: Too many open files in system (os error 23)
Error: No space left on device (os error 28)
   ↓ then, 3463 times:
Error: EOF while parsing a value at line 1 column 0
```

`save_sync_state` used a plain `fs::write`, which **truncates first, then writes**. It was interrupted by `ENOSPC` mid-write, leaving an empty file — and the loader then treated that empty file as fatal on every subsequent run.

This also silently killed the background `com.ai-hist.sync` launchd agent, which runs every 60s: it exited 1 each time for three days. Recovering required knowing to delete the file by hand.

## Fix

Sync state is an optimization, not a source of truth. Losing it should cost a re-scan, never stop sync.

- **`load_sync_state`** falls back to empty state with a warning on an empty, corrupt, or unreadable file. Re-scanning is safe: every insert path upserts (`ON CONFLICT ... DO UPDATE`), so no rows are duplicated.
- **`save_sync_state`** writes to a temp file then `fs::rename`s it into place. An interrupted or out-of-space write now leaves the previous state intact rather than a truncated file.
- Both paths carry `.with_context()` so a future failure names the file instead of surfacing a bare serde error.

## Testing

New test `load_sync_state_recovers_from_empty_or_corrupt_file` covers missing, empty, corrupt, and valid-round-trip states, and asserts no `.tmp` file is left behind. It fails against the old code. Full workspace suite passes (58 tests).

Verified end-to-end against a scratch DB with a deliberately emptied state file:

```
# old binary
$ AI_HIST_DB=$SCRATCH/test.db ai-hist-rust-bin.bak sync
Error: EOF while parsing a value at line 1 column 0

# new binary
$ AI_HIST_DB=$SCRATCH/test.db ai-hist-rust-bin sync
ai-hist: .../.sync-state.json is corrupt (EOF while parsing a value at line 1 column 0); starting from empty sync state
  [claude] syncing 147624087 new bytes...
```

## Note

This makes sync resilient to the symptom. The underlying trigger was a full disk, which is an operational issue, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

