### PR TITLE
fix(ai-hist): stop an interrupted sync from wedging into a permanent re-scan loop

### DIFF
--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 /// WS-9 cloud-sync: local recall store → WS-1 convergence envelope (Agent Relay Loop).
 pub mod convergence;
@@ -235,11 +236,23 @@ pub fn default_db_path() -> PathBuf {
         })
 }
 
+/// How long a writer waits for a competing writer before giving up.
+///
+/// Raised from rusqlite's 5s default. The database is shared by several
+/// long-lived writers (the sync agent, the MCP server, relay brokers) and WAL
+/// admits one at a time, so a lock can be held longer than 5s -- a large WAL
+/// being recovered or checkpointed is enough. Sync then dies mid-run with
+/// "database is locked" and, being long-running, is the process most likely to
+/// be waiting when that happens.
+const BUSY_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub fn open_db(path: &Path) -> Result<Connection> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
     let conn = Connection::open(path)?;
+    // Before init_db: creating the schema takes a write lock too.
+    conn.busy_timeout(BUSY_TIMEOUT)?;
     init_db(&conn)?;
     Ok(conn)
 }
@@ -880,6 +893,40 @@ pub fn import_json(conn: &Connection, entries: &[HistoryEntry]) -> Result<usize>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn open_db_waits_longer_than_the_rusqlite_default_for_a_busy_writer() {
+        let dir = std::env::temp_dir().join(format!("ai-hist-busy-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("busy.db");
+        let conn = open_db(&path).unwrap();
+
+        // rusqlite already waits 5s by default; this database is contended by
+        // several long-lived writers and a lock can outlast that, so sync needs
+        // a longer grace period than the default gives it.
+        let configured: i64 = conn
+            .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(configured, BUSY_TIMEOUT.as_millis() as i64);
+        assert!(
+            configured > 5_000,
+            "expected a longer wait than rusqlite's 5s default, got {configured}ms"
+        );
+
+        // The waiting is real: a competing writer blocks rather than erroring.
+        conn.execute_batch("BEGIN IMMEDIATE").unwrap();
+        let releaser = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(200));
+            conn.execute_batch("COMMIT").unwrap();
+        });
+        open_db(&path)
+            .unwrap()
+            .execute_batch("CREATE TABLE contended_probe (x)")
+            .expect("writer should wait for the lock, not fail with SQLITE_BUSY");
+        releaser.join().unwrap();
+
+        fs::remove_dir_all(&dir).ok();
+    }
 
     #[test]
     fn parses_claude_and_codex() {

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -2938,9 +2938,51 @@ fn load_sync_state(path: &Path) -> Result<Map<String, Value>> {
 /// leaves the previous state intact when a write fails, so the worst case is a
 /// re-scan rather than corruption.
 fn checkpoint_sync_state(path: &Path, state: &Map<String, Value>) {
-    if let Err(err) = save_sync_state(path, state) {
-        eprintln!("ai-hist: could not checkpoint sync state: {err:#}");
+    match merged_sync_state(path, state) {
+        // Disk is already current; skip the rewrite.
+        Ok(None) => {}
+        Ok(Some(merged)) => {
+            if let Err(err) = save_sync_state(path, &merged) {
+                eprintln!("ai-hist: could not checkpoint sync state: {err:#}");
+            }
+        }
+        Err(err) => eprintln!("ai-hist: could not checkpoint sync state: {err:#}"),
     }
+}
+
+/// Fold this run's cursors into whatever is already on disk.
+///
+/// Sync runs are not serialized -- the CLI, the background service, and the
+/// in-process napi entry point can all overlap -- and each holds its own copy
+/// of the whole state map. Writing that copy wholesale lets a slow run replace
+/// a fast run's newer cursors with its own stale ones, so the next run rescans
+/// work that was already finished: exactly the loop checkpointing exists to
+/// prevent. Merging per key keeps sources this run did not touch, and cursors
+/// are monotonic byte offsets so a smaller one is always staler and is dropped.
+///
+/// Returns `None` when disk already reflects everything here, so a steady-state
+/// run that finds every source up to date does not rewrite the file per source.
+fn merged_sync_state(path: &Path, ours: &Map<String, Value>) -> Result<Option<Map<String, Value>>> {
+    let mut merged = load_sync_state(path)?;
+    let mut changed = false;
+    for (key, value) in ours {
+        match (merged.get(key), value.as_u64()) {
+            // A cursor that has not advanced past what is on disk is stale.
+            (Some(existing), Some(ours_offset))
+                if existing
+                    .as_u64()
+                    .is_some_and(|on_disk| on_disk >= ours_offset) =>
+            {
+                continue
+            }
+            // Unchanged non-cursor entries (per-file maps) need no rewrite.
+            (Some(existing), None) if existing == value => continue,
+            _ => {}
+        }
+        merged.insert(key.clone(), value.clone());
+        changed = true;
+    }
+    Ok(if changed { Some(merged) } else { None })
 }
 
 /// Writes via a temp file + rename so an interrupted or out-of-space write
@@ -4929,6 +4971,64 @@ mod tests {
             .collect();
         found.sort();
         found
+    }
+
+    #[test]
+    fn a_slow_run_cannot_rewind_or_clobber_a_faster_runs_cursors() {
+        let dir = std::env::temp_dir().join(format!("ai-hist-merge-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".sync-state.json");
+
+        // A fast run finished claude and codex and moved on.
+        let mut fast = Map::new();
+        fast.insert("claude".into(), json!(900));
+        fast.insert("codex".into(), json!(500));
+        checkpoint_sync_state(&path, &fast);
+
+        // A slow overlapping run only just finished claude, at an older offset.
+        // Writing its whole map wholesale would rewind claude and delete codex,
+        // sending the next run back over work that was already done.
+        let mut slow = Map::new();
+        slow.insert("claude".into(), json!(400));
+        checkpoint_sync_state(&path, &slow);
+
+        let on_disk = load_sync_state(&path).unwrap();
+        assert_eq!(on_disk.get("claude").and_then(Value::as_u64), Some(900));
+        assert_eq!(on_disk.get("codex").and_then(Value::as_u64), Some(500));
+
+        // A genuinely newer cursor still advances.
+        let mut newer = Map::new();
+        newer.insert("claude".into(), json!(1200));
+        checkpoint_sync_state(&path, &newer);
+        assert_eq!(
+            load_sync_state(&path)
+                .unwrap()
+                .get("claude")
+                .and_then(Value::as_u64),
+            Some(1200)
+        );
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn an_unchanged_source_does_not_rewrite_the_state_file() {
+        let dir = std::env::temp_dir().join(format!("ai-hist-norewrite-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".sync-state.json");
+
+        let mut state = Map::new();
+        state.insert("claude".into(), json!(42));
+        state.insert("codex".into(), json!({"files": {"a.jsonl": 7}}));
+        assert!(super::merged_sync_state(&path, &state).unwrap().is_some());
+        checkpoint_sync_state(&path, &state);
+
+        // Steady state: every source reports "up to date" and checkpoints the
+        // same map after each one. Rewriting the full file seven times a minute
+        // for no change is pure cost, so nothing should be written.
+        assert!(super::merged_sync_state(&path, &state).unwrap().is_none());
+
+        fs::remove_dir_all(&dir).ok();
     }
 
     #[test]

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -1676,6 +1676,13 @@ fn sync_basic(conn: &Connection, db_path: &Path) -> Result<()> {
         .unwrap_or_else(|| Path::new("."))
         .join(".sync-state.json");
     let mut state = load_sync_state(&state_path)?;
+    // Checkpoint after every source that advances `state`, rather than once at
+    // the end. A run can die partway through -- killed process, locked database,
+    // full disk -- and state written only at the end discards every source that
+    // already finished, sending the next run back over the same files. That
+    // turns one interrupted run into a loop that re-scans from scratch forever
+    // and never persists anything. Checkpointing makes each source's cursor
+    // durable the moment that source completes.
     total_inserted += sync_jsonl_incremental(
         conn,
         &mut state,
@@ -1683,11 +1690,17 @@ fn sync_basic(conn: &Connection, db_path: &Path) -> Result<()> {
         &home.join(".claude/history.jsonl"),
         parse_claude_line,
     )?;
+    checkpoint_sync_state(&state_path, &state);
     sync_claude_session_metadata(conn, &mut state, &home.join(".claude/projects"))?;
+    checkpoint_sync_state(&state_path, &state);
     total_inserted += sync_codex(conn, &mut state, &home)?;
+    checkpoint_sync_state(&state_path, &state);
     total_inserted += sync_cursor(conn, &mut state, &home.join(".cursor/projects"))?;
+    checkpoint_sync_state(&state_path, &state);
     total_inserted += sync_grok(conn, &mut state, &home.join(".grok/sessions"))?;
+    checkpoint_sync_state(&state_path, &state);
     total_inserted += sync_trajectories(conn, &mut state)?;
+    checkpoint_sync_state(&state_path, &state);
     let opencode = std::env::var_os("OPENCODE_DB")
         .map(PathBuf::from)
         .unwrap_or_else(default_opencode_db_path);
@@ -1699,8 +1712,8 @@ fn sync_basic(conn: &Connection, db_path: &Path) -> Result<()> {
     }
     total_inserted += open_inserted;
     total_inserted += sync_relaycast(conn, &mut state)?;
+    checkpoint_sync_state(&state_path, &state);
     let total: i64 = conn.query_row("SELECT COUNT(*) FROM history", [], |row| row.get(0))?;
-    save_sync_state(&state_path, &state)?;
     sync_note!("  [rust-sync] +{total_inserted} rows");
     sync_note!("  Total: {total} entries");
     Ok(())
@@ -2914,6 +2927,19 @@ fn load_sync_state(path: &Path) -> Result<Map<String, Value>> {
             );
             Ok(Map::new())
         }
+    }
+}
+
+/// Persist progress mid-run, between sources.
+///
+/// Deliberately non-fatal: the rows are already committed, so a run that
+/// finished real work should not be reported as failed because its bookkeeping
+/// write did not land. The next checkpoint retries, and [`save_sync_state`]
+/// leaves the previous state intact when a write fails, so the worst case is a
+/// re-scan rather than corruption.
+fn checkpoint_sync_state(path: &Path, state: &Map<String, Value>) {
+    if let Err(err) = save_sync_state(path, state) {
+        eprintln!("ai-hist: could not checkpoint sync state: {err:#}");
     }
 }
 
@@ -4831,10 +4857,10 @@ fn home_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::{
-        cron_schedule, file_stamp, git_commit_time_ms, git_stdout, ingest_claude_transcript,
-        link_git_commit, load_sync_state, parse_trajectory_file, paths_overlap, save_sync_state,
-        search_all, shell_single_quote, strip_url_credentials, sync_claude_session_metadata,
-        xml_escape, SearchRole,
+        checkpoint_sync_state, cron_schedule, file_stamp, git_commit_time_ms, git_stdout,
+        ingest_claude_transcript, link_git_commit, load_sync_state, parse_trajectory_file,
+        paths_overlap, save_sync_state, search_all, shell_single_quote, strip_url_credentials,
+        sync_claude_session_metadata, xml_escape, SearchRole,
     };
     use ai_hist_core::{init_db, QueryFilter};
     use rusqlite::Connection;
@@ -4903,6 +4929,37 @@ mod tests {
             .collect();
         found.sort();
         found
+    }
+
+    #[test]
+    fn checkpoints_persist_between_sources_and_never_abort_a_run() {
+        let dir = std::env::temp_dir().join(format!("ai-hist-checkpoint-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".sync-state.json");
+
+        // A cursor saved mid-run is visible to the next run. This is what stops
+        // an interrupted sync from re-scanning what it already finished.
+        let mut state = Map::new();
+        state.insert("claude".into(), json!({"offset": 147_624_483u64}));
+        checkpoint_sync_state(&path, &state);
+        assert_eq!(load_sync_state(&path).unwrap(), state);
+
+        // A later source advances state; its checkpoint supersedes the earlier one.
+        state.insert("codex".into(), json!({"files": 3}));
+        checkpoint_sync_state(&path, &state);
+        assert_eq!(load_sync_state(&path).unwrap(), state);
+
+        // An unwritable destination warns instead of unwinding -- the rows are
+        // already committed, so a failed bookkeeping write must not fail the run.
+        let blocker = dir.join("blocker");
+        fs::write(&blocker, "not a directory").unwrap();
+        checkpoint_sync_state(&blocker.join("nested").join(".sync-state.json"), &state);
+
+        // ...and the last good checkpoint is left untouched by that failure.
+        assert_eq!(load_sync_state(&path).unwrap(), state);
+        assert_eq!(leftover_tmp_files(&dir), Vec::<String>::new());
+
+        fs::remove_dir_all(&dir).ok();
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #44. That PR stopped a truncated `.sync-state.json` from aborting sync. This one stops an *interrupted* sync from throwing away everything it had done.

## Problem

`sync_basic` wrote `.sync-state.json` exactly once, at the very end of the run. Any death before that point discarded every source that had already completed, so the next run re-scanned the same files from scratch — and died in the same place. One interrupted run becomes a loop that never persists anything.

Observed on a live ~3GB database: ~148MB of Claude history re-scanned every cycle, indefinitely.

## Changes

**1. Checkpoint after each source, and within a source.** State is saved as soon as a source completes, and JSONL ingestion now runs in 2000-line chunks that checkpoint their byte offset per commit. An interrupted run resumes mid-file rather than restarting. Chunking also takes the write lock once per chunk instead of once per row, and avoids holding it for minutes on a large backlog — which would starve the other writers.

Checkpoints are deliberately non-fatal: the rows are already committed, so a run that did real work shouldn't be reported as failed because a bookkeeping write didn't land.

**2. Merge checkpoints rather than overwriting.** Sync runs aren't serialized (CLI, background service, and in-process napi can overlap), so writing the whole in-memory map wholesale let a slow run replace a faster run's newer cursors. Checkpoints now merge per key, and monotonic cursors mean a non-advancing offset is dropped — a checkpoint can never rewind another run's progress. Also skips the write when disk is already current, instead of rewriting the full file once per source every minute.

**3. Raise the busy timeout from rusqlite's 5s default to 30s.** Scope note: this was written believing it addressed the outage that motivated this PR. It does not. That outage was caused by a process holding the write lock **permanently** (see below), which no timeout survives. This change only helps ordinary transient overlap between active writers, and is included on those narrower merits. Bounded retry with backoff would be the better mechanism — tracked in #49.

## Scope — what this does not do

None of this explains why a writer holds the lock. The outage that prompted the work was an `agent-relay` process **SIGSTOP'd mid-transaction**: a stopped process never runs again on its own, so it holds the single WAL write lock forever. `sqlite3` with a 10s busy timeout waited the full 10s and still failed.

This PR makes sync **survivable**: progress accumulates across runs instead of resetting, so sync converges over several cycles even when individual runs die. It does not make it contention-free. Tracked follow-ups: #47 (single-writer architecture), #48 (per-source isolation), #49 (BUSY retry), #50 (why brokers get suspended).

## Testing

- `jsonl_ingest_checkpoints_mid_source_and_resumes_from_there` — checkpoints land inside the source, advance monotonically, and resuming from one ingests exactly the remainder
- `a_slow_run_cannot_rewind_or_clobber_a_faster_runs_cursors` — verified as a real regression test: fails against the wholesale write, rewinding the cursor to 400
- `an_unchanged_source_does_not_rewrite_the_state_file`
- `checkpoints_persist_between_sources_and_never_abort_a_run` — including that an unwritable destination warns instead of unwinding
- `open_db_waits_longer_than_the_rusqlite_default_for_a_busy_writer` — verified as a real regression test: fails `left: 5000, right: 30000` without the change

Full workspace suite passes (64 tests). Validated end-to-end against the live database exhibiting the loop: the rollback-then-checkpoint path is what persisted state there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)