### PR TITLE
fix(ai-hist): refresh expired auth and serialize sync runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,13 @@ jobs:
           npm run lint
           npm test
 
+      - name: Native binding contract
+        working-directory: crates/ai-hist-napi
+        run: |
+          npm ci
+          npm run build:debug
+          git diff --exit-code -- index.d.ts
+
       - name: End-to-end wrapper verification
         run: AI_HIST_RUST_BIN="$PWD/target/debug/ai-hist" ./scripts/verify-e2e.sh
 

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -9,6 +9,8 @@ export interface SyncPushResult {
   accepted: number
   /** `false` when there's no stored relayhistory auth yet (a no-op, not an error). */
   authenticated: boolean
+  /** `true` when another process owned the history scan; existing rows were still pushed. */
+  syncSkipped: boolean
 }
 /**
  * Sync local agent history into the ai-hist DB, then push new records to

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -13,6 +13,8 @@ pub struct SyncPushResult {
     pub accepted: u32,
     /// `false` when there's no stored relayhistory auth yet (a no-op, not an error).
     pub authenticated: bool,
+    /// `true` when another process owned the history scan; existing rows were still pushed.
+    pub sync_skipped: bool,
 }
 
 /// Sync local agent history into the ai-hist DB, then push new records to
@@ -28,5 +30,6 @@ pub async fn sync_and_push() -> napi::Result<SyncPushResult> {
         sent: outcome.sent as u32,
         accepted: outcome.accepted as u32,
         authenticated: outcome.authenticated,
+        sync_skipped: outcome.sync_skipped,
     })
 }

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -697,15 +697,18 @@ fn is_unauthorized(error: &ureq::Error) -> bool {
     matches!(error, ureq::Error::Status(401, _))
 }
 
-/// Send one authenticated request and rotate an expired session at most once. Refresh-token
-/// rotation is serialized per stage: a waiter reloads credentials after acquiring the lock and
-/// reuses a pair already rotated by another process instead of submitting the revoked old token.
+/// Send one authenticated request and rotate an expired session at most once. The persisted
+/// session is loaded before each request so a long-lived caller holding an older `StoredAuth`
+/// transparently adopts a pair rotated by an earlier call. Refresh-token rotation is serialized
+/// per stage: a waiter reloads credentials after acquiring the lock and reuses a pair already
+/// rotated by another process instead of submitting the revoked old token.
 fn send_with_auth_refresh(
     auth: &StoredAuth,
     send: impl Fn(&StoredAuth) -> std::result::Result<ureq::Response, Box<ureq::Error>>,
     map_error: impl Fn(ureq::Error) -> anyhow::Error,
 ) -> Result<ureq::Response> {
-    let mut unauthorized = match send(auth) {
+    let attempted = load_auth(Some(&auth.base_url))?.unwrap_or_else(|| auth.clone());
+    let mut unauthorized = match send(&attempted) {
         Ok(response) => return Ok(response),
         Err(error) if is_unauthorized(&error) => *error,
         Err(error) => return Err(map_error(*error)),
@@ -716,7 +719,7 @@ fn send_with_auth_refresh(
 
     // A concurrent process may have completed rotation while this caller waited. Try its
     // persisted access token before touching the one-time refresh token again.
-    if current.access_token != auth.access_token {
+    if current.access_token != attempted.access_token {
         match send(&current) {
             Ok(response) => return Ok(response),
             Err(error) if is_unauthorized(&error) => unauthorized = *error,
@@ -2195,6 +2198,92 @@ mod tests {
             let stored = load_auth(Some(&auth.base_url)).unwrap().unwrap();
             assert_eq!(stored.access_token, "rth_at_fresh");
             assert_eq!(stored.refresh_token.as_deref(), Some("rth_rt_fresh"));
+        });
+    }
+
+    #[test]
+    fn a_reused_auth_value_adopts_the_persisted_rotation() {
+        with_temp_home(|| {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let addr = listener.local_addr().unwrap();
+            let stale_requests = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let refreshes = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let server_stale_requests = std::sync::Arc::clone(&stale_requests);
+            let server_refreshes = std::sync::Arc::clone(&refreshes);
+            let server = std::thread::spawn(move || {
+                let started = std::time::Instant::now();
+                let mut handled = 0;
+                while handled < 4 && started.elapsed() < std::time::Duration::from_secs(10) {
+                    let (mut stream, _) = match listener.accept() {
+                        Ok(connection) => connection,
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                            std::thread::sleep(std::time::Duration::from_millis(5));
+                            continue;
+                        }
+                        Err(error) => panic!("accept failed: {error}"),
+                    };
+                    handled += 1;
+                    let (line, headers, _) = read_http_request(&mut stream);
+                    if line.starts_with("POST /v1/auth/token/refresh ") {
+                        server_refreshes.fetch_add(1, Ordering::SeqCst);
+                        write_http_response(
+                            &mut stream,
+                            "200 OK",
+                            r#"{"accessToken":"rth_at_fresh","refreshToken":"rth_rt_fresh"}"#,
+                        );
+                        continue;
+                    }
+
+                    assert!(line.starts_with("POST /v1/ingest "), "{line}");
+                    match headers.get("authorization").map(String::as_str) {
+                        Some("Bearer rth_at_expired") => {
+                            server_stale_requests.fetch_add(1, Ordering::SeqCst);
+                            write_http_response(
+                                &mut stream,
+                                "401 Unauthorized",
+                                r#"{"error":"invalid_token"}"#,
+                            );
+                        }
+                        Some("Bearer rth_at_fresh") => write_http_response(
+                            &mut stream,
+                            "200 OK",
+                            r#"{"batchId":"b_test","received":0,"accepted":0}"#,
+                        ),
+                        other => panic!("unexpected authorization header: {other:?}"),
+                    }
+                }
+                assert_eq!(
+                    handled, 4,
+                    "expected one stale call, one refresh, and two successful calls"
+                );
+            });
+
+            let auth = StoredAuth {
+                base_url: format!("http://{addr}"),
+                access_token: "rth_at_expired".into(),
+                refresh_token: Some("rth_rt_old".into()),
+                ..Default::default()
+            };
+            save_auth(&auth).unwrap();
+            let request = IngestRequest {
+                machine: MachineIdentity {
+                    id: "m1".into(),
+                    ..Default::default()
+                },
+                batch_id: "b_test".into(),
+                cursors: None,
+                records: Vec::new(),
+            };
+
+            UreqIngestor.ingest(&auth, &request).unwrap();
+            // Deliberately reuse the stale value. The persisted rotated pair must be selected
+            // before sending, without another guaranteed-to-fail request or refresh.
+            UreqIngestor.ingest(&auth, &request).unwrap();
+            server.join().unwrap();
+
+            assert_eq!(stale_requests.load(Ordering::SeqCst), 1);
+            assert_eq!(refreshes.load(Ordering::SeqCst), 1);
         });
     }
 

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -625,6 +625,17 @@ fn ingest_status_error(code: u16, body: String, attempted_records: usize) -> any
     }
 }
 
+fn map_ingest_http_err(error: ureq::Error, attempted_records: usize) -> anyhow::Error {
+    match error {
+        ureq::Error::Status(code, response) => ingest_status_error(
+            code,
+            response.into_string().unwrap_or_default(),
+            attempted_records,
+        ),
+        other => other.into(),
+    }
+}
+
 // ----- ureq-backed live transport -----
 
 /// Live `Ingestor` over `ureq` (blocking HTTP — no async runtime, never compiled into the
@@ -635,19 +646,120 @@ impl Ingestor for UreqIngestor {
     fn ingest(&self, auth: &StoredAuth, req: &IngestRequest) -> Result<IngestResponse> {
         require_secure_transport(&auth.base_url)?;
         let url = format!("{}/v1/ingest", auth.base_url.trim_end_matches('/'));
-        let resp = ureq::post(&url)
-            .set("Authorization", &format!("Bearer {}", auth.access_token))
-            .set("Content-Type", "application/json")
-            .send_json(serde_json::to_value(req)?);
-        match resp {
-            Ok(r) => Ok(r.into_json::<IngestResponse>()?),
-            Err(ureq::Error::Status(code, r)) => {
-                let body = r.into_string().unwrap_or_default();
-                Err(ingest_status_error(code, body, req.records.len()))
-            }
-            Err(e) => Err(e.into()),
+        let payload = serde_json::to_value(req)?;
+        let response = send_with_auth_refresh(
+            auth,
+            |current| {
+                ureq::post(&url)
+                    .set("Authorization", &format!("Bearer {}", current.access_token))
+                    .set("Content-Type", "application/json")
+                    .send_json(payload.clone())
+                    .map_err(Box::new)
+            },
+            |error| map_ingest_http_err(error, req.records.len()),
+        )
+        .context("ingest failed")?;
+        Ok(response.into_json::<IngestResponse>()?)
+    }
+}
+
+struct AuthRefreshLock {
+    _file: fs::File,
+}
+
+fn refresh_lock_path(base_url: &str) -> Result<PathBuf> {
+    let auth = auth_path(base_url)?;
+    let mut name = auth
+        .file_name()
+        .context("stage auth path has no file name")?
+        .to_os_string();
+    name.push(".refresh.lock");
+    Ok(auth.with_file_name(name))
+}
+
+fn acquire_refresh_lock(base_url: &str) -> Result<AuthRefreshLock> {
+    let path = refresh_lock_path(base_url)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&path)?;
+    fs2::FileExt::lock_exclusive(&file)
+        .with_context(|| format!("locking token refresh state at {}", path.display()))?;
+    Ok(AuthRefreshLock { _file: file })
+}
+
+fn is_unauthorized(error: &ureq::Error) -> bool {
+    matches!(error, ureq::Error::Status(401, _))
+}
+
+/// Send one authenticated request and rotate an expired session at most once. Refresh-token
+/// rotation is serialized per stage: a waiter reloads credentials after acquiring the lock and
+/// reuses a pair already rotated by another process instead of submitting the revoked old token.
+fn send_with_auth_refresh(
+    auth: &StoredAuth,
+    send: impl Fn(&StoredAuth) -> std::result::Result<ureq::Response, Box<ureq::Error>>,
+    map_error: impl Fn(ureq::Error) -> anyhow::Error,
+) -> Result<ureq::Response> {
+    let mut unauthorized = match send(auth) {
+        Ok(response) => return Ok(response),
+        Err(error) if is_unauthorized(&error) => *error,
+        Err(error) => return Err(map_error(*error)),
+    };
+
+    let _refresh_lock = acquire_refresh_lock(&auth.base_url)?;
+    let current = load_auth(Some(&auth.base_url))?.unwrap_or_else(|| auth.clone());
+
+    // A concurrent process may have completed rotation while this caller waited. Try its
+    // persisted access token before touching the one-time refresh token again.
+    if current.access_token != auth.access_token {
+        match send(&current) {
+            Ok(response) => return Ok(response),
+            Err(error) if is_unauthorized(&error) => unauthorized = *error,
+            Err(error) => return Err(map_error(*error)),
         }
     }
+
+    if current
+        .refresh_token
+        .as_deref()
+        .is_none_or(|token| token.trim().is_empty())
+    {
+        return Err(map_error(unauthorized));
+    }
+    let refreshed = refresh_auth(&current).context("refreshing relayhistory session")?;
+    // Refresh tokens rotate and invalidate their predecessor. Persist the new pair atomically
+    // before retrying so a crash or network failure cannot strand the client on the old token.
+    save_auth(&refreshed).context("persisting refreshed relayhistory session")?;
+    send(&refreshed).map_err(|error| map_error(*error))
+}
+
+fn refresh_auth(auth: &StoredAuth) -> Result<StoredAuth> {
+    require_secure_transport(&auth.base_url)?;
+    let refresh_token = auth
+        .refresh_token
+        .as_deref()
+        .context("stored relayhistory session has no refresh token; run `ai-hist login`")?;
+    let url = format!(
+        "{}/v1/auth/token/refresh",
+        auth.base_url.trim_end_matches('/')
+    );
+    let response = ureq::post(&url)
+        .set("Content-Type", "application/json")
+        .send_json(serde_json::json!({ "refreshToken": refresh_token }))
+        .map_err(map_http_err)?;
+    let payload: serde_json::Value = response.into_json()?;
+    Ok(StoredAuth {
+        base_url: auth.base_url.clone(),
+        access_token: field(&payload, "accessToken")?,
+        refresh_token: Some(field(&payload, "refreshToken")?),
+        org_id: auth.org_id.clone(),
+        workspace_id: auth.workspace_id.clone(),
+    })
 }
 
 /// `POST /v1/admin/mint` (dev-only bootstrap) → store the `rth_at_` session.
@@ -938,18 +1050,20 @@ pub fn pair_check(auth: &StoredAuth, context: &PairContext, limit: usize) -> Res
     require_secure_transport(&auth.base_url)?;
     let url = format!("{}/v1/pair/check", auth.base_url.trim_end_matches('/'));
     let req = PairRequest { context, limit };
-    let resp = ureq::post(&url)
-        .set("Authorization", &format!("Bearer {}", auth.access_token))
-        .set("Content-Type", "application/json")
-        .send_json(serde_json::to_value(req)?);
-    match resp {
-        Ok(r) => Ok(r.into_json::<PairResponse>()?),
-        Err(ureq::Error::Status(code, r)) => {
-            let body = r.into_string().unwrap_or_default();
-            anyhow::bail!("pair check failed: HTTP {code}: {body}")
-        }
-        Err(e) => Err(e.into()),
-    }
+    let payload = serde_json::to_value(req)?;
+    let response = send_with_auth_refresh(
+        auth,
+        |current| {
+            ureq::post(&url)
+                .set("Authorization", &format!("Bearer {}", current.access_token))
+                .set("Content-Type", "application/json")
+                .send_json(payload.clone())
+                .map_err(Box::new)
+        },
+        map_http_err,
+    )
+    .context("pair check failed")?;
+    Ok(response.into_json::<PairResponse>()?)
 }
 
 /// Human-readable rendering of Pair warnings (the non-`--json` output).
@@ -1080,24 +1194,26 @@ pub struct CoverageQuery {
 pub fn fleet_coverage(auth: &StoredAuth, query: &CoverageQuery) -> Result<CoverageResponse> {
     require_secure_transport(&auth.base_url)?;
     let url = format!("{}/v1/machines", auth.base_url.trim_end_matches('/'));
-    let mut req = ureq::get(&url).set("Authorization", &format!("Bearer {}", auth.access_token));
-    if let Some(v) = query.stale_after_seconds {
-        req = req.query("staleAfterSeconds", &v.to_string());
-    }
-    if let Some(v) = query.missing_after_seconds {
-        req = req.query("missingAfterSeconds", &v.to_string());
-    }
-    if let Some(v) = query.window_hours {
-        req = req.query("windowHours", &v.to_string());
-    }
-    match req.call() {
-        Ok(r) => Ok(r.into_json::<CoverageResponse>()?),
-        Err(ureq::Error::Status(code, r)) => {
-            let body = r.into_string().unwrap_or_default();
-            anyhow::bail!("coverage query failed: HTTP {code}: {body}")
-        }
-        Err(e) => Err(e.into()),
-    }
+    let response = send_with_auth_refresh(
+        auth,
+        |current| {
+            let mut request =
+                ureq::get(&url).set("Authorization", &format!("Bearer {}", current.access_token));
+            if let Some(v) = query.stale_after_seconds {
+                request = request.query("staleAfterSeconds", &v.to_string());
+            }
+            if let Some(v) = query.missing_after_seconds {
+                request = request.query("missingAfterSeconds", &v.to_string());
+            }
+            if let Some(v) = query.window_hours {
+                request = request.query("windowHours", &v.to_string());
+            }
+            request.call().map_err(Box::new)
+        },
+        map_http_err,
+    )
+    .context("coverage query failed")?;
+    Ok(response.into_json::<CoverageResponse>()?)
 }
 
 /// Human-readable fleet table (the non-`--json` output).
@@ -1489,6 +1605,50 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let _relayhistory_home = EnvVarGuard::set("RELAYHISTORY_HOME", dir.path());
         f()
+    }
+
+    fn read_http_request(
+        stream: &mut std::net::TcpStream,
+    ) -> (String, std::collections::HashMap<String, String>, String) {
+        use std::io::{BufRead, BufReader, Read};
+
+        stream
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))
+            .unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut first_line = String::new();
+        reader.read_line(&mut first_line).unwrap();
+        let mut headers = std::collections::HashMap::new();
+        let mut content_length = 0usize;
+        loop {
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            let trimmed = line.trim_end();
+            if trimmed.is_empty() {
+                break;
+            }
+            if let Some((name, value)) = trimmed.split_once(':') {
+                let name = name.to_ascii_lowercase();
+                let value = value.trim().to_string();
+                if name == "content-length" {
+                    content_length = value.parse().unwrap();
+                }
+                headers.insert(name, value);
+            }
+        }
+        let mut body = vec![0; content_length];
+        reader.read_exact(&mut body).unwrap();
+        (first_line, headers, String::from_utf8(body).unwrap())
+    }
+
+    fn write_http_response(stream: &mut std::net::TcpStream, status: &str, body: &str) {
+        use std::io::Write;
+
+        let response = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        stream.write_all(response.as_bytes()).unwrap();
     }
 
     #[test]
@@ -1886,6 +2046,155 @@ mod tests {
             };
             save_cursor(&auth.base_url, &c).unwrap();
             assert_eq!(load_cursor(&auth.base_url).unwrap(), c);
+        });
+    }
+
+    #[test]
+    fn concurrent_auth_saves_never_publish_partial_json() {
+        with_temp_home(|| {
+            let mut writers = Vec::new();
+            for writer in 0..8 {
+                writers.push(std::thread::spawn(move || {
+                    for revision in 0..40 {
+                        save_auth(&StoredAuth {
+                            base_url: "http://localhost:8787".into(),
+                            access_token: format!("rth_at_{writer}_{revision}"),
+                            refresh_token: Some(format!("rth_rt_{writer}_{revision}")),
+                            ..Default::default()
+                        })
+                        .unwrap();
+                    }
+                }));
+            }
+            for writer in writers {
+                writer.join().unwrap();
+            }
+
+            let stored = load_auth(Some("http://localhost:8787")).unwrap().unwrap();
+            assert!(stored.access_token.starts_with("rth_at_"));
+            assert!(stored
+                .refresh_token
+                .as_deref()
+                .is_some_and(|token| token.starts_with("rth_rt_")));
+            let leftovers: Vec<_> = fs::read_dir(stage_dir())
+                .unwrap()
+                .filter_map(|entry| entry.ok())
+                .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp."))
+                .collect();
+            assert!(
+                leftovers.is_empty(),
+                "leftover auth temp files: {leftovers:?}"
+            );
+        });
+    }
+
+    #[test]
+    fn concurrent_401s_share_one_rotated_refresh_token() {
+        with_temp_home(|| {
+            use std::sync::{Arc, Barrier};
+
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.set_nonblocking(true).unwrap();
+            let addr = listener.local_addr().unwrap();
+            let refreshes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let server_refreshes = Arc::clone(&refreshes);
+            let server = std::thread::spawn(move || {
+                let started = std::time::Instant::now();
+                let mut handled = 0;
+                while handled < 5 && started.elapsed() < std::time::Duration::from_secs(10) {
+                    let (mut stream, _) = match listener.accept() {
+                        Ok(connection) => connection,
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                            std::thread::sleep(std::time::Duration::from_millis(5));
+                            continue;
+                        }
+                        Err(error) => panic!("accept failed: {error}"),
+                    };
+                    handled += 1;
+                    let (line, headers, body) = read_http_request(&mut stream);
+                    if line.starts_with("POST /v1/auth/token/refresh ") {
+                        assert_eq!(
+                            serde_json::from_str::<serde_json::Value>(&body).unwrap()
+                                ["refreshToken"],
+                            "rth_rt_old"
+                        );
+                        let prior = server_refreshes.fetch_add(1, Ordering::SeqCst);
+                        if prior == 0 {
+                            write_http_response(
+                                &mut stream,
+                                "200 OK",
+                                r#"{"accessToken":"rth_at_fresh","refreshToken":"rth_rt_fresh"}"#,
+                            );
+                        } else {
+                            write_http_response(
+                                &mut stream,
+                                "401 Unauthorized",
+                                r#"{"error":"refresh token already rotated"}"#,
+                            );
+                        }
+                        continue;
+                    }
+
+                    assert!(line.starts_with("POST /v1/ingest "), "{line}");
+                    match headers.get("authorization").map(String::as_str) {
+                        Some("Bearer rth_at_expired") => write_http_response(
+                            &mut stream,
+                            "401 Unauthorized",
+                            r#"{"error":"invalid_token"}"#,
+                        ),
+                        Some("Bearer rth_at_fresh") => write_http_response(
+                            &mut stream,
+                            "200 OK",
+                            r#"{"batchId":"b_test","received":0,"accepted":0}"#,
+                        ),
+                        other => panic!("unexpected authorization header: {other:?}"),
+                    }
+                }
+                assert_eq!(
+                    handled, 5,
+                    "expected two initial calls, one refresh, two retries"
+                );
+            });
+
+            let auth = StoredAuth {
+                base_url: format!("http://{addr}"),
+                access_token: "rth_at_expired".into(),
+                refresh_token: Some("rth_rt_old".into()),
+                org_id: Some("org-a".into()),
+                workspace_id: Some("ws-a".into()),
+            };
+            save_auth(&auth).unwrap();
+            let barrier = Arc::new(Barrier::new(3));
+            let mut clients = Vec::new();
+            for _ in 0..2 {
+                let auth = auth.clone();
+                let barrier = Arc::clone(&barrier);
+                clients.push(std::thread::spawn(move || {
+                    barrier.wait();
+                    UreqIngestor.ingest(
+                        &auth,
+                        &IngestRequest {
+                            machine: MachineIdentity {
+                                id: "m1".into(),
+                                ..Default::default()
+                            },
+                            batch_id: "b_test".into(),
+                            cursors: None,
+                            records: Vec::new(),
+                        },
+                    )
+                }));
+            }
+            barrier.wait();
+            for client in clients {
+                assert_eq!(client.join().unwrap().unwrap().batch_id, "b_test");
+            }
+            server.join().unwrap();
+
+            assert_eq!(refreshes.load(Ordering::SeqCst), 1);
+            let stored = load_auth(Some(&auth.base_url)).unwrap().unwrap();
+            assert_eq!(stored.access_token, "rth_at_fresh");
+            assert_eq!(stored.refresh_token.as_deref(), Some("rth_rt_fresh"));
         });
     }
 

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -2150,6 +2150,14 @@ struct SyncRunLock {
     _file: fs::File,
 }
 
+impl Drop for SyncRunLock {
+    fn drop(&mut self) {
+        // Do not rely solely on platform-specific close timing. Linux CI exposed a race where
+        // a just-dropped guard was not immediately reacquirable through an alias path.
+        let _ = fs2::FileExt::unlock(&self._file);
+    }
+}
+
 fn canonical_db_identity(db_path: &Path) -> Result<PathBuf> {
     if db_path.exists() {
         return fs::canonicalize(db_path)
@@ -5555,7 +5563,12 @@ mod tests {
         );
 
         drop(first);
-        assert!(try_acquire_sync_lock(&alias).unwrap().is_some());
+        for _ in 0..16 {
+            let reacquired = try_acquire_sync_lock(&alias)
+                .unwrap()
+                .expect("a dropped sync guard must release the lock immediately");
+            drop(reacquired);
+        }
     }
 
     #[test]

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -44,6 +44,8 @@ pub struct SyncPushOutcome {
     /// `false` when there's no stored relayhistory auth yet (treated as a no-op
     /// rather than an error, for background callers).
     pub authenticated: bool,
+    /// `true` when another process owned the scan lock. Already-indexed rows are still pushed.
+    pub sync_skipped: bool,
 }
 
 /// Sync local agent history into the DB, then push new records to
@@ -55,8 +57,7 @@ pub fn sync_and_push() -> Result<SyncPushOutcome> {
     SYNC_QUIET.store(true, AtomicOrdering::Relaxed);
 
     let db_path = default_db_path();
-    let conn = open_db(&db_path)?;
-    sync_basic(&conn, &db_path)?;
+    let (conn, sync_skipped) = prepare_sync_and_push_db(&db_path)?;
 
     // The in-process runtime has no CLI argument channel. Keep it pinned to the normal Cloud
     // origin rather than following whichever stage happened to be logged into most recently.
@@ -68,6 +69,7 @@ pub fn sync_and_push() -> Result<SyncPushOutcome> {
                 sent: 0,
                 accepted: 0,
                 authenticated: false,
+                sync_skipped,
             })
         }
     };
@@ -92,6 +94,7 @@ pub fn sync_and_push() -> Result<SyncPushOutcome> {
         sent: report.sent as u64,
         accepted: report.accepted,
         authenticated: true,
+        sync_skipped,
     })
 }
 
@@ -560,6 +563,32 @@ fn read_only_connection(command: &Command, db_path: &Path) -> Option<Connection>
 pub fn run() -> Result<()> {
     let cli = Cli::parse();
     let db_path = cli.db.unwrap_or_else(default_db_path);
+
+    // Sync commands must acquire their advisory lock before opening a writable connection.
+    // Pre-dispatch them so the common connection setup below cannot initialize the schema or
+    // wait on SQLite before contention is detected.
+    match &cli.command {
+        Command::Sync {
+            install_service,
+            uninstall_service,
+            interval,
+        } => {
+            if *install_service {
+                return install_managed_service(&SYNC_SERVICE, *interval, &[]);
+            }
+            if *uninstall_service {
+                return uninstall_managed_service(&SYNC_SERVICE);
+            }
+            return sync_exclusive(&db_path).map(|_| ());
+        }
+        Command::Watch { interval } => return watch_loop(&db_path, *interval),
+        Command::SyncOpencode { opencode_db } => {
+            let source = opencode_db.clone().unwrap_or_else(default_opencode_db_path);
+            return sync_opencode_exclusive(&db_path, &source).map(|_| ());
+        }
+        _ => {}
+    }
+
     // Read-only commands get a handle that cannot take the write lock, so a
     // query never contends with the writer. Falls back to a writable open when
     // the database does not exist yet (that first open creates it) or when it
@@ -768,26 +797,9 @@ pub fn run() -> Result<()> {
             }
             Ok(())
         }
-        Command::SyncOpencode { opencode_db } => {
-            let path = opencode_db.unwrap_or_else(default_opencode_db_path);
-            let inserted = sync_opencode_db(&conn, &path)?;
-            sync_note!("  [opencode] +{inserted} rows");
-            Ok(())
+        Command::SyncOpencode { .. } | Command::Sync { .. } | Command::Watch { .. } => {
+            unreachable!("sync commands are handled before opening the shared database")
         }
-        Command::Sync {
-            install_service,
-            uninstall_service,
-            interval,
-        } => {
-            if install_service {
-                install_managed_service(&SYNC_SERVICE, interval, &[])
-            } else if uninstall_service {
-                uninstall_managed_service(&SYNC_SERVICE)
-            } else {
-                sync_basic(&conn, &db_path)
-            }
-        }
-        Command::Watch { interval } => watch_loop(&db_path, interval),
         Command::Export {
             output,
             format,
@@ -2102,8 +2114,20 @@ fn sync_basic(conn: &Connection, db_path: &Path) -> Result<()> {
     // effort: a concurrent reader pinning an old snapshot blocks a full
     // checkpoint, and that is not a reason to fail a sync that did its work.
     // Left unchecked the WAL grows without bound (156MB observed in the wild).
-    if let Err(err) = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
-        sync_note!("  [wal] checkpoint skipped: {err}");
+    match conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, i64>(1)?,
+            row.get::<_, i64>(2)?,
+        ))
+    }) {
+        Ok((busy, log_frames, checkpointed_frames)) if busy != 0 => {
+            sync_note!(
+                "  [wal] checkpoint incomplete: {checkpointed_frames}/{log_frames} frames; another reader is active"
+            );
+        }
+        Ok(_) => {}
+        Err(err) => sync_note!("  [wal] checkpoint skipped: {err}"),
     }
     let wal_bytes = fs::metadata(wal_path(db_path))
         .map(|m| m.len())
@@ -2120,10 +2144,96 @@ fn sync_basic(conn: &Connection, db_path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Cross-process sync guard for one canonical database identity. Reflex, launchd, cron, and
+/// manual invocations can otherwise all walk the same multi-gigabyte history at once.
+struct SyncRunLock {
+    _file: fs::File,
+}
+
+fn canonical_db_identity(db_path: &Path) -> Result<PathBuf> {
+    if db_path.exists() {
+        return fs::canonicalize(db_path)
+            .with_context(|| format!("canonicalizing database path {}", db_path.display()));
+    }
+    let file_name = db_path
+        .file_name()
+        .context("database path has no file name")?;
+    let parent = db_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    Ok(fs::canonicalize(parent)?.join(file_name))
+}
+
+fn sync_lock_path(db_path: &Path) -> Result<PathBuf> {
+    let canonical = canonical_db_identity(db_path)?;
+    let mut name = canonical
+        .file_name()
+        .context("canonical database path has no file name")?
+        .to_os_string();
+    name.push(".sync.lock");
+    Ok(canonical.with_file_name(name))
+}
+
+fn try_acquire_sync_lock(db_path: &Path) -> Result<Option<SyncRunLock>> {
+    let path = sync_lock_path(db_path)?;
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&path)?;
+    match fs2::FileExt::try_lock_exclusive(&file) {
+        Ok(()) => Ok(Some(SyncRunLock { _file: file })),
+        Err(err) if err.kind() == io::ErrorKind::WouldBlock => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn sync_exclusive(db_path: &Path) -> Result<bool> {
+    let Some(_sync_lock) = try_acquire_sync_lock(db_path)? else {
+        sync_note!("  [sync] another sync is already running; skipped");
+        return Ok(false);
+    };
+    let conn = open_db(db_path)?;
+    sync_basic(&conn, db_path)?;
+    Ok(true)
+}
+
+fn sync_opencode_exclusive(db_path: &Path, opencode_path: &Path) -> Result<bool> {
+    let Some(_sync_lock) = try_acquire_sync_lock(db_path)? else {
+        sync_note!("  [sync-opencode] another sync is already running; skipped");
+        return Ok(false);
+    };
+    let conn = open_db(db_path)?;
+    let inserted = sync_opencode_db(&conn, opencode_path)?;
+    sync_note!("  [opencode] +{inserted} rows");
+    Ok(true)
+}
+
+fn prepare_sync_and_push_db(db_path: &Path) -> Result<(Connection, bool)> {
+    let Some(sync_lock) = try_acquire_sync_lock(db_path)? else {
+        // Pushing already-indexed rows only reads SQLite and remains useful while another
+        // process scans. A read-only connection avoids joining the writer contention.
+        let conn = open_db_readonly(db_path).with_context(|| {
+            format!(
+                "another sync owns the lock and no readable database is available at {}",
+                db_path.display()
+            )
+        })?;
+        return Ok((conn, true));
+    };
+    let conn = open_db(db_path)?;
+    sync_basic(&conn, db_path)?;
+    drop(sync_lock);
+    Ok((conn, false))
+}
+
 fn watch_loop(db_path: &Path, interval: u64) -> Result<()> {
     println!("Watching every {interval}s (Ctrl-C to stop)...");
     loop {
-        match open_db(db_path).and_then(|conn| sync_basic(&conn, db_path)) {
+        match sync_exclusive(db_path) {
             Ok(_) => {}
             Err(err) => eprintln!("Error: {err}"),
         }
@@ -5372,10 +5482,11 @@ mod tests {
     use super::{
         checkpoint_sync_state, cron_schedule, file_stamp, git_commit_time_ms, git_stdout,
         ingest_claude_transcript, link_git_commit, load_sync_state, parse_trajectory_file,
-        paths_overlap, save_sync_state, search_all, service_command_args, shell_single_quote,
-        strip_url_credentials, sync_claude_session_metadata, xml_escape, SearchRole, PUSH_SERVICE,
+        paths_overlap, prepare_sync_and_push_db, save_sync_state, search_all, service_command_args,
+        shell_single_quote, strip_url_credentials, sync_claude_session_metadata, sync_exclusive,
+        sync_opencode_exclusive, try_acquire_sync_lock, xml_escape, SearchRole, PUSH_SERVICE,
     };
-    use ai_hist_core::{init_db, QueryFilter};
+    use ai_hist_core::{init_db, open_db, QueryFilter};
     use rusqlite::Connection;
     use serde_json::{json, Map, Value};
     use std::fs;
@@ -5420,6 +5531,50 @@ mod tests {
                 "--limit".to_string(),
                 "50".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn sync_lock_canonicalizes_aliases_and_blocks_every_sync_entry_point_before_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("history.db");
+        let alias = dir.path().join(".").join("history.db");
+        let missing_opencode = dir.path().join("missing-opencode.db");
+
+        let first = try_acquire_sync_lock(&db_path).unwrap().unwrap();
+        assert!(try_acquire_sync_lock(&alias).unwrap().is_none());
+        assert!(
+            !db_path.exists(),
+            "the sidecar lock must not initialize SQLite"
+        );
+        assert!(!sync_exclusive(&alias).unwrap());
+        assert!(!sync_opencode_exclusive(&alias, &missing_opencode).unwrap());
+        assert!(
+            !db_path.exists(),
+            "contended sync paths must not create the DB"
+        );
+
+        drop(first);
+        assert!(try_acquire_sync_lock(&alias).unwrap().is_some());
+    }
+
+    #[test]
+    fn reflex_uses_a_read_only_database_and_keeps_pushing_when_scan_lock_is_busy() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("history.db");
+        drop(open_db(&db_path).unwrap());
+        let _scan_owner = try_acquire_sync_lock(&db_path).unwrap().unwrap();
+
+        let (conn, sync_skipped) = prepare_sync_and_push_db(&db_path).unwrap();
+        assert!(sync_skipped);
+        assert!(conn
+            .query_row("SELECT COUNT(*) FROM history", [], |row| row
+                .get::<_, i64>(0))
+            .is_ok());
+        assert!(
+            conn.execute("CREATE TABLE should_not_write(id INTEGER)", [])
+                .is_err(),
+            "the push-only fallback must not join SQLite writer contention"
         );
     }
 

--- a/docs/cloud-sync.md
+++ b/docs/cloud-sync.md
@@ -107,7 +107,8 @@ login. To test Cloud exchange against a trusted non-prod endpoint, set
 
 - **Auth + cursor are stage-scoped.** `login`/`admin-mint` store each target's session and
   watermark independently under `$RELAYHISTORY_HOME/stages/` (mode `0600`). A second login
-  cannot overwrite the first target's cursor.
+  cannot overwrite the first target's cursor. On an access-token 401, authenticated commands
+  serialize refresh-token rotation for that stage, atomically persist the new pair, and retry.
 - **Select deliberately when needed.** With one configured target, `ai-hist push` uses it.
   With more than one, use `ai-hist push --base-url <origin>`; the CLI refuses to guess. A
   service installed with `ai-hist push --install-service` pins that selected origin so later
@@ -117,9 +118,13 @@ login. To test Cloud exchange against a trusted non-prod endpoint, set
   advances only after the server accepts the batch.
 - **Exclude sessions:** `ai-hist push --incognito <sessionId> --incognito <trajectoryId>`.
 - To switch targets, pass the corresponding `--base-url`; for prod, re-run Agent Relay Cloud
-  login if that stored session expires.
+  login only if the refresh session expires or is revoked.
 
 ### Automation (cron / launchd)
+
+Choose one scheduler. If Agent Relay Reflex is enabled, its in-process loop already runs sync +
+push; do not also install standalone launchd/cron services. A cross-process lock prevents
+overlapping scans as a safeguard, and a contended Reflex tick still pushes already-indexed rows.
 
 ```cron
 */5 * * * * RELAYHISTORY_HOME=$HOME/.agentworkforce/relayhistory-prod ai-hist sync && RELAYHISTORY_HOME=$HOME/.agentworkforce/relayhistory-prod ai-hist push --base-url https://history.agentrelay.com --json >> /tmp/ai-hist-push.log 2>&1

