### PR TITLE
Codex rollout conversations as session events + events read surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .claude/
 target/
 .tmp/
+.npm-cache/

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -758,6 +758,153 @@ pub fn session(
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionEvent {
+    pub id: i64,
+    pub source: String,
+    pub session_id: String,
+    pub project: Option<String>,
+    pub cwd: Option<String>,
+    pub git_branch: Option<String>,
+    pub message_id: Option<String>,
+    pub parent_id: Option<String>,
+    pub ts_ms: i64,
+    pub role: String,
+    pub kind: String,
+    pub text: Option<String>,
+    pub model: Option<String>,
+    pub token_json: Option<String>,
+    pub event_uid: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionToolCall {
+    pub id: i64,
+    pub source: String,
+    pub session_id: String,
+    pub message_id: Option<String>,
+    pub tool_use_id: String,
+    pub name: String,
+    pub target: Option<String>,
+    pub args_json: Option<String>,
+    pub is_error: Option<i64>,
+    pub ts_ms: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionFileEdit {
+    pub id: i64,
+    pub source: String,
+    pub session_id: String,
+    pub tool_use_id: String,
+    pub file_path: String,
+    pub tool_name: Option<String>,
+    pub lines_added: Option<i64>,
+    pub lines_removed: Option<i64>,
+    pub user_modified: Option<i64>,
+    pub ts_ms: Option<i64>,
+}
+
+/// All normalized events for one session, oldest first. Rows sharing a
+/// timestamp keep insertion order via the rowid tiebreaker.
+pub fn session_events(
+    conn: &Connection,
+    session_id: &str,
+    source: Option<&str>,
+) -> Result<Vec<SessionEvent>> {
+    let mut sql = "SELECT id, source, session_id, project, cwd, git_branch, message_id, parent_id,                    ts_ms, role, kind, text, model, token_json, event_uid                    FROM session_events WHERE session_id = ?"
+        .to_string();
+    let mut params_vec = vec![session_id.to_string()];
+    if let Some(source) = source {
+        sql.push_str(" AND source = ?");
+        params_vec.push(source.to_string());
+    }
+    sql.push_str(" ORDER BY ts_ms ASC, id ASC");
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), |row| {
+        Ok(SessionEvent {
+            id: row.get(0)?,
+            source: row.get(1)?,
+            session_id: row.get(2)?,
+            project: row.get(3)?,
+            cwd: row.get(4)?,
+            git_branch: row.get(5)?,
+            message_id: row.get(6)?,
+            parent_id: row.get(7)?,
+            ts_ms: row.get(8)?,
+            role: row.get(9)?,
+            kind: row.get(10)?,
+            text: row.get(11)?,
+            model: row.get(12)?,
+            token_json: row.get(13)?,
+            event_uid: row.get(14)?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+pub fn session_tool_calls(
+    conn: &Connection,
+    session_id: &str,
+    source: Option<&str>,
+) -> Result<Vec<SessionToolCall>> {
+    let mut sql = "SELECT id, source, session_id, message_id, tool_use_id, name, target,                    args_json, is_error, ts_ms                    FROM tool_calls WHERE session_id = ?"
+        .to_string();
+    let mut params_vec = vec![session_id.to_string()];
+    if let Some(source) = source {
+        sql.push_str(" AND source = ?");
+        params_vec.push(source.to_string());
+    }
+    sql.push_str(" ORDER BY ts_ms ASC, id ASC");
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), |row| {
+        Ok(SessionToolCall {
+            id: row.get(0)?,
+            source: row.get(1)?,
+            session_id: row.get(2)?,
+            message_id: row.get(3)?,
+            tool_use_id: row.get(4)?,
+            name: row.get(5)?,
+            target: row.get(6)?,
+            args_json: row.get(7)?,
+            is_error: row.get(8)?,
+            ts_ms: row.get(9)?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+pub fn session_file_edits(
+    conn: &Connection,
+    session_id: &str,
+    source: Option<&str>,
+) -> Result<Vec<SessionFileEdit>> {
+    let mut sql = "SELECT id, source, session_id, tool_use_id, file_path, tool_name,                    lines_added, lines_removed, user_modified, ts_ms                    FROM file_edits WHERE session_id = ?"
+        .to_string();
+    let mut params_vec = vec![session_id.to_string()];
+    if let Some(source) = source {
+        sql.push_str(" AND source = ?");
+        params_vec.push(source.to_string());
+    }
+    sql.push_str(" ORDER BY ts_ms ASC, id ASC");
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), |row| {
+        Ok(SessionFileEdit {
+            id: row.get(0)?,
+            source: row.get(1)?,
+            session_id: row.get(2)?,
+            tool_use_id: row.get(3)?,
+            file_path: row.get(4)?,
+            tool_name: row.get(5)?,
+            lines_added: row.get(6)?,
+            lines_removed: row.get(7)?,
+            user_modified: row.get(8)?,
+            ts_ms: row.get(9)?,
+        })
+    })?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
 pub fn stats(conn: &Connection, tag: Option<&str>) -> Result<Stats> {
     let mut where_sql = String::new();
     let mut params_vec = Vec::new();

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -819,7 +819,7 @@ pub fn session_events(
         sql.push_str(" AND source = ?");
         params_vec.push(source.to_string());
     }
-    sql.push_str(" ORDER BY ts_ms ASC, id ASC");
+    sql.push_str(" ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC");
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), |row| {
         Ok(SessionEvent {
@@ -855,7 +855,7 @@ pub fn session_tool_calls(
         sql.push_str(" AND source = ?");
         params_vec.push(source.to_string());
     }
-    sql.push_str(" ORDER BY ts_ms ASC, id ASC");
+    sql.push_str(" ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC");
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), |row| {
         Ok(SessionToolCall {
@@ -886,7 +886,7 @@ pub fn session_file_edits(
         sql.push_str(" AND source = ?");
         params_vec.push(source.to_string());
     }
-    sql.push_str(" ORDER BY ts_ms ASC, id ASC");
+    sql.push_str(" ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC");
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), |row| {
         Ok(SessionFileEdit {

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -12,6 +12,8 @@ export interface SyncPushResult {
   /** `true` when another process owned the history scan; existing rows were still pushed. */
   syncSkipped: boolean
 }
+/** Refresh the local ai-hist database without performing any cloud operation. */
+export declare function syncLocal(): Promise<void>
 /**
  * Sync local agent history into the ai-hist DB, then push new records to
  * relayhistory-cloud. The blocking work (file/SQLite/HTTP) runs on a worker

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -12,7 +12,7 @@ export interface SyncPushResult {
   /** `true` when another process owned the history scan; existing rows were still pushed. */
   syncSkipped: boolean
 }
-/** Refresh the local ai-hist database without performing any cloud operation. */
+/** Refresh local history without reading auth or pushing to cloud. */
 export declare function syncLocal(): Promise<void>
 /**
  * Sync local agent history into the ai-hist DB, then push new records to

--- a/crates/ai-hist-napi/index.js
+++ b/crates/ai-hist-napi/index.js
@@ -310,6 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { syncAndPush } = nativeBinding
+const { syncLocal, syncAndPush } = nativeBinding
 
+module.exports.syncLocal = syncLocal
 module.exports.syncAndPush = syncAndPush

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -1,7 +1,6 @@
 //! Native (napi) binding for driving ai-hist in-process — no CLI shell-out.
 //!
-//! Exposes `syncAndPush()` to Node. The Agent Relay runtime calls this from its
-//! Reflex capture loop so history is synced + pushed inside the process.
+//! Exposes local-only `syncLocal()` and cloud-enabled `syncAndPush()` to Node.
 #![deny(clippy::all)]
 
 use napi_derive::napi;
@@ -15,6 +14,15 @@ pub struct SyncPushResult {
     pub authenticated: bool,
     /// `true` when another process owned the history scan; existing rows were still pushed.
     pub sync_skipped: bool,
+}
+
+/// Refresh local history without reading auth or pushing to cloud.
+#[napi]
+pub async fn sync_local() -> napi::Result<()> {
+    napi::tokio::task::spawn_blocking(ai_hist_cli::sync_local)
+        .await
+        .map_err(|e| napi::Error::from_reason(format!("worker thread panicked: {e}")))?
+        .map_err(|e| napi::Error::from_reason(format!("{e:#}")))
 }
 
 /// Sync local agent history into the ai-hist DB, then push new records to

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -4588,7 +4588,12 @@ fn ingest_codex_rollout(
                         // carried-over baseline of a resumed session (a fresh
                         // session's opening snapshot has `info: null`).
                         None if !saw_model_output => prev_totals = Some(totals),
-                        Some(prev) if totals.regressed_from(&prev) => prev_totals = Some(totals),
+                        // A regressed snapshot is treated as a transient
+                        // glitch: keeping the prior baseline means the next
+                        // advancing snapshot's delta covers exactly the spend
+                        // since that baseline, so per-event sums still
+                        // reproduce the cumulative totals.
+                        Some(prev) if totals.regressed_from(&prev) => {}
                         Some(prev) if !totals.advanced_from(&prev) => {}
                         _ => {
                             let baseline = prev_totals.unwrap_or_default();
@@ -7765,6 +7770,7 @@ mod tests {
                 r#"{"timestamp":"2026-08-02T09:00:00.000Z","type":"session_meta","payload":{"id":"sess-resumed","cwd":"/tmp/proj"}}"#, "\n",
                 r#"{"timestamp":"2026-08-02T09:00:00.100Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":120,"reasoning_output_tokens":0,"total_tokens":1120}}}}"#, "\n",
                 r#"{"timestamp":"2026-08-02T09:00:01.000Z","type":"event_msg","payload":{"type":"agent_message","message":"Picking the work back up."}}"#, "\n",
+                r#"{"timestamp":"2026-08-02T09:00:01.500Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":40,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":4,"reasoning_output_tokens":0,"total_tokens":44}}}}"#, "\n",
                 r#"{"timestamp":"2026-08-02T09:00:02.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1500,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":150,"reasoning_output_tokens":0,"total_tokens":1650}}}}"#, "\n",
             ),
         )

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -2,8 +2,8 @@ use ai_hist_core::convergence::MachineIdentity;
 use ai_hist_core::{
     default_db_path, import_json, insert_history, normalize_tag_name, open_db, open_db_readonly,
     parse_cursor_text, prompt_hash, raw_fts_query_error, recent, resume_command, schema_is_current,
-    search, session, sync_opencode_db, untag_session, HistoryEntry, QueryFilter,
-    SourceDatabaseError, SOURCE_CHOICES,
+    search, session, session_events, session_file_edits, session_tool_calls, sync_opencode_db,
+    untag_session, HistoryEntry, QueryFilter, SourceDatabaseError, SOURCE_CHOICES,
 };
 use anyhow::{Context, Result};
 use chrono::{Local, TimeZone};
@@ -170,6 +170,18 @@ enum Command {
         tag: Option<String>,
         #[arg(long)]
         full: bool,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Replay one session's normalized events: messages, thinking, tool calls, and file edits.
+    Events {
+        session_id: String,
+        #[arg(long)]
+        source: Option<String>,
+        /// Truncate event text to this many characters in the readable view (0 = no limit).
+        #[arg(long, default_value_t = 240)]
+        width: usize,
+        /// Emit JSON lines: {"type":"event"|"tool_call"|"file_edit", ...} per row.
         #[arg(long)]
         json: bool,
     },
@@ -533,6 +545,7 @@ fn is_read_only(command: &Command) -> bool {
         Command::Search { .. }
             | Command::Recent { .. }
             | Command::Session { .. }
+            | Command::Events { .. }
             | Command::Show { .. }
             | Command::Context { .. }
             | Command::Stats { .. }
@@ -683,6 +696,26 @@ pub fn run() -> Result<()> {
                 std::process::exit(1);
             }
             print_session_entries(&session_id, rows, json, full)
+        }
+        Command::Events {
+            session_id,
+            source,
+            width,
+            json,
+        } => {
+            validate_source(source.as_deref())?;
+            let events = session_events(&conn, &session_id, source.as_deref())?;
+            let tool_calls = session_tool_calls(&conn, &session_id, source.as_deref())?;
+            let file_edits = session_file_edits(&conn, &session_id, source.as_deref())?;
+            if events.is_empty() && tool_calls.is_empty() {
+                if json {
+                    println!("[]");
+                } else {
+                    println!("No events for session {session_id}");
+                }
+                std::process::exit(1);
+            }
+            print_session_events(&session_id, events, tool_calls, file_edits, width, json)
         }
         Command::Show { id, json } => show_entry(&conn, id, json),
         Command::Context { id, window } => show_context(&conn, id, window),
@@ -1280,6 +1313,59 @@ fn fmt_search_row(row: &SearchRow) -> String {
         row.text.replace('\n', " ")
     };
     format!("  #{:<5} {}  ({}){}  {}", row.id, dt, label, project, text)
+}
+
+fn print_session_events(
+    session_id: &str,
+    events: Vec<ai_hist_core::SessionEvent>,
+    tool_calls: Vec<ai_hist_core::SessionToolCall>,
+    file_edits: Vec<ai_hist_core::SessionFileEdit>,
+    width: usize,
+    json: bool,
+) -> Result<()> {
+    if json {
+        for event in &events {
+            println!(
+                "{}",
+                serde_json::to_string(&json!({ "type": "event", "record": event }))?
+            );
+        }
+        for call in &tool_calls {
+            println!(
+                "{}",
+                serde_json::to_string(&json!({ "type": "tool_call", "record": call }))?
+            );
+        }
+        for edit in &file_edits {
+            println!(
+                "{}",
+                serde_json::to_string(&json!({ "type": "file_edit", "record": edit }))?
+            );
+        }
+        return Ok(());
+    }
+    println!(
+        "  Session {session_id}: {} events, {} tool calls, {} file edits\n",
+        events.len(),
+        tool_calls.len(),
+        file_edits.len()
+    );
+    for event in &events {
+        let text = event.text.as_deref().unwrap_or("");
+        let flat = text.split_whitespace().collect::<Vec<_>>().join(" ");
+        let shown = if width > 0 && flat.chars().count() > width {
+            format!("{}…", flat.chars().take(width).collect::<String>())
+        } else {
+            flat
+        };
+        println!(
+            "  {}  {:<11} {}",
+            format_datetime(event.ts_ms),
+            format!("{}/{}", event.role, event.kind),
+            shown
+        );
+    }
+    Ok(())
 }
 
 fn print_session_entries(
@@ -3946,8 +4032,7 @@ fn sync_jsonl_incremental(
 }
 
 fn sync_codex(conn: &Connection, state: &mut Map<String, Value>, home: &Path) -> Result<usize> {
-    let (cwds, branches) = build_codex_session_maps(state, home)?;
-    let mut inserted = sync_codex_rollout_prompts(conn, state, home)?;
+    let (cwds, branches, mut inserted) = sync_codex_rollouts(conn, state, home)?;
     let path = home.join(".codex/history.jsonl");
     if !path.exists() {
         sync_note!("  [codex] not found: {} (skipped)", path.display());
@@ -4000,21 +4085,36 @@ fn sync_codex(conn: &Connection, state: &mut Map<String, Value>, home: &Path) ->
     Ok(inserted)
 }
 
-/// Codex Desktop records complete conversations in rollout JSONL files but does
-/// not mirror those prompts into `~/.codex/history.jsonl`. Import user turns
-/// here so desktop and CLI sessions converge on the same normalized history.
-fn sync_codex_rollout_prompts(
+/// One pass over every Codex rollout file: session metadata (cwd/branch maps
+/// plus `sessions` rows), user prompts into `history`, and the full
+/// conversation into `session_events` / `tool_calls` / `file_edits`.
+///
+/// Replaces the earlier split walks (state keys `codex_rollouts` and
+/// `codex_rollout_user_messages_v2`) with one stamp map, `codex_rollouts_v3`,
+/// whose per-file record also carries the session id so a wiped database
+/// forces re-ingestion even when the file stamp is unchanged.
+/// (session cwds, session branches, prompts inserted).
+type CodexRolloutWalk = (HashMap<String, String>, HashMap<String, String>, usize);
+
+fn sync_codex_rollouts(
     conn: &Connection,
     state: &mut Map<String, Value>,
     home: &Path,
-) -> Result<usize> {
+) -> Result<CodexRolloutWalk> {
+    let mut cwds = load_state_string_map(state, "codex_session_cwds");
+    let mut branches = load_state_string_map(state, "codex_session_branches");
     let mut seen = state
-        .get("codex_rollout_user_messages_v2")
+        .get("codex_rollouts_v3")
         .and_then(Value::as_object)
         .cloned()
         .unwrap_or_default();
+    // Superseded stamp maps from the split-walk era; keeping them would carry
+    // three path->stamp maps over the same 2K-file tree in .sync-state.json.
+    state.remove("codex_rollouts");
+    state.remove("codex_rollout_user_messages_v2");
     let mut inserted = 0;
     let mut scanned = 0;
+    let mut events = 0usize;
     for root in [
         home.join(".codex/sessions"),
         home.join(".codex/archived_sessions"),
@@ -4025,139 +4125,58 @@ fn sync_codex_rollout_prompts(
         for rollout in collect_matching_files(&root, "rollout-", "jsonl")? {
             let key = rollout.to_string_lossy().to_string();
             let stamp = file_stamp(&rollout)?;
-            if seen.get(&key).and_then(Value::as_str) == Some(stamp.as_str()) {
-                continue;
+            let record = seen.get(&key).and_then(Value::as_object);
+            let stamp_unchanged = record
+                .map(|r| r.get("stamp").and_then(Value::as_str) == Some(stamp.as_str()))
+                .unwrap_or(false);
+            if stamp_unchanged {
+                match record
+                    .and_then(|r| r.get("session"))
+                    .and_then(Value::as_str)
+                {
+                    // No session id was recorded because the file had no
+                    // usable session_meta; there is nothing to re-ingest.
+                    None => continue,
+                    Some(id) if codex_session_events_exist(conn, id)? => continue,
+                    // Stamp matches but the events are gone (wiped or rebuilt
+                    // database): fall through and re-ingest.
+                    _ => {}
+                }
             }
-            let Some((session_id, cwd, _)) = read_codex_session_meta(&rollout)? else {
-                seen.insert(key, json!(stamp));
+            let Some(meta) = read_codex_session_meta(&rollout)? else {
+                seen.insert(key, json!({ "stamp": stamp }));
                 continue;
             };
             scanned += 1;
-            let file = fs::File::open(&rollout)?;
-            for line in BufReader::new(file).lines() {
-                let Ok(line) = line else { continue };
-                let Ok(value) = serde_json::from_str::<Value>(&line) else {
-                    continue;
-                };
-                let timestamp_ms = value
-                    .get("timestamp")
-                    .and_then(Value::as_str)
-                    .and_then(parse_iso_ms)
-                    .unwrap_or(0);
-                for prompt in codex_rollout_user_prompts(&value) {
-                    if is_codex_control_context(&prompt) {
-                        continue;
-                    }
-                    inserted += insert_history(
+            cwds.insert(meta.session_id.clone(), meta.cwd.clone());
+            if let Some(branch) = &meta.git_branch {
+                branches.insert(meta.session_id.clone(), branch.clone());
+            }
+            let outcome = ingest_codex_rollout(conn, &rollout, &meta)?;
+            inserted += outcome.prompts;
+            events += outcome.events;
+            // Subagent threads (guardian/reviewer spawns) keep their events
+            // under their own thread id but stay out of the session list.
+            if !meta.is_subagent {
+                if let Some(first) = outcome.first_ts {
+                    upsert_session(
                         conn,
-                        &HistoryEntry {
-                            id: 0,
-                            source: "codex".into(),
-                            session_id: Some(session_id.clone()),
-                            project: Some(cwd.clone()),
-                            prompt_hash: Some(prompt_hash(&prompt)),
-                            prompt,
-                            timestamp_ms,
-                        },
+                        &meta.session_id,
+                        "codex",
+                        Some(&meta.cwd),
+                        meta.git_branch.as_deref(),
+                        first,
+                        outcome.last_ts.unwrap_or(first),
+                        outcome.last_assistant_text.as_deref(),
+                        Some(&rollout.to_string_lossy()),
                     )?;
                 }
             }
-            seen.insert(key, json!(stamp));
+            seen.insert(
+                key,
+                json!({ "stamp": stamp, "session": meta.session_id, "subagent": meta.is_subagent }),
+            );
         }
-    }
-    state.insert("codex_rollout_user_messages_v2".to_string(), Value::Object(seen));
-    if scanned > 0 {
-        sync_note!("  [codex-rollouts] scanned {scanned} files; +{inserted} rows");
-    }
-    Ok(inserted)
-}
-
-fn codex_rollout_user_prompts(value: &Value) -> Vec<String> {
-    let mut prompts = Vec::new();
-    let payload = value.get("payload").and_then(Value::as_object);
-    if value.get("type").and_then(Value::as_str) == Some("event_msg")
-        && payload.and_then(|p| p.get("type")).and_then(Value::as_str) == Some("user_message")
-    {
-        if let Some(message) = payload
-            .and_then(|p| p.get("message"))
-            .and_then(Value::as_str)
-        {
-            if !message.trim().is_empty() {
-                prompts.push(message.trim().to_string());
-            }
-        }
-    }
-    prompts
-}
-
-fn is_codex_control_context(prompt: &str) -> bool {
-    let value = prompt.trim_start();
-    [
-        "<environment_context",
-        "<permissions instructions",
-        "<app-context",
-        "<skills_instructions",
-    ]
-    .iter()
-    .any(|prefix| value.starts_with(prefix))
-}
-
-fn build_codex_session_maps(
-    state: &mut Map<String, Value>,
-    home: &Path,
-) -> Result<(HashMap<String, String>, HashMap<String, String>)> {
-    let mut cwds = state
-        .get("codex_session_cwds")
-        .and_then(Value::as_object)
-        .map(|m| {
-            m.iter()
-                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                .collect::<HashMap<_, _>>()
-        })
-        .unwrap_or_default();
-    let mut branches = state
-        .get("codex_session_branches")
-        .and_then(Value::as_object)
-        .map(|m| {
-            m.iter()
-                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                .collect::<HashMap<_, _>>()
-        })
-        .unwrap_or_default();
-    let mut seen = state
-        .get("codex_rollouts")
-        .and_then(Value::as_object)
-        .cloned()
-        .unwrap_or_default();
-    let mut scanned = 0;
-    for root in [
-        home.join(".codex/sessions"),
-        home.join(".codex/archived_sessions"),
-    ] {
-        if !root.exists() {
-            continue;
-        }
-        for rollout in collect_matching_files(&root, "rollout-", "jsonl")? {
-            let key = rollout.to_string_lossy().to_string();
-            let modified = file_stamp(&rollout)?;
-            if seen.get(&key).and_then(Value::as_str) == Some(modified.as_str()) {
-                continue;
-            }
-            seen.insert(key, json!(modified));
-            scanned += 1;
-            if let Some((session_id, cwd, branch)) = read_codex_session_meta(&rollout)? {
-                cwds.insert(session_id.clone(), cwd);
-                if let Some(branch) = branch {
-                    branches.insert(session_id, branch);
-                }
-            }
-        }
-    }
-    if scanned > 0 {
-        sync_note!(
-            "  [codex] scanned {scanned} new rollout files; {} sessions mapped",
-            cwds.len()
-        );
     }
     state.insert(
         "codex_session_cwds".to_string(),
@@ -4176,11 +4195,51 @@ fn build_codex_session_maps(
                 .collect::<Map<_, _>>(),
         ),
     );
-    state.insert("codex_rollouts".to_string(), Value::Object(seen));
-    Ok((cwds, branches))
+    state.insert("codex_rollouts_v3".to_string(), Value::Object(seen));
+    if scanned > 0 {
+        sync_note!(
+            "  [codex-rollouts] scanned {scanned} files; +{inserted} prompts, +{events} events"
+        );
+    }
+    Ok((cwds, branches, inserted))
 }
 
-fn read_codex_session_meta(path: &Path) -> Result<Option<(String, String, Option<String>)>> {
+fn load_state_string_map(state: &Map<String, Value>, key: &str) -> HashMap<String, String> {
+    state
+        .get(key)
+        .and_then(Value::as_object)
+        .map(|m| {
+            m.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect::<HashMap<_, _>>()
+        })
+        .unwrap_or_default()
+}
+
+fn codex_session_events_exist(conn: &Connection, session_id: &str) -> Result<bool> {
+    let exists: i64 = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM session_events WHERE source = 'codex' AND session_id = ? LIMIT 1)",
+        [session_id],
+        |row| row.get(0),
+    )?;
+    Ok(exists != 0)
+}
+
+struct CodexSessionMeta {
+    session_id: String,
+    cwd: String,
+    git_branch: Option<String>,
+    is_subagent: bool,
+}
+
+/// Read the `session_meta` line that opens every rollout file.
+///
+/// Sessions key on `payload.id` — the per-thread id. Newer rollouts also
+/// carry `payload.session_id`, but that names the *parent* conversation for
+/// subagent threads; keying on it would collapse every subagent into its
+/// parent. Subagent threads are detected instead (`thread_source`, or the
+/// object form of `payload.source`) and excluded from session registration.
+fn read_codex_session_meta(path: &Path) -> Result<Option<CodexSessionMeta>> {
     let first = fs::read_to_string(path)
         .ok()
         .and_then(|text| text.lines().next().map(str::to_string))
@@ -4210,13 +4269,640 @@ fn read_codex_session_meta(path: &Path) -> Result<Option<(String, String, Option
     else {
         return Ok(None);
     };
-    let branch = payload
+    let git_branch = payload
         .and_then(|p| p.get("git"))
         .and_then(Value::as_object)
         .and_then(|g| g.get("branch"))
         .and_then(Value::as_str)
         .map(str::to_string);
-    Ok(Some((session_id.to_string(), cwd.to_string(), branch)))
+    let is_subagent = payload
+        .and_then(|p| p.get("thread_source"))
+        .and_then(Value::as_str)
+        == Some("subagent")
+        || payload
+            .and_then(|p| p.get("source"))
+            .and_then(Value::as_object)
+            .is_some_and(|s| s.contains_key("subagent"));
+    Ok(Some(CodexSessionMeta {
+        session_id: session_id.to_string(),
+        cwd: cwd.to_string(),
+        git_branch,
+        is_subagent,
+    }))
+}
+
+#[derive(Default)]
+struct CodexIngestOutcome {
+    prompts: usize,
+    events: usize,
+    first_ts: Option<i64>,
+    last_ts: Option<i64>,
+    last_assistant_text: Option<String>,
+}
+
+/// Cumulative token totals from a Codex `token_count` event
+/// (`info.total_token_usage`). `input` is inclusive of `cached_input`.
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+struct CodexTokenTotals {
+    input: i64,
+    cached_input: i64,
+    cache_write: i64,
+    output: i64,
+    reasoning_output: i64,
+    total: i64,
+}
+
+impl CodexTokenTotals {
+    fn from_usage(value: &Value) -> Option<Self> {
+        let obj = value.as_object()?;
+        let get = |key: &str| obj.get(key).and_then(Value::as_i64).unwrap_or(0);
+        Some(Self {
+            input: get("input_tokens"),
+            cached_input: get("cached_input_tokens"),
+            cache_write: get("cache_write_input_tokens"),
+            output: get("output_tokens"),
+            reasoning_output: get("reasoning_output_tokens"),
+            total: get("total_tokens"),
+        })
+    }
+
+    fn fields(&self) -> [i64; 6] {
+        [
+            self.input,
+            self.cached_input,
+            self.cache_write,
+            self.output,
+            self.reasoning_output,
+            self.total,
+        ]
+    }
+
+    /// Strictly-advancing snapshots mark a completed model request; identical
+    /// repeats (Codex re-emits them) and regressions are not deltas.
+    fn advanced_from(&self, prev: &Self) -> bool {
+        let (a, b) = (self.fields(), prev.fields());
+        a.iter().zip(b.iter()).all(|(x, y)| x >= y) && a != b
+    }
+
+    fn regressed_from(&self, prev: &Self) -> bool {
+        self.fields()
+            .iter()
+            .zip(prev.fields().iter())
+            .any(|(x, y)| x < y)
+    }
+
+    fn minus(&self, prev: &Self) -> Self {
+        Self {
+            input: (self.input - prev.input).max(0),
+            cached_input: (self.cached_input - prev.cached_input).max(0),
+            cache_write: (self.cache_write - prev.cache_write).max(0),
+            output: (self.output - prev.output).max(0),
+            reasoning_output: (self.reasoning_output - prev.reasoning_output).max(0),
+            total: (self.total - prev.total).max(0),
+        }
+    }
+
+    fn plus(&self, other: &Self) -> Self {
+        Self {
+            input: self.input + other.input,
+            cached_input: self.cached_input + other.cached_input,
+            cache_write: self.cache_write + other.cache_write,
+            output: self.output + other.output,
+            reasoning_output: self.reasoning_output + other.reasoning_output,
+            total: self.total + other.total,
+        }
+    }
+
+    fn to_token_json(self) -> String {
+        json!({
+            "input_tokens": self.input,
+            "cached_input_tokens": self.cached_input,
+            "cache_write_input_tokens": self.cache_write,
+            "output_tokens": self.output,
+            "reasoning_output_tokens": self.reasoning_output,
+            "total_tokens": self.total,
+        })
+        .to_string()
+    }
+}
+
+/// Ingest one rollout file's conversation into `session_events`,
+/// `tool_calls`, and `file_edits`, and its user prompts into `history`.
+///
+/// Format notes (verified against rollouts spanning cli 0.36 to 0.148):
+/// message text is taken from the `event_msg` stream only — the
+/// `response_item/message` rows duplicate it, and `response_item/reasoning`
+/// carries encrypted content while the readable stream is
+/// `event_msg/agent_reasoning`. Tool calls are `response_item` rows
+/// correlated by `call_id`. Token usage arrives as cumulative
+/// `token_count` snapshots; consecutive strictly-advancing snapshots are
+/// diffed into per-request deltas and attached to the nearest assistant
+/// event, so summing `token_json` over a session equals the session total.
+fn ingest_codex_rollout(
+    conn: &Connection,
+    path: &Path,
+    meta: &CodexSessionMeta,
+) -> Result<CodexIngestOutcome> {
+    let file = fs::File::open(path)?;
+    let session_id = meta.session_id.as_str();
+    let cwd = Some(meta.cwd.as_str());
+    let branch = meta.git_branch.as_deref();
+    let mut outcome = CodexIngestOutcome::default();
+    let mut model: Option<String> = None;
+    let mut prev_totals: Option<CodexTokenTotals> = None;
+    let mut pending_delta: Option<CodexTokenTotals> = None;
+    let mut untokened_assistant_uid: Option<String> = None;
+    let mut saw_model_output = false;
+    let mut reader = BufReader::new(file);
+    let mut raw = Vec::new();
+    let mut line_index = 0usize;
+    loop {
+        raw.clear();
+        if reader.read_until(b'\n', &mut raw)? == 0 {
+            break;
+        }
+        // A line without its newline is the half-written tail of a live
+        // session; the next sync re-reads the whole file.
+        if raw.last() != Some(&b'\n') {
+            break;
+        }
+        let index = line_index;
+        line_index += 1;
+        let Ok(text) = std::str::from_utf8(&raw) else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(text.trim()) else {
+            continue;
+        };
+        let Some(payload) = value.get("payload").and_then(Value::as_object) else {
+            continue;
+        };
+        let line_type = value.get("type").and_then(Value::as_str).unwrap_or("");
+        let ts_ms = value
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .and_then(parse_iso_ms)
+            .unwrap_or(0);
+        if ts_ms > 0 {
+            outcome.first_ts.get_or_insert(ts_ms);
+            outcome.last_ts = Some(outcome.last_ts.map_or(ts_ms, |last| last.max(ts_ms)));
+        }
+        let payload_type = payload.get("type").and_then(Value::as_str).unwrap_or("");
+        let payload_str = |key: &str| payload.get(key).and_then(Value::as_str);
+        match line_type {
+            "turn_context" => {
+                if let Some(m) = payload_str("model") {
+                    model = Some(m.to_string());
+                }
+            }
+            "event_msg" => match payload_type {
+                "user_message" => {
+                    for prompt in codex_rollout_user_prompts(&value) {
+                        if is_codex_control_context(&prompt) {
+                            continue;
+                        }
+                        let uid = format!("{index}:user_message");
+                        insert_codex_event(
+                            conn, session_id, cwd, branch, ts_ms, "user", "text", &prompt, &uid,
+                            &uid, None, None,
+                        )?;
+                        outcome.events += 1;
+                        outcome.prompts += insert_history(
+                            conn,
+                            &HistoryEntry {
+                                id: 0,
+                                source: "codex".into(),
+                                session_id: Some(meta.session_id.clone()),
+                                project: Some(meta.cwd.clone()),
+                                prompt_hash: Some(prompt_hash(&prompt)),
+                                prompt,
+                                timestamp_ms: ts_ms,
+                            },
+                        )?;
+                    }
+                }
+                "agent_message" => {
+                    if let Some(message) = payload_str("message").filter(|m| !m.trim().is_empty()) {
+                        let uid = format!("{index}:agent_message");
+                        let token_json = pending_delta.take().map(CodexTokenTotals::to_token_json);
+                        insert_codex_event(
+                            conn,
+                            session_id,
+                            cwd,
+                            branch,
+                            ts_ms,
+                            "assistant",
+                            "text",
+                            message.trim(),
+                            &uid,
+                            &uid,
+                            model.as_deref(),
+                            token_json.as_deref(),
+                        )?;
+                        outcome.events += 1;
+                        untokened_assistant_uid = token_json.is_none().then(|| uid.clone());
+                        outcome.last_assistant_text =
+                            Some(message.trim().chars().take(4096).collect());
+                        saw_model_output = true;
+                    }
+                }
+                "agent_reasoning" => {
+                    if let Some(reasoning) = payload_str("text").filter(|t| !t.trim().is_empty()) {
+                        let uid = format!("{index}:agent_reasoning");
+                        insert_codex_event(
+                            conn,
+                            session_id,
+                            cwd,
+                            branch,
+                            ts_ms,
+                            "assistant",
+                            "thinking",
+                            reasoning.trim(),
+                            &uid,
+                            &uid,
+                            model.as_deref(),
+                            None,
+                        )?;
+                        outcome.events += 1;
+                        untokened_assistant_uid = Some(uid);
+                        saw_model_output = true;
+                    }
+                }
+                "token_count" => {
+                    let Some(totals) = payload
+                        .get("info")
+                        .and_then(|info| info.get("total_token_usage"))
+                        .and_then(CodexTokenTotals::from_usage)
+                    else {
+                        continue;
+                    };
+                    match prev_totals {
+                        // The first snapshot before any model output is the
+                        // carried-over baseline of a resumed session (a fresh
+                        // session's opening snapshot has `info: null`).
+                        None if !saw_model_output => prev_totals = Some(totals),
+                        Some(prev) if totals.regressed_from(&prev) => prev_totals = Some(totals),
+                        Some(prev) if !totals.advanced_from(&prev) => {}
+                        _ => {
+                            let baseline = prev_totals.unwrap_or_default();
+                            let mut delta = totals.minus(&baseline);
+                            prev_totals = Some(totals);
+                            if let Some(pending) = pending_delta.take() {
+                                delta = delta.plus(&pending);
+                            }
+                            if let Some(uid) = untokened_assistant_uid.take() {
+                                conn.execute(
+                                    "UPDATE session_events SET token_json = ? \
+                                     WHERE source = 'codex' AND session_id = ? AND event_uid = ?",
+                                    params![delta.to_token_json(), session_id, uid],
+                                )?;
+                            } else {
+                                pending_delta = Some(delta);
+                            }
+                        }
+                    }
+                }
+                "task_complete" => {
+                    if let Some(message) =
+                        payload_str("last_agent_message").filter(|m| !m.trim().is_empty())
+                    {
+                        outcome.last_assistant_text =
+                            Some(message.trim().chars().take(4096).collect());
+                    }
+                }
+                "thread_settings_applied" => {
+                    if let Some(m) = payload
+                        .get("thread_settings")
+                        .and_then(|s| s.get("model"))
+                        .and_then(Value::as_str)
+                    {
+                        model = Some(m.to_string());
+                    }
+                }
+                "mcp_tool_call_end" => {
+                    let Some(call_id) = payload_str("call_id").filter(|s| !s.is_empty()) else {
+                        continue;
+                    };
+                    let invocation = payload.get("invocation");
+                    let name = invocation
+                        .map(|inv| {
+                            format!(
+                                "{}.{}",
+                                inv.get("server").and_then(Value::as_str).unwrap_or("mcp"),
+                                inv.get("tool").and_then(Value::as_str).unwrap_or("tool"),
+                            )
+                        })
+                        .unwrap_or_else(|| "mcp.tool".to_string());
+                    let args_json = invocation
+                        .and_then(|inv| serde_json::to_string(inv).ok())
+                        .unwrap_or_else(|| "null".to_string());
+                    let is_error = payload
+                        .get("result")
+                        .and_then(Value::as_object)
+                        .map(|r| r.contains_key("Err"));
+                    insert_tool_call(
+                        conn,
+                        "codex",
+                        session_id,
+                        &format!("{index}:mcp_tool_call_end"),
+                        call_id,
+                        &name,
+                        None,
+                        &args_json,
+                        is_error,
+                        ts_ms,
+                    )?;
+                }
+                "web_search_end" => {
+                    let Some(call_id) = payload_str("call_id").filter(|s| !s.is_empty()) else {
+                        continue;
+                    };
+                    insert_tool_call(
+                        conn,
+                        "codex",
+                        session_id,
+                        &format!("{index}:web_search_end"),
+                        call_id,
+                        "web_search",
+                        payload_str("query"),
+                        "null",
+                        None,
+                        ts_ms,
+                    )?;
+                }
+                "patch_apply_end" => {
+                    let Some(call_id) = payload_str("call_id").filter(|s| !s.is_empty()) else {
+                        continue;
+                    };
+                    let success = payload.get("success").and_then(Value::as_bool);
+                    if let Some(success) = success {
+                        set_tool_call_error(conn, "codex", session_id, call_id, !success)?;
+                    }
+                    let Some(changes) = payload.get("changes").and_then(Value::as_object) else {
+                        continue;
+                    };
+                    for (file_path, change) in changes {
+                        // One patch can touch several files; file_edits keys
+                        // on tool_use_id, so scope the id per path.
+                        let edit_id = format!("{call_id}#{file_path}");
+                        upsert_file_edit_from_call(
+                            conn,
+                            "codex",
+                            session_id,
+                            &format!("{index}:patch_apply_end"),
+                            &edit_id,
+                            file_path,
+                            "apply_patch",
+                            ts_ms,
+                            branch,
+                            cwd,
+                        )?;
+                        let diff = change
+                            .get("unified_diff")
+                            .and_then(Value::as_str)
+                            .unwrap_or("");
+                        let (added, removed) = count_unified_diff_lines(diff);
+                        conn.execute(
+                            "UPDATE file_edits SET lines_added = ?, lines_removed = ?, structured_patch_json = ? \
+                             WHERE source = 'codex' AND session_id = ? AND tool_use_id = ?",
+                            params![
+                                added,
+                                removed,
+                                serde_json::to_string(change).ok(),
+                                session_id,
+                                edit_id,
+                            ],
+                        )?;
+                    }
+                }
+                "exec_command_end" => {
+                    if let Some(call_id) = payload_str("call_id").filter(|s| !s.is_empty()) {
+                        if let Some(exit_code) = payload.get("exit_code").and_then(Value::as_i64) {
+                            set_tool_call_error(
+                                conn,
+                                "codex",
+                                session_id,
+                                call_id,
+                                exit_code != 0,
+                            )?;
+                        }
+                    }
+                }
+                _ => {}
+            },
+            "response_item" => match payload_type {
+                "function_call" | "custom_tool_call" => {
+                    let name = payload_str("name").unwrap_or("");
+                    let call_id = payload_str("call_id").unwrap_or("");
+                    let args = if payload_type == "function_call" {
+                        let raw_args = payload_str("arguments").unwrap_or("");
+                        serde_json::from_str::<Value>(raw_args)
+                            .unwrap_or_else(|_| json!({ "arguments": raw_args }))
+                    } else {
+                        json!({ "input": payload_str("input").unwrap_or("") })
+                    };
+                    let target = if name == "apply_patch" {
+                        codex_apply_patch_target(payload_str("input").unwrap_or(""))
+                    } else {
+                        codex_pick_tool_target(name, &args)
+                    };
+                    let uid = format!("{index}:{payload_type}");
+                    let message_id = payload_str("id").unwrap_or(uid.as_str()).to_string();
+                    let event_text = format_tool_event_text(name, target.as_deref(), &args);
+                    let token_json = pending_delta.take().map(CodexTokenTotals::to_token_json);
+                    insert_codex_event(
+                        conn,
+                        session_id,
+                        cwd,
+                        branch,
+                        ts_ms,
+                        "assistant",
+                        "tool_use",
+                        &event_text,
+                        &uid,
+                        &message_id,
+                        model.as_deref(),
+                        token_json.as_deref(),
+                    )?;
+                    outcome.events += 1;
+                    untokened_assistant_uid = token_json.is_none().then(|| uid.clone());
+                    saw_model_output = true;
+                    if !call_id.is_empty() && !name.is_empty() {
+                        let args_json =
+                            serde_json::to_string(&args).unwrap_or_else(|_| "null".to_string());
+                        insert_tool_call(
+                            conn,
+                            "codex",
+                            session_id,
+                            &message_id,
+                            call_id,
+                            name,
+                            target.as_deref(),
+                            &args_json,
+                            None,
+                            ts_ms,
+                        )?;
+                    }
+                }
+                "function_call_output" | "custom_tool_call_output" => {
+                    if let Some(output_text) =
+                        materialize_codex_output_text(payload.get("output").unwrap_or(&Value::Null))
+                    {
+                        let uid = format!("{index}:{payload_type}");
+                        let message_id = payload_str("id").unwrap_or(uid.as_str()).to_string();
+                        insert_codex_event(
+                            conn,
+                            session_id,
+                            cwd,
+                            branch,
+                            ts_ms,
+                            "tool_result",
+                            "tool_result",
+                            &output_text,
+                            &uid,
+                            &message_id,
+                            None,
+                            None,
+                        )?;
+                        outcome.events += 1;
+                    }
+                }
+                // Readable reasoning arrives as event_msg/agent_reasoning;
+                // this row is encrypted, but it still marks model output.
+                "reasoning" => saw_model_output = true,
+                // `response_item` messages duplicate the event_msg text
+                // stream; ingesting both would double every message. An
+                // assistant one still marks model output for token baselines.
+                "message" if payload_str("role") == Some("assistant") => saw_model_output = true,
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    Ok(outcome)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn insert_codex_event(
+    conn: &Connection,
+    session_id: &str,
+    cwd: Option<&str>,
+    branch: Option<&str>,
+    ts_ms: i64,
+    role: &str,
+    kind: &str,
+    text: &str,
+    uid: &str,
+    message_id: &str,
+    model: Option<&str>,
+    token_json: Option<&str>,
+) -> Result<()> {
+    insert_session_event(
+        conn,
+        "codex",
+        session_id,
+        cwd,
+        cwd,
+        branch,
+        message_id,
+        None,
+        ts_ms,
+        role,
+        kind,
+        Some(text),
+        model,
+        token_json,
+        uid,
+    )
+}
+
+fn codex_pick_tool_target(name: &str, args: &Value) -> Option<String> {
+    let obj = args.as_object()?;
+    let get = |keys: &[&str]| {
+        keys.iter()
+            .find_map(|k| obj.get(*k).and_then(Value::as_str))
+            .map(str::to_string)
+    };
+    match name {
+        "exec_command" | "shell" | "exec" => get(&["cmd", "command"]),
+        "read_file" | "write_file" => get(&["path", "file_path"]),
+        _ => get(&["path", "file_path", "cmd", "command", "url", "query"]),
+    }
+}
+
+fn codex_apply_patch_target(input: &str) -> Option<String> {
+    input.lines().find_map(|line| {
+        let line = line.trim();
+        ["*** Update File: ", "*** Add File: ", "*** Delete File: "]
+            .iter()
+            .find_map(|prefix| line.strip_prefix(prefix))
+            .map(str::to_string)
+    })
+}
+
+fn materialize_codex_output_text(output: &Value) -> Option<String> {
+    match output {
+        Value::String(s) => (!s.trim().is_empty()).then(|| s.clone()),
+        Value::Array(items) => {
+            let parts = items
+                .iter()
+                .filter_map(|item| item.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>();
+            (!parts.is_empty()).then(|| parts.join("\n"))
+        }
+        Value::Null => None,
+        other => serde_json::to_string(other).ok(),
+    }
+}
+
+fn count_unified_diff_lines(diff: &str) -> (i64, i64) {
+    let mut added = 0;
+    let mut removed = 0;
+    for line in diff.lines() {
+        if line.starts_with("+++") || line.starts_with("---") {
+            continue;
+        }
+        if line.starts_with('+') {
+            added += 1;
+        } else if line.starts_with('-') {
+            removed += 1;
+        }
+    }
+    (added, removed)
+}
+
+fn codex_rollout_user_prompts(value: &Value) -> Vec<String> {
+    let mut prompts = Vec::new();
+    let payload = value.get("payload").and_then(Value::as_object);
+    if value.get("type").and_then(Value::as_str) == Some("event_msg")
+        && payload.and_then(|p| p.get("type")).and_then(Value::as_str) == Some("user_message")
+    {
+        if let Some(message) = payload
+            .and_then(|p| p.get("message"))
+            .and_then(Value::as_str)
+        {
+            if !message.trim().is_empty() {
+                prompts.push(message.trim().to_string());
+            }
+        }
+    }
+    prompts
+}
+
+fn is_codex_control_context(prompt: &str) -> bool {
+    let value = prompt.trim_start();
+    [
+        "<environment_context",
+        "<permissions instructions",
+        "<app-context",
+        "<skills_instructions",
+        "<collaboration_mode",
+        "<INSTRUCTIONS>",
+        "<user_instructions",
+        "# AGENTS.md",
+    ]
+    .iter()
+    .any(|prefix| value.starts_with(prefix))
 }
 
 fn backfill_codex_metadata(
@@ -4443,6 +5129,7 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
                 };
                 insert_session_event(
                     conn,
+                    "claude",
                     session_id,
                     project,
                     cwd,
@@ -4477,6 +5164,7 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
                             };
                             insert_session_event(
                                 conn,
+                                "claude",
                                 session_id,
                                 project,
                                 cwd,
@@ -4502,6 +5190,7 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
                     if text.is_some_and(|s| !s.trim().is_empty()) {
                         insert_session_event(
                             conn,
+                            "claude",
                             session_id,
                             project,
                             cwd,
@@ -4526,6 +5215,7 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
                     let event_text = format_tool_event_text(name, target.as_deref(), args);
                     insert_session_event(
                         conn,
+                        "claude",
                         session_id,
                         project,
                         cwd,
@@ -4545,6 +5235,7 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
                             serde_json::to_string(args).unwrap_or_else(|_| "null".to_string());
                         insert_tool_call(
                             conn,
+                            "claude",
                             session_id,
                             message_uuid,
                             tool_use_id,
@@ -4558,6 +5249,7 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
                             if let Some(file_path) = target.as_deref() {
                                 upsert_file_edit_from_call(
                                     conn,
+                                    "claude",
                                     session_id,
                                     message_uuid,
                                     tool_use_id,
@@ -4581,6 +5273,7 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
                     let text = materialize_tool_result_text(content);
                     insert_session_event(
                         conn,
+                        "claude",
                         session_id,
                         project,
                         cwd,
@@ -4598,14 +5291,12 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
                     let is_error = block.get("is_error").and_then(Value::as_bool);
                     if !tool_use_id.is_empty() {
                         if let Some(err) = is_error {
-                            conn.execute(
-                                "UPDATE tool_calls SET is_error = ? WHERE source = 'claude' AND session_id = ? AND tool_use_id = ?",
-                                params![if err { 1 } else { 0 }, session_id, tool_use_id],
-                            )?;
+                            set_tool_call_error(conn, "claude", session_id, tool_use_id, err)?;
                         }
                         if let Some(result) = find_tool_use_result(block) {
                             update_file_edit_from_tool_result(
                                 conn,
+                                "claude",
                                 session_id,
                                 message_uuid,
                                 tool_use_id,
@@ -4627,6 +5318,7 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
 #[allow(clippy::too_many_arguments)]
 fn insert_session_event(
     conn: &Connection,
+    source: &str,
     session_id: &str,
     project: Option<&str>,
     cwd: Option<&str>,
@@ -4644,12 +5336,13 @@ fn insert_session_event(
     conn.execute(
         "INSERT INTO session_events \
          (source, session_id, project, cwd, git_branch, message_id, parent_id, ts_ms, role, kind, text, model, token_json, event_uid) \
-         VALUES ('claude', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
          ON CONFLICT(source, session_id, event_uid) DO UPDATE SET \
          project=excluded.project, cwd=excluded.cwd, git_branch=excluded.git_branch, message_id=excluded.message_id, \
          parent_id=excluded.parent_id, ts_ms=excluded.ts_ms, role=excluded.role, kind=excluded.kind, text=excluded.text, \
          model=excluded.model, token_json=excluded.token_json",
         params![
+            source,
             session_id,
             project,
             cwd,
@@ -4671,6 +5364,7 @@ fn insert_session_event(
 #[allow(clippy::too_many_arguments)]
 fn insert_tool_call(
     conn: &Connection,
+    source: &str,
     session_id: &str,
     message_id: &str,
     tool_use_id: &str,
@@ -4683,11 +5377,12 @@ fn insert_tool_call(
     conn.execute(
         "INSERT INTO tool_calls \
          (source, session_id, message_id, tool_use_id, name, target, args_json, is_error, ts_ms) \
-         VALUES ('claude', ?, ?, ?, ?, ?, ?, ?, ?) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) \
          ON CONFLICT(source, session_id, tool_use_id) DO UPDATE SET \
          message_id=excluded.message_id, name=excluded.name, target=excluded.target, args_json=excluded.args_json, \
          is_error=COALESCE(excluded.is_error, tool_calls.is_error), ts_ms=excluded.ts_ms",
         params![
+            source,
             session_id,
             message_id,
             tool_use_id,
@@ -4701,9 +5396,24 @@ fn insert_tool_call(
     Ok(())
 }
 
+fn set_tool_call_error(
+    conn: &Connection,
+    source: &str,
+    session_id: &str,
+    tool_use_id: &str,
+    is_error: bool,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE tool_calls SET is_error = ? WHERE source = ? AND session_id = ? AND tool_use_id = ?",
+        params![if is_error { 1 } else { 0 }, source, session_id, tool_use_id],
+    )?;
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn upsert_file_edit_from_call(
     conn: &Connection,
+    source: &str,
     session_id: &str,
     message_id: &str,
     tool_use_id: &str,
@@ -4716,11 +5426,12 @@ fn upsert_file_edit_from_call(
     conn.execute(
         "INSERT INTO file_edits \
          (source, session_id, message_id, tool_use_id, file_path, tool_name, ts_ms, git_branch, cwd) \
-         VALUES ('claude', ?, ?, ?, ?, ?, ?, ?, ?) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) \
          ON CONFLICT(source, session_id, tool_use_id) DO UPDATE SET \
          message_id=excluded.message_id, file_path=excluded.file_path, tool_name=excluded.tool_name, \
          ts_ms=excluded.ts_ms, git_branch=COALESCE(excluded.git_branch, file_edits.git_branch), cwd=COALESCE(excluded.cwd, file_edits.cwd)",
         params![
+            source,
             session_id,
             message_id,
             tool_use_id,
@@ -4737,6 +5448,7 @@ fn upsert_file_edit_from_call(
 #[allow(clippy::too_many_arguments)]
 fn update_file_edit_from_tool_result(
     conn: &Connection,
+    source: &str,
     session_id: &str,
     message_id: &str,
     tool_use_id: &str,
@@ -4766,7 +5478,7 @@ fn update_file_edit_from_tool_result(
          lines_added = ?, lines_removed = ?, structured_patch_json = COALESCE(?, structured_patch_json), \
          user_modified = COALESCE(?, user_modified), ts_ms = COALESCE(ts_ms, ?), \
          git_branch = COALESCE(?, git_branch), cwd = COALESCE(?, cwd) \
-         WHERE source = 'claude' AND session_id = ? AND tool_use_id = ?",
+         WHERE source = ? AND session_id = ? AND tool_use_id = ?",
         params![
             message_id,
             file_path,
@@ -4777,6 +5489,7 @@ fn update_file_edit_from_tool_result(
             ts_ms,
             git_branch,
             cwd,
+            source,
             session_id,
             tool_use_id,
         ],
@@ -6758,5 +7471,327 @@ mod tests {
 {"type":"user","uuid":"r1","parentUuid":"a1","sessionId":"s-rich","cwd":"/tmp/proj","gitBranch":"feat/rich","timestamp":"2026-06-25T10:00:02.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok","toolUseResult":{"filePath":"/tmp/proj/auth.ts","structuredPatch":"--- a/auth.ts\n+++ b/auth.ts\n-old\n+new\n","userModified":true}}]}}"#,
         )
         .unwrap();
+    }
+
+    fn write_rich_codex_rollout(path: &std::path::Path) {
+        fs::write(
+            path,
+            concat!(
+                r#"{"timestamp":"2026-08-01T10:00:00.000Z","type":"session_meta","payload":{"id":"sess-top","cwd":"/tmp/proj","git":{"branch":"main"},"cli_version":"0.148.0"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:00.100Z","type":"turn_context","payload":{"turn_id":"t1","cwd":"/tmp/proj","model":"gpt-5.4"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:00.150Z","type":"event_msg","payload":{"type":"token_count","info":null,"rate_limits":{}}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:00.200Z","type":"event_msg","payload":{"type":"task_started","turn_id":"t1"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"fix the importer"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:01.100Z","type":"event_msg","payload":{"type":"user_message","message":"<environment_context>injected</environment_context>"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:02.000Z","type":"event_msg","payload":{"type":"agent_reasoning","text":"I should check git status."}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:02.500Z","type":"response_item","payload":{"type":"reasoning","id":"rs_1","summary":[],"encrypted_content":"opaque"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:03.000Z","type":"response_item","payload":{"type":"function_call","id":"fc_1","name":"exec_command","arguments":"{\"cmd\":\"git status\"}","call_id":"call_1"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:04.000Z","type":"response_item","payload":{"type":"function_call_output","id":"fco_1","call_id":"call_1","output":"clean tree"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:04.500Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"cache_write_input_tokens":0,"output_tokens":120,"reasoning_output_tokens":30,"total_tokens":1120}}}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:04.600Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":400,"cache_write_input_tokens":0,"output_tokens":120,"reasoning_output_tokens":30,"total_tokens":1120}}}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:05.000Z","type":"response_item","payload":{"type":"custom_tool_call","id":"ctc_1","status":"completed","call_id":"call_2","name":"apply_patch","input":"*** Begin Patch\n*** Update File: /tmp/proj/README.md\n@@\n+banner\n-old\n*** End Patch\n"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:05.500Z","type":"event_msg","payload":{"type":"patch_apply_end","call_id":"call_2","turn_id":"t1","success":true,"changes":{"/tmp/proj/README.md":{"type":"update","unified_diff":"@@\n+banner\n-old"}}}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:06.000Z","type":"event_msg","payload":{"type":"agent_message","message":"Done. The importer is fixed.","phase":"final_answer"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:06.200Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1600,"cached_input_tokens":900,"cache_write_input_tokens":50,"output_tokens":180,"reasoning_output_tokens":40,"total_tokens":1780}}}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:06.300Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"t1","last_agent_message":"Done. The importer is fixed.","duration_ms":5000}}"#, "\n",
+            ),
+        )
+        .unwrap();
+    }
+
+    fn codex_meta(path: &std::path::Path) -> super::CodexSessionMeta {
+        super::read_codex_session_meta(path).unwrap().unwrap()
+    }
+
+    #[test]
+    fn ingests_codex_rollout_events_tools_edits_and_token_deltas() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout-rich.jsonl");
+        write_rich_codex_rollout(&path);
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+
+        let meta = codex_meta(&path);
+        assert_eq!(meta.session_id, "sess-top");
+        assert_eq!(meta.cwd, "/tmp/proj");
+        assert_eq!(meta.git_branch.as_deref(), Some("main"));
+        assert!(!meta.is_subagent);
+
+        let outcome = super::ingest_codex_rollout(&conn, &path, &meta).unwrap();
+        assert_eq!(outcome.prompts, 1);
+        assert_eq!(outcome.events, 6);
+        assert_eq!(
+            outcome.last_assistant_text.as_deref(),
+            Some("Done. The importer is fixed.")
+        );
+        assert_eq!(outcome.first_ts, Some(1_785_578_400_000));
+
+        let kinds: Vec<(String, String, Option<String>)> = conn
+            .prepare("SELECT role, kind, model FROM session_events ORDER BY id")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(
+            kinds,
+            vec![
+                ("user".into(), "text".into(), None),
+                (
+                    "assistant".into(),
+                    "thinking".into(),
+                    Some("gpt-5.4".into())
+                ),
+                (
+                    "assistant".into(),
+                    "tool_use".into(),
+                    Some("gpt-5.4".into())
+                ),
+                ("tool_result".into(), "tool_result".into(), None),
+                (
+                    "assistant".into(),
+                    "tool_use".into(),
+                    Some("gpt-5.4".into())
+                ),
+                ("assistant".into(), "text".into(), Some("gpt-5.4".into())),
+            ]
+        );
+
+        // The boilerplate user message is filtered from both stores.
+        let prompt_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM history WHERE source='codex'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(prompt_count, 1);
+
+        // Request 1's cumulative snapshot lands on the tool_use event that
+        // closed it; the duplicate snapshot adds nothing; request 2's delta
+        // lands on the final assistant message.
+        let first: String = conn
+            .query_row(
+                "SELECT token_json FROM session_events WHERE event_uid = '8:function_call'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let first: Value = serde_json::from_str(&first).unwrap();
+        assert_eq!(first["input_tokens"], 1000);
+        assert_eq!(first["cached_input_tokens"], 400);
+        assert_eq!(first["output_tokens"], 120);
+        assert_eq!(first["reasoning_output_tokens"], 30);
+        let second: String = conn
+            .query_row(
+                "SELECT token_json FROM session_events WHERE event_uid = '14:agent_message'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let second: Value = serde_json::from_str(&second).unwrap();
+        assert_eq!(second["input_tokens"], 600);
+        assert_eq!(second["cached_input_tokens"], 500);
+        assert_eq!(second["cache_write_input_tokens"], 50);
+        assert_eq!(second["output_tokens"], 60);
+        let token_rows: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_events WHERE token_json IS NOT NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(token_rows, 2);
+        // Summing per-event deltas reproduces the session's final totals.
+        let output_sum: i64 = conn
+            .query_row(
+                "SELECT SUM(json_extract(token_json, '$.output_tokens')) FROM session_events",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(output_sum, 180);
+
+        let calls: Vec<(String, String, Option<String>, Option<i64>)> = conn
+            .prepare("SELECT tool_use_id, name, target, is_error FROM tool_calls ORDER BY id")
+            .unwrap()
+            .query_map([], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(
+            calls,
+            vec![
+                (
+                    "call_1".into(),
+                    "exec_command".into(),
+                    Some("git status".into()),
+                    None
+                ),
+                (
+                    "call_2".into(),
+                    "apply_patch".into(),
+                    Some("/tmp/proj/README.md".into()),
+                    Some(0),
+                ),
+            ]
+        );
+
+        let edit: (String, i64, i64, String) = conn
+            .query_row(
+                "SELECT file_path, lines_added, lines_removed, structured_patch_json FROM file_edits",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(edit.0, "/tmp/proj/README.md");
+        assert_eq!((edit.1, edit.2), (1, 1));
+        assert!(edit.3.contains("unified_diff"));
+    }
+
+    #[test]
+    fn codex_rollout_reingest_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout-rich.jsonl");
+        write_rich_codex_rollout(&path);
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let meta = codex_meta(&path);
+        super::ingest_codex_rollout(&conn, &path, &meta).unwrap();
+        super::ingest_codex_rollout(&conn, &path, &meta).unwrap();
+        let counts: (i64, i64, i64, i64) = conn
+            .query_row(
+                "SELECT (SELECT COUNT(*) FROM session_events), (SELECT COUNT(*) FROM tool_calls), \
+                 (SELECT COUNT(*) FROM file_edits), (SELECT COUNT(*) FROM history)",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(counts, (6, 2, 1, 1));
+    }
+
+    #[test]
+    fn resumed_codex_rollout_treats_first_snapshot_as_carried_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout-resumed.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                r#"{"timestamp":"2026-08-02T09:00:00.000Z","type":"session_meta","payload":{"id":"sess-resumed","cwd":"/tmp/proj"}}"#, "\n",
+                r#"{"timestamp":"2026-08-02T09:00:00.100Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1000,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":120,"reasoning_output_tokens":0,"total_tokens":1120}}}}"#, "\n",
+                r#"{"timestamp":"2026-08-02T09:00:01.000Z","type":"event_msg","payload":{"type":"agent_message","message":"Picking the work back up."}}"#, "\n",
+                r#"{"timestamp":"2026-08-02T09:00:02.000Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":1500,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":150,"reasoning_output_tokens":0,"total_tokens":1650}}}}"#, "\n",
+            ),
+        )
+        .unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        super::ingest_codex_rollout(&conn, &path, &codex_meta(&path)).unwrap();
+        let token_json: String = conn
+            .query_row(
+                "SELECT token_json FROM session_events WHERE token_json IS NOT NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let delta: Value = serde_json::from_str(&token_json).unwrap();
+        assert_eq!(delta["input_tokens"], 500);
+        assert_eq!(delta["output_tokens"], 30);
+    }
+
+    #[test]
+    fn codex_rollout_ignores_a_half_written_trailing_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout-torn.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                r#"{"timestamp":"2026-08-02T09:00:00.000Z","type":"session_meta","payload":{"id":"sess-torn","cwd":"/tmp/proj"}}"#, "\n",
+                r#"{"timestamp":"2026-08-02T09:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"first"}}"#, "\n",
+                r#"{"timestamp":"2026-08-02T09:00:02.000Z","type":"event_msg","payload":{"type":"user_message","message":"tor"#,
+            ),
+        )
+        .unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let outcome = super::ingest_codex_rollout(&conn, &path, &codex_meta(&path)).unwrap();
+        assert_eq!(outcome.events, 1);
+        let text: String = conn
+            .query_row("SELECT text FROM session_events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(text, "first");
+    }
+
+    #[test]
+    fn subagent_rollouts_keep_events_but_stay_out_of_the_session_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        let day = home.join(".codex/sessions/2026/08/01");
+        fs::create_dir_all(&day).unwrap();
+        fs::write(
+            day.join("rollout-2026-08-01T10-00-00-top.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-08-01T10:00:00.000Z","type":"session_meta","payload":{"id":"sess-top","cwd":"/tmp/proj"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"do the thing"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:00:02.000Z","type":"event_msg","payload":{"type":"agent_message","message":"Doing it."}}"#, "\n",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            day.join("rollout-2026-08-01T10-01-00-sub.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-08-01T10:01:00.000Z","type":"session_meta","payload":{"id":"sess-sub","session_id":"sess-top","parent_thread_id":"sess-top","thread_source":"subagent","source":{"subagent":{"other":"guardian"}},"cwd":"/tmp/proj"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:01:01.000Z","type":"event_msg","payload":{"type":"agent_message","message":"Reviewing."}}"#, "\n",
+            ),
+        )
+        .unwrap();
+
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let mut state = Map::new();
+        // Stale keys from the split-walk era are dropped from state.
+        state.insert("codex_rollouts".into(), json!({"old": "1:1"}));
+        state.insert(
+            "codex_rollout_user_messages_v2".into(),
+            json!({"old": "1:1"}),
+        );
+        let (cwds, _, inserted) = super::sync_codex_rollouts(&conn, &mut state, home).unwrap();
+        assert_eq!(inserted, 1);
+        assert_eq!(cwds.get("sess-sub").map(String::as_str), Some("/tmp/proj"));
+        assert!(state.get("codex_rollouts").is_none());
+        assert!(state.get("codex_rollout_user_messages_v2").is_none());
+
+        let sessions: Vec<String> = conn
+            .prepare("SELECT session_id FROM sessions WHERE source='codex' ORDER BY session_id")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(sessions, vec!["sess-top".to_string()]);
+        let event_sessions: Vec<String> = conn
+            .prepare("SELECT DISTINCT session_id FROM session_events ORDER BY session_id")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(
+            event_sessions,
+            vec!["sess-sub".to_string(), "sess-top".to_string()]
+        );
+
+        // A second walk with unchanged stamps ingests nothing new.
+        let before: i64 = conn
+            .query_row("SELECT COUNT(*) FROM session_events", [], |r| r.get(0))
+            .unwrap();
+        let (_, _, inserted_again) = super::sync_codex_rollouts(&conn, &mut state, home).unwrap();
+        assert_eq!(inserted_again, 0);
+        let after: i64 = conn
+            .query_row("SELECT COUNT(*) FROM session_events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(before, after);
     }
 }

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -51,11 +51,11 @@ pub struct SyncPushOutcome {
 
 /// Refresh local agent history without performing any cloud operation.
 /// Embedding applications should use this before opening the local catalog.
+/// When another process owns the sync lock the refresh is skipped — the
+/// concurrent scan is already producing the fresh data this caller wants.
 pub fn sync_local() -> Result<()> {
     SYNC_QUIET.store(true, AtomicOrdering::Relaxed);
-    let db_path = default_db_path();
-    let conn = open_db(&db_path)?;
-    sync_basic(&conn, &db_path)
+    sync_exclusive(&default_db_path()).map(|_| ())
 }
 
 /// Sync local agent history into the DB, then push new records to
@@ -708,9 +708,9 @@ pub fn run() -> Result<()> {
             let tool_calls = session_tool_calls(&conn, &session_id, source.as_deref())?;
             let file_edits = session_file_edits(&conn, &session_id, source.as_deref())?;
             if events.is_empty() && tool_calls.is_empty() {
-                if json {
-                    println!("[]");
-                } else {
+                // JSON mode emits record lines only; an empty session is just
+                // an empty stream plus the exit code.
+                if !json {
                     println!("No events for session {session_id}");
                 }
                 std::process::exit(1);
@@ -1324,23 +1324,33 @@ fn print_session_events(
     json: bool,
 ) -> Result<()> {
     if json {
+        // One replay stream, merged chronologically across the three record
+        // types (unknown timestamps last, ties broken by row id).
+        let mut lines: Vec<(Option<i64>, i64, String)> = Vec::new();
         for event in &events {
-            println!(
-                "{}",
-                serde_json::to_string(&json!({ "type": "event", "record": event }))?
-            );
+            lines.push((
+                Some(event.ts_ms),
+                event.id,
+                serde_json::to_string(&json!({ "type": "event", "record": event }))?,
+            ));
         }
         for call in &tool_calls {
-            println!(
-                "{}",
-                serde_json::to_string(&json!({ "type": "tool_call", "record": call }))?
-            );
+            lines.push((
+                call.ts_ms,
+                call.id,
+                serde_json::to_string(&json!({ "type": "tool_call", "record": call }))?,
+            ));
         }
         for edit in &file_edits {
-            println!(
-                "{}",
-                serde_json::to_string(&json!({ "type": "file_edit", "record": edit }))?
-            );
+            lines.push((
+                edit.ts_ms,
+                edit.id,
+                serde_json::to_string(&json!({ "type": "file_edit", "record": edit }))?,
+            ));
+        }
+        lines.sort_by_key(|(ts, id, _)| (ts.is_none(), ts.unwrap_or(0), *id));
+        for (_, _, line) in lines {
+            println!("{line}");
         }
         return Ok(());
     }
@@ -1364,6 +1374,20 @@ fn print_session_events(
             format!("{}/{}", event.role, event.kind),
             shown
         );
+    }
+    // Tool calls already render above as their tool_use events; file edits
+    // have no event row, so list them explicitly.
+    if !file_edits.is_empty() {
+        println!("\n  Files changed:");
+        for edit in &file_edits {
+            let counts = match (edit.lines_added, edit.lines_removed) {
+                (Some(added), Some(removed)) if added + removed > 0 => {
+                    format!(" (+{added} -{removed})")
+                }
+                _ => String::new(),
+            };
+            println!("    {}{}", edit.file_path, counts);
+        }
     }
     Ok(())
 }
@@ -4148,9 +4172,26 @@ fn sync_codex_rollouts(
                 continue;
             };
             scanned += 1;
-            cwds.insert(meta.session_id.clone(), meta.cwd.clone());
-            if let Some(branch) = &meta.git_branch {
-                branches.insert(meta.session_id.clone(), branch.clone());
+            if meta.is_subagent {
+                // Earlier syncs (before subagent detection) registered these
+                // threads: their map entries feed backfill_codex_metadata and
+                // their history rows feed session discovery, either of which
+                // would resurrect the session row this walk refuses to create.
+                cwds.remove(&meta.session_id);
+                branches.remove(&meta.session_id);
+                conn.execute(
+                    "DELETE FROM history WHERE source = 'codex' AND session_id = ?",
+                    [meta.session_id.as_str()],
+                )?;
+                conn.execute(
+                    "DELETE FROM sessions WHERE source = 'codex' AND session_id = ?",
+                    [meta.session_id.as_str()],
+                )?;
+            } else {
+                cwds.insert(meta.session_id.clone(), meta.cwd.clone());
+                if let Some(branch) = &meta.git_branch {
+                    branches.insert(meta.session_id.clone(), branch.clone());
+                }
             }
             let outcome = ingest_codex_rollout(conn, &rollout, &meta)?;
             inserted += outcome.prompts;
@@ -4467,6 +4508,12 @@ fn ingest_codex_rollout(
                             &uid, None, None,
                         )?;
                         outcome.events += 1;
+                        // A subagent's "user" turns are the parent agent's
+                        // task prompts; only human threads feed the prompt
+                        // history that session discovery is built on.
+                        if meta.is_subagent {
+                            continue;
+                        }
                         outcome.prompts += insert_history(
                             conn,
                             &HistoryEntry {
@@ -4947,11 +4994,15 @@ fn sync_claude_session_metadata(
     if !root.exists() {
         return Ok(());
     }
+    // The v2 key forces one full re-scan on upgrade: transcripts whose
+    // stamps never change again still need the sidechain healing pass that
+    // removes previously ingested fake user turns.
     let mut session_state = state
-        .get("claude_sessions")
+        .get("claude_sessions_v2")
         .and_then(Value::as_object)
         .cloned()
         .unwrap_or_default();
+    state.remove("claude_sessions");
     let mut scanned = 0;
     let mut upserted = 0;
     for path in collect_matching_files(root, "", "jsonl")? {
@@ -4980,7 +5031,10 @@ fn sync_claude_session_metadata(
             upserted += 1;
         }
     }
-    state.insert("claude_sessions".to_string(), Value::Object(session_state));
+    state.insert(
+        "claude_sessions_v2".to_string(),
+        Value::Object(session_state),
+    );
     if scanned > 0 {
         sync_note!("  [claude-sessions] scanned {scanned} files, {upserted} sessions updated");
     }
@@ -7392,7 +7446,7 @@ mod tests {
         );
         let mut state = Map::new();
         state.insert(
-            "claude_sessions".to_string(),
+            "claude_sessions_v2".to_string(),
             Value::Object(claude_sessions),
         );
 
@@ -7786,9 +7840,35 @@ mod tests {
             "codex_rollout_user_messages_v2".into(),
             json!({"old": "1:1"}),
         );
+        // A sync predating subagent detection left the thread registered:
+        // a cwd-map entry, a prompt row, and a session row.
+        state.insert(
+            "codex_session_cwds".into(),
+            json!({"sess-sub": "/tmp/proj"}),
+        );
+        conn.execute(
+            "INSERT INTO history (source, session_id, project, prompt, timestamp_ms) VALUES ('codex', 'sess-sub', '/tmp/proj', 'do a review', 1)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions (session_id, source, cwd) VALUES ('sess-sub', 'codex', '/tmp/proj')",
+            [],
+        )
+        .unwrap();
         let (cwds, _, inserted) = super::sync_codex_rollouts(&conn, &mut state, home).unwrap();
         assert_eq!(inserted, 1);
-        assert_eq!(cwds.get("sess-sub").map(String::as_str), Some("/tmp/proj"));
+        // Subagent threads never reach the maps, prompt history, or session
+        // registration — including rows left behind by earlier syncs.
+        assert_eq!(cwds.get("sess-sub"), None);
+        let sub_history: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM history WHERE session_id = 'sess-sub'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(sub_history, 0);
         assert!(state.get("codex_rollouts").is_none());
         assert!(state.get("codex_rollout_user_messages_v2").is_none());
 

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -5043,7 +5043,9 @@ fn scan_claude_session_file(path: &Path) -> Result<Option<ClaudeSessionMeta>> {
             first_ts.get_or_insert(ts);
             last_ts = Some(ts);
         }
-        if value.get("type").and_then(Value::as_str) == Some("assistant") {
+        if value.get("type").and_then(Value::as_str) == Some("assistant")
+            && value.get("isSidechain").and_then(Value::as_bool) != Some(true)
+        {
             if let Some(content) = value.pointer("/message/content") {
                 if let Some(text) = content.as_str() {
                     last_assistant_text = Some(text.chars().take(4096).collect());
@@ -5087,6 +5089,33 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
             Some(s) if !s.is_empty() => s,
             _ => continue,
         };
+        // Subagent sidecar transcripts share the parent's sessionId with
+        // isSidechain rows. The subagent's assistant output is real session
+        // activity (text and token spend), but its user-role rows are the
+        // parent agent's own prompts and tool results — ingesting those
+        // manufactures fake human turns.
+        let sidechain = obj
+            .get("isSidechain")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if sidechain
+            && obj
+                .get("message")
+                .and_then(|m| m.get("role"))
+                .and_then(Value::as_str)
+                != Some("assistant")
+        {
+            // Heal databases that ingested these rows before this guard:
+            // the uid prefix is this row's uuid, so stale events (and any
+            // per-block siblings) can be removed as the file is re-read.
+            if let Some(uuid) = obj.get("uuid").and_then(Value::as_str) {
+                conn.execute(
+                    "DELETE FROM session_events WHERE source = 'claude' AND session_id = ? AND (event_uid = ? || ':0' OR event_uid LIKE ? || ':%')",
+                    params![session_id, uuid, uuid],
+                )?;
+            }
+            continue;
+        }
         let cwd = obj.get("cwd").and_then(Value::as_str);
         let project = cwd;
         let git_branch = obj.get("gitBranch").and_then(Value::as_str);
@@ -7793,5 +7822,33 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM session_events", [], |r| r.get(0))
             .unwrap();
         assert_eq!(before, after);
+    }
+
+    #[test]
+    fn sidechain_rows_keep_assistant_output_but_drop_fake_user_turns() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent-sub.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                r#"{"type":"user","uuid":"su1","sessionId":"s-parent","isSidechain":true,"cwd":"/tmp/proj","timestamp":"2026-06-25T10:00:00.000Z","message":{"role":"user","content":"Research the repo thoroughly."}}"#, "\n",
+                r#"{"type":"assistant","uuid":"sa1","sessionId":"s-parent","isSidechain":true,"cwd":"/tmp/proj","timestamp":"2026-06-25T10:01:00.000Z","message":{"id":"msg_sub","role":"assistant","model":"claude-opus-5","usage":{"input_tokens":10,"output_tokens":20},"content":[{"type":"text","text":"Here is the report."}]}}"#, "\n",
+            ),
+        )
+        .unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        ingest_claude_transcript(&conn, &path).unwrap();
+        let rows: Vec<(String, String)> = conn
+            .prepare("SELECT role, text FROM session_events ORDER BY id")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![("assistant".into(), "Here is the report.".into())]
+        );
     }
 }

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -1325,31 +1325,37 @@ fn print_session_events(
 ) -> Result<()> {
     if json {
         // One replay stream, merged chronologically across the three record
-        // types (unknown timestamps last, ties broken by row id).
-        let mut lines: Vec<(Option<i64>, i64, String)> = Vec::new();
+        // types (unknown timestamps last, ties broken by row id). Sorting
+        // references and serializing at write time keeps peak memory at the
+        // fetched rows themselves, not a second serialized copy.
+        enum ReplayRecord<'a> {
+            Event(&'a ai_hist_core::SessionEvent),
+            ToolCall(&'a ai_hist_core::SessionToolCall),
+            FileEdit(&'a ai_hist_core::SessionFileEdit),
+        }
+        let mut records: Vec<(Option<i64>, i64, ReplayRecord)> = Vec::new();
         for event in &events {
-            lines.push((
-                Some(event.ts_ms),
-                event.id,
-                serde_json::to_string(&json!({ "type": "event", "record": event }))?,
-            ));
+            records.push((Some(event.ts_ms), event.id, ReplayRecord::Event(event)));
         }
         for call in &tool_calls {
-            lines.push((
-                call.ts_ms,
-                call.id,
-                serde_json::to_string(&json!({ "type": "tool_call", "record": call }))?,
-            ));
+            records.push((call.ts_ms, call.id, ReplayRecord::ToolCall(call)));
         }
         for edit in &file_edits {
-            lines.push((
-                edit.ts_ms,
-                edit.id,
-                serde_json::to_string(&json!({ "type": "file_edit", "record": edit }))?,
-            ));
+            records.push((edit.ts_ms, edit.id, ReplayRecord::FileEdit(edit)));
         }
-        lines.sort_by_key(|(ts, id, _)| (ts.is_none(), ts.unwrap_or(0), *id));
-        for (_, _, line) in lines {
+        records.sort_by_key(|(ts, id, _)| (ts.is_none(), ts.unwrap_or(0), *id));
+        for (_, _, record) in records {
+            let line = match record {
+                ReplayRecord::Event(event) => {
+                    serde_json::to_string(&json!({ "type": "event", "record": event }))?
+                }
+                ReplayRecord::ToolCall(call) => {
+                    serde_json::to_string(&json!({ "type": "tool_call", "record": call }))?
+                }
+                ReplayRecord::FileEdit(edit) => {
+                    serde_json::to_string(&json!({ "type": "file_edit", "record": edit }))?
+                }
+            };
             println!("{line}");
         }
         return Ok(());

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -49,6 +49,15 @@ pub struct SyncPushOutcome {
     pub sync_skipped: bool,
 }
 
+/// Refresh local agent history without performing any cloud operation.
+/// Embedding applications should use this before opening the local catalog.
+pub fn sync_local() -> Result<()> {
+    SYNC_QUIET.store(true, AtomicOrdering::Relaxed);
+    let db_path = default_db_path();
+    let conn = open_db(&db_path)?;
+    sync_basic(&conn, &db_path)
+}
+
 /// Sync local agent history into the DB, then push new records to
 /// relayhistory-cloud — the in-process equivalent of `ai-hist sync && ai-hist
 /// push`, with sync progress output suppressed. This is the entry point the
@@ -3938,14 +3947,14 @@ fn sync_jsonl_incremental(
 
 fn sync_codex(conn: &Connection, state: &mut Map<String, Value>, home: &Path) -> Result<usize> {
     let (cwds, branches) = build_codex_session_maps(state, home)?;
+    let mut inserted = sync_codex_rollout_prompts(conn, state, home)?;
     let path = home.join(".codex/history.jsonl");
     if !path.exists() {
         sync_note!("  [codex] not found: {} (skipped)", path.display());
-        return Ok(0);
+        return Ok(inserted);
     }
     let size = path.metadata()?.len();
     let offset = state.get("codex").and_then(Value::as_u64).unwrap_or(0);
-    let mut inserted = 0;
     let mut errors = 0;
     if offset < size {
         sync_note!("  [codex] syncing {} new bytes...", size - offset);
@@ -3989,6 +3998,108 @@ fn sync_codex(conn: &Connection, state: &mut Map<String, Value>, home: &Path) ->
         sync_note!("  [codex] {}", parts.join(", "));
     }
     Ok(inserted)
+}
+
+/// Codex Desktop records complete conversations in rollout JSONL files but does
+/// not mirror those prompts into `~/.codex/history.jsonl`. Import user turns
+/// here so desktop and CLI sessions converge on the same normalized history.
+fn sync_codex_rollout_prompts(
+    conn: &Connection,
+    state: &mut Map<String, Value>,
+    home: &Path,
+) -> Result<usize> {
+    let mut seen = state
+        .get("codex_rollout_user_messages_v2")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let mut inserted = 0;
+    let mut scanned = 0;
+    for root in [
+        home.join(".codex/sessions"),
+        home.join(".codex/archived_sessions"),
+    ] {
+        if !root.exists() {
+            continue;
+        }
+        for rollout in collect_matching_files(&root, "rollout-", "jsonl")? {
+            let key = rollout.to_string_lossy().to_string();
+            let stamp = file_stamp(&rollout)?;
+            if seen.get(&key).and_then(Value::as_str) == Some(stamp.as_str()) {
+                continue;
+            }
+            let Some((session_id, cwd, _)) = read_codex_session_meta(&rollout)? else {
+                seen.insert(key, json!(stamp));
+                continue;
+            };
+            scanned += 1;
+            let file = fs::File::open(&rollout)?;
+            for line in BufReader::new(file).lines() {
+                let Ok(line) = line else { continue };
+                let Ok(value) = serde_json::from_str::<Value>(&line) else {
+                    continue;
+                };
+                let timestamp_ms = value
+                    .get("timestamp")
+                    .and_then(Value::as_str)
+                    .and_then(parse_iso_ms)
+                    .unwrap_or(0);
+                for prompt in codex_rollout_user_prompts(&value) {
+                    if is_codex_control_context(&prompt) {
+                        continue;
+                    }
+                    inserted += insert_history(
+                        conn,
+                        &HistoryEntry {
+                            id: 0,
+                            source: "codex".into(),
+                            session_id: Some(session_id.clone()),
+                            project: Some(cwd.clone()),
+                            prompt_hash: Some(prompt_hash(&prompt)),
+                            prompt,
+                            timestamp_ms,
+                        },
+                    )?;
+                }
+            }
+            seen.insert(key, json!(stamp));
+        }
+    }
+    state.insert("codex_rollout_user_messages_v2".to_string(), Value::Object(seen));
+    if scanned > 0 {
+        sync_note!("  [codex-rollouts] scanned {scanned} files; +{inserted} rows");
+    }
+    Ok(inserted)
+}
+
+fn codex_rollout_user_prompts(value: &Value) -> Vec<String> {
+    let mut prompts = Vec::new();
+    let payload = value.get("payload").and_then(Value::as_object);
+    if value.get("type").and_then(Value::as_str) == Some("event_msg")
+        && payload.and_then(|p| p.get("type")).and_then(Value::as_str) == Some("user_message")
+    {
+        if let Some(message) = payload
+            .and_then(|p| p.get("message"))
+            .and_then(Value::as_str)
+        {
+            if !message.trim().is_empty() {
+                prompts.push(message.trim().to_string());
+            }
+        }
+    }
+    prompts
+}
+
+fn is_codex_control_context(prompt: &str) -> bool {
+    let value = prompt.trim_start();
+    [
+        "<environment_context",
+        "<permissions instructions",
+        "<app-context",
+        "<skills_instructions",
+    ]
+    .iter()
+    .any(|prefix| value.starts_with(prefix))
 }
 
 fn build_codex_session_maps(
@@ -5774,19 +5885,48 @@ fn home_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::{
-        checkpoint_sync_state, cleanup_stale_sync_state_temps, cron_schedule, file_stamp,
-        git_commit_time_ms, git_stdout, ingest_claude_transcript, is_sqlite_contention,
-        link_git_commit, load_sync_state, parse_trajectory_file, paths_overlap,
-        prepare_sync_and_push_db, process_status_with_programs, save_sync_state, search_all,
-        service_command_args, shell_single_quote, source_database_path, strip_url_credentials,
-        sync_claude_session_metadata, sync_exclusive, sync_opencode_exclusive,
-        try_acquire_sync_lock, wal_contention_line, write_contention_diagnostic, xml_escape,
-        SearchRole, SyncSourceReport, PUSH_SERVICE, WAL_WARN_BYTES,
+        checkpoint_sync_state, cleanup_stale_sync_state_temps, codex_rollout_user_prompts,
+        cron_schedule, file_stamp, git_commit_time_ms, git_stdout, ingest_claude_transcript,
+        is_sqlite_contention, link_git_commit, load_sync_state, parse_trajectory_file,
+        paths_overlap, prepare_sync_and_push_db, process_status_with_programs, save_sync_state,
+        search_all, service_command_args, shell_single_quote, source_database_path,
+        strip_url_credentials, sync_claude_session_metadata, sync_exclusive,
+        sync_opencode_exclusive, try_acquire_sync_lock, wal_contention_line,
+        write_contention_diagnostic, xml_escape, SearchRole, SyncSourceReport, PUSH_SERVICE,
+        WAL_WARN_BYTES,
     };
     use ai_hist_core::{init_db, open_db, QueryFilter, SourceDatabaseError};
     use rusqlite::Connection;
     use serde_json::{json, Map, Value};
     use std::fs;
+
+    #[test]
+    fn codex_rollout_prompts_normalize_desktop_user_turns() {
+        let event = json!({
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "  fix the importer  "}
+        });
+        assert_eq!(codex_rollout_user_prompts(&event), vec!["fix the importer"]);
+
+        let mirrored_response_item = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "summarize this task"},
+                    {"type": "image", "url": "ignored"}
+                ]
+            }
+        });
+        assert!(codex_rollout_user_prompts(&mirrored_response_item).is_empty());
+
+        let assistant = json!({
+            "type": "response_item",
+            "payload": {"type": "message", "role": "assistant", "content": "ignored"}
+        });
+        assert!(codex_rollout_user_prompts(&assistant).is_empty());
+    }
 
     #[test]
     fn cron_schedule_maps_intervals_to_step_expressions() {

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-20
+
+### Added
+
+- `getSessionEvents(sessionId, { source? })` — the normalized transcript for one
+  session from the `session_events` table: user/assistant text, thinking, tool
+  calls, and tool results in order, with parsed per-event token usage
+  (`tokenUsage`). Returns `[]` on databases that predate the table and in JSONL
+  fallback mode. On large databases prefer streaming from the native CLI
+  (`ai-hist events <session-id> --json`); this SDK loads the whole file into
+  memory.
+- `getToolCalls(sessionId, { source? })` — the session's `tool_calls` rows with
+  typed `isError`.
+- `SessionEvent` and `SessionToolCall` types.
+
 ## [0.4.1] - 2026-07-07
 
 ### Added

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -85,6 +85,8 @@ hist.projectScope: string | undefined
 hist.recent(opts?): HistoryEntry[]            // newest prompts first
 hist.listSessions(opts?): SessionSummary[]    // grouped by session_id, last activity DESC
 hist.getSession(sessionId): HistoryEntry[]    // all prompts in a session, oldest first
+hist.getSessionEvents(sessionId): SessionEvent[] // full transcript: text, thinking, tool calls/results, token usage
+hist.getToolCalls(sessionId): SessionToolCall[]  // the session's tool invocations
 hist.getEntry(id): HistoryEntry | null
 hist.getInTimeWindow(timestampMs, windowMs): HistoryEntry[]
 hist.search(query, opts?): HistoryEntry[]     // literal substring search, recent matches first

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-hist",
-  "version": "0.3.2",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-hist",
-      "version": "0.3.2",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-hist",
-  "version": "0.4.1",
-  "description": "TypeScript SDK and MCP server for AI coding agent session history — Claude Code, Codex, Cursor, Grok, and Agent Relay in one searchable index. Works with or without ai-hist sync via automatic JSONL fallback.",
+  "version": "0.5.0",
+  "description": "TypeScript SDK and MCP server for AI coding agent session history \u2014 Claude Code, Codex, Cursor, Grok, and Agent Relay in one searchable index. Works with or without ai-hist sync via automatic JSONL fallback.",
   "license": "MIT",
   "private": false,
   "type": "module",

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -97,6 +97,46 @@ export interface SessionSummary {
   promptCount: number;
 }
 
+/**
+ * One normalized transcript event from the `session_events` table: user and
+ * assistant text, thinking, tool calls, and tool results, in order.
+ * `tokenUsage` is the parsed `token_json` blob — Claude's per-message
+ * `usage` shape, or a Codex per-request delta (`input_tokens` inclusive of
+ * `cached_input_tokens`). Claude repeats the same usage on every content
+ * block of a message, so sum per distinct `messageId`, not per row.
+ */
+export interface SessionEvent {
+  id: number;
+  source: Source;
+  sessionId: string;
+  project: string | null;
+  cwd: string | null;
+  gitBranch: string | null;
+  messageId: string | null;
+  parentId: string | null;
+  tsMs: number;
+  role: 'user' | 'assistant' | 'tool_result';
+  kind: 'text' | 'thinking' | 'tool_use' | 'tool_result';
+  text: string | null;
+  model: string | null;
+  tokenUsage: Record<string, unknown> | null;
+  eventUid: string;
+}
+
+/** One tool invocation from the `tool_calls` table. */
+export interface SessionToolCall {
+  id: number;
+  source: Source;
+  sessionId: string;
+  messageId: string | null;
+  toolUseId: string;
+  name: string;
+  target: string | null;
+  argsJson: string | null;
+  isError: boolean | null;
+  tsMs: number | null;
+}
+
 export interface ListOptions {
   source?: Source;
   project?: string;
@@ -642,6 +682,26 @@ function buildFilters(opts: ListOptions, projectScope?: string): { sql: string; 
   };
 }
 
+function tableExists(db: Database, name: string): boolean {
+  return (
+    runQuery<{ c: number }>(
+      db,
+      "SELECT COUNT(*) AS c FROM sqlite_master WHERE type = 'table' AND name = ?",
+      [name],
+    )[0]?.c > 0
+  );
+}
+
+function parseTokenJson(raw: string | null): Record<string, unknown> | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
+}
+
 function runQuery<T>(db: Database, sql: string, params: unknown[]): T[] {
   const stmt = db.prepare(sql);
   try {
@@ -980,6 +1040,110 @@ export class AiHist {
        ORDER BY timestamp_ms ASC`,
       params,
     ).map(rowToEntry);
+  }
+
+  /**
+   * All normalized events for a session, oldest first — messages, thinking,
+   * tool calls, and tool results with per-event token usage where the
+   * transcript provides it. Returns `[]` when the database predates the
+   * `session_events` table (or in JSONL fallback mode, which has no events).
+   *
+   * Size caveat: this SDK loads the whole database file into memory, so on
+   * large event-bearing databases prefer streaming from the native CLI
+   * (`ai-hist events <session-id> --json`).
+   */
+  getSessionEvents(sessionId: string, opts: { source?: Source } = {}): SessionEvent[] {
+    if (!tableExists(this.db, 'session_events')) return [];
+    const clauses = ['session_id = ?'];
+    const params: unknown[] = [sessionId];
+    if (opts.source) {
+      clauses.push('source = ?');
+      params.push(opts.source);
+    }
+    interface RawEventRow {
+      id: number;
+      source: Source;
+      session_id: string;
+      project: string | null;
+      cwd: string | null;
+      git_branch: string | null;
+      message_id: string | null;
+      parent_id: string | null;
+      ts_ms: number;
+      role: SessionEvent['role'];
+      kind: SessionEvent['kind'];
+      text: string | null;
+      model: string | null;
+      token_json: string | null;
+      event_uid: string;
+    }
+    return runQuery<RawEventRow>(
+      this.db,
+      `SELECT id, source, session_id, project, cwd, git_branch, message_id, parent_id,
+              ts_ms, role, kind, text, model, token_json, event_uid
+       FROM session_events
+       WHERE ${clauses.join(' AND ')}
+       ORDER BY ts_ms ASC, id ASC`,
+      params,
+    ).map((row) => ({
+      id: row.id,
+      source: row.source,
+      sessionId: row.session_id,
+      project: row.project,
+      cwd: row.cwd,
+      gitBranch: row.git_branch,
+      messageId: row.message_id,
+      parentId: row.parent_id,
+      tsMs: row.ts_ms,
+      role: row.role,
+      kind: row.kind,
+      text: row.text,
+      model: row.model,
+      tokenUsage: parseTokenJson(row.token_json),
+      eventUid: row.event_uid,
+    }));
+  }
+
+  /** All tool calls for a session, oldest first; `[]` on pre-events databases. */
+  getToolCalls(sessionId: string, opts: { source?: Source } = {}): SessionToolCall[] {
+    if (!tableExists(this.db, 'tool_calls')) return [];
+    const clauses = ['session_id = ?'];
+    const params: unknown[] = [sessionId];
+    if (opts.source) {
+      clauses.push('source = ?');
+      params.push(opts.source);
+    }
+    interface RawToolCallRow {
+      id: number;
+      source: Source;
+      session_id: string;
+      message_id: string | null;
+      tool_use_id: string;
+      name: string;
+      target: string | null;
+      args_json: string | null;
+      is_error: number | null;
+      ts_ms: number | null;
+    }
+    return runQuery<RawToolCallRow>(
+      this.db,
+      `SELECT id, source, session_id, message_id, tool_use_id, name, target, args_json, is_error, ts_ms
+       FROM tool_calls
+       WHERE ${clauses.join(' AND ')}
+       ORDER BY ts_ms ASC, id ASC`,
+      params,
+    ).map((row) => ({
+      id: row.id,
+      source: row.source,
+      sessionId: row.session_id,
+      messageId: row.message_id,
+      toolUseId: row.tool_use_id,
+      name: row.name,
+      target: row.target,
+      argsJson: row.args_json,
+      isError: row.is_error === null ? null : row.is_error !== 0,
+      tsMs: row.ts_ms,
+    }));
   }
 
   /**

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -1060,6 +1060,7 @@ export class AiHist {
       clauses.push('source = ?');
       params.push(opts.source);
     }
+    appendProjectFilter(clauses, params, undefined, this._projectScope);
     interface RawEventRow {
       id: number;
       source: Source;
@@ -1083,7 +1084,7 @@ export class AiHist {
               ts_ms, role, kind, text, model, token_json, event_uid
        FROM session_events
        WHERE ${clauses.join(' AND ')}
-       ORDER BY ts_ms ASC, id ASC`,
+       ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC`,
       params,
     ).map((row) => ({
       id: row.id,
@@ -1113,6 +1114,17 @@ export class AiHist {
       clauses.push('source = ?');
       params.push(opts.source);
     }
+    // tool_calls has no project column; the configured scope constrains
+    // through the session's events.
+    if (this._projectScope) {
+      const scope = scopedPathClause('e.project', this._projectScope);
+      clauses.push(
+        `EXISTS (SELECT 1 FROM session_events e
+                 WHERE e.source = tool_calls.source AND e.session_id = tool_calls.session_id
+                   AND ${scope.sql})`,
+      );
+      params.push(...scope.params);
+    }
     interface RawToolCallRow {
       id: number;
       source: Source;
@@ -1130,7 +1142,7 @@ export class AiHist {
       `SELECT id, source, session_id, message_id, tool_use_id, name, target, args_json, is_error, ts_ms
        FROM tool_calls
        WHERE ${clauses.join(' AND ')}
-       ORDER BY ts_ms ASC, id ASC`,
+       ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC`,
       params,
     ).map((row) => ({
       id: row.id,

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -1115,8 +1115,10 @@ export class AiHist {
       params.push(opts.source);
     }
     // tool_calls has no project column; the configured scope constrains
-    // through the session's events.
+    // through the session's events. Without that table the scoped answer is
+    // unknowable — fail closed rather than throw.
     if (this._projectScope) {
+      if (!tableExists(this.db, 'session_events')) return [];
       const scope = scopedPathClause('e.project', this._projectScope);
       clauses.push(
         `EXISTS (SELECT 1 FROM session_events e

--- a/sdk-ts/src/session-events.test.ts
+++ b/sdk-ts/src/session-events.test.ts
@@ -70,6 +70,11 @@ async function writeEventsFixtureDb(dbPath: string): Promise<void> {
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       ['codex', 'sess-1', 'fc_1', 'call_1', 'exec_command', 'git status', '{"cmd":"git status"}', 0, 2000],
     );
+    db.run(
+      `INSERT INTO tool_calls (source, session_id, message_id, tool_use_id, name, target, args_json, is_error, ts_ms)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ['claude', 'sess-other', 'msg_1', 'toolu_1', 'Bash', 'ls', '{"command":"ls"}', null, 1500],
+    );
     await writeFile(dbPath, Buffer.from(db.export()));
   } finally {
     db.close();
@@ -154,6 +159,7 @@ test('a configured project scope constrains event and tool-call reads', async ()
       assert.deepEqual(scoped.getToolCalls('sess-1'), []);
       // sess-other lives in /tmp/other — inside it.
       assert.equal(scoped.getSessionEvents('sess-other').length, 1);
+      assert.equal(scoped.getToolCalls('sess-other').length, 1);
     } finally {
       scoped.close();
     }

--- a/sdk-ts/src/session-events.test.ts
+++ b/sdk-ts/src/session-events.test.ts
@@ -142,6 +142,26 @@ test('getSessionEvents returns ordered typed events with parsed token usage', as
   }
 });
 
+test('a configured project scope constrains event and tool-call reads', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'ai-hist-events-scope-'));
+  const dbPath = join(dir, 'events.db');
+  try {
+    await writeEventsFixtureDb(dbPath);
+    const scoped = await openAiHist({ dbPath, projectScope: '/tmp/other' });
+    try {
+      // sess-1 lives in /tmp/proj — outside the scope.
+      assert.deepEqual(scoped.getSessionEvents('sess-1'), []);
+      assert.deepEqual(scoped.getToolCalls('sess-1'), []);
+      // sess-other lives in /tmp/other — inside it.
+      assert.equal(scoped.getSessionEvents('sess-other').length, 1);
+    } finally {
+      scoped.close();
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test('events reads return [] on databases that predate session_events', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'ai-hist-preevents-'));
   const dbPath = join(dir, 'old.db');

--- a/sdk-ts/src/session-events.test.ts
+++ b/sdk-ts/src/session-events.test.ts
@@ -1,0 +1,161 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import initSqlJs from 'sql.js';
+import { openAiHist } from './index.js';
+
+async function writeEventsFixtureDb(dbPath: string): Promise<void> {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  try {
+    db.run(`CREATE TABLE history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source TEXT NOT NULL,
+      session_id TEXT,
+      project TEXT,
+      prompt TEXT NOT NULL,
+      timestamp_ms INTEGER NOT NULL,
+      git_branch TEXT
+    )`);
+    db.run(`CREATE TABLE session_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      project TEXT,
+      cwd TEXT,
+      git_branch TEXT,
+      message_id TEXT,
+      parent_id TEXT,
+      ts_ms INTEGER NOT NULL,
+      role TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      text TEXT,
+      model TEXT,
+      token_json TEXT,
+      event_uid TEXT NOT NULL
+    )`);
+    db.run(`CREATE TABLE tool_calls (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      message_id TEXT,
+      tool_use_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      target TEXT,
+      args_json TEXT,
+      is_error INTEGER,
+      ts_ms INTEGER
+    )`);
+    const insertEvent = `INSERT INTO session_events
+      (source, session_id, project, cwd, git_branch, message_id, parent_id, ts_ms, role, kind, text, model, token_json, event_uid)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+    db.run(insertEvent, [
+      'codex', 'sess-1', '/tmp/proj', '/tmp/proj', 'main', '4:user_message', null,
+      1000, 'user', 'text', 'fix the importer', null, null, '4:user_message',
+    ]);
+    db.run(insertEvent, [
+      'codex', 'sess-1', '/tmp/proj', '/tmp/proj', 'main', 'fc_1', null,
+      2000, 'assistant', 'tool_use', 'exec_command git status', 'gpt-5.4',
+      '{"input_tokens":1000,"cached_input_tokens":400,"output_tokens":120,"total_tokens":1120}',
+      '8:function_call',
+    ]);
+    db.run(insertEvent, [
+      'claude', 'sess-other', '/tmp/other', '/tmp/other', null, 'msg_1', null,
+      1500, 'assistant', 'text', 'unrelated session', 'claude-opus-5', 'not json', 'msg_1:0',
+    ]);
+    db.run(
+      `INSERT INTO tool_calls (source, session_id, message_id, tool_use_id, name, target, args_json, is_error, ts_ms)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ['codex', 'sess-1', 'fc_1', 'call_1', 'exec_command', 'git status', '{"cmd":"git status"}', 0, 2000],
+    );
+    await writeFile(dbPath, Buffer.from(db.export()));
+  } finally {
+    db.close();
+  }
+}
+
+async function writePreEventsDb(dbPath: string): Promise<void> {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  try {
+    db.run(`CREATE TABLE history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      source TEXT NOT NULL,
+      session_id TEXT,
+      project TEXT,
+      prompt TEXT NOT NULL,
+      timestamp_ms INTEGER NOT NULL,
+      git_branch TEXT
+    )`);
+    db.run(
+      `INSERT INTO history (source, session_id, project, prompt, timestamp_ms) VALUES (?, ?, ?, ?, ?)`,
+      ['codex', 'sess-1', '/tmp/proj', 'hello', 1000],
+    );
+    await writeFile(dbPath, Buffer.from(db.export()));
+  } finally {
+    db.close();
+  }
+}
+
+test('getSessionEvents returns ordered typed events with parsed token usage', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'ai-hist-events-'));
+  const dbPath = join(dir, 'events.db');
+  try {
+    await writeEventsFixtureDb(dbPath);
+    const hist = await openAiHist({ dbPath });
+    try {
+      const events = hist.getSessionEvents('sess-1');
+      assert.equal(events.length, 2);
+      assert.deepEqual(
+        events.map((e) => e.eventUid),
+        ['4:user_message', '8:function_call'],
+      );
+      assert.equal(events[0]!.role, 'user');
+      assert.equal(events[0]!.tokenUsage, null);
+      assert.equal(events[1]!.kind, 'tool_use');
+      assert.equal(events[1]!.model, 'gpt-5.4');
+      assert.deepEqual(events[1]!.tokenUsage, {
+        input_tokens: 1000,
+        cached_input_tokens: 400,
+        output_tokens: 120,
+        total_tokens: 1120,
+      });
+
+      // Source filter and unparsable token_json.
+      const other = hist.getSessionEvents('sess-other', { source: 'claude' });
+      assert.equal(other.length, 1);
+      assert.equal(other[0]!.tokenUsage, null);
+      assert.equal(hist.getSessionEvents('sess-other', { source: 'codex' }).length, 0);
+
+      const calls = hist.getToolCalls('sess-1');
+      assert.equal(calls.length, 1);
+      assert.equal(calls[0]!.name, 'exec_command');
+      assert.equal(calls[0]!.target, 'git status');
+      assert.equal(calls[0]!.isError, false);
+    } finally {
+      hist.close();
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('events reads return [] on databases that predate session_events', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'ai-hist-preevents-'));
+  const dbPath = join(dir, 'old.db');
+  try {
+    await writePreEventsDb(dbPath);
+    const hist = await openAiHist({ dbPath });
+    try {
+      assert.deepEqual(hist.getSessionEvents('sess-1'), []);
+      assert.deepEqual(hist.getToolCalls('sess-1'), []);
+      assert.equal(hist.getSession('sess-1').length, 1);
+    } finally {
+      hist.close();
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What this is

Codex sessions now carry the same transcript fidelity as Claude, and there is a per-session events read surface on every layer.

**Rust sync** — one walk over `~/.codex/sessions` + `archived_sessions` writes, per rollout file:
- messages (`event_msg` stream only — `response_item/message` rows are duplicates), reasoning (`agent_reasoning`; `response_item/reasoning` is encrypted), tool calls (`response_item` rows correlated by `call_id`), tool results, MCP/web-search calls, and `apply_patch` file edits with line counts, into `session_events` / `tool_calls` / `file_edits`
- per-request token deltas: cumulative `token_count` snapshots are diffed under a strict-advance guard (Codex re-emits identical snapshots) and attached to the nearest assistant event — summing `token_json` over a session reproduces the file's final totals exactly, verified to the token on 372 MB of real rollouts
- a leading snapshot before any model output is a resumed session's carried baseline; a trailing line without its newline is a live session's half-written tail and is left for the next sync
- sessions key on `session_meta.payload.id` (the thread id); subagent threads keep their events but stay out of the `sessions` table; `git.branch` and `task_complete.last_agent_message` populate session metadata that was always NULL for Codex
- the split rollout walks and their two stamp maps consolidate into one pass with one state key (`codex_rollouts_v3`) whose records carry the session id, so a wiped database re-ingests even when stamps match

**CLI** — `ai-hist events <session-id> [--source S] [--json]` replays one session's normalized events, tool calls, and file edits, readable or as JSON lines. This is the P1.6 "session replay" primitive from docs/substrate-improvements-proposal.md.

**sdk-ts 0.5.0** — `getSessionEvents()` / `getToolCalls()` with parsed per-event token usage; `[]` on pre-events databases and in JSONL fallback. Docs steer large-database consumers to the CLI stream because the SDK loads the whole file into memory (#64 tracks that separately).

The first commit lands the previously uncommitted local rollout-prompt sync from the primary checkout, rebased onto main.

Covers the Codex half of #40. Event/tool/edit inserters take `source` as a parameter instead of hardcoding `'claude'`.

## Verification

- 84 Rust lib tests (5 new: rich-rollout ingestion, idempotent re-ingest, resumed-baseline token math, torn-tail handling, subagent exclusion + state-key migration) and 17 sdk-ts tests pass
- Synced 4 real rollout files (372 MB, incl. one subagent thread) into a scratch DB: 4,598 events, 558+ tool calls, 414 file edits; token delta sums equal final cumulative totals exactly for every session; `ai-hist events --json` streams 1,766 typed records for one of them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

