### PR TITLE
fix(cloud): scope sessions and cursors by stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
           cache: npm
           cache-dependency-path: sdk-ts/package-lock.json
 
+      - name: Rust formatting
+        run: cargo fmt --all -- --check
+
+      - name: Rust lint
+        run: cargo clippy --workspace --all-targets -- -A clippy::needless-question_mark -A clippy::unnecessary_map_or -A clippy::too_many_arguments -D warnings
+
       - name: Rust tests
         run: cargo test --workspace
 
@@ -40,6 +46,7 @@ jobs:
         working-directory: sdk-ts
         run: |
           npm ci
+          npm run lint
           npm test
 
       - name: End-to-end wrapper verification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Rust lint
-        run: cargo clippy --workspace --all-targets -- -A clippy::needless-question_mark -A clippy::unnecessary_map_or -A clippy::too_many_arguments -D warnings
+        run: cargo clippy --workspace --all-targets -- -A clippy::too_many_arguments -D warnings
 
       - name: Rust tests
         run: cargo test --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "ureq",
+ "url",
 ]
 
 [[package]]

--- a/crates/ai-hist-core/src/convergence.rs
+++ b/crates/ai-hist-core/src/convergence.rs
@@ -1074,9 +1074,11 @@ mod tests {
             .iter()
             .all(|e| e.project_id.as_deref() == Some("relayhistory")));
         assert!(events.iter().all(|e| e.task_title.is_none()));