--- a/docs/reflex-zero-setup.md
+++ b/docs/reflex-zero-setup.md
@@ -24,7 +24,12 @@ agent-relay up  ──(every few minutes, if reflex.json.enabled)──▶  requ
   push. The CLI binary and the addon call the same code.
 - **Auth:** the `rth_at_` token written by `reflex on` (in the stage-scoped
   `~/.agentworkforce/relayhistory/stages/` store). `syncAndPush()` returns
-  `authenticated: false` (a no-op) until the user is logged in.
+  `authenticated: false` (a no-op) until the user is logged in. If the access token expires,
+  the addon serializes refresh-token rotation, atomically persists the new pair, and retries.
+- **One sync owner:** Reflex supplies the periodic sync + push loop. Do not run standalone
+  `ai-hist sync` / `ai-hist push` launchd services at the same time. A cross-process lock
+  prevents overlapping scans as a safeguard. If another scanner owns it, `syncAndPush()` sets
+  `syncSkipped: true` and still pushes rows already present in SQLite.
 
 ## The packages
 


### PR DESCRIPTION
## Summary

- retry authenticated RelayHistory requests once after exchanging an expired access token with the stored refresh token
- persist the rotated access and refresh token pair before retrying ingest, Pair, or coverage
- serialize sync work across Reflex, launchd, cron, and manual invocations with an OS-released file lock
- inspect the actual SQLite checkpoint result so an incomplete checkpoint is visible
- document the single-scheduler rule for Reflex deployments

