### PR TITLE
feat: cache JSONL fallback scans

### DIFF
--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -2,7 +2,7 @@
 
 TypeScript reader for the [ai-hist](../README.md) history database, plus an MCP server for searching local AI coding-agent history from Claude Code, Codex, Cursor, Grok, and Agent Relay.
 
-The SDK uses `sql.js`, so it has no native build step. It reads the same SQLite file that `ai-hist sync` writes, or falls back to scanning local Claude/Codex/Cursor/Grok JSONL files and compacted trajectory JSON when the database is missing.
+The SDK uses `sql.js`, so it has no native build step. It reads the same SQLite file that `ai-hist sync` writes, or falls back to scanning local Claude/Codex/Cursor/Grok JSONL files and compacted trajectory JSON when the database is missing. The first fallback scan is persisted separately at `~/.local/share/ai-hist/jsonl-fallback-cache.db`; later opens re-read only new or changed source files. Override that cache path with `AI_HIST_JSONL_CACHE_DB`.
 
 ## Install
 
@@ -98,6 +98,7 @@ All list-style methods accept `{ source?, project?, limit?, beforeMs? }`. `befor
 ```ts
 resumeCommand(entry): string | null           // shell command per source; null for relay
 defaultDbPath(): string                       // resolve env / OS default
+defaultJsonlCacheDbPath(): string             // resolve fallback-cache env / OS default
 ```
 
 ## Trajectories

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -13,16 +13,21 @@
  */
 
 import initSqlJs, { type Database, type SqlJsStatic } from 'sql.js';
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { writeFileSync } from 'node:fs';
 import { execFile } from 'node:child_process';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { basename, dirname, join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { promisify } from 'node:util';
-import { scanLocalSources, LOCAL_SOURCE_PATHS } from './jsonl-sources.js';
 import {
-  scanLocalTrajectories,
+  scanLocalSourceFiles,
+  LOCAL_SOURCE_PATHS,
+  type FileFingerprint,
+} from './jsonl-sources.js';
+import {
+  scanLocalTrajectoryFiles,
   trajectoryRootDescription,
   type TrajectoryDecision,
   type TrajectoryRetrospective,
@@ -165,6 +170,13 @@ export function defaultDbPath(): string {
   return join(homedir(), '.local', 'share', 'ai-hist', 'ai-history.db');
 }
 
+/** Resolve the standalone JSONL fallback cache path. */
+export function defaultJsonlCacheDbPath(): string {
+  const fromEnv = process.env.AI_HIST_JSONL_CACHE_DB;
+  if (fromEnv && fromEnv.trim().length > 0) return fromEnv;
+  return join(homedir(), '.local', 'share', 'ai-hist', 'jsonl-fallback-cache.db');
+}
+
 function defaultOpenCodeDbPath(): string {
   return process.env.OPENCODE_DB && process.env.OPENCODE_DB.trim().length > 0
     ? process.env.OPENCODE_DB
@@ -241,6 +253,100 @@ function ensureTagSchema(db: Database): void {
   db.run('CREATE INDEX IF NOT EXISTS idx_session_tags_tag ON session_tags(tag_id)');
 }
 
+const JSONL_FALLBACK_CACHE_SCHEMA_VERSION = 1;
+
+function ensureJsonlCacheSchema(db: Database): void {
+  db.run(`CREATE TABLE IF NOT EXISTS history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL,
+    session_id TEXT,
+    project TEXT,
+    prompt TEXT NOT NULL,
+    timestamp_ms INTEGER NOT NULL,
+    git_branch TEXT,
+    ingest_path TEXT NOT NULL,
+    UNIQUE(source, timestamp_ms, prompt, ingest_path)
+  )`);
+  db.run('CREATE INDEX IF NOT EXISTS idx_history_timestamp ON history (timestamp_ms DESC)');
+  db.run('CREATE INDEX IF NOT EXISTS idx_history_session ON history (session_id)');
+  db.run('CREATE INDEX IF NOT EXISTS idx_history_ingest_path ON history (ingest_path)');
+  db.run(`CREATE TABLE IF NOT EXISTS ingested_files (
+    path TEXT PRIMARY KEY,
+    mtime_ms INTEGER NOT NULL,
+    size INTEGER NOT NULL
+  )`);
+  db.run(`CREATE TABLE IF NOT EXISTS cache_metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  )`);
+  db.run(
+    `INSERT OR IGNORE INTO cache_metadata (key, value) VALUES ('schema_version', ?)`,
+    [String(JSONL_FALLBACK_CACHE_SCHEMA_VERSION)],
+  );
+  ensureTrajectorySchema(db);
+  ensureTagSchema(db);
+  ensureSessionsSchema(db);
+}
+
+function jsonlCacheVersion(db: Database): number | null {
+  try {
+    const row = runQuery<{ value: string }>(
+      db,
+      `SELECT value FROM cache_metadata WHERE key = 'schema_version'`,
+      [],
+    )[0];
+    if (!row) return null;
+    const version = Number(row.value);
+    return Number.isInteger(version) ? version : null;
+  } catch {
+    return null;
+  }
+}
+
+async function openJsonlCache(
+  SQL: SqlJsStatic,
+  cachePath: string,
+): Promise<{ db: Database; rebuilt: boolean }> {
+  if (await pathExists(cachePath)) {
+    let cachedDb: Database | undefined;
+    try {
+      cachedDb = new SQL.Database(await readFile(cachePath));
+      if (jsonlCacheVersion(cachedDb) === JSONL_FALLBACK_CACHE_SCHEMA_VERSION) {
+        ensureJsonlCacheSchema(cachedDb);
+        return { db: cachedDb, rebuilt: false };
+      }
+    } catch {
+      // A corrupt or incompatible cache is disposable and rebuilt below.
+    }
+    cachedDb?.close();
+  }
+
+  const db = new SQL.Database();
+  ensureJsonlCacheSchema(db);
+  return { db, rebuilt: true };
+}
+
+function readIngestedFiles(db: Database): Map<string, FileFingerprint> {
+  const rows = runQuery<{ path: string; mtime_ms: number; size: number }>(
+    db,
+    'SELECT path, mtime_ms, size FROM ingested_files',
+    [],
+  );
+  return new Map(rows.map((row) => [row.path, { mtimeMs: row.mtime_ms, size: row.size }]));
+}
+
+async function persistJsonlCacheAtomically(db: Database, cachePath: string): Promise<void> {
+  const cacheDir = dirname(cachePath);
+  await mkdir(cacheDir, { recursive: true });
+  const tempPath = join(cacheDir, `.${basename(cachePath)}.${process.pid}.${randomUUID()}.tmp`);
+  try {
+    await writeFile(tempPath, Buffer.from(db.export()), { flag: 'wx' });
+    await rename(tempPath, cachePath);
+  } finally {
+    await rm(tempPath, { force: true });
+  }
+}
+
 export interface OpenOptions {
   /** Override the SQLite path (default: `$AI_HIST_DB` or `~/.local/share/ai-hist/ai-history.db`). */
   dbPath?: string;
@@ -252,8 +358,9 @@ export interface OpenOptions {
   /**
    * What to do when the SQLite DB is missing:
    *   - `'jsonl'` (default): scan local Claude/Codex/Cursor/Grok history files
-   *     directly into an in-memory SQLite — works without the Python
-   *     `ai-hist sync` tool installed.
+   *     into a standalone incremental cache — works without the Python
+   *     `ai-hist sync` tool installed. The cache path is controlled by
+   *     `$AI_HIST_JSONL_CACHE_DB`.
    *   - `'error'`: throw with an install hint (legacy 0.1.x behavior).
    */
   fallback?: 'jsonl' | 'error';
@@ -309,35 +416,34 @@ export async function openAiHist(opts: OpenOptions = {}): Promise<AiHist> {
     );
   }
 
-  // Fallback: scan local source files (Claude/Codex/Cursor/Grok) directly.
-  // No Python dependency; uses the same parsers documented in the Python
-  // CLI's source. Yields control to the event loop between sources so a
-  // large local history doesn't freeze the host.
-  const db = new SQL.Database();
-  db.run(`CREATE TABLE history (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    source TEXT NOT NULL,
-    session_id TEXT,
-    project TEXT,
-    prompt TEXT NOT NULL,
-    timestamp_ms INTEGER NOT NULL,
-    git_branch TEXT,
-    UNIQUE(source, timestamp_ms, prompt)
-  )`);
-  db.run('CREATE INDEX idx_history_timestamp ON history (timestamp_ms DESC)');
-  db.run('CREATE INDEX idx_history_session ON history (session_id)');
-  ensureTrajectorySchema(db);
-  ensureTagSchema(db);
-  ensureSessionsSchema(db);
+  // Fallback cache is intentionally separate from the real CLI database.
+  // The fast path above always wins when the CLI-written database exists.
+  const cachePath = defaultJsonlCacheDbPath();
+  if (resolve(cachePath) === resolve(dbPath)) {
+    throw new Error('AI_HIST_JSONL_CACHE_DB must resolve to a different path than the ai-hist sync database');
+  }
+  const { db, rebuilt: cacheRebuilt } = await openJsonlCache(SQL, cachePath);
+  const ingestedFiles = readIngestedFiles(db);
 
-  // scanLocalSources is async with yields between sources so the event
-  // loop stays responsive while we scan many MB of JSONL.
-  const rows = await scanLocalSources();
-  const openCodeRows = await scanOpenCode(SQL);
-  const trajectories = await scanLocalTrajectories();
+  // The four JSONL providers scan concurrently; each scanner only reads
+  // files whose mtime or size differs from the persisted manifest.
+  const [sourceFiles, openCodeFile, trajectoryFiles] = await Promise.all([
+    scanLocalSourceFiles(ingestedFiles),
+    scanOpenCodeFile(SQL, ingestedFiles),
+    scanLocalTrajectoryFiles(ingestedFiles),
+  ]);
+  const currentPaths = new Set([
+    ...sourceFiles.map((file) => file.path),
+    ...(openCodeFile ? [openCodeFile.path] : []),
+    ...trajectoryFiles.map((file) => file.path),
+  ]);
+  const removedPaths = [...ingestedFiles.keys()].filter((path) => !currentPaths.has(path));
+  let cacheDirty = cacheRebuilt || removedPaths.length > 0;
 
   const insert = db.prepare(
-    'INSERT OR IGNORE INTO history (source, session_id, project, prompt, timestamp_ms, git_branch) VALUES (?, ?, ?, ?, ?, ?)',
+    `INSERT OR IGNORE INTO history
+     (source, session_id, project, prompt, timestamp_ms, git_branch, ingest_path)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
   );
   const insertTrajectory = db.prepare(
     `INSERT OR REPLACE INTO trajectories
@@ -346,45 +452,104 @@ export async function openAiHist(opts: OpenOptions = {}): Promise<AiHist> {
       path, updated_ms, timestamp_ms)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
+  const upsertFile = db.prepare(
+    `INSERT INTO ingested_files (path, mtime_ms, size) VALUES (?, ?, ?)
+     ON CONFLICT(path) DO UPDATE SET mtime_ms = excluded.mtime_ms, size = excluded.size`,
+  );
+  let inTransaction = false;
   try {
     db.exec('BEGIN');
-    for (const row of rows) {
-      insert.run([row.source, row.sessionId, row.project, row.prompt, row.timestampMs, row.gitBranch]);
+    inTransaction = true;
+
+    for (const removedPath of removedPaths) {
+      db.run('DELETE FROM history WHERE ingest_path = ?', [removedPath]);
+      db.run('DELETE FROM trajectories WHERE path = ?', [removedPath]);
+      db.run('DELETE FROM ingested_files WHERE path = ?', [removedPath]);
     }
-    for (const row of openCodeRows) {
-      insert.run(['opencode', row.sessionId, row.project, row.prompt, row.timestampMs, null]);
+
+    for (const file of sourceFiles) {
+      if (file.rows === undefined) continue;
+      cacheDirty = true;
+      db.run('DELETE FROM history WHERE ingest_path = ?', [file.path]);
+      for (const row of file.rows) {
+        insert.run([
+          row.source,
+          row.sessionId,
+          row.project,
+          row.prompt,
+          row.timestampMs,
+          row.gitBranch,
+          file.path,
+        ]);
+      }
+      upsertFile.run([file.path, file.mtimeMs, file.size]);
     }
-    for (const trajectory of trajectories) {
-      insertTrajectory.run([
-        trajectory.id,
-        trajectory.version,
-        trajectory.personaId,
-        trajectory.projectId,
-        trajectory.task.title,
-        trajectory.task.description,
-        trajectory.status,
-        trajectory.startedAt,
-        trajectory.completedAt,
-        JSON.stringify(trajectory.decisions),
-        JSON.stringify(trajectory.retrospective),
-        trajectory.searchText,
-        trajectory.path,
-        trajectory.updatedMs,
-        trajectory.timestampMs,
-      ]);
-      insert.run([
-        'trajectory',
-        trajectory.id,
-        trajectory.projectId,
-        trajectory.searchText,
-        trajectory.timestampMs,
-        null,
-      ]);
+
+    if (openCodeFile?.rows !== undefined) {
+      cacheDirty = true;
+      db.run('DELETE FROM history WHERE ingest_path = ?', [openCodeFile.path]);
+      for (const row of openCodeFile.rows) {
+        insert.run(['opencode', row.sessionId, row.project, row.prompt, row.timestampMs, null, openCodeFile.path]);
+      }
+      upsertFile.run([openCodeFile.path, openCodeFile.mtimeMs, openCodeFile.size]);
+    }
+
+    for (const file of trajectoryFiles) {
+      if (file.trajectory === undefined) continue;
+      cacheDirty = true;
+      db.run('DELETE FROM history WHERE ingest_path = ?', [file.path]);
+      db.run('DELETE FROM trajectories WHERE path = ?', [file.path]);
+      const trajectory = file.trajectory;
+      if (trajectory) {
+        insertTrajectory.run([
+          trajectory.id,
+          trajectory.version,
+          trajectory.personaId,
+          trajectory.projectId,
+          trajectory.task.title,
+          trajectory.task.description,
+          trajectory.status,
+          trajectory.startedAt,
+          trajectory.completedAt,
+          JSON.stringify(trajectory.decisions),
+          JSON.stringify(trajectory.retrospective),
+          trajectory.searchText,
+          trajectory.path,
+          trajectory.updatedMs,
+          trajectory.timestampMs,
+        ]);
+        insert.run([
+          'trajectory',
+          trajectory.id,
+          trajectory.projectId,
+          trajectory.searchText,
+          trajectory.timestampMs,
+          null,
+          file.path,
+        ]);
+      }
+      upsertFile.run([file.path, file.mtimeMs, file.size]);
     }
     db.exec('COMMIT');
+    inTransaction = false;
+  } catch (error) {
+    if (inTransaction) {
+      try { db.exec('ROLLBACK'); } catch { /* preserve the original error */ }
+    }
+    throw error;
   } finally {
     insert.free();
     insertTrajectory.free();
+    upsertFile.free();
+  }
+
+  if (cacheDirty) {
+    try {
+      await persistJsonlCacheAtomically(db, cachePath);
+    } catch (error) {
+      db.close();
+      throw error;
+    }
   }
   const scannedPaths = `${LOCAL_SOURCE_PATHS.claude}, ${LOCAL_SOURCE_PATHS.codex}, ${LOCAL_SOURCE_PATHS.cursorRoot}, ${LOCAL_SOURCE_PATHS.grokSessionsRoot}, ${trajectoryRootDescription()}`;
   return new AiHist(db, { kind: 'jsonl', path: scannedPaths }, { projectScope: opts.projectScope });
@@ -425,6 +590,47 @@ type ScannedOpenCodeRow = {
   prompt: string;
   timestampMs: number;
 };
+
+type ScannedOpenCodeFile = FileFingerprint & {
+  path: string;
+  /** Undefined when the manifest fingerprint matched and the DB was not read. */
+  rows?: ScannedOpenCodeRow[];
+};
+
+async function sqliteFingerprint(dbPath: string): Promise<FileFingerprint | null> {
+  try {
+    const dbStat = await stat(dbPath);
+    if (!dbStat.isFile()) return null;
+    let mtimeMs = Math.trunc(dbStat.mtimeMs);
+    let size = dbStat.size;
+    try {
+      const walStat = await stat(`${dbPath}-wal`);
+      if (walStat.isFile()) {
+        mtimeMs = Math.max(mtimeMs, Math.trunc(walStat.mtimeMs));
+        size += walStat.size;
+      }
+    } catch {
+      // No WAL is the common case.
+    }
+    return { mtimeMs, size };
+  } catch {
+    return null;
+  }
+}
+
+async function scanOpenCodeFile(
+  SQL: SqlJsStatic,
+  ingestedFiles: ReadonlyMap<string, FileFingerprint>,
+): Promise<ScannedOpenCodeFile | null> {
+  const dbPath = defaultOpenCodeDbPath();
+  const fingerprint = await sqliteFingerprint(dbPath);
+  if (!fingerprint) return null;
+  const previous = ingestedFiles.get(dbPath);
+  if (previous?.mtimeMs === fingerprint.mtimeMs && previous.size === fingerprint.size) {
+    return { path: dbPath, ...fingerprint };
+  }
+  return { path: dbPath, ...fingerprint, rows: await scanOpenCode(SQL) };
+}
 
 async function scanOpenCode(SQL: SqlJsStatic): Promise<ScannedOpenCodeRow[]> {
   const dbPath = defaultOpenCodeDbPath();

--- a/sdk-ts/src/jsonl-cache.test.ts
+++ b/sdk-ts/src/jsonl-cache.test.ts
@@ -1,0 +1,152 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, readFile, rm, stat, unlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import initSqlJs from 'sql.js';
+
+test('JSONL fallback persists, skips unchanged files, and yields to a real database', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'ai-hist-jsonl-cache-'));
+  const fakeHome = join(root, 'home');
+  const claudeDir = join(fakeHome, '.claude');
+  const claudeHistory = join(claudeDir, 'history.jsonl');
+  const cachePath = join(root, 'cache', 'jsonl-fallback-cache.db');
+  const realDbPath = join(root, 'ai-history.db');
+  await mkdir(claudeDir, { recursive: true });
+  await writeFile(
+    claudeHistory,
+    `${JSON.stringify({
+      display: 'fixture JSONL prompt',
+      timestamp: 1_700_000_000_000,
+      project: '/fixture/project',
+      sessionId: 'fixture-session',
+    })}\n`,
+  );
+
+  const previousEnv = {
+    HOME: process.env.HOME,
+    AI_HIST_JSONL_CACHE_DB: process.env.AI_HIST_JSONL_CACHE_DB,
+    OPENCODE_DB: process.env.OPENCODE_DB,
+    TRAJECTORY_ROOT: process.env.TRAJECTORY_ROOT,
+  };
+  process.env.HOME = fakeHome;
+  process.env.AI_HIST_JSONL_CACHE_DB = cachePath;
+  process.env.OPENCODE_DB = join(root, 'missing-opencode.db');
+  process.env.TRAJECTORY_ROOT = join(root, 'missing-trajectories');
+
+  let setJsonlReadObserver: ((observer?: (path: string) => void) => void) | undefined;
+  try {
+    const index = await import('./index.js');
+    ({ setJsonlReadObserver } = await import('./jsonl-sources.js'));
+
+    let reads: string[] = [];
+    setJsonlReadObserver((path) => reads.push(path));
+    const first = await index.openAiHist({ dbPath: realDbPath, fallback: 'jsonl' });
+    try {
+      assert.equal(first.sourceKind, 'jsonl');
+      assert.deepEqual(first.recent({ limit: 10 }).map((entry) => entry.prompt), ['fixture JSONL prompt']);
+    } finally {
+      first.close();
+    }
+    assert.deepEqual(reads, [claudeHistory]);
+    assert.equal((await stat(cachePath)).isFile(), true);
+
+    const SQL = await initSqlJs();
+    let cacheDb = new SQL.Database(await readFile(cachePath));
+    try {
+      const manifest = cacheDb.exec('SELECT path, mtime_ms, size FROM ingested_files');
+      assert.deepEqual(manifest[0]?.values.map((row) => row[0]), [claudeHistory]);
+      assert.equal(cacheDb.exec("SELECT value FROM cache_metadata WHERE key = 'schema_version'")[0]?.values[0]?.[0], '1');
+    } finally {
+      cacheDb.close();
+    }
+
+    reads = [];
+    const second = await index.openAiHist({ dbPath: realDbPath, fallback: 'jsonl' });
+    try {
+      assert.deepEqual(second.recent({ limit: 10 }).map((entry) => entry.prompt), ['fixture JSONL prompt']);
+    } finally {
+      second.close();
+    }
+    assert.deepEqual(reads, [], 'the unchanged JSONL file must not be read again');
+
+    cacheDb = new SQL.Database(await readFile(cachePath));
+    try {
+      cacheDb.run("UPDATE cache_metadata SET value = '999' WHERE key = 'schema_version'");
+      await writeFile(cachePath, Buffer.from(cacheDb.export()));
+    } finally {
+      cacheDb.close();
+    }
+    reads = [];
+    const rebuilt = await index.openAiHist({ dbPath: realDbPath, fallback: 'jsonl' });
+    try {
+      assert.deepEqual(rebuilt.recent({ limit: 10 }).map((entry) => entry.prompt), ['fixture JSONL prompt']);
+    } finally {
+      rebuilt.close();
+    }
+    assert.deepEqual(reads, [claudeHistory], 'an incompatible cache version must trigger a clean rebuild');
+
+    await writeRealDb(realDbPath, 'real SQLite prompt');
+    reads = [];
+    const real = await index.openAiHist({ dbPath: realDbPath, fallback: 'jsonl' });
+    try {
+      assert.equal(real.sourceKind, 'sqlite');
+      assert.deepEqual(real.recent({ limit: 10 }).map((entry) => entry.prompt), ['real SQLite prompt']);
+    } finally {
+      real.close();
+    }
+    assert.deepEqual(reads, [], 'the real database fast path must not consult the fallback sources');
+
+    await unlink(realDbPath);
+    await unlink(claudeHistory);
+    const afterDeletion = await index.openAiHist({ dbPath: realDbPath, fallback: 'jsonl' });
+    try {
+      assert.deepEqual(afterDeletion.recent({ limit: 10 }), []);
+    } finally {
+      afterDeletion.close();
+    }
+    cacheDb = new SQL.Database(await readFile(cachePath));
+    try {
+      assert.equal(cacheDb.exec('SELECT path FROM ingested_files').length, 0);
+      assert.equal(cacheDb.exec("SELECT prompt FROM history WHERE source = 'claude'").length, 0);
+    } finally {
+      cacheDb.close();
+    }
+  } finally {
+    setJsonlReadObserver?.();
+    restoreEnv('HOME', previousEnv.HOME);
+    restoreEnv('AI_HIST_JSONL_CACHE_DB', previousEnv.AI_HIST_JSONL_CACHE_DB);
+    restoreEnv('OPENCODE_DB', previousEnv.OPENCODE_DB);
+    restoreEnv('TRAJECTORY_ROOT', previousEnv.TRAJECTORY_ROOT);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+async function writeRealDb(path: string, prompt: string): Promise<void> {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  try {
+    db.run(`CREATE TABLE history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source TEXT NOT NULL,
+      session_id TEXT,
+      project TEXT,
+      prompt TEXT NOT NULL,
+      timestamp_ms INTEGER NOT NULL,
+      git_branch TEXT
+    )`);
+    db.run(
+      `INSERT INTO history (source, session_id, project, prompt, timestamp_ms, git_branch)
+       VALUES ('codex', 'real-session', '/real/project', ?, 1700000001000, NULL)`,
+      [prompt],
+    );
+    await writeFile(path, Buffer.from(db.export()));
+  } finally {
+    db.close();
+  }
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}

--- a/sdk-ts/src/jsonl-sources.ts
+++ b/sdk-ts/src/jsonl-sources.ts
@@ -30,6 +30,17 @@ export interface RawRow {
   gitBranch: string | null;
 }
 
+export interface FileFingerprint {
+  mtimeMs: number;
+  size: number;
+}
+
+export interface ScannedSourceFile extends FileFingerprint {
+  path: string;
+  /** Undefined when the manifest fingerprint matched and the file was not read. */
+  rows?: RawRow[];
+}
+
 const CLAUDE_HISTORY = join(homedir(), '.claude', 'history.jsonl');
 const CODEX_HISTORY = join(homedir(), '.codex', 'history.jsonl');
 const CURSOR_ROOT = join(homedir(), '.cursor', 'projects');
@@ -38,13 +49,21 @@ const GROK_SESSIONS_ROOT = join(homedir(), '.grok', 'sessions');
 async function safeStat(path: string): Promise<{ isDirectory: boolean; isFile: boolean; size: number; mtimeMs: number } | null> {
   try {
     const s = await stat(path);
-    return { isDirectory: s.isDirectory(), isFile: s.isFile(), size: s.size, mtimeMs: s.mtimeMs };
+    return { isDirectory: s.isDirectory(), isFile: s.isFile(), size: s.size, mtimeMs: Math.trunc(s.mtimeMs) };
   } catch {
     return null;
   }
 }
 
+let jsonlReadObserver: ((path: string) => void) | undefined;
+
+/** @internal Test/diagnostic hook for verifying incremental scans. */
+export function setJsonlReadObserver(observer?: (path: string) => void): void {
+  jsonlReadObserver = observer;
+}
+
 async function readLines(path: string): Promise<string[]> {
+  jsonlReadObserver?.(path);
   try {
     const content = await readFile(path, 'utf8');
     return content.split('\n');
@@ -175,30 +194,47 @@ async function collectMatchingFiles(root: string, filename: string, out: string[
   return out;
 }
 
-async function scanClaude(): Promise<RawRow[]> {
-  const lines = await readLines(CLAUDE_HISTORY);
+function unchanged(
+  path: string,
+  fileStat: FileFingerprint,
+  ingestedFiles: ReadonlyMap<string, FileFingerprint>,
+): boolean {
+  const previous = ingestedFiles.get(path);
+  return previous?.mtimeMs === fileStat.mtimeMs && previous.size === fileStat.size;
+}
+
+async function scanClaude(ingestedFiles: ReadonlyMap<string, FileFingerprint>): Promise<ScannedSourceFile[]> {
+  const fileStat = await safeStat(CLAUDE_HISTORY);
+  if (!fileStat?.isFile) return [];
+  if (unchanged(CLAUDE_HISTORY, fileStat, ingestedFiles)) {
+    return [{ path: CLAUDE_HISTORY, mtimeMs: fileStat.mtimeMs, size: fileStat.size }];
+  }
   const rows: RawRow[] = [];
-  for (const line of lines) {
+  for (const line of await readLines(CLAUDE_HISTORY)) {
     const row = parseClaudeLine(line);
     if (row) rows.push(row);
   }
-  return rows;
+  return [{ path: CLAUDE_HISTORY, mtimeMs: fileStat.mtimeMs, size: fileStat.size, rows }];
 }
 
-async function scanCodex(): Promise<RawRow[]> {
-  const lines = await readLines(CODEX_HISTORY);
+async function scanCodex(ingestedFiles: ReadonlyMap<string, FileFingerprint>): Promise<ScannedSourceFile[]> {
+  const fileStat = await safeStat(CODEX_HISTORY);
+  if (!fileStat?.isFile) return [];
+  if (unchanged(CODEX_HISTORY, fileStat, ingestedFiles)) {
+    return [{ path: CODEX_HISTORY, mtimeMs: fileStat.mtimeMs, size: fileStat.size }];
+  }
   const rows: RawRow[] = [];
-  for (const line of lines) {
+  for (const line of await readLines(CODEX_HISTORY)) {
     const row = parseCodexLine(line);
     if (row) rows.push(row);
   }
-  return rows;
+  return [{ path: CODEX_HISTORY, mtimeMs: fileStat.mtimeMs, size: fileStat.size, rows }];
 }
 
-async function scanCursor(): Promise<RawRow[]> {
+async function scanCursor(ingestedFiles: ReadonlyMap<string, FileFingerprint>): Promise<ScannedSourceFile[]> {
   const root = await safeStat(CURSOR_ROOT);
   if (!root) return [];
-  const rows: RawRow[] = [];
+  const files: ScannedSourceFile[] = [];
   const projectDirs = await readDirSafe(CURSOR_ROOT);
   for (const projectDirName of projectDirs) {
     const projectDir = join(CURSOR_ROOT, projectDirName);
@@ -213,8 +249,13 @@ async function scanCursor(): Promise<RawRow[]> {
       const sessionId = sessionDirName;
       const jsonl = join(sessionDir, `${sessionId}.jsonl`);
       const fileStat = await safeStat(jsonl);
-      if (!fileStat) continue;
+      if (!fileStat?.isFile) continue;
+      if (unchanged(jsonl, fileStat, ingestedFiles)) {
+        files.push({ path: jsonl, mtimeMs: fileStat.mtimeMs, size: fileStat.size });
+        continue;
+      }
       const tsMs = Math.trunc(fileStat.mtimeMs);
+      const rows: RawRow[] = [];
       for (const line of await readLines(jsonl)) {
         const text = parseCursorLine(line);
         if (!text) continue;
@@ -227,12 +268,13 @@ async function scanCursor(): Promise<RawRow[]> {
           gitBranch: null,
         });
       }
+      files.push({ path: jsonl, mtimeMs: fileStat.mtimeMs, size: fileStat.size, rows });
     }
     // Yield between project dirs so very large cursor histories don't
     // hold the event loop for seconds at a time.
     await yieldToEventLoop();
   }
-  return rows;
+  return files;
 }
 
 function parseIsoMs(value: unknown, fallbackMs: number): number {
@@ -290,18 +332,24 @@ function nestedString(obj: Record<string, unknown> | null, path: string[]): stri
   return asString(current);
 }
 
-async function scanGrok(): Promise<RawRow[]> {
+async function scanGrok(ingestedFiles: ReadonlyMap<string, FileFingerprint>): Promise<ScannedSourceFile[]> {
   const root = await safeStat(GROK_SESSIONS_ROOT);
   if (!root) return [];
-  const rows: RawRow[] = [];
+  const files: ScannedSourceFile[] = [];
   for (const chatPath of await collectMatchingFiles(GROK_SESSIONS_ROOT, 'chat_history.jsonl')) {
-    const summary = await readGrokSummary(chatPath);
     const fileStat = await safeStat(chatPath);
-    const fallbackMs = Math.trunc(fileStat?.mtimeMs ?? 0);
+    if (!fileStat?.isFile) continue;
+    if (unchanged(chatPath, fileStat, ingestedFiles)) {
+      files.push({ path: chatPath, mtimeMs: fileStat.mtimeMs, size: fileStat.size });
+      continue;
+    }
+    const summary = await readGrokSummary(chatPath);
+    const fallbackMs = Math.trunc(fileStat.mtimeMs);
     const sessionId = nestedString(summary, ['info', 'id']) ?? basename(dirname(chatPath));
     const project = nestedString(summary, ['info', 'cwd']) ?? asString(summary?.git_root_dir) ?? grokProjectFromPath(chatPath);
     const gitBranch = asString(summary?.head_branch);
     const baseMs = parseIsoMs(summary?.created_at, fallbackMs);
+    const rows: RawRow[] = [];
     let idx = 0;
     for (const line of await readLines(chatPath)) {
       const obj = readJsonRecord(line);
@@ -318,9 +366,10 @@ async function scanGrok(): Promise<RawRow[]> {
       });
       idx += 1;
     }
+    files.push({ path: chatPath, mtimeMs: fileStat.mtimeMs, size: fileStat.size, rows });
     await yieldToEventLoop();
   }
-  return rows;
+  return files;
 }
 
 /**
@@ -329,15 +378,21 @@ async function scanGrok(): Promise<RawRow[]> {
  * Silently skips sources whose paths don't exist — that's the common
  * case for users who only have one CLI.
  */
+export async function scanLocalSourceFiles(
+  ingestedFiles: ReadonlyMap<string, FileFingerprint> = new Map(),
+): Promise<ScannedSourceFile[]> {
+  const files = await Promise.all([
+    scanClaude(ingestedFiles),
+    scanCodex(ingestedFiles),
+    scanCursor(ingestedFiles),
+    scanGrok(ingestedFiles),
+  ]);
+  return files.flat();
+}
+
 export async function scanLocalSources(): Promise<RawRow[]> {
-  const claudeRows = await scanClaude();
-  await yieldToEventLoop();
-  const codexRows = await scanCodex();
-  await yieldToEventLoop();
-  const cursorRows = await scanCursor();
-  await yieldToEventLoop();
-  const grokRows = await scanGrok();
-  return [...claudeRows, ...codexRows, ...cursorRows, ...grokRows];
+  const files = await scanLocalSourceFiles();
+  return files.flatMap((file) => file.rows ?? []);
 }
 
 export const LOCAL_SOURCE_PATHS = {

--- a/sdk-ts/src/mcp-smoke.test.ts
+++ b/sdk-ts/src/mcp-smoke.test.ts
@@ -158,8 +158,10 @@ test('SDK fallback ingests compacted per-run trajectories from TRAJECTORY_ROOT',
 
   const previousRoot = process.env.TRAJECTORY_ROOT;
   const previousDb = process.env.AI_HIST_DB;
+  const previousCacheDb = process.env.AI_HIST_JSONL_CACHE_DB;
   process.env.TRAJECTORY_ROOT = root;
   process.env.AI_HIST_DB = join(root, 'missing.db');
+  process.env.AI_HIST_JSONL_CACHE_DB = join(root, 'fallback-cache.db');
   const hist = await openAiHist({ dbPath: join(root, 'missing.db') });
   try {
     const results = hist.searchTrajectories('exponential backoff', { limit: 5 });
@@ -174,6 +176,8 @@ test('SDK fallback ingests compacted per-run trajectories from TRAJECTORY_ROOT',
     else process.env.TRAJECTORY_ROOT = previousRoot;
     if (previousDb === undefined) delete process.env.AI_HIST_DB;
     else process.env.AI_HIST_DB = previousDb;
+    if (previousCacheDb === undefined) delete process.env.AI_HIST_JSONL_CACHE_DB;
+    else process.env.AI_HIST_JSONL_CACHE_DB = previousCacheDb;
   }
 });
 
@@ -212,9 +216,11 @@ time.sleep(60)
   child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
 
   const previousDb = process.env.AI_HIST_DB;
+  const previousCacheDb = process.env.AI_HIST_JSONL_CACHE_DB;
   const previousOpenCode = process.env.OPENCODE_DB;
   const previousTrajectory = process.env.TRAJECTORY_ROOT;
   process.env.AI_HIST_DB = join(root, 'missing-ai-hist.db');
+  process.env.AI_HIST_JSONL_CACHE_DB = join(root, 'fallback-cache.db');
   process.env.OPENCODE_DB = dbPath;
   process.env.TRAJECTORY_ROOT = join(root, 'missing-trajectories');
   try {
@@ -232,6 +238,8 @@ time.sleep(60)
     child.kill();
     if (previousDb === undefined) delete process.env.AI_HIST_DB;
     else process.env.AI_HIST_DB = previousDb;
+    if (previousCacheDb === undefined) delete process.env.AI_HIST_JSONL_CACHE_DB;
+    else process.env.AI_HIST_JSONL_CACHE_DB = previousCacheDb;
     if (previousOpenCode === undefined) delete process.env.OPENCODE_DB;
     else process.env.OPENCODE_DB = previousOpenCode;
     if (previousTrajectory === undefined) delete process.env.TRAJECTORY_ROOT;

--- a/sdk-ts/src/trajectory-sources.ts
+++ b/sdk-ts/src/trajectory-sources.ts
@@ -1,6 +1,7 @@
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
+import type { FileFingerprint } from './jsonl-sources.js';
 
 export interface TrajectoryDecision {
   question: string;
@@ -36,6 +37,12 @@ export interface RawTrajectory {
   timestampMs: number;
 }
 
+export interface ScannedTrajectoryFile extends FileFingerprint {
+  path: string;
+  /** Undefined when the manifest fingerprint matched and the file was not read. */
+  trajectory?: RawTrajectory | null;
+}
+
 export const DEFAULT_TRAJECTORY_SEARCH_ROOT = join(homedir(), 'Projects');
 
 function yieldToEventLoop(): Promise<void> {
@@ -45,7 +52,7 @@ function yieldToEventLoop(): Promise<void> {
 async function safeStat(path: string): Promise<{ isDirectory: boolean; isFile: boolean; size: number; mtimeMs: number } | null> {
   try {
     const s = await stat(path);
-    return { isDirectory: s.isDirectory(), isFile: s.isFile(), size: s.size, mtimeMs: s.mtimeMs };
+    return { isDirectory: s.isDirectory(), isFile: s.isFile(), size: s.size, mtimeMs: Math.trunc(s.mtimeMs) };
   } catch {
     return null;
   }
@@ -220,18 +227,37 @@ export async function readTrajectoryFile(path: string): Promise<RawTrajectory | 
   return { ...trajectory, searchText: buildSearchText(trajectory) };
 }
 
-export async function scanLocalTrajectories(): Promise<RawTrajectory[]> {
+export async function scanLocalTrajectoryFiles(
+  ingestedFiles: ReadonlyMap<string, FileFingerprint> = new Map(),
+): Promise<ScannedTrajectoryFile[]> {
   const roots = await trajectoryRoots();
   const seen = new Set<string>();
-  const trajectories: RawTrajectory[] = [];
+  const files: ScannedTrajectoryFile[] = [];
   for (const root of roots) {
     for (const file of await compactedJsonFiles(root)) {
       if (seen.has(file)) continue;
       seen.add(file);
+      const fileStat = await safeStat(file);
+      if (!fileStat?.isFile) continue;
+      const previous = ingestedFiles.get(file);
+      if (previous?.mtimeMs === fileStat.mtimeMs && previous.size === fileStat.size) {
+        files.push({ path: file, mtimeMs: fileStat.mtimeMs, size: fileStat.size });
+        continue;
+      }
       const trajectory = await readTrajectoryFile(file);
-      if (trajectory) trajectories.push(trajectory);
+      files.push({
+        path: file,
+        mtimeMs: fileStat.mtimeMs,
+        size: fileStat.size,
+        trajectory,
+      });
     }
     await yieldToEventLoop();
   }
-  return trajectories;
+  return files;
+}
+
+export async function scanLocalTrajectories(): Promise<RawTrajectory[]> {
+  const files = await scanLocalTrajectoryFiles();
+  return files.flatMap((file) => file.trajectory ? [file.trajectory] : []);
 }


### PR DESCRIPTION
## Summary

Work in progress: persist and incrementally refresh the TypeScript SDK's JSONL fallback cache without changing the CLI database fast path.

## Validation

- [ ] npm run typecheck
- [ ] npm run test
- [ ] manual two-run local-history sanity check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/63?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