-        assert!(events.iter().all(|e| e.record.as_ref().map_or(true, |r| {
-            r.get("sourceTrajectories").is_none() && r.get("raw").is_none()
-        })));
+        assert!(events
+            .iter()
+            .all(|e| e.record.as_ref().is_none_or(|r| {
+                r.get("sourceTrajectories").is_none() && r.get("raw").is_none()
+            })));
         assert!(events[0]
             .content
             .contains("Impact: Pair can rank prior work"));

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -646,9 +646,8 @@ pub fn search(
     let rows = stmt
         .query_map(rusqlite::params_from_iter(params_vec), row_to_entry)
         .map_err(|error| raw_fts_query_error(raw_fts, error))?;
-    Ok(rows
-        .collect::<rusqlite::Result<Vec<_>>>()
-        .map_err(|error| raw_fts_query_error(raw_fts, error))?)
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|error| raw_fts_query_error(raw_fts, error))
 }
 
 pub fn recent(conn: &Connection, filter: &QueryFilter) -> Result<Vec<HistoryEntry>> {

--- a/crates/ai-hist/Cargo.toml
+++ b/crates/ai-hist/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 ureq = { version = "2", features = ["json"] }
+url = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -3,8 +3,8 @@
 //!
 //! This is the **binding layer** — it does the network I/O the WASM-bound `ai-hist-core`
 //! deliberately avoids. It wires `ai_hist_core::outbox::build_outbox_batch` (pure batch
-//! building) to `POST /v1/ingest` with `rth_at_` bearer auth, persists the single cursor
-//! store, and advances it to the server-confirmed watermark.
+//! building) to `POST /v1/ingest` with `rth_at_` bearer auth, persists a cursor per Cloud
+//! stage, and advances only that stage's server-confirmed watermark.
 //!
 //! Token bootstrap: `/v1/cli/login` (RelayAuth JWT → `rth_at_`/`rth_rt_`) for real use, or
 //! `/v1/admin/mint` (dev-only, `ADMIN_MINT_SECRET`) for local `wrangler dev` iteration.
@@ -120,11 +120,28 @@ fn authority_is_loopback(rest: &str) -> bool {
             .is_ok_and(|ip| ip.is_loopback())
 }
 
-fn auth_path() -> PathBuf {
+fn legacy_auth_path() -> PathBuf {
     config_dir().join("auth.json")
 }
-fn cursor_path() -> PathBuf {
+
+fn legacy_cursor_path() -> PathBuf {
     config_dir().join("cursor.json")
+}
+
+fn stage_key(base_url: &str) -> String {
+    ai_hist_core::prompt_hash(base_url.trim().trim_end_matches('/'))
+}
+
+fn stage_dir() -> PathBuf {
+    config_dir().join("stages")
+}
+
+fn auth_path(base_url: &str) -> PathBuf {
+    stage_dir().join(format!("{}.auth.json", stage_key(base_url)))
+}
+
+fn cursor_path(base_url: &str) -> PathBuf {
+    stage_dir().join(format!("{}.cursor.json", stage_key(base_url)))
 }
 fn machine_path() -> PathBuf {
     config_dir().join("machine-id")
@@ -144,32 +161,134 @@ fn write_private(path: &std::path::Path, body: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn load_auth() -> Result<Option<StoredAuth>> {
-    let path = auth_path();
-    if !path.exists() {
-        return Ok(None);
+fn read_auth(path: &std::path::Path) -> Result<StoredAuth> {
+    let body = fs::read_to_string(path)?;
+    serde_json::from_str(&body).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn staged_auths() -> Result<Vec<StoredAuth>> {
+    let dir = stage_dir();
+    if !dir.exists() {
+        return Ok(Vec::new());
     }
-    let body = fs::read_to_string(&path)?;
-    Ok(Some(
-        serde_json::from_str(&body).context("parsing stored auth.json")?,
-    ))
+    let mut auths = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let path = entry?.path();
+        if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.ends_with(".auth.json"))
+        {
+            auths.push(read_auth(&path)?);
+        }
+    }
+    Ok(auths)
 }
 
+fn same_stage(left: &str, right: &str) -> bool {
+    left.trim().trim_end_matches('/') == right.trim().trim_end_matches('/')
+}
+
+/// Load one stored session. A caller that knows its destination must pass it explicitly.
+/// Without a destination, only a single configured stage is accepted; choosing the last
+/// successful login was the old behavior and could silently divert a scheduled push.
+pub fn load_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
+    if let Some(base_url) = base_url {
+        let path = auth_path(base_url);
+        if path.exists() {
+            let auth = read_auth(&path)?;
+            anyhow::ensure!(
+                same_stage(&auth.base_url, base_url),
+                "stored session stage does not match the requested --base-url"
+            );
+            return Ok(Some(auth));
+        }
+        let legacy = legacy_auth_path();
+        if !legacy.exists() {
+            return Ok(None);
+        }
+        let auth = read_auth(&legacy)?;
+        return Ok(same_stage(&auth.base_url, base_url).then_some(auth));
+    }
+
+    let auths = staged_auths()?;
+    match auths.len() {
+        0 => {
+            let path = legacy_auth_path();
+            if path.exists() {
+                Ok(Some(read_auth(&path)?))
+            } else {
+                Ok(None)
+            }
+        }
+        1 => Ok(auths.into_iter().next()),
+        count => anyhow::bail!(
+            "{count} relayhistory stages are configured; pass --base-url to select one. \
+             Refusing to guess, because a global cloud session can skip records in another stage."
+        ),
+    }
+}
+
+/// Store a session only under its base URL. If upgrading from the old one-file layout, preserve
+/// that old stage and cursor before adding the new one; overwriting it is exactly what caused
+/// cross-stage cursor corruption.
 pub fn save_auth(auth: &StoredAuth) -> Result<()> {
-    write_private(&auth_path(), &serde_json::to_string_pretty(auth)?)
+    migrate_legacy_stage()?;
+    write_private(
+        &auth_path(&auth.base_url),
+        &serde_json::to_string_pretty(auth)?,
+    )
 }
 
-pub fn load_cursor() -> Result<SyncCursor> {
-    let path = cursor_path();
-    if !path.exists() {
+fn migrate_legacy_stage() -> Result<()> {
+    let legacy_auth = legacy_auth_path();
+    if !legacy_auth.exists() {
+        return Ok(());
+    }
+    let auth = read_auth(&legacy_auth)?;
+    let staged_auth_path = auth_path(&auth.base_url);
+    if !staged_auth_path.exists() {
+        write_private(&staged_auth_path, &serde_json::to_string_pretty(&auth)?)?;
+    }
+
+    let legacy_cursor = legacy_cursor_path();
+    if legacy_cursor.exists() {
+        let staged_cursor = cursor_path(&auth.base_url);
+        if !staged_cursor.exists() {
+            let body = fs::read_to_string(&legacy_cursor)?;
+            write_private(&staged_cursor, &body)?;
+        }
+    }
+
+    fs::remove_file(legacy_auth)?;
+    if legacy_cursor.exists() {
+        fs::remove_file(legacy_cursor)?;
+    }
+    Ok(())
+}
+
+pub fn load_cursor(base_url: &str) -> Result<SyncCursor> {
+    let path = cursor_path(base_url);
+    if path.exists() {
+        let body = fs::read_to_string(&path)?;
+        return serde_json::from_str(&body).context("parsing stage-scoped cursor.json");
+    }
+
+    // Compatibility for an existing single-stage install. The next successful push writes the
+    // scoped path; a subsequent login migrates it eagerly with the corresponding auth session.
+    let legacy = legacy_cursor_path();
+    if !legacy.exists() {
         return Ok(SyncCursor::default());
     }
-    let body = fs::read_to_string(&path)?;
-    serde_json::from_str(&body).context("parsing cursor.json")
+    let body = fs::read_to_string(&legacy)?;
+    serde_json::from_str(&body).context("parsing legacy cursor.json")
 }
 
-pub fn save_cursor(cursor: &SyncCursor) -> Result<()> {
-    write_private(&cursor_path(), &serde_json::to_string_pretty(cursor)?)
+pub fn save_cursor(base_url: &str, cursor: &SyncCursor) -> Result<()> {
+    write_private(
+        &cursor_path(base_url),
+        &serde_json::to_string_pretty(cursor)?,
+    )
 }
 
 /// Stable per-machine id (the WS-1 `machineId` sub-tenant), generated once and persisted.
@@ -281,7 +400,7 @@ pub fn push(
     };
     let resp = client.ingest(auth, &req).context("POST /v1/ingest")?;
     // advance the cursor only after the server accepts the batch (durable outbox)
-    save_cursor(&batch.cursor)?;
+    save_cursor(&auth.base_url, &batch.cursor)?;
     Ok(PushReport {
         sent: req.records.len(),
         accepted: resp.accepted,
@@ -1124,7 +1243,7 @@ mod tests {
             assert!(sent.batch_id.starts_with("b_"));
             assert_eq!(sent.records.len(), 2);
             // cursor persisted to disk and reloads to the advanced value
-            assert_eq!(load_cursor().unwrap().history_id, 2);
+            assert_eq!(load_cursor(&auth.base_url).unwrap().history_id, 2);
         });
     }
 
@@ -1177,13 +1296,55 @@ mod tests {
                 workspace_id: None,
             };
             save_auth(&auth).unwrap();
-            assert_eq!(load_auth().unwrap().unwrap(), auth);
+            assert_eq!(load_auth(Some(&auth.base_url)).unwrap().unwrap(), auth);
             let c = SyncCursor {
                 history_id: 9,
                 trajectory_rowid: 4,
             };
-            save_cursor(&c).unwrap();
-            assert_eq!(load_cursor().unwrap(), c);
+            save_cursor(&auth.base_url, &c).unwrap();
+            assert_eq!(load_cursor(&auth.base_url).unwrap(), c);
+        });
+    }
+
+    /// A login to a second stage must preserve both the original stage's bearer session and
+    /// its outbox watermark. The previous single auth.json/cursor.json layout overwrote both.
+    #[test]
+    fn auth_and_cursor_are_scoped_to_the_cloud_stage() {
+        with_temp_home(|| {
+            let prod = StoredAuth {
+                base_url: "https://history.agentrelay.com".into(),
+                access_token: "test-prod-access".into(),
+                ..Default::default()
+            };
+            let dev = StoredAuth {
+                base_url: "http://localhost:8787".into(),
+                access_token: "test-dev-access".into(),
+                ..Default::default()
+            };
+            let prod_cursor = SyncCursor {
+                history_id: 101,
+                trajectory_rowid: 7,
+            };
+            let dev_cursor = SyncCursor {
+                history_id: 9,
+                trajectory_rowid: 2,
+            };
+
+            save_auth(&prod).unwrap();
+            save_cursor(&prod.base_url, &prod_cursor).unwrap();
+            save_auth(&dev).unwrap();
+            save_cursor(&dev.base_url, &dev_cursor).unwrap();
+
+            assert_eq!(load_auth(Some(&prod.base_url)).unwrap(), Some(prod));
+            assert_eq!(
+                load_cursor("https://history.agentrelay.com").unwrap(),
+                prod_cursor
+            );
+            assert_eq!(load_auth(Some(&dev.base_url)).unwrap(), Some(dev));
+            assert_eq!(load_cursor("http://localhost:8787").unwrap(), dev_cursor);
+
+            let err = load_auth(None).unwrap_err().to_string();
+            assert!(err.contains("pass --base-url"), "{err}");
         });
     }
 

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -1358,6 +1358,16 @@ mod tests {
                 auth_path("http://LocalHost:8787/").unwrap(),
                 auth_path("http://localhost:8787").unwrap()
             );
+            assert_eq!(
+                auth_path("https://History.AgentRelay.com:443/").unwrap(),
+                auth_path("https://history.agentrelay.com").unwrap(),
+                "an explicit default HTTPS port must not create another stage"
+            );
+            assert_eq!(
+                auth_path("http://Example.test:80/").unwrap(),
+                auth_path("http://example.test").unwrap(),
+                "an explicit default HTTP port must not create another stage"
+            );
         });
     }
 

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
+use url::Url;
 
 const DEFAULT_BASE_URL: &str = "https://history.agentrelay.com";
 
@@ -59,12 +60,25 @@ pub fn default_base_url() -> String {
 }
 
 fn normalize_base_url(value: &str) -> Option<String> {
-    let normalized = value.trim().trim_end_matches('/').to_string();
-    if normalized.is_empty() {
-        None
-    } else {
-        Some(normalized)
+    let parsed = Url::parse(value.trim()).ok()?;
+    if parsed.host_str().is_none()
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        return None;
     }
+    Some(parsed.to_string().trim_end_matches('/').to_string())
+}
+
+fn normalized_stage(value: &str) -> Result<String> {
+    normalize_base_url(value).with_context(|| {
+        format!(
+            "invalid relayhistory base URL `{}`; expected an absolute URL without credentials, query, or fragment",
+            value.trim()
+        )
+    })
 }
 
 /// Refuse to put a credential on the wire in cleartext.
@@ -83,7 +97,8 @@ fn normalize_base_url(value: &str) -> Option<String> {
 /// alone would have left the high-frequency `push` path sending the same token to the same
 /// URL — an inconsistent CLI that closes none of the exposure.
 fn require_secure_transport(base_url: &str) -> Result<()> {
-    let url = base_url.trim();
+    let normalized = normalized_stage(base_url)?;
+    let url = normalized.as_str();
     if url.starts_with("https://") {
         return Ok(());
     }
@@ -128,20 +143,20 @@ fn legacy_cursor_path() -> PathBuf {
     config_dir().join("cursor.json")
 }
 
-fn stage_key(base_url: &str) -> String {
-    ai_hist_core::prompt_hash(base_url.trim().trim_end_matches('/'))
+fn stage_key(base_url: &str) -> Result<String> {
+    Ok(ai_hist_core::prompt_hash(&normalized_stage(base_url)?))
 }
 
 fn stage_dir() -> PathBuf {
     config_dir().join("stages")
 }
 
-fn auth_path(base_url: &str) -> PathBuf {
-    stage_dir().join(format!("{}.auth.json", stage_key(base_url)))
+fn auth_path(base_url: &str) -> Result<PathBuf> {
+    Ok(stage_dir().join(format!("{}.auth.json", stage_key(base_url)?)))
 }
 
-fn cursor_path(base_url: &str) -> PathBuf {
-    stage_dir().join(format!("{}.cursor.json", stage_key(base_url)))
+fn cursor_path(base_url: &str) -> Result<PathBuf> {
+    Ok(stage_dir().join(format!("{}.cursor.json", stage_key(base_url)?)))
 }
 fn machine_path() -> PathBuf {
     config_dir().join("machine-id")
@@ -186,7 +201,10 @@ fn staged_auths() -> Result<Vec<StoredAuth>> {
 }
 
 fn same_stage(left: &str, right: &str) -> bool {
-    left.trim().trim_end_matches('/') == right.trim().trim_end_matches('/')
+    matches!(
+        (normalize_base_url(left), normalize_base_url(right)),
+        (Some(left), Some(right)) if left == right
+    )
 }
 
 /// Load one stored session. A caller that knows its destination must pass it explicitly.
@@ -194,7 +212,7 @@ fn same_stage(left: &str, right: &str) -> bool {
 /// successful login was the old behavior and could silently divert a scheduled push.
 pub fn load_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
     if let Some(base_url) = base_url {
-        let path = auth_path(base_url);
+        let path = auth_path(base_url)?;
         if path.exists() {
             let auth = read_auth(&path)?;
             anyhow::ensure!(
@@ -211,16 +229,19 @@ pub fn load_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
         return Ok(same_stage(&auth.base_url, base_url).then_some(auth));
     }
 
-    let auths = staged_auths()?;
-    match auths.len() {
-        0 => {
-            let path = legacy_auth_path();
-            if path.exists() {
-                Ok(Some(read_auth(&path)?))
-            } else {
-                Ok(None)
-            }
+    let mut auths = staged_auths()?;
+    let legacy = legacy_auth_path();
+    if legacy.exists() {
+        let legacy_auth = read_auth(&legacy)?;
+        if !auths
+            .iter()
+            .any(|auth| same_stage(&auth.base_url, &legacy_auth.base_url))
+        {
+            auths.push(legacy_auth);
         }
+    }
+    match auths.len() {
+        0 => Ok(None),
         1 => Ok(auths.into_iter().next()),
         count => anyhow::bail!(
             "{count} relayhistory stages are configured; pass --base-url to select one. \
@@ -234,9 +255,11 @@ pub fn load_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
 /// cross-stage cursor corruption.
 pub fn save_auth(auth: &StoredAuth) -> Result<()> {
     migrate_legacy_stage()?;
+    let mut stored = auth.clone();
+    stored.base_url = normalized_stage(&auth.base_url)?;
     write_private(
-        &auth_path(&auth.base_url),
-        &serde_json::to_string_pretty(auth)?,
+        &auth_path(&stored.base_url)?,
+        &serde_json::to_string_pretty(&stored)?,
     )
 }
 
@@ -245,15 +268,16 @@ fn migrate_legacy_stage() -> Result<()> {
     if !legacy_auth.exists() {
         return Ok(());
     }
-    let auth = read_auth(&legacy_auth)?;
-    let staged_auth_path = auth_path(&auth.base_url);
+    let mut auth = read_auth(&legacy_auth)?;
+    auth.base_url = normalized_stage(&auth.base_url)?;
+    let staged_auth_path = auth_path(&auth.base_url)?;
     if !staged_auth_path.exists() {
         write_private(&staged_auth_path, &serde_json::to_string_pretty(&auth)?)?;
     }
 
     let legacy_cursor = legacy_cursor_path();
     if legacy_cursor.exists() {
-        let staged_cursor = cursor_path(&auth.base_url);
+        let staged_cursor = cursor_path(&auth.base_url)?;
         if !staged_cursor.exists() {
             let body = fs::read_to_string(&legacy_cursor)?;
             write_private(&staged_cursor, &body)?;
@@ -268,7 +292,7 @@ fn migrate_legacy_stage() -> Result<()> {
 }
 
 pub fn load_cursor(base_url: &str) -> Result<SyncCursor> {
-    let path = cursor_path(base_url);
+    let path = cursor_path(base_url)?;
     if path.exists() {
         let body = fs::read_to_string(&path)?;
         return serde_json::from_str(&body).context("parsing stage-scoped cursor.json");
@@ -276,8 +300,13 @@ pub fn load_cursor(base_url: &str) -> Result<SyncCursor> {
 
     // Compatibility for an existing single-stage install. The next successful push writes the
     // scoped path; a subsequent login migrates it eagerly with the corresponding auth session.
+    let legacy_auth = legacy_auth_path();
     let legacy = legacy_cursor_path();
-    if !legacy.exists() {
+    if !legacy_auth.exists() || !legacy.exists() {
+        return Ok(SyncCursor::default());
+    }
+    let auth = read_auth(&legacy_auth)?;
+    if !same_stage(&auth.base_url, base_url) {
         return Ok(SyncCursor::default());
     }
     let body = fs::read_to_string(&legacy)?;
@@ -286,7 +315,7 @@ pub fn load_cursor(base_url: &str) -> Result<SyncCursor> {
 
 pub fn save_cursor(base_url: &str, cursor: &SyncCursor) -> Result<()> {
     write_private(
-        &cursor_path(base_url),
+        &cursor_path(base_url)?,
         &serde_json::to_string_pretty(cursor)?,
     )
 }
@@ -1303,6 +1332,77 @@ mod tests {
             };
             save_cursor(&auth.base_url, &c).unwrap();
             assert_eq!(load_cursor(&auth.base_url).unwrap(), c);
+        });
+    }
+
+    #[test]
+    fn equivalent_url_forms_share_one_stage_store() {
+        with_temp_home(|| {
+            let auth = StoredAuth {
+                base_url: "http://LocalHost:8787/".into(),
+                access_token: "rth_at_equivalent".into(),
+                ..Default::default()
+            };
+            save_auth(&auth).unwrap();
+            let cursor = SyncCursor {
+                history_id: 17,
+                trajectory_rowid: 3,
+            };
+            save_cursor(&auth.base_url, &cursor).unwrap();
+
+            let stored = load_auth(Some("http://localhost:8787")).unwrap().unwrap();
+            assert_eq!(stored.base_url, "http://localhost:8787");
+            assert_eq!(stored.access_token, auth.access_token);
+            assert_eq!(load_cursor(" HTTP://LOCALHOST:8787/ ").unwrap(), cursor);
+            assert_eq!(
+                auth_path("http://LocalHost:8787/").unwrap(),
+                auth_path("http://localhost:8787").unwrap()
+            );
+        });
+    }
+
+    #[test]
+    fn legacy_state_cannot_make_an_unqualified_command_guess_or_leak_a_cursor() {
+        with_temp_home(|| {
+            let prod = StoredAuth {
+                base_url: "https://history.agentrelay.com".into(),
+                access_token: "rth_at_prod".into(),
+                ..Default::default()
+            };
+            save_auth(&prod).unwrap();
+
+            let legacy_dev = StoredAuth {
+                base_url: "http://localhost:8787".into(),
+                access_token: "rth_at_dev".into(),
+                ..Default::default()
+            };
+            write_private(
+                &legacy_auth_path(),
+                &serde_json::to_string_pretty(&legacy_dev).unwrap(),
+            )
+            .unwrap();
+            let legacy_cursor = SyncCursor {
+                history_id: 900,
+                trajectory_rowid: 42,
+            };
+            write_private(
+                &legacy_cursor_path(),
+                &serde_json::to_string_pretty(&legacy_cursor).unwrap(),
+            )
+            .unwrap();
+
+            let err = load_auth(None).unwrap_err().to_string();
+            assert!(err.contains("2 relayhistory stages"), "{err}");
+            assert_eq!(
+                load_cursor(&prod.base_url).unwrap(),
+                SyncCursor::default(),
+                "a prod push must not inherit the dev cursor"
+            );
+            assert_eq!(
+                load_cursor("http://LOCALHOST:8787/").unwrap(),
+                legacy_cursor,
+                "the legacy cursor remains available to its own normalized stage"
+            );
         });
     }
 

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -58,7 +58,10 @@ pub fn sync_and_push() -> Result<SyncPushOutcome> {
     let conn = open_db(&db_path)?;
     sync_basic(&conn, &db_path)?;
 
-    let auth = match cloud::load_auth()? {
+    // The in-process runtime has no CLI argument channel. Keep it pinned to the normal Cloud
+    // origin rather than following whichever stage happened to be logged into most recently.
+    let default_base_url = cloud::default_base_url();
+    let auth = match cloud::load_auth(Some(&default_base_url))? {
         Some(auth) => auth,
         None => {
             return Ok(SyncPushOutcome {
@@ -75,7 +78,7 @@ pub fn sync_and_push() -> Result<SyncPushOutcome> {
         cli_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         ..Default::default()
     };
-    let cursor = cloud::load_cursor()?;
+    let cursor = cloud::load_cursor(&auth.base_url)?;
     let report = cloud::push(
         &conn,
         &cloud::UreqIngestor,
@@ -344,6 +347,9 @@ enum Command {
     },
     /// Push new local history + trajectory events to relayhistory-cloud.
     Push {
+        /// Select the cloud stage. Required when this machine has sessions for multiple stages.
+        #[arg(long)]
+        base_url: Option<String>,
         #[arg(long, default_value_t = 500)]
         limit: usize,
         /// Session ids (or trajectory ids) to exclude from the sync (incognito).
@@ -370,6 +376,9 @@ enum Command {
     /// stops pushing keeps its row and shows up as STALE or MISSING rather than
     /// disappearing quietly.
     Coverage {
+        /// Select the cloud stage. Required when this machine has sessions for multiple stages.
+        #[arg(long)]
+        base_url: Option<String>,
         /// Seconds without a push before a machine counts as stale (server default: 900,
         /// three times the 300s push service interval).
         #[arg(long)]
@@ -402,6 +411,9 @@ enum Command {
 enum PairAction {
     /// Ask relayhistory-cloud for advisory warnings before an action (POST /v1/pair/check).
     Check {
+        /// Select the cloud stage. Required when this machine has sessions for multiple stages.
+        #[arg(long)]
+        base_url: Option<String>,
         /// Files in scope / about to be touched (paths only — never contents).
         #[arg(long)]
         file: Vec<String>,
@@ -768,7 +780,7 @@ pub fn run() -> Result<()> {
             interval,
         } => {
             if install_service {
-                install_managed_service(&SYNC_SERVICE, interval)
+                install_managed_service(&SYNC_SERVICE, interval, &[])
             } else if uninstall_service {
                 uninstall_managed_service(&SYNC_SERVICE)
             } else {
@@ -890,6 +902,7 @@ pub fn run() -> Result<()> {
             Ok(())
         }
         Command::Push {
+            base_url,
             limit,
             incognito,
             json,
@@ -909,12 +922,17 @@ pub fn run() -> Result<()> {
                          it when installing the service."
                     );
                 }
-                return install_managed_service(&PUSH_SERVICE, interval);
+                let auth = cloud::load_auth(base_url.as_deref())?.context(
+                    "not authenticated for the selected stage — run `ai-hist login` or \
+                     `ai-hist admin-mint` first",
+                )?;
+                let service_args = vec!["--base-url".to_string(), auth.base_url];
+                return install_managed_service(&PUSH_SERVICE, interval, &service_args);
             }
             if uninstall_service {
                 return uninstall_managed_service(&PUSH_SERVICE);
             }
-            let auth = cloud::load_auth()?
+            let auth = cloud::load_auth(base_url.as_deref())?
                 .context("not authenticated — run `ai-hist login` or `ai-hist admin-mint` first")?;
             let machine = MachineIdentity {
                 id: cloud::machine_id()?,
@@ -923,7 +941,7 @@ pub fn run() -> Result<()> {
                 cli_version: Some(env!("CARGO_PKG_VERSION").to_string()),
                 ..Default::default()
             };
-            let cursor = cloud::load_cursor()?;
+            let cursor = cloud::load_cursor(&auth.base_url)?;
             let incognito_set: HashSet<String> = incognito.into_iter().collect();
             let report = cloud::push(
                 &conn,
@@ -958,13 +976,14 @@ pub fn run() -> Result<()> {
             Ok(())
         }
         Command::Coverage {
+            base_url,
             stale_after,
             missing_after,
             window_hours,
             fail_on_stale,
             json,
         } => {
-            let auth = cloud::load_auth()?
+            let auth = cloud::load_auth(base_url.as_deref())?
                 .context("not authenticated — run `ai-hist login` or `ai-hist admin-mint` first")?;
             let resp = cloud::fleet_coverage(
                 &auth,
@@ -988,6 +1007,7 @@ pub fn run() -> Result<()> {
         }
         Command::Pair { action } => match action {
             PairAction::Check {
+                base_url,
                 file,
                 task,
                 tool,
@@ -997,7 +1017,7 @@ pub fn run() -> Result<()> {
                 limit,
                 json,
             } => {
-                let auth = cloud::load_auth()?.context(
+                let auth = cloud::load_auth(base_url.as_deref())?.context(
                     "not authenticated — run `ai-hist login` or `ai-hist admin-mint` first",
                 )?;
                 let cwd = std::env::current_dir()
@@ -2147,13 +2167,20 @@ fn xml_escape(s: &str) -> String {
         .replace('>', "&gt;")
 }
 
-fn install_managed_service(spec: &ServiceSpec, interval: u64) -> Result<()> {
+fn service_command_args(spec: &ServiceSpec, args: &[String]) -> Vec<String> {
+    let mut command = Vec::with_capacity(args.len() + 1);
+    command.push(spec.subcommand.to_string());
+    command.extend(args.iter().cloned());
+    command
+}
+
+fn install_managed_service(spec: &ServiceSpec, interval: u64, args: &[String]) -> Result<()> {
     let bin = service_binary()?;
     let bin = bin.to_string_lossy();
     if cfg!(target_os = "macos") {
-        install_launchd_service(spec, &bin, interval)
+        install_launchd_service(spec, &bin, interval, args)
     } else if cfg!(target_os = "linux") {
-        install_cron_service(spec, &bin, interval)
+        install_cron_service(spec, &bin, interval, args)
     } else {
         anyhow::bail!(
             "Automatic {} service install is only supported on macOS and Linux. \
@@ -2222,11 +2249,21 @@ fn cron_schedule(interval: u64) -> (String, String, u64) {
     ("0 0 * * *".to_string(), "once a day".to_string(), 86_400)
 }
 
-fn install_launchd_service(spec: &ServiceSpec, bin: &str, interval: u64) -> Result<()> {
+fn install_launchd_service(
+    spec: &ServiceSpec,
+    bin: &str,
+    interval: u64,
+    args: &[String],
+) -> Result<()> {
     let plist_path = launchd_plist_path(spec);
     if let Some(dir) = plist_path.parent() {
         fs::create_dir_all(dir).with_context(|| format!("creating {}", dir.display()))?;
     }
+    let command_args = service_command_args(spec, args)
+        .iter()
+        .map(|arg| format!("        <string>{}</string>", xml_escape(arg)))
+        .collect::<Vec<_>>()
+        .join("\n");
     let plist = format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -2237,7 +2274,7 @@ fn install_launchd_service(spec: &ServiceSpec, bin: &str, interval: u64) -> Resu
     <key>ProgramArguments</key>
     <array>
         <string>{bin}</string>
-        <string>{subcommand}</string>
+{command_args}
     </array>
     <key>StartInterval</key>
     <integer>{interval}</integer>
@@ -2252,7 +2289,7 @@ fn install_launchd_service(spec: &ServiceSpec, bin: &str, interval: u64) -> Resu
 "#,
         label = spec.label,
         bin = xml_escape(bin),
-        subcommand = spec.subcommand,
+        command_args = command_args,
         interval = interval,
         log_stem = spec.log_stem,
     );
@@ -2308,7 +2345,12 @@ fn write_crontab(contents: &str) -> Result<()> {
     Ok(())
 }
 
-fn install_cron_service(spec: &ServiceSpec, bin: &str, interval: u64) -> Result<()> {
+fn install_cron_service(
+    spec: &ServiceSpec,
+    bin: &str,
+    interval: u64,
+    args: &[String],
+) -> Result<()> {
     let (schedule, cadence, effective) = cron_schedule(interval);
     // cron can't match every interval exactly; the confirmation below states the
     // cadence actually scheduled. Only note a mismatch when it isn't exact, so a
@@ -2319,10 +2361,16 @@ fn install_cron_service(spec: &ServiceSpec, bin: &str, interval: u64) -> Result<
         );
     }
     let marker = cron_marker(spec);
+    let command = std::iter::once(shell_single_quote(bin))
+        .chain(
+            service_command_args(spec, args)
+                .iter()
+                .map(|arg| shell_single_quote(arg)),
+        )
+        .collect::<Vec<_>>()
+        .join(" ");
     let line = format!(
-        "{schedule} {} {} >> /tmp/{}.log 2>&1 {marker}",
-        shell_single_quote(bin),
-        spec.subcommand,
+        "{schedule} {command} >> /tmp/{}.log 2>&1 {marker}",
         spec.log_stem
     );
     // Drop any previously managed line, then append the current one.
@@ -5310,8 +5358,8 @@ mod tests {
     use super::{
         checkpoint_sync_state, cron_schedule, file_stamp, git_commit_time_ms, git_stdout,
         ingest_claude_transcript, link_git_commit, load_sync_state, parse_trajectory_file,
-        paths_overlap, save_sync_state, search_all, shell_single_quote, strip_url_credentials,
-        sync_claude_session_metadata, xml_escape, SearchRole,
+        paths_overlap, save_sync_state, search_all, service_command_args, shell_single_quote,
+        strip_url_credentials, sync_claude_session_metadata, xml_escape, SearchRole, PUSH_SERVICE,
     };
     use ai_hist_core::{init_db, QueryFilter};
     use rusqlite::Connection;
@@ -5339,6 +5387,22 @@ mod tests {
         assert_eq!(cron_schedule(300).2, 300);
         assert_eq!(cron_schedule(5400).2, 7200);
         assert_eq!(cron_schedule(420).2, 600);
+    }
+
+    #[test]
+    fn push_service_command_pins_the_selected_cloud_stage() {
+        let args = vec![
+            "--base-url".to_string(),
+            "https://history.agentrelay.com".to_string(),
+        ];
+        assert_eq!(
+            service_command_args(&PUSH_SERVICE, &args),
+            vec![
+                "push".to_string(),
+                "--base-url".to_string(),
+                "https://history.agentrelay.com".to_string(),
+            ]
+        );
     }
 
     #[test]
@@ -5455,6 +5519,7 @@ mod tests {
         // Opening writably would park a scheduled `coverage --fail-on-stale` behind the 60s
         // sync service's write lock, for a query that reads nothing local.
         assert!(super::is_read_only(&super::Command::Coverage {
+            base_url: None,
             stale_after: None,
             missing_after: None,
             window_hours: None,

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -411,7 +411,7 @@ enum Command {
 enum PairAction {
     /// Ask relayhistory-cloud for advisory warnings before an action (POST /v1/pair/check).
     Check {
-        /// Select the cloud stage. Required when this machine has sessions for multiple stages.
+        /// Select the cloud stage. Defaults to RELAYHISTORY_BASE_URL/AI_HIST_BASE_URL, then prod.
         #[arg(long)]
         base_url: Option<String>,
         /// Files in scope / about to be touched (paths only — never contents).
@@ -1017,7 +1017,11 @@ pub fn run() -> Result<()> {
                 limit,
                 json,
             } => {
-                let auth = cloud::load_auth(base_url.as_deref())?.context(
+                // Hooks and MCP wrappers do not have an interactive stage-selection channel.
+                // Pin them to the configured/default origin instead of making Pair disappear
+                // when an unrelated second-stage login exists.
+                let base_url = base_url.unwrap_or_else(cloud::default_base_url);
+                let auth = cloud::load_auth(Some(&base_url))?.context(
                     "not authenticated — run `ai-hist login` or `ai-hist admin-mint` first",
                 )?;
                 let cwd = std::env::current_dir()

--- a/docs/cloud-sync.md
+++ b/docs/cloud-sync.md
@@ -105,24 +105,24 @@ login. To test Cloud exchange against a trusted non-prod endpoint, set
 
 `ai-hist push` output (example): `{"sent":N,"accepted":N,"batchId":"b_…","cursor":{…}}`
 
-- **Auth + base_url are stored** in `$RELAYHISTORY_HOME/auth.json` (mode `0600`) by
-  `login`/`admin-mint`. Authenticate once per target, then just `ai-hist push` — **`push`
-  takes no `--base-url`** (it uses stored context).
-- **Use a separate `RELAYHISTORY_HOME` for dev vs prod** (as above): `auth.json` holds one
-  base_url + token + the cursor, so a shared home would make dev/prod overwrite each other's
-  auth and resume state.
+- **Auth + cursor are stage-scoped.** `login`/`admin-mint` store each target's session and
+  watermark independently under `$RELAYHISTORY_HOME/stages/` (mode `0600`). A second login
+  cannot overwrite the first target's cursor.
+- **Select deliberately when needed.** With one configured target, `ai-hist push` uses it.
+  With more than one, use `ai-hist push --base-url <origin>`; the CLI refuses to guess. A
+  service installed with `ai-hist push --install-service` pins that selected origin so later
+  foreground logins cannot redirect it.
 - **Incremental + idempotent:** the cursor only sends new rows; re-running `push` (or a
   cron) is safe — duplicates dedupe server-side on the event PK + batch id. The cursor
   advances only after the server accepts the batch.
 - **Exclude sessions:** `ai-hist push --incognito <sessionId> --incognito <trajectoryId>`.
-- To switch targets, use the per-target `RELAYHISTORY_HOME`; for prod, re-run Agent Relay
-  Cloud login if the stored session expires.
+- To switch targets, pass the corresponding `--base-url`; for prod, re-run Agent Relay Cloud
+  login if that stored session expires.
 
 ### Automation (cron / launchd)
 
 ```cron
-*/5 * * * * RELAYHISTORY_HOME=$HOME/.agentworkforce/relayhistory-prod ai-hist sync && \
-            RELAYHISTORY_HOME=$HOME/.agentworkforce/relayhistory-prod ai-hist push --json >> /tmp/ai-hist-push.log 2>&1
+*/5 * * * * ai-hist sync && ai-hist push --base-url https://history.agentrelay.com --json >> /tmp/ai-hist-push.log 2>&1
 ```
 
 `push` exits non-zero on transport/auth failure (cursor not advanced → safe retry next run).

--- a/docs/cloud-sync.md
+++ b/docs/cloud-sync.md
@@ -122,7 +122,8 @@ login. To test Cloud exchange against a trusted non-prod endpoint, set
 ### Automation (cron / launchd)
 
 ```cron
-*/5 * * * * ai-hist sync && ai-hist push --base-url https://history.agentrelay.com --json >> /tmp/ai-hist-push.log 2>&1
+*/5 * * * * RELAYHISTORY_HOME=$HOME/.agentworkforce/relayhistory-prod ai-hist sync && \
+            RELAYHISTORY_HOME=$HOME/.agentworkforce/relayhistory-prod ai-hist push --base-url https://history.agentrelay.com --json >> /tmp/ai-hist-push.log 2>&1
 ```
 
 `push` exits non-zero on transport/auth failure (cursor not advanced → safe retry next run).

--- a/docs/cloud-sync.md
+++ b/docs/cloud-sync.md
@@ -122,8 +122,7 @@ login. To test Cloud exchange against a trusted non-prod endpoint, set
 ### Automation (cron / launchd)
 
 ```cron
-*/5 * * * * RELAYHISTORY_HOME=$HOME/.agentworkforce/relayhistory-prod ai-hist sync && \
-            RELAYHISTORY_HOME=$HOME/.agentworkforce/relayhistory-prod ai-hist push --base-url https://history.agentrelay.com --json >> /tmp/ai-hist-push.log 2>&1
+*/5 * * * * RELAYHISTORY_HOME=$HOME/.agentworkforce/relayhistory-prod ai-hist sync && RELAYHISTORY_HOME=$HOME/.agentworkforce/relayhistory-prod ai-hist push --base-url https://history.agentrelay.com --json >> /tmp/ai-hist-push.log 2>&1
 ```
 
 `push` exits non-zero on transport/auth failure (cursor not advanced → safe retry next run).

--- a/docs/pair-hooks.md
+++ b/docs/pair-hooks.md
@@ -13,9 +13,11 @@ ai-hist pair check --json --task "refactor auth middleware" --file src/auth/midd
 ```
 
 That primitive owns relayhistory-cloud auth and reads the same auth file as cloud sync.
-Hooks and MCP calls are pinned to `RELAYHISTORY_BASE_URL` (or `AI_HIST_BASE_URL`), falling
-back to production. Pass `--base-url` for direct CLI calls that need another stage. This
-keeps Pair active even when the same home contains sessions for multiple stages.
+Stage selection uses this precedence: an explicit `--base-url`, then
+`RELAYHISTORY_BASE_URL`, then `AI_HIST_BASE_URL`, and finally the production default. Hooks
+and MCP calls use the environment/default selection; pass `--base-url` for direct CLI calls
+that need another stage. This keeps Pair active even when the same home contains sessions
+for multiple stages.
 For production users, auth should come from Agent Relay Cloud login; `admin-mint` is
 dev/team-internal only and requires an admin secret:
 

--- a/docs/pair-hooks.md
+++ b/docs/pair-hooks.md
@@ -13,6 +13,9 @@ ai-hist pair check --json --task "refactor auth middleware" --file src/auth/midd
 ```
 
 That primitive owns relayhistory-cloud auth and reads the same auth file as cloud sync.
+Hooks and MCP calls are pinned to `RELAYHISTORY_BASE_URL` (or `AI_HIST_BASE_URL`), falling
+back to production. Pass `--base-url` for direct CLI calls that need another stage. This
+keeps Pair active even when the same home contains sessions for multiple stages.
 For production users, auth should come from Agent Relay Cloud login; `admin-mint` is
 dev/team-internal only and requires an admin secret:
 

--- a/docs/reflex-zero-setup.md
+++ b/docs/reflex-zero-setup.md
@@ -22,8 +22,8 @@ agent-relay up  ──(every few minutes, if reflex.json.enabled)──▶  requ
   on a worker thread so the event loop isn't blocked.
 - **Single source of truth:** the Rust `ai_hist_cli` library does the sync +
   push. The CLI binary and the addon call the same code.
-- **Auth:** the `rth_at_` token written by `reflex on`
-  (`~/.agentworkforce/relayhistory/auth.json`). `syncAndPush()` returns
+- **Auth:** the `rth_at_` token written by `reflex on` (in the stage-scoped
+  `~/.agentworkforce/relayhistory/stages/` store). `syncAndPush()` returns
   `authenticated: false` (a no-op) until the user is logged in.
 
 ## The packages


### PR DESCRIPTION
Closes #57.\n\nSessions and durable cursors are now keyed by a normalized Cloud origin, so a login to another stage cannot overwrite or advance the active stage's state. Ambiguous legacy state requires an explicit --base-url rather than guessing. Installed push services persist the selected origin.\n\nTests: cargo test -p ai-hist-cli --no-fail-fast (59 passed).