### PR TITLE
fix(cli): request the unmasked Cloud token on login

### DIFF
--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -354,8 +354,9 @@ fn read_agent_relay_session(bin: &str) -> Result<AgentRelayCloudSession> {
             stderr.trim()
         );
     }
-    serde_json::from_slice(&output.stdout)
-        .context("parsing Agent Relay Cloud session JSON from `agent-relay cloud session --json`")
+    serde_json::from_slice(&output.stdout).context(
+        "parsing Agent Relay Cloud session JSON from `agent-relay cloud session --json --reveal-token`",
+    )
 }
 
 fn ensure_agent_relay_session(
@@ -925,12 +926,14 @@ exit 42"#,
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let log_dir = tempfile::tempdir().unwrap();
         let argv_log = log_dir.path().join("argv.log");
-        let (_dir, bin) = fake_agent_relay(&format!(
-            r#"echo "$*" > {}
-echo '{{"apiUrl":"https://agentrelay.com/cloud","accessToken":"relay_at_abc","accessTokenExpiresAt":"2999-01-01T00:00:00.000Z"}}'
+        // Pass the capture path via env and expand it quoted — a temp dir containing spaces or
+        // shell metacharacters would otherwise break the fixture rather than the assertion.
+        let _argv_log_env = EnvVarGuard::set("AI_HIST_TEST_ARGV_LOG", argv_log.as_os_str());
+        let (_dir, bin) = fake_agent_relay(
+            r#"printf '%s\n' "$@" > "$AI_HIST_TEST_ARGV_LOG"
+echo '{"apiUrl":"https://agentrelay.com/cloud","accessToken":"relay_at_abc","accessTokenExpiresAt":"2999-01-01T00:00:00.000Z"}'
 exit 0"#,
-            argv_log.display()
-        ));
+        );
         let _cloud_token = EnvVarGuard::remove("CLOUD_API_ACCESS_TOKEN");
 
         read_agent_relay_session(bin.to_str().unwrap()).unwrap();

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -331,12 +331,17 @@ fn agent_relay_bin() -> String {
 }
 
 fn read_agent_relay_session(bin: &str) -> Result<AgentRelayCloudSession> {
+    // `--reveal-token` is REQUIRED. Without it `agent-relay cloud session --json` returns the
+    // access token *masked* (e.g. `cld_at_…Knv4`), which is not a usable bearer: relayhistory
+    // forwards it to Cloud `api/v1/auth/whoami`, which rejects it, and `ai-hist login` fails with
+    // `HTTP 401: {"error":"invalid Agent Relay Cloud token"}`. The masked form is still a
+    // syntactically plausible `cld_at_…` string, so nothing upstream catches it.
     let output = std::process::Command::new(bin)
-        .args(["cloud", "session", "--json"])
+        .args(["cloud", "session", "--json", "--reveal-token"])
         .output()
         .with_context(|| {
             format!(
-                "failed to run `{bin} cloud session --json` — install Agent Relay and run `agent-relay login`"
+                "failed to run `{bin} cloud session --json --reveal-token` — install Agent Relay and run `agent-relay login`"
             )
         })?;
     if !output.status.success() {
@@ -878,9 +883,19 @@ mod tests {
     fn login_via_cloud_exchanges_agent_relay_session() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let (base_url, server) = one_shot_login_server("relay_at_abc", Some("sync"));
+        // Models the real `agent-relay cloud session --json` contract: the access token comes
+        // back MASKED unless `--reveal-token` is passed. If ai-hist ever drops that flag it gets
+        // `relay_at_MASKED`, the login server below rejects the payload, and this test fails —
+        // which is exactly the production failure it stands in for.
         let (_dir, bin) = fake_agent_relay(
-            r#"if [ "$1 $2 $3" = "cloud session --json" ]; then
-  echo '{"apiUrl":"https://agentrelay.com/cloud","accessToken":"relay_at_abc","accessTokenExpiresAt":"2999-01-01T00:00:00.000Z"}'
+            r#"case " $* " in
+  *" --reveal-token "*)
+    echo '{"apiUrl":"https://agentrelay.com/cloud","accessToken":"relay_at_abc","accessTokenExpiresAt":"2999-01-01T00:00:00.000Z"}'
+    exit 0
+    ;;
+esac
+if [ "$1 $2 $3" = "cloud session --json" ]; then
+  echo '{"apiUrl":"https://agentrelay.com/cloud","accessToken":"relay_at_MASKED","accessTokenExpiresAt":"2999-01-01T00:00:00.000Z"}'
   exit 0
 fi
 echo "unexpected args: $*" 1>&2
@@ -898,6 +913,34 @@ exit 42"#,
         assert_eq!(auth.refresh_token.as_deref(), Some("rth_rt_def"));
         assert_eq!(auth.org_id.as_deref(), Some("org_dev"));
         assert_eq!(auth.workspace_id.as_deref(), Some("ws_dev"));
+    }
+
+    /// Guards the exact defect that made `ai-hist login` fail fleet-wide: the session lookup must
+    /// ask for the UNMASKED token. `agent-relay cloud session --json` masks it by default, and the
+    /// masked stub is a plausible-looking `cld_at_…` string that only fails later, at Cloud
+    /// `whoami`, as an opaque 401.
+    #[cfg(unix)]
+    #[test]
+    fn cloud_session_invocation_requests_unmasked_token() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let log_dir = tempfile::tempdir().unwrap();
+        let argv_log = log_dir.path().join("argv.log");
+        let (_dir, bin) = fake_agent_relay(&format!(
+            r#"echo "$*" > {}
+echo '{{"apiUrl":"https://agentrelay.com/cloud","accessToken":"relay_at_abc","accessTokenExpiresAt":"2999-01-01T00:00:00.000Z"}}'
+exit 0"#,
+            argv_log.display()
+        ));
+        let _cloud_token = EnvVarGuard::remove("CLOUD_API_ACCESS_TOKEN");
+
+        read_agent_relay_session(bin.to_str().unwrap()).unwrap();
+
+        let argv = fs::read_to_string(&argv_log).unwrap();
+        assert!(
+            argv.contains("--reveal-token"),
+            "ai-hist must request the unmasked token; without `--reveal-token` the CLI forwards a \
+             masked stub and login fails with `invalid Agent Relay Cloud token`. argv was: {argv}"
+        );
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

`ai-hist login` fails on every machine with:

```
Error: HTTP 401: {"error":"invalid Agent Relay Cloud token"}
```

Root cause: `read_agent_relay_session` invoked `agent-relay cloud session --json`, which returns the access token **masked** unless `--reveal-token` is passed:

```
--json           Output the session as JSON (access token masked unless --reveal-token)
--reveal-token   Include the raw access token in --json output
```

So ai-hist forwarded a 12-char masked stub instead of the real 50-char bearer:

```
accessToken: len=12 startswith='cld_at_' has_ellipsis=True     <- what ai-hist sent
revealed token len = 50 prefix = cld_at_ masked = False        <- the real one
```

That stub goes to relayhistory `/v1/cli/login`, which relays it to Cloud `api/v1/auth/whoami`; Cloud rejects it and the CLI surfaces an opaque 401. Because the masked form is still a plausible-looking `cld_at_…` string, nothing between the two flagged it.

One-line fix: pass `--reveal-token`.

## Evidence

Same live session, same endpoint, both directions:

```
masked token   -> GET /cloud/api/v1/auth/whoami -> HTTP_STATUS:401
revealed token -> GET /cloud/api/v1/auth/whoami -> HTTP_STATUS:200
                  authenticated = True
                  scopes        = ['auth:workspace:follow-user', 'cli:auth']
```

End-to-end, real binaries:

```
# before (installed 0.1.0)
$ ai-hist login --mode sync
Error: HTTP 401: {"error":"invalid Agent Relay Cloud token"}

# after (this branch, CLOUD_API_ACCESS_TOKEN unset — no workaround)
$ ./target/debug/ai-hist login --mode sync
Logged in to https://history.agentrelay.com (session stored).
```

Confirmed at binary level that the shipped build never passed the flag — `strings ai-hist-rust-bin` returns 0 occurrences of `reveal-token`.

## Tests

The existing `login_via_cloud_exchanges_agent_relay_session` **encoded the bug**: its fake `agent-relay` matched on `"cloud session --json"` and returned an *unmasked* token, so the masked path was never exercised. Two changes:

1. That stub now models the real contract — masked unless `--reveal-token` is present. Drop the flag and the whole login path fails, which is the production failure it stands in for.
2. New `cloud_session_invocation_requests_unmasked_token` captures the argv and asserts the flag is passed.

Both are **red against the unfixed parent** (verified by reverting only the source line and keeping the tests):

```
test cloud::tests::login_via_cloud_exchanges_agent_relay_session ... FAILED
test cloud::tests::cloud_session_invocation_requests_unmasked_token ... FAILED
test result: FAILED. 14 passed; 2 failed
```

With the fix, full workspace green:

```
test result: ok. 41 passed; 0 failed
test result: ok. 30 passed; 0 failed
```

`cargo build -q -p ai-hist-cli` (the CI gate) exits 0.

## Note on scope

This is **not** the relayhistory assertion key from AgentWorkforce/cloud#2931. That secret (`RelayhistoryAssertionRelayauthApiKey`) is consumed only by Cloud's *outbound* assertion route `/api/v1/workspaces/{id}/relayhistory/session`, which the CLI never calls. `ai-hist login --cloud` goes CLI → relayhistory `/v1/cli/login` → Cloud `api/v1/auth/whoami` (read-only introspection). Seeding that secret would not have fixed login; this is the actual blocker. Details on cloud#2931.

`Cargo.lock` has pre-existing unrelated drift (`ai-hist-napi` 0.4.1→0.4.3) which I deliberately left out to keep this focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

