### PR TITLE
fix(cloud): retry oversized push batches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,13 @@ jobs:
 
       - name: End-to-end wrapper verification
         run: AI_HIST_RUST_BIN="$PWD/target/debug/ai-hist" ./scripts/verify-e2e.sh
+
+  windows-state-replacement:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify repeated private-state replacement
+        run: cargo test -p ai-hist-cli write_private_replaces_existing_state

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "chrono",
  "clap",
  "flate2",
+ "fs2",
  "hostname",
  "rusqlite",
  "serde",
@@ -366,6 +367,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1213,6 +1224,28 @@ checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ version = "0.1.0"
 dependencies = [
  "ai-hist-core",
  "anyhow",
+ "atomicwrites",
  "chrono",
  "clap",
  "flate2",
@@ -135,6 +136,17 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "atomicwrites"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef1bb8d1b645fe38d51dfc331d720fb5fc2c94b440c76cc79c80ff265ca33e3"
+dependencies = [
+ "rustix 0.38.44",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "autocfg"
@@ -649,6 +661,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -870,6 +888,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -877,7 +908,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1055,7 +1086,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ launchd/cron plumbing:
 
 ```bash
 ai-hist push --install-service      # schedule automatic cloud push (macOS: every 300s)
+ai-hist push --install-service --limit 50  # persist a smaller batch for a heavy machine
 ai-hist push --uninstall-service    # remove it
 ai-hist push                        # push new history now
 ```
@@ -263,6 +264,9 @@ a cron entry: whole-minute intervals become a step schedule (300s → `*/5`), an
 sub-minute intervals run every minute (cron's finest granularity).
 
 Running both services keeps local capture and cloud upload going end-to-end.
+When the Cloud worker rejects a batch for resource limits, `push` halves the batch and retries
+from the unchanged cursor down to a safe floor. If even that floor is rejected, it exits with a
+clear error that the cursor was not advanced; this is distinct from `Nothing new to push.`
 The push job authenticates with the `rth_at_` token written by `ai-hist login`.
 Because that token goes on the wire, an `https://` endpoint is required; plain
 `http://` is accepted only for loopback (`http://127.0.0.1:8787`, the `wrangler

--- a/crates/ai-hist/Cargo.toml
+++ b/crates/ai-hist/Cargo.toml
@@ -19,6 +19,7 @@ anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
 flate2 = "1"
+fs2 = "0.4"
 hostname = "0.4"
 rusqlite = { version = "0.32", features = ["backup", "bundled", "functions"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/ai-hist/Cargo.toml
+++ b/crates/ai-hist/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 ai-hist-core = { path = "../ai-hist-core" }
 anyhow = "1"
+atomicwrites = "0.4"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
 flate2 = "1"

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -395,6 +395,10 @@ pub struct PushReport {
     pub accepted: u64,
     pub cursor: SyncCursor,
     pub batch_id: Option<String>,
+    /// The per-source scan limit that produced the accepted batch.
+    pub batch_limit: usize,
+    /// Number of ingest attempts in this push run, including any smaller retry.
+    pub attempts: usize,
 }
 
 /// Build the next outbox batch and push it. On success, persists the advanced cursor.
@@ -408,13 +412,59 @@ pub fn push(
     limit: usize,
     incognito: &HashSet<String>,
 ) -> Result<PushReport> {
-    let batch = build_outbox_batch(conn, cursor, limit, incognito)?;
+    const MIN_RECOVERABLE_BATCH_LIMIT: usize = 10;
+    let mut batch_limit = limit.max(1);
+    let mut attempts = 1;
+
+    loop {
+        match push_once(
+            conn,
+            client,
+            auth,
+            machine,
+            cursor,
+            batch_limit,
+            incognito,
+            attempts,
+        ) {
+            Ok(report) => return Ok(report),
+            Err(err)
+                if is_worker_capacity_error(&err) && batch_limit > MIN_RECOVERABLE_BATCH_LIMIT =>
+            {
+                let next_limit = (batch_limit / 2).max(MIN_RECOVERABLE_BATCH_LIMIT);
+                batch_limit = next_limit;
+                attempts += 1;
+            }
+            Err(err) if is_worker_capacity_error(&err) => {
+                return Err(err.context(format!(
+                    "cloud ingest still exceeded its resource limit at batch limit {batch_limit} \
+                     after {attempts} attempt(s); cursor was not advanced"
+                )));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+fn push_once(
+    conn: &Connection,
+    client: &dyn Ingestor,
+    auth: &StoredAuth,
+    machine: &MachineIdentity,
+    cursor: &SyncCursor,
+    batch_limit: usize,
+    incognito: &HashSet<String>,
+    attempts: usize,
+) -> Result<PushReport> {
+    let batch = build_outbox_batch(conn, cursor, batch_limit, incognito)?;
     if batch.records.is_empty() {
         return Ok(PushReport {
             sent: 0,
             accepted: 0,
             cursor: cursor.clone(),
             batch_id: None,
+            batch_limit,
+            attempts: 0,
         });
     }
     let bid = batch_id(&machine.id, cursor, &batch.cursor, batch.records.len());
@@ -435,6 +485,21 @@ pub fn push(
         accepted: resp.accepted,
         cursor: batch.cursor,
         batch_id: Some(bid),
+        batch_limit,
+        attempts,
+    })
+}
+
+/// Cloudflare's worker overload currently arrives as an HTML 503, while a future structured
+/// response may retain the text without that status. Treat either signal as safe to retry with
+/// the exact same starting cursor and a smaller batch; no cursor is persisted before success.
+fn is_worker_capacity_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        let message = cause.to_string();
+        message.contains("HTTP 503")
+            || message
+                .to_ascii_lowercase()
+                .contains("worker exceeded resource limits")
     })
 }
 
@@ -1195,6 +1260,30 @@ mod tests {
         }
     }
 
+    /// Simulates the Worker rejecting a request whose encoded records are too large. It records
+    /// every attempt so the test verifies we retry from the same cursor at a smaller limit.
+    struct CapacityLimitedIngestor {
+        max_records: usize,
+        attempted_record_counts: RefCell<Vec<usize>>,
+    }
+
+    impl Ingestor for CapacityLimitedIngestor {
+        fn ingest(&self, _auth: &StoredAuth, req: &IngestRequest) -> Result<IngestResponse> {
+            self.attempted_record_counts
+                .borrow_mut()
+                .push(req.records.len());
+            if req.records.len() > self.max_records {
+                anyhow::bail!("ingest failed: HTTP 503: Worker exceeded resource limits");
+            }
+            Ok(IngestResponse {
+                batch_id: req.batch_id.clone(),
+                received: req.records.len() as u64,
+                accepted: req.records.len() as u64,
+                cursors: None,
+            })
+        }
+    }
+
     // RELAYHISTORY_HOME is process-global; serialize env-home tests so cargo's parallel
     // runner can't clobber it across tests.
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -1273,6 +1362,79 @@ mod tests {
             assert_eq!(sent.records.len(), 2);
             // cursor persisted to disk and reloads to the advanced value
             assert_eq!(load_cursor(&auth.base_url).unwrap().history_id, 2);
+        });
+    }
+
+    #[test]
+    fn push_halves_a_worker_rejected_batch_and_makes_progress() {
+        with_temp_home(|| {
+            let conn = mem();
+            for id in 1..=32 {
+                add(&conn, &format!("entry {id}"), id);
+            }
+            let client = CapacityLimitedIngestor {
+                max_records: 10,
+                attempted_record_counts: RefCell::new(Vec::new()),
+            };
+            let auth = StoredAuth {
+                base_url: "http://localhost:8787".into(),
+                access_token: "test-access-token".into(),
+                ..Default::default()
+            };
+            let report = push(
+                &conn,
+                &client,
+                &auth,
+                &MachineIdentity {
+                    id: "m1".into(),
+                    ..Default::default()
+                },
+                &SyncCursor::default(),
+                32,
+                &HashSet::new(),
+            )
+            .unwrap();
+
+            assert_eq!(*client.attempted_record_counts.borrow(), vec![32, 16, 10]);
+            assert_eq!(report.batch_limit, 10);
+            assert_eq!(report.attempts, 3);
+            assert_eq!(report.cursor.history_id, 10);
+            assert_eq!(load_cursor(&auth.base_url).unwrap().history_id, 10);
+        });
+    }
+
+    #[test]
+    fn worker_rejection_at_the_minimum_limit_is_loud_and_keeps_the_cursor() {
+        with_temp_home(|| {
+            let conn = mem();
+            add(&conn, "too large even alone", 1);
+            let client = CapacityLimitedIngestor {
+                max_records: 0,
+                attempted_record_counts: RefCell::new(Vec::new()),
+            };
+            let auth = StoredAuth {
+                base_url: "http://localhost:8787".into(),
+                access_token: "test-access-token".into(),
+                ..Default::default()
+            };
+            let err = push(
+                &conn,
+                &client,
+                &auth,
+                &MachineIdentity {
+                    id: "m1".into(),
+                    ..Default::default()
+                },
+                &SyncCursor::default(),
+                1,
+                &HashSet::new(),
+            )
+            .unwrap_err()
+            .to_string();
+
+            assert!(err.contains("cursor was not advanced"), "{err}");
+            assert_eq!(*client.attempted_record_counts.borrow(), vec![1]);
+            assert_eq!(load_cursor(&auth.base_url).unwrap(), SyncCursor::default());
         });
     }
 

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -486,13 +486,22 @@ fn push_once(
 ) -> Result<PushReport> {
     let batch = build_outbox_batch(conn, cursor, batch_limit, incognito)?;
     if batch.records.is_empty() {
+        // Incognito and zero-emission rows still advance scan cursors. Persist that progress
+        // even though there is no payload, otherwise a reduced capacity retry can report a
+        // no-op and rebuild the original oversized request on the next run.
+        if batch.cursor != *cursor {
+            save_cursor(&auth.base_url, &batch.cursor)?;
+        }
         return Ok(PushReport {
             sent: 0,
             accepted: 0,
-            cursor: cursor.clone(),
+            cursor: batch.cursor,
             batch_id: None,
             batch_limit,
-            attempts: 0,
+            // `attempts` names the next attempted HTTP call. If this empty batch followed
+            // rejected requests, retain the number of calls already made; a first-run no-op
+            // still reports zero.
+            attempts: attempts.saturating_sub(1),
         });
     }
     let bid = batch_id(&machine.id, cursor, &batch.cursor, batch.records.len());
@@ -1270,12 +1279,16 @@ mod tests {
     }
 
     fn add(conn: &Connection, prompt: &str, ts: i64) {
+        add_for_session(conn, "s1", prompt, ts);
+    }
+
+    fn add_for_session(conn: &Connection, session: &str, prompt: &str, ts: i64) {
         insert_history(
             conn,
             &HistoryEntry {
                 id: 0,
                 source: "claude".into(),
-                session_id: Some("s1".into()),
+                session_id: Some(session.into()),
                 project: None,
                 prompt: prompt.into(),
                 prompt_hash: Some(ai_hist_core::prompt_hash(prompt)),
@@ -1526,6 +1539,78 @@ mod tests {
             assert_eq!(report.attempts, 2);
             assert_eq!(report.cursor.history_id, 3);
             assert_eq!(report.cursor.trajectory_rowid, 3);
+        });
+    }
+
+    #[test]
+    fn empty_reduced_retry_persists_skipped_source_cursors() {
+        with_temp_home(|| {
+            let conn = mem();
+            add_for_session(&conn, "private-history", "private", 1);
+            add_for_session(&conn, "public-history", "public", 2);
+            add_trajectory(&conn, "private-trajectory");
+            add_trajectory(&conn, "public-trajectory");
+            let incognito: HashSet<String> = [
+                "private-history".to_string(),
+                "private-trajectory".to_string(),
+            ]
+            .into_iter()
+            .collect();
+            let client = CapacityLimitedIngestor {
+                max_records: 1,
+                attempted_record_counts: RefCell::new(Vec::new()),
+            };
+            let auth = StoredAuth {
+                base_url: "http://localhost:8787".into(),
+                access_token: "test-access-token".into(),
+                ..Default::default()
+            };
+            let report = push(
+                &conn,
+                &client,
+                &auth,
+                &MachineIdentity {
+                    id: "m1".into(),
+                    ..Default::default()
+                },
+                &SyncCursor::default(),
+                2,
+                &incognito,
+            )
+            .unwrap();
+
+            // The first request contains the two public rows and is rejected. Limit one then
+            // scans only the two private rows, producing no records but advancing both cursors.
+            assert_eq!(*client.attempted_record_counts.borrow(), vec![2]);
+            assert_eq!(report.sent, 0);
+            assert_eq!(report.attempts, 1);
+            assert_eq!(report.cursor.history_id, 1);
+            assert_eq!(report.cursor.trajectory_rowid, 1);
+            assert_eq!(load_cursor(&auth.base_url).unwrap(), report.cursor);
+
+            // A later run starts after the skipped rows and can send the public rows instead of
+            // reconstructing the original rejected span.
+            let accepting = CapacityLimitedIngestor {
+                max_records: 2,
+                attempted_record_counts: RefCell::new(Vec::new()),
+            };
+            let next = push(
+                &conn,
+                &accepting,
+                &auth,
+                &MachineIdentity {
+                    id: "m1".into(),
+                    ..Default::default()
+                },
+                &report.cursor,
+                2,
+                &incognito,
+            )
+            .unwrap();
+            assert_eq!(*accepting.attempted_record_counts.borrow(), vec![2]);
+            assert_eq!(next.sent, 2);
+            assert_eq!(next.cursor.history_id, 2);
+            assert_eq!(next.cursor.trajectory_rowid, 2);
         });
     }
 

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -454,13 +454,20 @@ pub fn push(
                 let Some(attempted_records) = worker_capacity_attempted_records(&err) else {
                     return Err(err);
                 };
-                if attempted_records <= 1 {
+                if batch_limit <= 1 || attempted_records <= 1 {
                     return Err(err.context(format!(
-                        "cloud ingest still exceeded its resource limit with one record after \
-                         {attempts} attempt(s); cursor was not advanced"
+                        "cloud ingest still exceeded its resource limit at the minimum batch \
+                         limit after {attempts} attempt(s) ({attempted_records} emitted \
+                         record(s)); cursor was not advanced"
                     )));
                 }
-                batch_limit = (attempted_records / 2).max(1);
+                // The outbox applies this limit per source, and one trajectory row can emit
+                // several records. Halving the emitted count can therefore reproduce the same
+                // per-source limit and retry the identical rejected payload forever. Every
+                // retry must strictly lower the controlling limit.
+                batch_limit = (attempted_records / 2)
+                    .max(1)
+                    .min(batch_limit.saturating_sub(1));
                 attempts += 1;
             }
         }
@@ -1278,6 +1285,28 @@ mod tests {
         .unwrap();
     }
 
+    fn add_trajectory(conn: &Connection, id: &str) {
+        conn.execute(
+            "INSERT INTO trajectories (id, version, persona_id, project_id, task_title, \
+             task_description, status, decisions_json, retrospective_json, search_text, path, \
+             updated_ms, timestamp_ms) VALUES (?,1,?,?,?,?,?,?,?,?,NULL,?,?)",
+            rusqlite::params![
+                id,
+                "planner",
+                "proj",
+                "Build forms",
+                "desc",
+                "completed",
+                "[]",
+                format!(r#"{{"summary":"summary {id}"}}"#),
+                "search",
+                1,
+                1_782_036_000_000i64
+            ],
+        )
+        .unwrap();
+    }
+
     /// Captures the request and returns a canned response.
     struct FakeIngestor {
         last: RefCell<Option<IngestRequest>>,
@@ -1455,6 +1484,48 @@ mod tests {
             assert_eq!(report.attempts, 3);
             assert_eq!(report.cursor.history_id, 8);
             assert_eq!(load_cursor(&auth.base_url).unwrap().history_id, 8);
+        });
+    }
+
+    #[test]
+    fn capacity_retry_strictly_reduces_a_per_source_limit() {
+        with_temp_home(|| {
+            let conn = mem();
+            for id in 1..=4 {
+                add(&conn, &format!("entry {id}"), id);
+                add_trajectory(&conn, &format!("trajectory-{id}"));
+            }
+            let client = CapacityLimitedIngestor {
+                max_records: 6,
+                attempted_record_counts: RefCell::new(Vec::new()),
+            };
+            let auth = StoredAuth {
+                base_url: "http://localhost:8787".into(),
+                access_token: "test-access-token".into(),
+                ..Default::default()
+            };
+            let report = push(
+                &conn,
+                &client,
+                &auth,
+                &MachineIdentity {
+                    id: "m1".into(),
+                    ..Default::default()
+                },
+                &SyncCursor::default(),
+                4,
+                &HashSet::new(),
+            )
+            .unwrap();
+
+            // Four rows from each source emit eight records. Halving the emitted count would
+            // leave the per-source limit at four and retry those same eight forever; the retry
+            // must lower it to three and make progress.
+            assert_eq!(*client.attempted_record_counts.borrow(), vec![8, 6]);
+            assert_eq!(report.batch_limit, 3);
+            assert_eq!(report.attempts, 2);
+            assert_eq!(report.cursor.history_id, 3);
+            assert_eq!(report.cursor.trajectory_rowid, 3);
         });
     }
 

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -19,7 +19,9 @@ use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs;
+use std::io::Write;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use url::Url;
 
 const DEFAULT_BASE_URL: &str = "https://history.agentrelay.com";
@@ -163,17 +165,48 @@ fn machine_path() -> PathBuf {
 }
 
 fn write_private(path: &std::path::Path, body: &str) -> Result<()> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| std::path::Path::new("."));
+    fs::create_dir_all(parent)?;
+
+    static NEXT_TMP_ID: AtomicU64 = AtomicU64::new(0);
+    let file_name = path
+        .file_name()
+        .context("private state path has no file name")?
+        .to_string_lossy();
+    let tmp_path = parent.join(format!(
+        ".{file_name}.tmp.{}.{}",
+        std::process::id(),
+        NEXT_TMP_ID.fetch_add(1, Ordering::Relaxed)
+    ));
+
+    let saved = (|| -> Result<()> {
+        let mut options = fs::OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut tmp = options
+            .open(&tmp_path)
+            .with_context(|| format!("creating private state at {}", tmp_path.display()))?;
+        tmp.write_all(body.as_bytes())?;
+        tmp.sync_all()?;
+        fs::rename(&tmp_path, path)
+            .with_context(|| format!("atomically replacing {}", path.display()))?;
+        // A directory fsync makes the rename durable on filesystems that support it. Some
+        // platforms reject directory sync, so it remains best effort after the file itself is
+        // safely flushed and replaced.
+        let _ = fs::File::open(parent).and_then(|dir| dir.sync_all());
+        Ok(())
+    })();
+    if saved.is_err() {
+        let _ = fs::remove_file(&tmp_path);
     }
-    fs::write(path, body)?;
-    // best-effort 0600 on unix (token/secret hygiene)
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
-    }
-    Ok(())
+    saved
 }
 
 fn read_auth(path: &std::path::Path) -> Result<StoredAuth> {
@@ -314,10 +347,48 @@ pub fn load_cursor(base_url: &str) -> Result<SyncCursor> {
 }
 
 pub fn save_cursor(base_url: &str, cursor: &SyncCursor) -> Result<()> {
+    let _cursor_lock = acquire_cursor_lock(base_url)?;
+    let current = load_cursor(base_url)?;
+    let merged = SyncCursor {
+        history_id: current.history_id.max(cursor.history_id),
+        trajectory_rowid: current.trajectory_rowid.max(cursor.trajectory_rowid),
+    };
     write_private(
         &cursor_path(base_url)?,
-        &serde_json::to_string_pretty(cursor)?,
+        &serde_json::to_string_pretty(&merged)?,
     )
+}
+
+struct CursorWriteLock {
+    file: fs::File,
+}
+
+impl Drop for CursorWriteLock {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.file);
+    }
+}
+
+fn acquire_cursor_lock(base_url: &str) -> Result<CursorWriteLock> {
+    let cursor = cursor_path(base_url)?;
+    let mut name = cursor
+        .file_name()
+        .context("stage cursor path has no file name")?
+        .to_os_string();
+    name.push(".lock");
+    let path = cursor.with_file_name(name);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&path)?;
+    fs2::FileExt::lock_exclusive(&file)
+        .with_context(|| format!("locking cursor state at {}", path.display()))?;
+    Ok(CursorWriteLock { file })
 }
 
 /// Stable per-machine id (the WS-1 `machineId` sub-tenant), generated once and persisted.
@@ -465,9 +536,7 @@ pub fn push(
                 // several records. Halving the emitted count can therefore reproduce the same
                 // per-source limit and retry the identical rejected payload forever. Every
                 // retry must strictly lower the controlling limit.
-                batch_limit = (attempted_records / 2)
-                    .max(1)
-                    .min(batch_limit.saturating_sub(1));
+                batch_limit = (attempted_records / 2).min(batch_limit / 2).max(1);
                 attempts += 1;
             }
         }
@@ -1534,11 +1603,72 @@ mod tests {
             // Four rows from each source emit eight records. Halving the emitted count would
             // leave the per-source limit at four and retry those same eight forever; the retry
             // must lower it to three and make progress.
-            assert_eq!(*client.attempted_record_counts.borrow(), vec![8, 6]);
-            assert_eq!(report.batch_limit, 3);
+            assert_eq!(*client.attempted_record_counts.borrow(), vec![8, 4]);
+            assert_eq!(report.batch_limit, 2);
             assert_eq!(report.attempts, 2);
-            assert_eq!(report.cursor.history_id, 3);
-            assert_eq!(report.cursor.trajectory_rowid, 3);
+            assert_eq!(report.cursor.history_id, 2);
+            assert_eq!(report.cursor.trajectory_rowid, 2);
+        });
+    }
+
+    #[test]
+    fn cursor_saves_merge_monotonically_across_concurrent_pushes() {
+        with_temp_home(|| {
+            let base_url = "http://localhost:8787";
+            save_cursor(
+                base_url,
+                &SyncCursor {
+                    history_id: 100,
+                    trajectory_rowid: 1,
+                },
+            )
+            .unwrap();
+            // Even a later stale writer cannot rewind either watermark.
+            save_cursor(
+                base_url,
+                &SyncCursor {
+                    history_id: 1,
+                    trajectory_rowid: 100,
+                },
+            )
+            .unwrap();
+            assert_eq!(
+                load_cursor(base_url).unwrap(),
+                SyncCursor {
+                    history_id: 100,
+                    trajectory_rowid: 100,
+                }
+            );
+
+            let mut writers = Vec::new();
+            for writer in 0..8 {
+                writers.push(std::thread::spawn(move || {
+                    for revision in 1..=25 {
+                        let cursor = if writer % 2 == 0 {
+                            SyncCursor {
+                                history_id: 100 + revision,
+                                trajectory_rowid: 1,
+                            }
+                        } else {
+                            SyncCursor {
+                                history_id: 1,
+                                trajectory_rowid: 100 + revision,
+                            }
+                        };
+                        save_cursor("http://localhost:8787", &cursor).unwrap();
+                    }
+                }));
+            }
+            for writer in writers {
+                writer.join().unwrap();
+            }
+            assert_eq!(
+                load_cursor(base_url).unwrap(),
+                SyncCursor {
+                    history_id: 125,
+                    trajectory_rowid: 125,
+                }
+            );
         });
     }
 

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -401,6 +401,29 @@ pub struct PushReport {
     pub attempts: usize,
 }
 
+/// A typed Cloudflare Worker capacity rejection. Keeping the status, body, and attempted
+/// record count together lets the retry loop distinguish a real resource-limit response from
+/// an unrelated 503 and shrink from the payload that was actually emitted.
+#[derive(Debug)]
+struct WorkerCapacityError {
+    status: u16,
+    body: String,
+    attempted_records: usize,
+}
+
+impl std::fmt::Display for WorkerCapacityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ingest failed: HTTP {}: {}",
+            self.status,
+            self.body.trim()
+        )
+    }
+}
+
+impl std::error::Error for WorkerCapacityError {}
+
 /// Build the next outbox batch and push it. On success, persists the advanced cursor.
 /// No-op (no HTTP call) when there's nothing new to send.
 pub fn push(
@@ -412,7 +435,6 @@ pub fn push(
     limit: usize,
     incognito: &HashSet<String>,
 ) -> Result<PushReport> {
-    const MIN_RECOVERABLE_BATCH_LIMIT: usize = 10;
     let mut batch_limit = limit.max(1);
     let mut attempts = 1;
 
@@ -428,20 +450,19 @@ pub fn push(
             attempts,
         ) {
             Ok(report) => return Ok(report),
-            Err(err)
-                if is_worker_capacity_error(&err) && batch_limit > MIN_RECOVERABLE_BATCH_LIMIT =>
-            {
-                let next_limit = (batch_limit / 2).max(MIN_RECOVERABLE_BATCH_LIMIT);
-                batch_limit = next_limit;
+            Err(err) => {
+                let Some(attempted_records) = worker_capacity_attempted_records(&err) else {
+                    return Err(err);
+                };
+                if attempted_records <= 1 {
+                    return Err(err.context(format!(
+                        "cloud ingest still exceeded its resource limit with one record after \
+                         {attempts} attempt(s); cursor was not advanced"
+                    )));
+                }
+                batch_limit = (attempted_records / 2).max(1);
                 attempts += 1;
             }
-            Err(err) if is_worker_capacity_error(&err) => {
-                return Err(err.context(format!(
-                    "cloud ingest still exceeded its resource limit at batch limit {batch_limit} \
-                     after {attempts} attempt(s); cursor was not advanced"
-                )));
-            }
-            Err(err) => return Err(err),
         }
     }
 }
@@ -490,17 +511,30 @@ fn push_once(
     })
 }
 
-/// Cloudflare's worker overload currently arrives as an HTML 503, while a future structured
-/// response may retain the text without that status. Treat either signal as safe to retry with
-/// the exact same starting cursor and a smaller batch; no cursor is persisted before success.
-fn is_worker_capacity_error(err: &anyhow::Error) -> bool {
-    err.chain().any(|cause| {
-        let message = cause.to_string();
-        message.contains("HTTP 503")
-            || message
-                .to_ascii_lowercase()
-                .contains("worker exceeded resource limits")
+fn worker_capacity_attempted_records(err: &anyhow::Error) -> Option<usize> {
+    err.chain().find_map(|cause| {
+        cause
+            .downcast_ref::<WorkerCapacityError>()
+            .map(|failure| failure.attempted_records)
     })
+}
+
+fn ingest_status_error(code: u16, body: String, attempted_records: usize) -> anyhow::Error {
+    let normalized = body.to_ascii_lowercase();
+    let is_capacity = code == 503
+        && (normalized.contains("worker exceeded resource limits")
+            || normalized.contains("error code: 1102")
+            || normalized.contains("worker_capacity"));
+    if is_capacity {
+        WorkerCapacityError {
+            status: code,
+            body,
+            attempted_records,
+        }
+        .into()
+    } else {
+        anyhow::anyhow!("ingest failed: HTTP {code}: {body}")
+    }
 }
 
 // ----- ureq-backed live transport -----
@@ -521,7 +555,7 @@ impl Ingestor for UreqIngestor {
             Ok(r) => Ok(r.into_json::<IngestResponse>()?),
             Err(ureq::Error::Status(code, r)) => {
                 let body = r.into_string().unwrap_or_default();
-                anyhow::bail!("ingest failed: HTTP {code}: {body}")
+                Err(ingest_status_error(code, body, req.records.len()))
             }
             Err(e) => Err(e.into()),
         }
@@ -1273,7 +1307,11 @@ mod tests {
                 .borrow_mut()
                 .push(req.records.len());
             if req.records.len() > self.max_records {
-                anyhow::bail!("ingest failed: HTTP 503: Worker exceeded resource limits");
+                return Err(ingest_status_error(
+                    503,
+                    "Worker exceeded resource limits".to_string(),
+                    req.records.len(),
+                ));
             }
             Ok(IngestResponse {
                 batch_id: req.batch_id.clone(),
@@ -1281,6 +1319,21 @@ mod tests {
                 accepted: req.records.len() as u64,
                 cursors: None,
             })
+        }
+    }
+
+    struct GenericUnavailableIngestor {
+        attempts: RefCell<usize>,
+    }
+
+    impl Ingestor for GenericUnavailableIngestor {
+        fn ingest(&self, _auth: &StoredAuth, _req: &IngestRequest) -> Result<IngestResponse> {
+            *self.attempts.borrow_mut() += 1;
+            Err(ingest_status_error(
+                503,
+                "service temporarily unavailable".to_string(),
+                32,
+            ))
         }
     }
 
@@ -1366,7 +1419,7 @@ mod tests {
     }
 
     #[test]
-    fn push_halves_a_worker_rejected_batch_and_makes_progress() {
+    fn push_shrinks_from_the_emitted_batch_size_and_makes_progress() {
         with_temp_home(|| {
             let conn = mem();
             for id in 1..=32 {
@@ -1390,16 +1443,54 @@ mod tests {
                     ..Default::default()
                 },
                 &SyncCursor::default(),
-                32,
+                500,
                 &HashSet::new(),
             )
             .unwrap();
 
-            assert_eq!(*client.attempted_record_counts.borrow(), vec![32, 16, 10]);
-            assert_eq!(report.batch_limit, 10);
+            // The configured limit is 500 but only 32 rows are pending. Retrying from 250
+            // would resend the same 32-record payload; shrink from the emitted size instead.
+            assert_eq!(*client.attempted_record_counts.borrow(), vec![32, 16, 8]);
+            assert_eq!(report.batch_limit, 8);
             assert_eq!(report.attempts, 3);
-            assert_eq!(report.cursor.history_id, 10);
-            assert_eq!(load_cursor(&auth.base_url).unwrap().history_id, 10);
+            assert_eq!(report.cursor.history_id, 8);
+            assert_eq!(load_cursor(&auth.base_url).unwrap().history_id, 8);
+        });
+    }
+
+    #[test]
+    fn an_unrelated_503_is_not_retried_as_a_capacity_failure() {
+        with_temp_home(|| {
+            let conn = mem();
+            for id in 1..=32 {
+                add(&conn, &format!("entry {id}"), id);
+            }
+            let client = GenericUnavailableIngestor {
+                attempts: RefCell::new(0),
+            };
+            let auth = StoredAuth {
+                base_url: "http://localhost:8787".into(),
+                access_token: "test-access-token".into(),
+                ..Default::default()
+            };
+            let err = push(
+                &conn,
+                &client,
+                &auth,
+                &MachineIdentity {
+                    id: "m1".into(),
+                    ..Default::default()
+                },
+                &SyncCursor::default(),
+                500,
+                &HashSet::new(),
+            )
+            .unwrap_err();
+            let message = format!("{err:#}");
+
+            assert!(message.contains("temporarily unavailable"), "{message}");
+            assert_eq!(*client.attempts.borrow(), 1);
+            assert_eq!(load_cursor(&auth.base_url).unwrap(), SyncCursor::default());
         });
     }
 

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -195,7 +195,10 @@ fn write_private(path: &std::path::Path, body: &str) -> Result<()> {
             .with_context(|| format!("creating private state at {}", tmp_path.display()))?;
         tmp.write_all(body.as_bytes())?;
         tmp.sync_all()?;
-        fs::rename(&tmp_path, path)
+        // `std::fs::rename` replaces an existing file on Unix, but not on
+        // Windows. `replace_atomic` uses the platform replacement primitive so
+        // every cursor/auth update has the same atomic overwrite semantics.
+        atomicwrites::replace_atomic(&tmp_path, path)
             .with_context(|| format!("atomically replacing {}", path.display()))?;
         // A directory fsync makes the rename durable on filesystems that support it. Some
         // platforms reject directory sync, so it remains best effort after the file itself is
@@ -1486,6 +1489,18 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let _relayhistory_home = EnvVarGuard::set("RELAYHISTORY_HOME", dir.path());
         f()
+    }
+
+    #[test]
+    fn write_private_replaces_existing_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cursor.json");
+
+        write_private(&path, r#"{"history_id":1}"#).unwrap();
+        write_private(&path, r#"{"history_id":2}"#).unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), r#"{"history_id":2}"#);
+        assert_eq!(fs::read_dir(dir.path()).unwrap().count(), 1);
     }
 
     #[test]

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -913,8 +913,9 @@ pub fn run() -> Result<()> {
             if install_service {
                 // `--incognito` is a per-run privacy filter; the scheduled job
                 // runs a plain `push`, so silently dropping it would give a
-                // false sense that it applies. Reject the combo. (`--limit` is
-                // only a batch-size knob and is harmless to ignore here.)
+                // false sense that it applies. Reject the combo. `--limit`, on
+                // the other hand, is part of the reliability configuration and
+                // is recorded in the service command.
                 if !incognito.is_empty() {
                     anyhow::bail!(
                         "--incognito is a per-run privacy filter and is NOT applied to the scheduled \
@@ -926,7 +927,12 @@ pub fn run() -> Result<()> {
                     "not authenticated for the selected stage — run `ai-hist login` or \
                      `ai-hist admin-mint` first",
                 )?;
-                let service_args = vec!["--base-url".to_string(), auth.base_url];
+                let service_args = vec![
+                    "--base-url".to_string(),
+                    auth.base_url,
+                    "--limit".to_string(),
+                    limit.to_string(),
+                ];
                 return install_managed_service(&PUSH_SERVICE, interval, &service_args);
             }
             if uninstall_service {
@@ -960,17 +966,21 @@ pub fn run() -> Result<()> {
                         "accepted": report.accepted,
                         "batchId": report.batch_id,
                         "cursor": report.cursor,
+                        "batchLimit": report.batch_limit,
+                        "attempts": report.attempts,
                     })
                 );
             } else if report.sent == 0 {
                 println!("Nothing new to push.");
             } else {
                 println!(
-                    "Pushed {} record(s), {} accepted (cursor → history #{}, trajectory rowid {}).",
+                    "Pushed {} record(s), {} accepted (cursor → history #{}, trajectory rowid {}; batch limit {}, {} attempt(s)).",
                     report.sent,
                     report.accepted,
                     report.cursor.history_id,
-                    report.cursor.trajectory_rowid
+                    report.cursor.trajectory_rowid,
+                    report.batch_limit,
+                    report.attempts,
                 );
             }
             Ok(())
@@ -5398,6 +5408,8 @@ mod tests {
         let args = vec![
             "--base-url".to_string(),
             "https://history.agentrelay.com".to_string(),
+            "--limit".to_string(),
+            "50".to_string(),
         ];
         assert_eq!(
             service_command_args(&PUSH_SERVICE, &args),
@@ -5405,6 +5417,8 @@ mod tests {
                 "push".to_string(),
                 "--base-url".to_string(),
                 "https://history.agentrelay.com".to_string(),
+                "--limit".to_string(),
+                "50".to_string(),
             ]
         );
     }

--- a/sdk-ts/src/cloud-push.test.ts
+++ b/sdk-ts/src/cloud-push.test.ts
@@ -34,12 +34,26 @@ function fakeSpawn(script: { stdout?: string; stderr?: string; code?: number; er
 
 test('pushToCloud parses ai-hist push --json output into a report', async () => {
   const { spawnFn, calls } = fakeSpawn({
-    stdout: JSON.stringify({ sent: 3, accepted: 3, batchId: 'b_abc', cursor: { history_id: 9 } }),
+    stdout: JSON.stringify({
+      sent: 3,
+      accepted: 3,
+      batchId: 'b_abc',
+      cursor: { history_id: 9 },
+      batchLimit: 100,
+      attempts: 2,
+    }),
   });
 
   const report = await pushToCloud({ binPath: '/bin/echo', spawnFn, limit: 200, incognito: ['s1', 's2'] });
 
-  assert.deepEqual(report, { sent: 3, accepted: 3, batchId: 'b_abc', cursor: { history_id: 9 } });
+  assert.deepEqual(report, {
+    sent: 3,
+    accepted: 3,
+    batchId: 'b_abc',
+    cursor: { history_id: 9 },
+    batchLimit: 100,
+    attempts: 2,
+  });
   // Forwards the flags to the binary.
   assert.deepEqual(calls[0].args, ['push', '--json', '--limit', '200', '--incognito', 's1', '--incognito', 's2']);
 });

--- a/sdk-ts/src/cloud-push.ts
+++ b/sdk-ts/src/cloud-push.ts
@@ -19,6 +19,10 @@ export interface PushReport {
   accepted: number;
   batchId: string | null;
   cursor?: unknown;
+  /** Accepted per-source record limit after any capacity retry. */
+  batchLimit?: number;
+  /** Number of HTTP ingest attempts made by this push. */
+  attempts?: number;
 }
 
 export interface PushOptions {
@@ -125,6 +129,8 @@ export function pushToCloud(opts: PushOptions = {}): Promise<PushReport | null> 
           accepted: typeof parsed.accepted === 'number' ? parsed.accepted : 0,
           batchId: typeof parsed.batchId === 'string' ? parsed.batchId : null,
           cursor: parsed.cursor,
+          ...(typeof parsed.batchLimit === 'number' ? { batchLimit: parsed.batchLimit } : {}),
+          ...(typeof parsed.attempts === 'number' ? { attempts: parsed.attempts } : {}),
         });
       } catch (err) {
         reject(


### PR DESCRIPTION
Closes #58.\n\nWhen the Cloud worker reports a resource-limit 503, push retries the same durable cursor with a halved batch limit down to 10 records. The cursor advances only after acceptance; a rejection at the floor fails loudly instead of silently leaving a machine permanently muted. The installed service also preserves its selected batch limit.\n\nStacked on #60 because service installation must retain both the stage and batch limit.\n\nTests: cargo test -p ai-hist-cli --no-fail-fast (61 passed).