### PR TITLE
fix(sync): make JSONL cursors rotation and partial-write safe

### DIFF
--- a/ai-hist-python
+++ b/ai-hist-python
@@ -141,7 +141,7 @@ def _open_sync_cursor(path: Path, value):
     }
 
 
-def _commit_sync_cursor(path: Path, opened: dict, offset: int):
+def _commit_sync_cursor(path: Path, opened: dict, offset: int, consumed_prefix_hash=None):
     """Revalidate the starting prefix before publishing committed progress."""
     stat = path.stat()
     generation = opened["generation"]
@@ -164,7 +164,13 @@ def _commit_sync_cursor(path: Path, opened: dict, offset: int):
         return _new_sync_cursor(stat, epoch)
 
     committed_hash = _hash_file_prefix(path, offset)
-    if committed_hash is None:
+    if (
+        committed_hash is None
+        or (
+            consumed_prefix_hash is not None
+            and committed_hash != consumed_prefix_hash
+        )
+    ):
         epoch = _sync_offset(generation.get("rewrite_epoch", 0)) + 1
         return _new_sync_cursor(stat, epoch)
     return {
@@ -176,14 +182,26 @@ def _commit_sync_cursor(path: Path, opened: dict, offset: int):
 
 
 def _complete_jsonl_lines(path: Path, offset: int):
-    """Yield decoded complete records and their committed byte offsets."""
+    """Yield complete records, offsets, and hashes of the bytes consumed."""
     with open(path, "rb") as source:
-        source.seek(offset)
+        digest = hashlib.sha256()
+        remaining = offset
+        while remaining:
+            chunk = source.read(min(64 * 1024, remaining))
+            if not chunk:
+                return
+            digest.update(chunk)
+            remaining -= len(chunk)
         while True:
             raw = source.readline()
             if not raw or not raw.endswith(b"\n"):
                 return
-            yield raw.decode("utf-8", errors="replace"), source.tell()
+            digest.update(raw)
+            yield (
+                raw.decode("utf-8", errors="replace"),
+                source.tell(),
+                digest.hexdigest(),
+            )
 
 # --- Schema ------------------------------------------------------------------
 
@@ -807,13 +825,15 @@ def sync_codex(conn: sqlite3.Connection, state: dict):
     file_size = path.stat().st_size
     offset = _sync_offset(opened_cursor)
     committed_offset = offset
+    consumed_prefix_hash = opened_cursor["prefix_hash"]
     inserted = 0
     errors = 0
 
     if offset < file_size:
         print(f"  [codex] syncing {file_size - offset:,} new bytes...")
-        for line, line_end in _complete_jsonl_lines(path, offset):
+        for line, line_end, line_hash in _complete_jsonl_lines(path, offset):
             committed_offset = line_end
+            consumed_prefix_hash = line_hash
             line = line.strip()
             if not line:
                 continue
@@ -841,7 +861,9 @@ def sync_codex(conn: sqlite3.Connection, state: dict):
             except sqlite3.Error:
                 errors += 1
         conn.commit()
-    state["codex"] = _commit_sync_cursor(path, opened_cursor, committed_offset)
+    state["codex"] = _commit_sync_cursor(
+        path, opened_cursor, committed_offset, consumed_prefix_hash
+    )
 
     backfilled = _backfill_codex_projects(conn, cwds, branches)
 
@@ -916,19 +938,19 @@ def sync_cursor(conn: sqlite3.Connection, state: dict):
             files_seen += 1
             try:
                 stat = jsonl.stat()
-            except OSError:
-                errors += 1
-                continue
-            opened_cursor = _open_sync_cursor(jsonl, cursor_state.get(str(jsonl), 0))
-            offset = _sync_offset(opened_cursor)
-            if offset >= stat.st_size:
-                cursor_state[str(jsonl)] = _commit_sync_cursor(jsonl, opened_cursor, offset)
-                continue
-            ts_ms = int(stat.st_mtime * 1000)
-            committed_offset = offset
-            try:
-                for line, line_end in _complete_jsonl_lines(jsonl, offset):
+                opened_cursor = _open_sync_cursor(jsonl, cursor_state.get(str(jsonl), 0))
+                offset = _sync_offset(opened_cursor)
+                consumed_prefix_hash = opened_cursor["prefix_hash"]
+                if offset >= stat.st_size:
+                    cursor_state[str(jsonl)] = _commit_sync_cursor(
+                        jsonl, opened_cursor, offset, consumed_prefix_hash
+                    )
+                    continue
+                ts_ms = int(stat.st_mtime * 1000)
+                committed_offset = offset
+                for line, line_end, line_hash in _complete_jsonl_lines(jsonl, offset):
                     committed_offset = line_end
+                    consumed_prefix_hash = line_hash
                     line = line.strip()
                     if not line:
                         continue
@@ -950,12 +972,12 @@ def sync_cursor(conn: sqlite3.Connection, state: dict):
                             inserted += 1
                     except sqlite3.Error:
                         errors += 1
+                cursor_state[str(jsonl)] = _commit_sync_cursor(
+                    jsonl, opened_cursor, committed_offset, consumed_prefix_hash
+                )
             except OSError:
                 errors += 1
                 continue
-            cursor_state[str(jsonl)] = _commit_sync_cursor(
-                jsonl, opened_cursor, committed_offset
-            )
 
     conn.commit()
     state["cursor"] = cursor_state
@@ -1635,7 +1657,9 @@ def cmd_sync(args=None):
         file_size = path.stat().st_size
         offset = _sync_offset(opened_cursor)
         if offset >= file_size:
-            state[name] = _commit_sync_cursor(path, opened_cursor, offset)
+            state[name] = _commit_sync_cursor(
+                path, opened_cursor, offset, opened_cursor["prefix_hash"]
+            )
             print(f"  [{name}] up to date")
             continue
 
@@ -1645,8 +1669,10 @@ def cmd_sync(args=None):
         errors = 0
 
         committed_offset = offset
-        for line, line_end in _complete_jsonl_lines(path, offset):
+        consumed_prefix_hash = opened_cursor["prefix_hash"]
+        for line, line_end, line_hash in _complete_jsonl_lines(path, offset):
             committed_offset = line_end
+            consumed_prefix_hash = line_hash
             line = line.strip()
             if not line:
                 continue
@@ -1670,7 +1696,9 @@ def cmd_sync(args=None):
                 errors += 1
 
         conn.commit()
-        state[name] = _commit_sync_cursor(path, opened_cursor, committed_offset)
+        state[name] = _commit_sync_cursor(
+            path, opened_cursor, committed_offset, consumed_prefix_hash
+        )
         print(f"  [{name}] +{inserted:,} rows" + (f" ({errors} errors)" if errors else ""))
 
     # Sync Claude per-session JSONL files for gitBranch + last assistant text

--- a/ai-hist-python
+++ b/ai-hist-python
@@ -58,6 +58,133 @@ def _sync_offset(value) -> int:
     except (TypeError, ValueError):
         return 0
 
+
+def _file_identity(stat):
+    """Return the stable file identity fields used by Rust cursors."""
+    return getattr(stat, "st_dev", None), getattr(stat, "st_ino", None)
+
+
+def _hash_file_prefix(path: Path, offset: int):
+    """Hash exactly offset bytes, requiring the offset to end at a newline."""
+    remaining = offset
+    digest = hashlib.sha256()
+    last = None
+    try:
+        with open(path, "rb") as source:
+            while remaining:
+                chunk = source.read(min(64 * 1024, remaining))
+                if not chunk:
+                    return None
+                digest.update(chunk)
+                last = chunk[-1]
+                remaining -= len(chunk)
+    except OSError:
+        return None
+    if offset and last != ord("\n"):
+        return None
+    return digest.hexdigest()
+
+
+def _new_sync_cursor(stat, rewrite_epoch=0):
+    device, inode = _file_identity(stat)
+    observed_at_ns = time.time_ns()
+    return {
+        "offset": 0,
+        "generation": {
+            "device": device,
+            "inode": inode,
+            "started_mtime_ns": stat.st_mtime_ns,
+            "started_size": stat.st_size,
+            "observed_at_ns": observed_at_ns,
+            "rewrite_epoch": rewrite_epoch,
+        },
+        "observed_mtime_ns": stat.st_mtime_ns,
+        "prefix_hash": hashlib.sha256(b"").hexdigest(),
+    }
+
+
+def _open_sync_cursor(path: Path, value):
+    """Validate a Rust-compatible cursor, safely upgrading legacy offsets."""
+    stat = path.stat()
+    if not isinstance(value, dict) or not isinstance(value.get("generation"), dict):
+        # Numeric cursors have no file identity. Rescan once while upgrading;
+        # history inserts are idempotent, so this cannot duplicate rows.
+        return _new_sync_cursor(stat)
+
+    saved_offset = _sync_offset(value)
+    generation = value["generation"]
+    device, inode = _file_identity(stat)
+    saved_device = generation.get("device")
+    saved_inode = generation.get("inode")
+    identity_changed = (
+        saved_device is not None
+        and device is not None
+        and (saved_device, saved_inode) != (device, inode)
+    )
+    prefix_hash = _hash_file_prefix(path, saved_offset)
+    replaced = (
+        identity_changed
+        or stat.st_size < saved_offset
+        or stat.st_mtime_ns < _sync_offset(value.get("observed_mtime_ns", 0))
+        or prefix_hash is None
+        or prefix_hash != value.get("prefix_hash")
+    )
+    if replaced:
+        epoch = _sync_offset(generation.get("rewrite_epoch", 0)) + 1
+        return _new_sync_cursor(stat, epoch)
+
+    return {
+        "offset": saved_offset,
+        "generation": dict(generation),
+        "observed_mtime_ns": stat.st_mtime_ns,
+        "prefix_hash": prefix_hash,
+    }
+
+
+def _commit_sync_cursor(path: Path, opened: dict, offset: int):
+    """Revalidate the starting prefix before publishing committed progress."""
+    stat = path.stat()
+    generation = opened["generation"]
+    device, inode = _file_identity(stat)
+    expected = generation.get("device"), generation.get("inode")
+    identity_changed = (
+        expected[0] is not None
+        and device is not None
+        and expected != (device, inode)
+    )
+    start_offset = _sync_offset(opened)
+    start_hash = _hash_file_prefix(path, start_offset)
+    if (
+        identity_changed
+        or stat.st_size < start_offset
+        or start_hash is None
+        or start_hash != opened.get("prefix_hash")
+    ):
+        epoch = _sync_offset(generation.get("rewrite_epoch", 0)) + 1
+        return _new_sync_cursor(stat, epoch)
+
+    committed_hash = _hash_file_prefix(path, offset)
+    if committed_hash is None:
+        epoch = _sync_offset(generation.get("rewrite_epoch", 0)) + 1
+        return _new_sync_cursor(stat, epoch)
+    return {
+        "offset": offset,
+        "generation": dict(generation),
+        "observed_mtime_ns": stat.st_mtime_ns,
+        "prefix_hash": committed_hash,
+    }
+
+
+def _complete_jsonl_lines(path: Path, offset: int):
+    """Yield decoded complete records and their committed byte offsets."""
+    with open(path, "rb") as source:
+        source.seek(offset)
+        while True:
+            raw = source.readline()
+            if not raw or not raw.endswith(b"\n"):
+                return
+            yield raw.decode("utf-8", errors="replace"), source.tell()
+
 # --- Schema ------------------------------------------------------------------
 
 SCHEMA = """\
@@ -676,44 +803,45 @@ def sync_codex(conn: sqlite3.Connection, state: dict):
 
     cwds, branches = build_codex_session_map(state)
 
+    opened_cursor = _open_sync_cursor(path, state.get("codex", 0))
     file_size = path.stat().st_size
-    offset = _sync_offset(state.get("codex", 0))
+    offset = _sync_offset(opened_cursor)
+    committed_offset = offset
     inserted = 0
     errors = 0
 
     if offset < file_size:
         print(f"  [codex] syncing {file_size - offset:,} new bytes...")
-        with open(path, "r", encoding="utf-8") as f:
-            f.seek(offset)
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    row = parse_codex(line)
-                except (json.JSONDecodeError, KeyError, TypeError):
-                    errors += 1
-                    continue
-                if row is None:
-                    continue
-                sid = row.get("session_id")
-                if sid:
-                    if not row.get("project"):
-                        row["project"] = cwds.get(sid)
-                    row["git_branch"] = branches.get(sid)
-                try:
-                    cur = conn.execute(
-                        "INSERT OR IGNORE INTO history "
-                        "(source, session_id, project, prompt, prompt_hash, timestamp_ms, git_branch) "
-                        "VALUES (:source, :session_id, :project, :prompt, :prompt_hash, :timestamp_ms, :git_branch)",
-                        row,
-                    )
-                    if cur.rowcount > 0:
-                        inserted += 1
-                except sqlite3.Error:
-                    errors += 1
+        for line, line_end in _complete_jsonl_lines(path, offset):
+            committed_offset = line_end
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = parse_codex(line)
+            except (json.JSONDecodeError, KeyError, TypeError):
+                errors += 1
+                continue
+            if row is None:
+                continue
+            sid = row.get("session_id")
+            if sid:
+                if not row.get("project"):
+                    row["project"] = cwds.get(sid)
+                row["git_branch"] = branches.get(sid)
+            try:
+                cur = conn.execute(
+                    "INSERT OR IGNORE INTO history "
+                    "(source, session_id, project, prompt, prompt_hash, timestamp_ms, git_branch) "
+                    "VALUES (:source, :session_id, :project, :prompt, :prompt_hash, :timestamp_ms, :git_branch)",
+                    row,
+                )
+                if cur.rowcount > 0:
+                    inserted += 1
+            except sqlite3.Error:
+                errors += 1
         conn.commit()
-        state["codex"] = file_size
+    state["codex"] = _commit_sync_cursor(path, opened_cursor, committed_offset)
 
     backfilled = _backfill_codex_projects(conn, cwds, branches)
 
@@ -791,39 +919,43 @@ def sync_cursor(conn: sqlite3.Connection, state: dict):
             except OSError:
                 errors += 1
                 continue
-            offset = _sync_offset(cursor_state.get(str(jsonl), 0))
+            opened_cursor = _open_sync_cursor(jsonl, cursor_state.get(str(jsonl), 0))
+            offset = _sync_offset(opened_cursor)
             if offset >= stat.st_size:
+                cursor_state[str(jsonl)] = _commit_sync_cursor(jsonl, opened_cursor, offset)
                 continue
             ts_ms = int(stat.st_mtime * 1000)
+            committed_offset = offset
             try:
-                with open(jsonl, "r", encoding="utf-8") as f:
-                    f.seek(offset)
-                    for line in f:
-                        line = line.strip()
-                        if not line:
-                            continue
-                        try:
-                            text = parse_cursor_line(line)
-                        except (json.JSONDecodeError, KeyError, TypeError):
-                            errors += 1
-                            continue
-                        if not text:
-                            continue
-                        try:
-                            cur = conn.execute(
-                                "INSERT OR IGNORE INTO history "
-                                "(source, session_id, project, prompt, prompt_hash, timestamp_ms) "
-                                "VALUES (?, ?, ?, ?, ?, ?)",
-                                ("cursor", session_id, project_path, text, _prompt_hash(text), ts_ms),
-                            )
-                            if cur.rowcount > 0:
-                                inserted += 1
-                        except sqlite3.Error:
-                            errors += 1
+                for line, line_end in _complete_jsonl_lines(jsonl, offset):
+                    committed_offset = line_end
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        text = parse_cursor_line(line)
+                    except (json.JSONDecodeError, KeyError, TypeError):
+                        errors += 1
+                        continue
+                    if not text:
+                        continue
+                    try:
+                        cur = conn.execute(
+                            "INSERT OR IGNORE INTO history "
+                            "(source, session_id, project, prompt, prompt_hash, timestamp_ms) "
+                            "VALUES (?, ?, ?, ?, ?, ?)",
+                            ("cursor", session_id, project_path, text, _prompt_hash(text), ts_ms),
+                        )
+                        if cur.rowcount > 0:
+                            inserted += 1
+                    except sqlite3.Error:
+                        errors += 1
             except OSError:
                 errors += 1
                 continue
-            cursor_state[str(jsonl)] = stat.st_size
+            cursor_state[str(jsonl)] = _commit_sync_cursor(
+                jsonl, opened_cursor, committed_offset
+            )
 
     conn.commit()
     state["cursor"] = cursor_state
@@ -1499,9 +1631,11 @@ def cmd_sync(args=None):
             print(f"  [{name}] not found: {path} (skipped)")
             continue
 
+        opened_cursor = _open_sync_cursor(path, state.get(name, 0))
         file_size = path.stat().st_size
-        offset = _sync_offset(state.get(name, 0))
+        offset = _sync_offset(opened_cursor)
         if offset >= file_size:
+            state[name] = _commit_sync_cursor(path, opened_cursor, offset)
             print(f"  [{name}] up to date")
             continue
 
@@ -1510,33 +1644,33 @@ def cmd_sync(args=None):
         inserted = 0
         errors = 0
 
-        with open(path, "r", encoding="utf-8") as f:
-            f.seek(offset)
-            for line in f:
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    row = parser(line)
-                except (json.JSONDecodeError, KeyError, TypeError):
-                    errors += 1
-                    continue
-                if row is None:
-                    continue
-                try:
-                    cur = conn.execute(
-                        "INSERT OR IGNORE INTO history "
-                        "(source, session_id, project, prompt, prompt_hash, timestamp_ms, git_branch) "
-                        "VALUES (:source, :session_id, :project, :prompt, :prompt_hash, :timestamp_ms, :git_branch)",
-                        row,
-                    )
-                    if cur.rowcount > 0:
-                        inserted += 1
-                except sqlite3.Error:
-                    errors += 1
+        committed_offset = offset
+        for line, line_end in _complete_jsonl_lines(path, offset):
+            committed_offset = line_end
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = parser(line)
+            except (json.JSONDecodeError, KeyError, TypeError):
+                errors += 1
+                continue
+            if row is None:
+                continue
+            try:
+                cur = conn.execute(
+                    "INSERT OR IGNORE INTO history "
+                    "(source, session_id, project, prompt, prompt_hash, timestamp_ms, git_branch) "
+                    "VALUES (:source, :session_id, :project, :prompt, :prompt_hash, :timestamp_ms, :git_branch)",
+                    row,
+                )
+                if cur.rowcount > 0:
+                    inserted += 1
+            except sqlite3.Error:
+                errors += 1
 
         conn.commit()
-        state[name] = file_size
+        state[name] = _commit_sync_cursor(path, opened_cursor, committed_offset)
         print(f"  [{name}] +{inserted:,} rows" + (f" ({errors} errors)" if errors else ""))
 
     # Sync Claude per-session JSONL files for gitBranch + last assistant text

--- a/ai-hist-python
+++ b/ai-hist-python
@@ -64,8 +64,8 @@ def _file_identity(stat):
     return getattr(stat, "st_dev", None), getattr(stat, "st_ino", None)
 
 
-def _hash_file_prefix(path: Path, offset: int):
-    """Hash exactly offset bytes, requiring the offset to end at a newline."""
+def _hash_file_prefix_state(path: Path, offset: int):
+    """Build a SHA-256 state for exactly offset newline-terminated bytes."""
     remaining = offset
     digest = hashlib.sha256()
     last = None
@@ -82,13 +82,18 @@ def _hash_file_prefix(path: Path, offset: int):
         return None
     if offset and last != ord("\n"):
         return None
-    return digest.hexdigest()
+    return digest
 
 
-def _new_sync_cursor(stat, rewrite_epoch=0):
+def _hash_file_prefix(path: Path, offset: int):
+    digest = _hash_file_prefix_state(path, offset)
+    return digest.hexdigest() if digest is not None else None
+
+
+def _new_sync_cursor(stat, rewrite_epoch=0, include_hasher=False):
     device, inode = _file_identity(stat)
     observed_at_ns = time.time_ns()
-    return {
+    cursor = {
         "offset": 0,
         "generation": {
             "device": device,
@@ -101,6 +106,9 @@ def _new_sync_cursor(stat, rewrite_epoch=0):
         "observed_mtime_ns": stat.st_mtime_ns,
         "prefix_hash": hashlib.sha256(b"").hexdigest(),
     }
+    if include_hasher:
+        cursor["_prefix_hasher"] = hashlib.sha256()
+    return cursor
 
 
 def _open_sync_cursor(path: Path, value):
@@ -109,7 +117,7 @@ def _open_sync_cursor(path: Path, value):
     if not isinstance(value, dict) or not isinstance(value.get("generation"), dict):
         # Numeric cursors have no file identity. Rescan once while upgrading;
         # history inserts are idempotent, so this cannot duplicate rows.
-        return _new_sync_cursor(stat)
+        return _new_sync_cursor(stat, include_hasher=True)
 
     saved_offset = _sync_offset(value)
     generation = value["generation"]
@@ -121,7 +129,8 @@ def _open_sync_cursor(path: Path, value):
         and device is not None
         and (saved_device, saved_inode) != (device, inode)
     )
-    prefix_hash = _hash_file_prefix(path, saved_offset)
+    prefix_hasher = _hash_file_prefix_state(path, saved_offset)
+    prefix_hash = prefix_hasher.hexdigest() if prefix_hasher is not None else None
     replaced = (
         identity_changed
         or stat.st_size < saved_offset
@@ -131,18 +140,19 @@ def _open_sync_cursor(path: Path, value):
     )
     if replaced:
         epoch = _sync_offset(generation.get("rewrite_epoch", 0)) + 1
-        return _new_sync_cursor(stat, epoch)
+        return _new_sync_cursor(stat, epoch, include_hasher=True)
 
     return {
         "offset": saved_offset,
         "generation": dict(generation),
         "observed_mtime_ns": stat.st_mtime_ns,
         "prefix_hash": prefix_hash,
+        "_prefix_hasher": prefix_hasher,
     }
 
 
 def _commit_sync_cursor(path: Path, opened: dict, offset: int, consumed_prefix_hash=None):
-    """Revalidate the starting prefix before publishing committed progress."""
+    """Verify the consumed prefix before publishing committed progress."""
     stat = path.stat()
     generation = opened["generation"]
     device, inode = _file_identity(stat)
@@ -152,20 +162,11 @@ def _commit_sync_cursor(path: Path, opened: dict, offset: int, consumed_prefix_h
         and device is not None
         and expected != (device, inode)
     )
-    start_offset = _sync_offset(opened)
-    start_hash = _hash_file_prefix(path, start_offset)
-    if (
-        identity_changed
-        or stat.st_size < start_offset
-        or start_hash is None
-        or start_hash != opened.get("prefix_hash")
-    ):
-        epoch = _sync_offset(generation.get("rewrite_epoch", 0)) + 1
-        return _new_sync_cursor(stat, epoch)
-
     committed_hash = _hash_file_prefix(path, offset)
     if (
-        committed_hash is None
+        identity_changed
+        or stat.st_size < offset
+        or committed_hash is None
         or (
             consumed_prefix_hash is not None
             and committed_hash != consumed_prefix_hash
@@ -181,17 +182,20 @@ def _commit_sync_cursor(path: Path, opened: dict, offset: int, consumed_prefix_h
     }
 
 
-def _complete_jsonl_lines(path: Path, offset: int):
+def _complete_jsonl_lines(path: Path, offset: int, prefix_hasher=None):
     """Yield complete records, offsets, and hashes of the bytes consumed."""
     with open(path, "rb") as source:
-        digest = hashlib.sha256()
-        remaining = offset
-        while remaining:
-            chunk = source.read(min(64 * 1024, remaining))
-            if not chunk:
-                return
-            digest.update(chunk)
-            remaining -= len(chunk)
+        digest = prefix_hasher.copy() if prefix_hasher is not None else hashlib.sha256()
+        if prefix_hasher is None:
+            remaining = offset
+            while remaining:
+                chunk = source.read(min(64 * 1024, remaining))
+                if not chunk:
+                    return
+                digest.update(chunk)
+                remaining -= len(chunk)
+        else:
+            source.seek(offset)
         while True:
             raw = source.readline()
             if not raw or not raw.endswith(b"\n"):
@@ -202,6 +206,7 @@ def _complete_jsonl_lines(path: Path, offset: int):
                 source.tell(),
                 digest.hexdigest(),
             )
+
 
 # --- Schema ------------------------------------------------------------------
 
@@ -831,7 +836,9 @@ def sync_codex(conn: sqlite3.Connection, state: dict):
 
     if offset < file_size:
         print(f"  [codex] syncing {file_size - offset:,} new bytes...")
-        for line, line_end, line_hash in _complete_jsonl_lines(path, offset):
+        for line, line_end, line_hash in _complete_jsonl_lines(
+            path, offset, opened_cursor["_prefix_hasher"]
+        ):
             committed_offset = line_end
             consumed_prefix_hash = line_hash
             line = line.strip()
@@ -948,7 +955,9 @@ def sync_cursor(conn: sqlite3.Connection, state: dict):
                     continue
                 ts_ms = int(stat.st_mtime * 1000)
                 committed_offset = offset
-                for line, line_end, line_hash in _complete_jsonl_lines(jsonl, offset):
+                for line, line_end, line_hash in _complete_jsonl_lines(
+                    jsonl, offset, opened_cursor["_prefix_hasher"]
+                ):
                     committed_offset = line_end
                     consumed_prefix_hash = line_hash
                     line = line.strip()
@@ -1670,7 +1679,9 @@ def cmd_sync(args=None):
 
         committed_offset = offset
         consumed_prefix_hash = opened_cursor["prefix_hash"]
-        for line, line_end, line_hash in _complete_jsonl_lines(path, offset):
+        for line, line_end, line_hash in _complete_jsonl_lines(
+            path, offset, opened_cursor["_prefix_hasher"]
+        ):
             committed_offset = line_end
             consumed_prefix_hash = line_hash
             line = line.strip()

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -12,10 +12,11 @@ use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use rusqlite::{params, Connection, ErrorCode};
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::io::{self, BufRead, BufReader, Read, Write};
+use std::io::{self, BufRead, BufReader, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -3715,8 +3716,9 @@ fn checkpoint_sync_state(path: &Path, state: &Map<String, Value>) {
 /// of the whole state map. Writing that copy wholesale lets a slow run replace
 /// a fast run's newer cursors with its own stale ones, so the next run rescans
 /// work that was already finished: exactly the loop checkpointing exists to
-/// prevent. Merging per key keeps sources this run did not touch, and cursors
-/// are monotonic byte offsets so a smaller one is always staler and is dropped.
+/// prevent. Merging per key keeps sources this run did not touch. File cursors
+/// advance monotonically only within one generation; a newer generation must
+/// replace the old cursor even when it starts at a smaller offset.
 ///
 /// Returns `None` when disk already reflects everything here, so a steady-state
 /// run that finds every source up to date does not rewrite the file per source.
@@ -3724,23 +3726,53 @@ fn merged_sync_state(path: &Path, ours: &Map<String, Value>) -> Result<Option<Ma
     let mut merged = load_sync_state(path)?;
     let mut changed = false;
     for (key, value) in ours {
-        match (merged.get(key), value.as_u64()) {
-            // A cursor that has not advanced past what is on disk is stale.
-            (Some(existing), Some(ours_offset))
-                if existing
-                    .as_u64()
-                    .is_some_and(|on_disk| on_disk >= ours_offset) =>
-            {
-                continue
-            }
-            // Unchanged non-cursor entries (per-file maps) need no rewrite.
-            (Some(existing), None) if existing == value => continue,
-            _ => {}
+        let next = match merged.get(key) {
+            Some(existing) if key == "cursor" => merge_file_cursor_map(existing, value),
+            Some(existing) => merge_sync_value(existing, value),
+            None => value.clone(),
+        };
+        if merged.get(key) == Some(&next) {
+            continue;
         }
-        merged.insert(key.clone(), value.clone());
+        merged.insert(key.clone(), next);
         changed = true;
     }
     Ok(if changed { Some(merged) } else { None })
+}
+
+fn merge_sync_value(on_disk: &Value, ours: &Value) -> Value {
+    match (FileCursor::decode(on_disk), FileCursor::decode(ours)) {
+        (Some(DecodedFileCursor::Typed(on_disk)), Some(DecodedFileCursor::Typed(ours))) => {
+            FileCursor::merge(on_disk, ours).to_value()
+        }
+        // Once a cursor carries a generation, a concurrent legacy writer cannot
+        // safely replace it: its numeric offset may belong to the previous file.
+        (Some(DecodedFileCursor::Typed(on_disk)), Some(DecodedFileCursor::Legacy(_))) => {
+            on_disk.to_value()
+        }
+        (Some(DecodedFileCursor::Legacy(_)), Some(DecodedFileCursor::Typed(ours))) => {
+            ours.to_value()
+        }
+        (Some(DecodedFileCursor::Legacy(on_disk)), Some(DecodedFileCursor::Legacy(ours))) => {
+            json!(on_disk.max(ours))
+        }
+        _ if on_disk == ours => on_disk.clone(),
+        _ => ours.clone(),
+    }
+}
+
+fn merge_file_cursor_map(on_disk: &Value, ours: &Value) -> Value {
+    let (Some(on_disk), Some(ours)) = (on_disk.as_object(), ours.as_object()) else {
+        return merge_sync_value(on_disk, ours);
+    };
+    let mut merged = on_disk.clone();
+    for (path, cursor) in ours {
+        let next = merged
+            .get(path)
+            .map_or_else(|| cursor.clone(), |saved| merge_sync_value(saved, cursor));
+        merged.insert(path.clone(), next);
+    }
+    Value::Object(merged)
 }
 
 const STALE_SYNC_STATE_TMP_AGE: Duration = Duration::from_secs(24 * 60 * 60);
@@ -3858,6 +3890,201 @@ fn save_sync_state(path: &Path, state: &Map<String, Value>) -> Result<()> {
 /// minutes and starve everyone else.
 const JSONL_CHUNK_LINES: usize = 2_000;
 
+/// A byte cursor is valid only for the file generation that produced it.
+/// `observed_at_ns` orders overlapping writers across rotations, while the
+/// identity and start metadata let writers recognize the same generation.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct FileGeneration {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    device: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    inode: Option<u64>,
+    started_mtime_ns: u64,
+    started_size: u64,
+    observed_at_ns: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct FileCursor {
+    /// Bytes through the last newline whose database work has committed.
+    offset: u64,
+    generation: FileGeneration,
+    /// Latest mtime seen for this generation, used to catch backwards rewrites.
+    observed_mtime_ns: u64,
+}
+
+enum DecodedFileCursor {
+    Legacy(u64),
+    Typed(FileCursor),
+}
+
+impl FileCursor {
+    fn decode(value: &Value) -> Option<DecodedFileCursor> {
+        if let Some(offset) = value.as_u64() {
+            return Some(DecodedFileCursor::Legacy(offset));
+        }
+        serde_json::from_value(value.clone())
+            .ok()
+            .map(DecodedFileCursor::Typed)
+    }
+
+    fn to_value(&self) -> Value {
+        serde_json::to_value(self).expect("file cursor serialization cannot fail")
+    }
+
+    fn same_generation(&self, other: &Self) -> bool {
+        self.generation.device == other.generation.device
+            && self.generation.inode == other.generation.inode
+            && self.generation.started_mtime_ns == other.generation.started_mtime_ns
+            && self.generation.started_size == other.generation.started_size
+    }
+
+    fn generation_order(&self) -> (u64, u64, Option<u64>, Option<u64>, u64) {
+        (
+            self.generation.observed_at_ns,
+            self.generation.started_mtime_ns,
+            self.generation.device,
+            self.generation.inode,
+            self.generation.started_size,
+        )
+    }
+
+    fn merge(on_disk: Self, ours: Self) -> Self {
+        if on_disk.same_generation(&ours) {
+            let (mut winner, other) = if on_disk.offset >= ours.offset {
+                (on_disk, ours)
+            } else {
+                (ours, on_disk)
+            };
+            winner.observed_mtime_ns = winner.observed_mtime_ns.max(other.observed_mtime_ns);
+            winner
+        } else if ours.generation_order() > on_disk.generation_order() {
+            ours
+        } else {
+            on_disk
+        }
+    }
+}
+
+fn metadata_mtime_ns(metadata: &fs::Metadata) -> u64 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+fn now_ns() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+#[cfg(unix)]
+fn metadata_identity(metadata: &fs::Metadata) -> (Option<u64>, Option<u64>) {
+    use std::os::unix::fs::MetadataExt;
+    (Some(metadata.dev()), Some(metadata.ino()))
+}
+
+#[cfg(not(unix))]
+fn metadata_identity(_metadata: &fs::Metadata) -> (Option<u64>, Option<u64>) {
+    (None, None)
+}
+
+struct CompleteJsonlReader {
+    reader: BufReader<fs::File>,
+    cursor: FileCursor,
+    position: u64,
+}
+
+impl CompleteJsonlReader {
+    fn open(path: &Path, saved: Option<&Value>) -> Result<Self> {
+        let file = fs::File::open(path)?;
+        let metadata = file.metadata()?;
+        let size = metadata.len();
+        let mtime_ns = metadata_mtime_ns(&metadata);
+        let (device, inode) = metadata_identity(&metadata);
+        let decoded = saved.and_then(FileCursor::decode);
+
+        let (offset, generation) = match decoded {
+            Some(DecodedFileCursor::Typed(saved)) => {
+                let identity_changed = saved.generation.device.is_some()
+                    && device.is_some()
+                    && (saved.generation.device, saved.generation.inode) != (device, inode);
+                let replaced =
+                    identity_changed || size < saved.offset || mtime_ns < saved.observed_mtime_ns;
+                if replaced {
+                    (
+                        0,
+                        FileGeneration {
+                            device,
+                            inode,
+                            started_mtime_ns: mtime_ns,
+                            started_size: size,
+                            observed_at_ns: now_ns(),
+                        },
+                    )
+                } else {
+                    (saved.offset, saved.generation)
+                }
+            }
+            Some(DecodedFileCursor::Legacy(saved)) if saved <= size => (
+                saved,
+                FileGeneration {
+                    device,
+                    inode,
+                    started_mtime_ns: mtime_ns,
+                    started_size: size,
+                    observed_at_ns: now_ns(),
+                },
+            ),
+            _ => (
+                0,
+                FileGeneration {
+                    device,
+                    inode,
+                    started_mtime_ns: mtime_ns,
+                    started_size: size,
+                    observed_at_ns: now_ns(),
+                },
+            ),
+        };
+
+        let mut reader = BufReader::new(file);
+        reader.seek(std::io::SeekFrom::Start(offset))?;
+        Ok(Self {
+            reader,
+            cursor: FileCursor {
+                offset,
+                generation,
+                observed_mtime_ns: mtime_ns,
+            },
+            position: offset,
+        })
+    }
+
+    /// Returns only newline-terminated records. A partial final buffer remains
+    /// uncommitted and will be read again after the writer completes it.
+    fn next_line(&mut self, line: &mut String) -> Result<Option<u64>> {
+        line.clear();
+        let read = self.reader.read_line(line)?;
+        if read == 0 || !line.ends_with('\n') {
+            return Ok(None);
+        }
+        self.position += read as u64;
+        Ok(Some(self.position))
+    }
+
+    fn committed_cursor(&self, offset: u64) -> Result<FileCursor> {
+        let mut cursor = self.cursor.clone();
+        cursor.offset = offset;
+        cursor.observed_mtime_ns = metadata_mtime_ns(&self.reader.get_ref().metadata()?);
+        Ok(cursor)
+    }
+}
+
 fn sync_jsonl_incremental(
     conn: &Connection,
     state: &mut Map<String, Value>,
@@ -3870,16 +4097,15 @@ fn sync_jsonl_incremental(
         sync_note!("  [{name}] not found: {} (skipped)", path.display());
         return Ok(0);
     }
-    let size = path.metadata()?.len();
-    let offset = state.get(name).and_then(Value::as_u64).unwrap_or(0);
-    if offset >= size {
+    let mut source = CompleteJsonlReader::open(path, state.get(name))?;
+    let offset = source.position;
+    let size = source.reader.get_ref().metadata()?.len();
+    let opened_cursor = source.committed_cursor(offset)?.to_value();
+    if offset >= size && state.get(name) == Some(&opened_cursor) {
         sync_note!("  [{name}] up to date");
         return Ok(0);
     }
     sync_note!("  [{name}] syncing {} new bytes...", size - offset);
-    let file = fs::File::open(path)?;
-    let mut reader = BufReader::new(file);
-    reader.seek_relative(offset as i64)?;
     let mut inserted = 0;
     let mut errors = 0;
     // Byte position of the last line handed to the database, tracked as we read
@@ -3892,12 +4118,10 @@ fn sync_jsonl_incremental(
             let mut pending = 0usize;
             let mut line = String::new();
             loop {
-                line.clear();
-                let read = reader.read_line(&mut line)?;
-                if read == 0 {
+                let Some(position) = source.next_line(&mut line)? else {
                     break;
-                }
-                consumed += read as u64;
+                };
+                consumed = position;
                 if !line.trim().is_empty() {
                     match parser(&line) {
                         Ok(Some(entry)) => inserted += insert_history(conn, &entry)?,
@@ -3908,14 +4132,20 @@ fn sync_jsonl_incremental(
                 pending += 1;
                 if pending >= JSONL_CHUNK_LINES {
                     conn.execute_batch("COMMIT")?;
-                    state.insert(name.to_string(), json!(consumed));
+                    state.insert(
+                        name.to_string(),
+                        source.committed_cursor(consumed)?.to_value(),
+                    );
                     checkpoint(state);
                     conn.execute_batch("BEGIN")?;
                     pending = 0;
                 }
             }
             conn.execute_batch("COMMIT")?;
-            state.insert(name.to_string(), json!(consumed));
+            state.insert(
+                name.to_string(),
+                source.committed_cursor(consumed)?.to_value(),
+            );
             Ok(())
         };
         run()
@@ -3943,17 +4173,17 @@ fn sync_codex(conn: &Connection, state: &mut Map<String, Value>, home: &Path) ->
         sync_note!("  [codex] not found: {} (skipped)", path.display());
         return Ok(0);
     }
-    let size = path.metadata()?.len();
-    let offset = state.get("codex").and_then(Value::as_u64).unwrap_or(0);
+    let mut source = CompleteJsonlReader::open(&path, state.get("codex"))?;
+    let offset = source.position;
+    let size = source.reader.get_ref().metadata()?.len();
     let mut inserted = 0;
     let mut errors = 0;
+    let mut consumed = offset;
     if offset < size {
         sync_note!("  [codex] syncing {} new bytes...", size - offset);
-        let file = fs::File::open(&path)?;
-        let mut reader = BufReader::new(file);
-        reader.seek_relative(offset as i64)?;
-        for line in reader.lines() {
-            let line = line?;
+        let mut line = String::new();
+        while let Some(position) = source.next_line(&mut line)? {
+            consumed = position;
             if line.trim().is_empty() {
                 continue;
             }
@@ -3970,14 +4200,19 @@ fn sync_codex(conn: &Connection, state: &mut Map<String, Value>, home: &Path) ->
                 Err(_) => errors += 1,
             }
         }
-        state.insert("codex".to_string(), json!(size));
     }
+    // This also upgrades legacy numeric cursors at EOF. The actual committed
+    // position may include complete lines appended after the initial stat.
+    state.insert(
+        "codex".to_string(),
+        source.committed_cursor(consumed)?.to_value(),
+    );
     let backfilled = backfill_codex_metadata(conn, &cwds, &branches)?;
-    if offset >= size && backfilled == 0 {
+    if consumed == offset && backfilled == 0 {
         sync_note!("  [codex] up to date");
     } else {
         let mut parts = Vec::new();
-        if inserted > 0 || offset < size {
+        if inserted > 0 || consumed > offset {
             parts.push(format!("+{inserted} rows"));
         }
         if backfilled > 0 {
@@ -4874,12 +5109,10 @@ fn sync_cursor(conn: &Connection, state: &mut Map<String, Value>, root: &Path) -
                 continue;
             }
             files_seen += 1;
-            let size = jsonl.metadata()?.len();
             let key = jsonl.to_string_lossy().to_string();
-            let offset = cursor_state.get(&key).and_then(Value::as_u64).unwrap_or(0);
-            if offset >= size {
-                continue;
-            }
+            let mut source = CompleteJsonlReader::open(&jsonl, cursor_state.get(&key))?;
+            let offset = source.position;
+            let size = source.reader.get_ref().metadata()?.len();
             let ts_ms = jsonl
                 .metadata()
                 .and_then(|m| m.modified())
@@ -4887,31 +5120,32 @@ fn sync_cursor(conn: &Connection, state: &mut Map<String, Value>, root: &Path) -
                 .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
                 .map(|d| d.as_millis() as i64)
                 .unwrap_or(0);
-            let file = fs::File::open(&jsonl)?;
-            let mut reader = BufReader::new(file);
-            reader.seek_relative(offset as i64)?;
-            for line in reader.lines() {
-                let line = line?;
-                match parse_cursor_text(&line) {
-                    Ok(Some(prompt)) => {
-                        inserted += insert_history(
-                            conn,
-                            &HistoryEntry {
-                                id: 0,
-                                source: "cursor".into(),
-                                session_id: Some(session_id.clone()),
-                                project: Some(project_path.clone()),
-                                prompt_hash: Some(prompt_hash(&prompt)),
-                                prompt,
-                                timestamp_ms: ts_ms,
-                            },
-                        )?;
+            let mut consumed = offset;
+            if offset < size {
+                let mut line = String::new();
+                while let Some(position) = source.next_line(&mut line)? {
+                    consumed = position;
+                    match parse_cursor_text(&line) {
+                        Ok(Some(prompt)) => {
+                            inserted += insert_history(
+                                conn,
+                                &HistoryEntry {
+                                    id: 0,
+                                    source: "cursor".into(),
+                                    session_id: Some(session_id.clone()),
+                                    project: Some(project_path.clone()),
+                                    prompt_hash: Some(prompt_hash(&prompt)),
+                                    prompt,
+                                    timestamp_ms: ts_ms,
+                                },
+                            )?;
+                        }
+                        Ok(None) => {}
+                        Err(_) => errors += 1,
                     }
-                    Ok(None) => {}
-                    Err(_) => errors += 1,
                 }
             }
-            cursor_state.insert(key, json!(size));
+            cursor_state.insert(key, source.committed_cursor(consumed)?.to_value());
         }
     }
     state.insert("cursor".to_string(), Value::Object(cursor_state));
@@ -5787,6 +6021,29 @@ mod tests {
     use rusqlite::Connection;
     use serde_json::{json, Map, Value};
     use std::fs;
+    use std::io::Write as _;
+
+    fn saved_cursor_offset(value: &Value) -> u64 {
+        match super::FileCursor::decode(value).expect("valid file cursor") {
+            super::DecodedFileCursor::Legacy(offset) => offset,
+            super::DecodedFileCursor::Typed(cursor) => cursor.offset,
+        }
+    }
+
+    fn test_file_cursor(offset: u64, inode: u64, generation: u64) -> Value {
+        super::FileCursor {
+            offset,
+            generation: super::FileGeneration {
+                device: Some(1),
+                inode: Some(inode),
+                started_mtime_ns: generation,
+                started_size: 100,
+                observed_at_ns: generation,
+            },
+            observed_mtime_ns: generation,
+        }
+        .to_value()
+    }
 
     #[test]
     fn cron_schedule_maps_intervals_to_step_expressions() {
@@ -6053,6 +6310,43 @@ mod tests {
     }
 
     #[test]
+    fn typed_cursor_merges_are_monotonic_within_a_generation_and_replace_stale_generations() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".sync-state.json");
+        let transcript = "/cursor/session.jsonl";
+
+        let mut newest = Map::new();
+        newest.insert("claude".into(), test_file_cursor(25, 10, 200));
+        newest.insert(
+            "cursor".into(),
+            json!({transcript: test_file_cursor(30, 10, 200)}),
+        );
+        checkpoint_sync_state(&path, &newest);
+
+        // A stale writer from the prior inode cannot restore its larger offset.
+        let mut stale_generation = Map::new();
+        stale_generation.insert("claude".into(), test_file_cursor(900, 9, 100));
+        stale_generation.insert(
+            "cursor".into(),
+            json!({transcript: test_file_cursor(800, 9, 100)}),
+        );
+        checkpoint_sync_state(&path, &stale_generation);
+
+        // Nor can a slow writer rewind the active generation.
+        let mut slow_same_generation = Map::new();
+        slow_same_generation.insert("claude".into(), test_file_cursor(12, 10, 200));
+        slow_same_generation.insert(
+            "cursor".into(),
+            json!({transcript: test_file_cursor(14, 10, 200)}),
+        );
+        checkpoint_sync_state(&path, &slow_same_generation);
+
+        let saved = load_sync_state(&path).unwrap();
+        assert_eq!(saved_cursor_offset(&saved["claude"]), 25);
+        assert_eq!(saved_cursor_offset(&saved["cursor"][transcript]), 30);
+    }
+
+    #[test]
     fn an_unchanged_source_does_not_rewrite_the_state_file() {
         let dir = std::env::temp_dir().join(format!("ai-hist-norewrite-{}", std::process::id()));
         fs::create_dir_all(&dir).unwrap();
@@ -6171,7 +6465,7 @@ mod tests {
             &path,
             super::parse_claude_line,
             &mut |in_progress| {
-                checkpoints.push(in_progress.get("claude").and_then(Value::as_u64).unwrap());
+                checkpoints.push(saved_cursor_offset(&in_progress["claude"]));
             },
         )
         .unwrap();
@@ -6182,10 +6476,7 @@ mod tests {
         assert_eq!(checkpoints.len(), lines / super::JSONL_CHUNK_LINES);
         assert!(checkpoints.windows(2).all(|w| w[0] < w[1]));
         assert!(checkpoints.iter().all(|&at| at < body.len() as u64));
-        assert_eq!(
-            state.get("claude").and_then(Value::as_u64),
-            Some(body.len() as u64)
-        );
+        assert_eq!(saved_cursor_offset(&state["claude"]), body.len() as u64);
 
         // Resuming from a mid-file checkpoint ingests only the remainder, and
         // the offsets line up exactly -- nothing skipped, nothing double-counted.
@@ -6205,6 +6496,271 @@ mod tests {
         assert_eq!(after, lines - super::JSONL_CHUNK_LINES);
 
         fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn generic_jsonl_retries_partial_lines_then_imports_them_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("history.jsonl");
+        fs::write(&path, r#"{"display":"half"#).unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let mut state = Map::new();
+
+        assert_eq!(
+            super::sync_jsonl_incremental(
+                &conn,
+                &mut state,
+                "claude",
+                &path,
+                super::parse_claude_line,
+                &mut |_| {},
+            )
+            .unwrap(),
+            0
+        );
+        assert_eq!(saved_cursor_offset(&state["claude"]), 0);
+
+        let mut file = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        file.write_all(br#" prompt","timestamp":1,"project":"/p","sessionId":"s"}"#)
+            .unwrap();
+        file.write_all(b"\n").unwrap();
+        drop(file);
+        assert_eq!(
+            super::sync_jsonl_incremental(
+                &conn,
+                &mut state,
+                "claude",
+                &path,
+                super::parse_claude_line,
+                &mut |_| {},
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!(
+            super::sync_jsonl_incremental(
+                &conn,
+                &mut state,
+                "claude",
+                &path,
+                super::parse_claude_line,
+                &mut |_| {},
+            )
+            .unwrap(),
+            0
+        );
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM history", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn generic_jsonl_skips_complete_malformed_lines_permanently() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("history.jsonl");
+        fs::write(&path, "{malformed}\n").unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let mut state = Map::new();
+        let sync = |state: &mut Map<String, Value>| {
+            super::sync_jsonl_incremental(
+                &conn,
+                state,
+                "claude",
+                &path,
+                super::parse_claude_line,
+                &mut |_| {},
+            )
+            .unwrap()
+        };
+
+        assert_eq!(sync(&mut state), 0);
+        assert_eq!(saved_cursor_offset(&state["claude"]), 12);
+        assert_eq!(sync(&mut state), 0);
+        assert_eq!(saved_cursor_offset(&state["claude"]), 12);
+    }
+
+    #[test]
+    fn generic_jsonl_resets_after_truncation_and_atomic_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("history.jsonl");
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let mut state = Map::new();
+        let sync = |state: &mut Map<String, Value>| {
+            super::sync_jsonl_incremental(
+                &conn,
+                state,
+                "claude",
+                &path,
+                super::parse_claude_line,
+                &mut |_| {},
+            )
+            .unwrap()
+        };
+
+        fs::write(
+            &path,
+            concat!(
+                r#"{"display":"a deliberately long original prompt","timestamp":1,"sessionId":"old"}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+        assert_eq!(sync(&mut state), 1);
+
+        fs::write(
+            &path,
+            concat!(
+                r#"{"display":"short","timestamp":2,"sessionId":"new"}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+        assert_eq!(sync(&mut state), 1, "same-inode truncation must reset");
+        assert_eq!(sync(&mut state), 0);
+
+        let replacement = dir.path().join("replacement.jsonl");
+        fs::write(
+            &replacement,
+            concat!(
+                r#"{"display":"replacement prompt longer than the prior cursor","timestamp":3,"sessionId":"replacement"}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+        fs::rename(&replacement, &path).unwrap();
+        assert_eq!(sync(&mut state), 1, "new inode must reset even when larger");
+        assert_eq!(sync(&mut state), 0);
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM history", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            3
+        );
+    }
+
+    #[test]
+    fn generic_jsonl_consumes_complete_data_appended_during_a_scan() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("history.jsonl");
+        let initial: String = (0..super::JSONL_CHUNK_LINES)
+            .map(|i| format!(r#"{{"display":"prompt {i}","timestamp":{i}}}"#) + "\n")
+            .collect();
+        fs::write(&path, initial).unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let mut state = Map::new();
+        let mut appended = false;
+        let inserted = super::sync_jsonl_incremental(
+            &conn,
+            &mut state,
+            "claude",
+            &path,
+            super::parse_claude_line,
+            &mut |_| {
+                if !appended {
+                    let mut file = fs::OpenOptions::new().append(true).open(&path).unwrap();
+                    writeln!(file, r#"{{"display":"appended","timestamp":999999}}"#).unwrap();
+                    appended = true;
+                }
+            },
+        )
+        .unwrap();
+        assert_eq!(inserted, super::JSONL_CHUNK_LINES + 1);
+        assert_eq!(
+            saved_cursor_offset(&state["claude"]),
+            fs::metadata(&path).unwrap().len()
+        );
+    }
+
+    #[test]
+    fn legacy_numeric_cursor_upgrades_after_a_successful_scan() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("history.jsonl");
+        let first = concat!(r#"{"display":"already imported","timestamp":1}"#, "\n");
+        let second = concat!(r#"{"display":"new record","timestamp":2}"#, "\n");
+        fs::write(&path, format!("{first}{second}")).unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let mut state = Map::new();
+        state.insert("claude".into(), json!(first.len() as u64));
+
+        assert_eq!(
+            super::sync_jsonl_incremental(
+                &conn,
+                &mut state,
+                "claude",
+                &path,
+                super::parse_claude_line,
+                &mut |_| {},
+            )
+            .unwrap(),
+            1
+        );
+        assert!(matches!(
+            super::FileCursor::decode(&state["claude"]),
+            Some(super::DecodedFileCursor::Typed(_))
+        ));
+        assert_eq!(
+            saved_cursor_offset(&state["claude"]),
+            fs::metadata(&path).unwrap().len()
+        );
+    }
+
+    #[test]
+    fn codex_and_cursor_sources_retry_unterminated_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let mut state = Map::new();
+
+        let codex = dir.path().join(".codex/history.jsonl");
+        fs::create_dir_all(codex.parent().unwrap()).unwrap();
+        fs::write(&codex, r#"{"text":"codex"#).unwrap();
+        assert_eq!(super::sync_codex(&conn, &mut state, dir.path()).unwrap(), 0);
+        assert_eq!(saved_cursor_offset(&state["codex"]), 0);
+        let mut file = fs::OpenOptions::new().append(true).open(&codex).unwrap();
+        file.write_all(br#" prompt","ts":1,"session_id":"c1"}"#)
+            .unwrap();
+        file.write_all(b"\n").unwrap();
+        drop(file);
+        assert_eq!(super::sync_codex(&conn, &mut state, dir.path()).unwrap(), 1);
+
+        let cursor_root = dir.path().join(".cursor/projects");
+        let cursor = cursor_root.join("P/agent-transcripts/s1/s1.jsonl");
+        fs::create_dir_all(cursor.parent().unwrap()).unwrap();
+        fs::write(&cursor, r#"{"role":"user","message":{"content":"cursor"#).unwrap();
+        assert_eq!(
+            super::sync_cursor(&conn, &mut state, &cursor_root).unwrap(),
+            0
+        );
+        assert_eq!(
+            saved_cursor_offset(&state["cursor"][cursor.to_string_lossy().as_ref()]),
+            0
+        );
+        let mut file = fs::OpenOptions::new().append(true).open(&cursor).unwrap();
+        file.write_all(br#" prompt"}}"#).unwrap();
+        file.write_all(b"\n").unwrap();
+        drop(file);
+        assert_eq!(
+            super::sync_cursor(&conn, &mut state, &cursor_root).unwrap(),
+            1
+        );
+        assert_eq!(
+            super::sync_cursor(&conn, &mut state, &cursor_root).unwrap(),
+            0
+        );
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM history", [], |row| row
+                .get::<_, i64>(0))
+                .unwrap(),
+            2
+        );
     }
 
     #[test]

--- a/test_ai_hist.py
+++ b/test_ai_hist.py
@@ -412,6 +412,23 @@ class TestCmdSync:
         assert prompts == [("new",), ("old",)]
         assert ai_hist.load_state()["claude"]["generation"]["rewrite_epoch"] == 1
 
+    def test_checkpoint_rejects_a_rewrite_after_records_are_consumed(self, tmp_env):
+        original = make_claude_entry("old", 1700000001000, session_id="old") + "\n"
+        replacement = make_claude_entry("new", 1700000002000, session_id="new") + "\n"
+        assert len(original.encode()) == len(replacement.encode())
+        tmp_env.claude_hist.write_text(original)
+        opened = ai_hist._open_sync_cursor(tmp_env.claude_hist, None)
+        records = list(ai_hist._complete_jsonl_lines(tmp_env.claude_hist, 0))
+        _, committed_offset, consumed_hash = records[-1]
+
+        tmp_env.claude_hist.write_text(replacement)
+        committed = ai_hist._commit_sync_cursor(
+            tmp_env.claude_hist, opened, committed_offset, consumed_hash
+        )
+
+        assert committed["offset"] == 0
+        assert committed["generation"]["rewrite_epoch"] == 1
+
     def test_sync_up_to_date(self, tmp_env, capsys):
         tmp_env.claude_hist.write_text(make_claude_entry("first", 1700000001000) + "\n")
         ai_hist.cmd_sync()
@@ -1833,6 +1850,23 @@ class TestSyncCursor:
         ai_hist.init_db(conn)
         ai_hist.sync_cursor(conn, {})
         conn.close()
+
+    def test_disappearing_transcript_is_recoverable(self, tmp_env, monkeypatch, capsys):
+        jsonl = make_cursor_session(tmp_env.cursor_root, "P", "s1", ["prompt"])
+        original_open = ai_hist._open_sync_cursor
+
+        def disappearing(path, value):
+            if path == jsonl:
+                raise FileNotFoundError(path)
+            return original_open(path, value)
+
+        monkeypatch.setattr(ai_hist, "_open_sync_cursor", disappearing)
+        conn = sqlite3.connect(str(tmp_env.db_path))
+        ai_hist.init_db(conn)
+        ai_hist.sync_cursor(conn, {})
+        conn.close()
+
+        assert "1 errors" in capsys.readouterr().out
 
     def test_imports_user_prompts(self, tmp_env, capsys):
         make_cursor_session(

--- a/test_ai_hist.py
+++ b/test_ai_hist.py
@@ -318,12 +318,11 @@ class TestCmdSync:
         first = make_claude_entry("already imported", 1700000001000) + "\n"
         second = make_claude_entry("new from fallback", 1700000002000) + "\n"
         tmp_env.claude_hist.write_text(first + second)
-        ai_hist.save_state({
-            "claude": {
-                "offset": len(first.encode()),
-                "generation": {"device": 1, "inode": 2},
-            }
-        })
+        opened = ai_hist._open_sync_cursor(tmp_env.claude_hist, None)
+        cursor = ai_hist._commit_sync_cursor(
+            tmp_env.claude_hist, opened, len(first.encode())
+        )
+        ai_hist.save_state({"claude": cursor})
 
         ai_hist.cmd_sync()
 
@@ -333,6 +332,33 @@ class TestCmdSync:
         ).fetchall()
         conn.close()
         assert prompts == [("new from fallback",)]
+
+    def test_sync_retries_unterminated_generic_and_codex_records(self, tmp_env):
+        claude = make_claude_entry("claude partial", 1700000001000)
+        codex = make_codex_entry("codex partial", 1700000001)
+        tmp_env.claude_hist.write_text(claude[:-1])
+        tmp_env.codex_hist.write_text(codex[:-1])
+
+        ai_hist.cmd_sync()
+        state = ai_hist.load_state()
+        assert state["claude"]["offset"] == 0
+        assert state["codex"]["offset"] == 0
+
+        with open(tmp_env.claude_hist, "a") as source:
+            source.write(claude[-1:] + "\n")
+        with open(tmp_env.codex_hist, "a") as source:
+            source.write(codex[-1:] + "\n")
+        ai_hist.cmd_sync()
+
+        conn = sqlite3.connect(str(tmp_env.db_path))
+        prompts = conn.execute(
+            "SELECT source, prompt FROM history ORDER BY source"
+        ).fetchall()
+        conn.close()
+        assert prompts == [
+            ("claude", "claude partial"),
+            ("codex", "codex partial"),
+        ]
 
     def test_sync_claude_entries(self, tmp_env, capsys):
         tmp_env.claude_hist.write_text(
@@ -367,6 +393,24 @@ class TestCmdSync:
         ai_hist.cmd_sync()
         captured = capsys.readouterr()
         assert "Total: 2" in captured.out
+
+    def test_typed_cursor_resets_after_same_size_replacement(self, tmp_env):
+        original = make_claude_entry("old", 1700000001000, session_id="old") + "\n"
+        replacement = make_claude_entry("new", 1700000002000, session_id="new") + "\n"
+        assert len(original.encode()) == len(replacement.encode())
+        tmp_env.claude_hist.write_text(original)
+        ai_hist.cmd_sync()
+
+        tmp_env.claude_hist.write_text(replacement)
+        ai_hist.cmd_sync()
+
+        conn = sqlite3.connect(str(tmp_env.db_path))
+        prompts = conn.execute(
+            "SELECT prompt FROM history WHERE source='claude' ORDER BY prompt"
+        ).fetchall()
+        conn.close()
+        assert prompts == [("new",), ("old",)]
+        assert ai_hist.load_state()["claude"]["generation"]["rewrite_epoch"] == 1
 
     def test_sync_up_to_date(self, tmp_env, capsys):
         tmp_env.claude_hist.write_text(make_claude_entry("first", 1700000001000) + "\n")
@@ -1848,13 +1892,39 @@ class TestSyncCursor:
         jsonl = make_cursor_session(tmp_env.cursor_root, "P", "s1", ["x"])
         conn = sqlite3.connect(str(tmp_env.db_path))
         ai_hist.init_db(conn)
-        state = {"cursor": {str(jsonl): jsonl.stat().st_size}}
+        opened = ai_hist._open_sync_cursor(jsonl, None)
+        cursor = ai_hist._commit_sync_cursor(jsonl, opened, jsonl.stat().st_size)
+        state = {"cursor": {str(jsonl): cursor}}
         ai_hist.sync_cursor(conn, state)
         count = conn.execute(
             "SELECT COUNT(*) FROM history WHERE source='cursor'"
         ).fetchone()[0]
         conn.close()
         assert count == 0
+
+    def test_retries_unterminated_record(self, tmp_env):
+        session_dir = tmp_env.cursor_root / "P" / "agent-transcripts" / "s1"
+        session_dir.mkdir(parents=True)
+        jsonl = session_dir / "s1.jsonl"
+        complete = json.dumps({
+            "role": "user",
+            "message": {"content": [{"type": "text", "text": "partial"}]},
+        })
+        jsonl.write_text(complete[:-1])
+        conn = sqlite3.connect(str(tmp_env.db_path))
+        ai_hist.init_db(conn)
+        state = {}
+
+        ai_hist.sync_cursor(conn, state)
+        assert state["cursor"][str(jsonl)]["offset"] == 0
+        with open(jsonl, "a") as source:
+            source.write(complete[-1:] + "\n")
+        ai_hist.sync_cursor(conn, state)
+        rows = conn.execute(
+            "SELECT prompt FROM history WHERE source='cursor'"
+        ).fetchall()
+        conn.close()
+        assert rows == [("partial",)]
 
     def test_handles_invalid_json(self, tmp_env, capsys):
         session_dir = tmp_env.cursor_root / "P" / "agent-transcripts" / "s1"


### PR DESCRIPTION
Closes #65

## Summary
- replace bare JSONL byte offsets with backward-compatible, generation-aware file cursors
- centralize newline-complete incremental reads across Claude-style, Codex, and Cursor importers
- reset cursors after truncation, inode replacement, or backwards modification time
- merge concurrent cursor checkpoints monotonically within a generation while rejecting stale prior-generation writers
- cover partial writes, malformed complete lines, rotation, appends during scans, legacy upgrades, and concurrent merges

## Verification
- cargo fmt --all -- --check
- cargo test -p ai-hist-cli --lib (85 passed)
- cargo test -p ai-hist-core (31 passed)
- uv run --with pytest python -m pytest test_ai_hist.py -q (174 passed)
- cargo clippy -p ai-hist-cli --lib --tests (passes with three pre-existing too_many_arguments warnings)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