## Why

The chief broker incident combined two independent feedback loops:

- Relay Reflex was retrying cloud ingest with an expired service-local RelayHistory access token.
- Legacy launchd sync and push jobs duplicated the in-process Reflex scheduler. A sync scheduled every 60 seconds ran for several minutes, drove sustained CPU, and grew the SQLite WAL to 1.5 GB while another process held the database open.

Restarting the broker only clears the transient pressure. This change prevents overlapping sync scans and makes the stored refresh session useful instead of requiring a manual login every time the 24-hour access token expires.

## Behavior

On an authenticated HTTP 401, the client now:

1. exchanges the stored RelayHistory refresh token at /v1/auth/token/refresh;
2. persists the rotated token pair with the existing private-file handling;
3. retries the original request exactly once.

A per-database advisory lock ensures only one sync scan runs at a time. The OS releases the lock automatically if a process exits or is killed.

## QA

- cargo test --workspace — 89 tests passed
- cargo fmt --all -- --check
- git diff --check
- cargo clippy -p ai-hist-cli --all-targets --no-deps -- -D warnings -A clippy::too_many_arguments
- live production credential exchange succeeded
- bounded live ingest sent 1 and accepted 1
- live WAL checkpoint reduced the WAL from 1.5 GB to 0 B; subsequent doctor output reported no problems
- chief-broker remained connected with 22 agents throughout; no broker restart was performed

Full workspace Clippy still reports existing warnings in ai-hist-core and existing too-many-argument functions outside this change.

## Rollout note

The host-side legacy com.ai-hist.sync and com.ai-hist.push launchd labels were disabled without deleting their plist files. This source change becomes active in the embedded Reflex path after the normal ai-hist-native release and Agent Relay upgrade/restart cycle.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

