### PR TITLE
test: cover the paths the Python removal left untested

### DIFF
--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -1447,6 +1447,254 @@ mod tests {
     }
 
     #[test]
+    fn cursor_rows_unwrap_the_user_query_envelope_around_the_real_prompt() {
+        // Cursor writes the prompt inside a <user_query> envelope; the stored
+        // prompt is the text, not the markup.
+        assert_eq!(
+            parse_cursor_text(
+                r#"{"role":"user","message":{"content":[{"type":"text","text":"<user_query>\n tag the release \n</user_query>"}]}}"#
+            )
+            .unwrap(),
+            Some("tag the release".to_string())
+        );
+        // Older rows carry the prompt with no envelope at all.
+        assert_eq!(
+            parse_cursor_text(
+                r#"{"role":"user","message":{"content":[{"type":"text","text":"  tag the release  "}]}}"#
+            )
+            .unwrap(),
+            Some("tag the release".to_string())
+        );
+        // Content is sometimes a bare string rather than a parts array.
+        assert_eq!(
+            parse_cursor_text(r#"{"role":"user","message":{"content":"tag the release"}}"#)
+                .unwrap(),
+            Some("tag the release".to_string())
+        );
+    }
+
+    #[test]
+    fn cursor_rows_without_a_user_prompt_are_skipped() {
+        // Only user turns are history; the assistant's reply is not a prompt.
+        assert_eq!(
+            parse_cursor_text(
+                r#"{"role":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}"#
+            )
+            .unwrap(),
+            None
+        );
+        // Whitespace-only text carries no prompt.
+        assert_eq!(
+            parse_cursor_text(
+                r#"{"role":"user","message":{"content":[{"type":"text","text":"   \n  "}]}}"#
+            )
+            .unwrap(),
+            None
+        );
+        // An envelope with nothing inside it is not a prompt either.
+        assert_eq!(
+            parse_cursor_text(
+                r#"{"role":"user","message":{"content":[{"type":"text","text":"<user_query></user_query>"}]}}"#
+            )
+            .unwrap(),
+            None
+        );
+        // Non-text parts (images, tool payloads) contribute no prompt text.
+        assert_eq!(
+            parse_cursor_text(
+                r#"{"role":"user","message":{"content":[{"type":"image","url":"file:///shot.png"}]}}"#
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    fn resume_entry(source: &str, session_id: Option<&str>, project: Option<&str>) -> HistoryEntry {
+        HistoryEntry {
+            id: 0,
+            source: source.into(),
+            session_id: session_id.map(str::to_string),
+            project: project.map(str::to_string),
+            prompt: "tag the release".into(),
+            prompt_hash: None,
+            timestamp_ms: 1,
+        }
+    }
+
+    #[test]
+    fn resume_commands_use_each_agents_own_cli_and_cd_into_the_project() {
+        assert_eq!(
+            resume_command(&resume_entry("claude", Some("s1"), Some("/tmp/p"))),
+            Some("cd /tmp/p && claude --resume s1".to_string())
+        );
+        // Codex resumes by session id alone; it has no project argument.
+        assert_eq!(
+            resume_command(&resume_entry("codex", Some("s1"), Some("/tmp/p"))),
+            Some("codex resume s1".to_string())
+        );
+        assert_eq!(
+            resume_command(&resume_entry("cursor", Some("s1"), Some("/tmp/p"))),
+            Some("cd /tmp/p && cursor-agent --resume=s1".to_string())
+        );
+        assert_eq!(
+            resume_command(&resume_entry("grok", Some("s1"), Some("/tmp/p"))),
+            Some("cd /tmp/p && grok resume s1".to_string())
+        );
+        // A project with shell metacharacters is quoted, not interpolated raw.
+        assert_eq!(
+            resume_command(&resume_entry("claude", Some("s1"), Some("/tmp/my proj"))),
+            Some("cd '/tmp/my proj' && claude --resume s1".to_string())
+        );
+    }
+
+    #[test]
+    fn resume_drops_the_cd_without_a_project_and_is_absent_without_a_session() {
+        assert_eq!(
+            resume_command(&resume_entry("claude", Some("s1"), None)),
+            Some("claude --resume s1".to_string())
+        );
+        assert_eq!(
+            resume_command(&resume_entry("cursor", Some("s1"), None)),
+            Some("cursor-agent --resume=s1".to_string())
+        );
+        // No session id means there is nothing to resume.
+        assert_eq!(
+            resume_command(&resume_entry("claude", None, Some("/tmp/p"))),
+            None
+        );
+        // Sources with no resumable CLI (opencode, trajectory) offer nothing.
+        assert_eq!(
+            resume_command(&resume_entry("opencode", Some("s1"), Some("/tmp/p"))),
+            None
+        );
+        assert_eq!(
+            resume_command(&resume_entry("trajectory", Some("s1"), Some("/tmp/p"))),
+            None
+        );
+    }
+
+    fn add_event(
+        conn: &Connection,
+        source: &str,
+        session_id: &str,
+        ts_ms: i64,
+        role: &str,
+        text: &str,
+        token_json: Option<&str>,
+        event_uid: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO session_events (source, session_id, project, cwd, git_branch, message_id, \
+             parent_id, ts_ms, role, kind, text, model, token_json, event_uid) \
+             VALUES (?, ?, '/tmp/p', '/tmp/p', 'main', NULL, NULL, ?, ?, 'text', ?, 'claude-opus-5', ?, ?)",
+            rusqlite::params![source, session_id, ts_ms, role, text, token_json, event_uid],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn session_events_read_back_oldest_first_and_scoped_to_one_source() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        // Inserted out of order, and with a tie the ordering must break by
+        // insertion order rather than at random.
+        add_event(&conn, "claude", "s1", 300, "assistant", "third", None, "e3");
+        add_event(&conn, "claude", "s1", 100, "user", "first", None, "e1");
+        add_event(
+            &conn,
+            "claude",
+            "s1",
+            300,
+            "user",
+            "fourth",
+            Some(r#"{"input_tokens":10,"output_tokens":20}"#),
+            "e4",
+        );
+        add_event(&conn, "claude", "s1", 200, "user", "second", None, "e2");
+        // A different agent reusing the same session id must not bleed in.
+        add_event(&conn, "codex", "s1", 150, "user", "other agent", None, "e5");
+
+        let all = session_events(&conn, "s1", None).unwrap();
+        assert_eq!(
+            all.iter()
+                .map(|e| e.text.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["first", "other agent", "second", "third", "fourth"]
+        );
+
+        let claude_only = session_events(&conn, "s1", Some("claude")).unwrap();
+        assert_eq!(
+            claude_only
+                .iter()
+                .map(|e| e.text.as_deref().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["first", "second", "third", "fourth"]
+        );
+        assert_eq!(claude_only[0].role, "user");
+        assert_eq!(claude_only[0].project.as_deref(), Some("/tmp/p"));
+        assert_eq!(claude_only[0].git_branch.as_deref(), Some("main"));
+        assert_eq!(claude_only[0].model.as_deref(), Some("claude-opus-5"));
+        assert_eq!(claude_only[0].event_uid, "e1");
+
+        // Token usage round-trips as parseable JSON, not an opaque blob.
+        let usage: serde_json::Value =
+            serde_json::from_str(claude_only[3].token_json.as_deref().unwrap()).unwrap();
+        assert_eq!(usage["input_tokens"], 10);
+        assert_eq!(usage["output_tokens"], 20);
+
+        // An unknown session reads back empty rather than erroring.
+        assert!(session_events(&conn, "nope", None).unwrap().is_empty());
+    }
+
+    #[test]
+    fn tool_calls_and_file_edits_read_back_oldest_first_and_scoped_to_one_source() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn.execute_batch(
+            r#"
+            INSERT INTO tool_calls (source, session_id, message_id, tool_use_id, name, target, args_json, is_error, ts_ms)
+            VALUES ('claude', 's1', 'm2', 'tu2', 'Bash', 'cargo test', '{"command":"cargo test"}', 1, 200),
+                   ('claude', 's1', 'm1', 'tu1', 'Read', '/tmp/p/lib.rs', '{"file_path":"/tmp/p/lib.rs"}', 0, 100),
+                   ('codex', 's1', 'm9', 'tu9', 'Shell', 'ls', '{}', 0, 150);
+            INSERT INTO file_edits (source, session_id, message_id, tool_use_id, file_path, tool_name, lines_added, lines_removed, user_modified, ts_ms)
+            VALUES ('claude', 's1', 'm3', 'tu3', '/tmp/p/b.rs', 'Edit', 2, 1, 0, 300),
+                   ('claude', 's1', 'm1', 'tu1', '/tmp/p/a.rs', 'Write', 10, 0, 1, 100),
+                   ('codex', 's1', 'm9', 'tu9', '/tmp/p/z.rs', 'apply_patch', 1, 1, 0, 150);
+            "#,
+        )
+        .unwrap();
+
+        let calls = session_tool_calls(&conn, "s1", Some("claude")).unwrap();
+        assert_eq!(
+            calls.iter().map(|c| c.name.as_str()).collect::<Vec<_>>(),
+            vec!["Read", "Bash"]
+        );
+        assert_eq!(calls[0].tool_use_id, "tu1");
+        assert_eq!(calls[0].target.as_deref(), Some("/tmp/p/lib.rs"));
+        assert_eq!(calls[0].is_error, Some(0));
+        assert_eq!(calls[1].is_error, Some(1));
+        let args: serde_json::Value =
+            serde_json::from_str(calls[1].args_json.as_deref().unwrap()).unwrap();
+        assert_eq!(args["command"], "cargo test");
+        assert_eq!(session_tool_calls(&conn, "s1", None).unwrap().len(), 3);
+
+        let edits = session_file_edits(&conn, "s1", Some("claude")).unwrap();
+        assert_eq!(
+            edits
+                .iter()
+                .map(|e| e.file_path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["/tmp/p/a.rs", "/tmp/p/b.rs"]
+        );
+        assert_eq!(edits[0].tool_name.as_deref(), Some("Write"));
+        assert_eq!(edits[0].lines_added, Some(10));
+        assert_eq!(edits[0].lines_removed, Some(0));
+        assert_eq!(edits[0].user_modified, Some(1));
+        assert_eq!(session_file_edits(&conn, "s1", None).unwrap().len(), 3);
+        assert!(session_file_edits(&conn, "nope", None).unwrap().is_empty());
+    }
+
+    #[test]
     fn init_db_uses_wal_and_legacy_session_schema() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("fresh.db");

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -2183,7 +2183,18 @@ const WAL_WARN_BYTES: u64 = 64 * 1024 * 1024;
 /// how the `.sync-state.json` corruption started.
 const FREE_SPACE_FLOOR_BYTES: u64 = 512 * 1024 * 1024;
 
-fn doctor(db_path: &Path, json: bool) -> Result<()> {
+/// Everything `doctor` measured about one database, before it is rendered as
+/// text or JSON. Split out from the printing so the report can be asserted on.
+struct DoctorReport {
+    db_bytes: u64,
+    wal_bytes: u64,
+    free: Option<u64>,
+    lock: std::result::Result<(), String>,
+    holders: Vec<DbHolder>,
+    problems: Vec<String>,
+}
+
+fn doctor_report(db_path: &Path) -> DoctorReport {
     let db_bytes = fs::metadata(db_path).map(|m| m.len()).unwrap_or(0);
     let wal_bytes = fs::metadata(wal_path(db_path))
         .map(|m| m.len())
@@ -2226,30 +2237,56 @@ fn doctor(db_path: &Path, json: bool) -> Result<()> {
         ));
     }
 
+    DoctorReport {
+        db_bytes,
+        wal_bytes,
+        free,
+        lock,
+        holders,
+        problems,
+    }
+}
+
+impl DoctorReport {
+    fn to_json(&self, db_path: &Path) -> Value {
+        json!({
+            "db_path": db_path.display().to_string(),
+            "db_bytes": self.db_bytes,
+            "wal_bytes": self.wal_bytes,
+            "free_bytes": self.free,
+            "write_lock": match &self.lock {
+                Ok(()) => json!("available"),
+                Err(err) => json!({"blocked": err}),
+            },
+            "write_capable": self.lock.is_ok(),
+            "holders": self.holders.iter().map(|h| json!({
+                "pid": h.pid,
+                "state": h.state,
+                "command": h.command,
+                "wedged": h.is_wedged(),
+            })).collect::<Vec<_>>(),
+            "problems": self.problems,
+        })
+    }
+}
+
+fn doctor(db_path: &Path, json: bool) -> Result<()> {
+    let report = doctor_report(db_path);
     if json {
         println!(
             "{}",
-            serde_json::to_string_pretty(&json!({
-                "db_path": db_path.display().to_string(),
-                "db_bytes": db_bytes,
-                "wal_bytes": wal_bytes,
-                "free_bytes": free,
-                "write_lock": match &lock {
-                    Ok(()) => json!("available"),
-                    Err(err) => json!({"blocked": err}),
-                },
-                "write_capable": lock.is_ok(),
-                "holders": holders.iter().map(|h| json!({
-                    "pid": h.pid,
-                    "state": h.state,
-                    "command": h.command,
-                    "wedged": h.is_wedged(),
-                })).collect::<Vec<_>>(),
-                "problems": problems,
-            }))?
+            serde_json::to_string_pretty(&report.to_json(db_path))?
         );
         return Ok(());
     }
+    let DoctorReport {
+        db_bytes,
+        wal_bytes,
+        free,
+        lock,
+        holders,
+        problems,
+    } = report;
 
     println!("database: {}", db_path.display());
     println!("  size:  {}", human_bytes(db_bytes));
@@ -7136,20 +7173,24 @@ fn home_dir() -> PathBuf {
 mod tests {
     use super::{
         checkpoint_sync_state, cleanup_stale_sync_state_temps, codex_rollout_user_prompts,
-        cron_schedule, file_stamp, git_commit_time_ms, git_stdout, ingest_claude_transcript,
-        is_sqlite_contention, link_git_commit, load_sync_state, parse_trajectory_file,
-        paths_overlap, prepare_sync_and_push_db, process_status_with_programs, save_sync_state,
-        search_all, service_command_args, shell_single_quote, source_database_path,
-        strip_url_credentials, sync_claude_session_metadata, sync_exclusive,
-        sync_opencode_exclusive, try_acquire_sync_lock, wal_contention_line,
-        write_contention_diagnostic, xml_escape, SearchRole, SyncSourceReport, PUSH_SERVICE,
-        WAL_WARN_BYTES,
+        cron_schedule, doctor_report, export_history, file_stamp, git_commit_time_ms, git_stdout,
+        import_history, ingest_claude_transcript, is_sqlite_contention, link_git_commit,
+        load_sync_state, parse_trajectory_file, paths_overlap, prepare_sync_and_push_db,
+        process_status_with_programs, save_sync_state, search_all, service_command_args,
+        shell_single_quote, source_database_path, strip_url_credentials,
+        sync_claude_session_metadata, sync_exclusive, sync_opencode_exclusive, sync_relaycast,
+        try_acquire_sync_lock, wal_contention_line, write_contention_diagnostic, xml_escape,
+        SearchRole, SyncSourceReport, PUSH_SERVICE, WAL_WARN_BYTES,
     };
-    use ai_hist_core::{init_db, open_db, QueryFilter, SourceDatabaseError};
+    use ai_hist_core::{
+        init_db, insert_history, open_db, prompt_hash, HistoryEntry, QueryFilter,
+        SourceDatabaseError,
+    };
     use rusqlite::Connection;
     use serde_json::{json, Map, Value};
     use std::fs;
     use std::io::Write as _;
+    use std::time::Duration;
 
     fn saved_cursor_offset(value: &Value) -> u64 {
         match super::FileCursor::decode(value).expect("valid file cursor") {
@@ -8950,5 +8991,504 @@ mod tests {
             rows,
             vec![("assistant".into(), "Here is the report.".into())]
         );
+    }
+
+    // AI_HIST_DB and the RELAYCAST_* credentials are process-global; serialize
+    // the tests that set them so cargo's parallel runner can't clobber them.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.previous {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn seed_exportable_history(conn: &Connection) {
+        for (source, session, project, prompt, ts) in [
+            (
+                "claude",
+                "s1",
+                Some("/tmp/p"),
+                "tag the release",
+                1_700_000_000_000i64,
+            ),
+            (
+                "codex",
+                "s2",
+                Some("/tmp/q"),
+                "fix the importer",
+                1_700_000_001_000,
+            ),
+            // A row with no project at all: the JSON round-trip has to keep the
+            // null rather than inventing a directory.
+            (
+                "cursor",
+                "s3",
+                None,
+                "write the changelog",
+                1_700_000_002_000,
+            ),
+        ] {
+            insert_history(
+                conn,
+                &HistoryEntry {
+                    id: 0,
+                    source: source.into(),
+                    session_id: Some(session.into()),
+                    project: project.map(str::to_string),
+                    prompt: prompt.into(),
+                    prompt_hash: Some(prompt_hash(prompt)),
+                    timestamp_ms: ts,
+                },
+            )
+            .unwrap();
+        }
+    }
+
+    type ExportedRow = (String, Option<String>, Option<String>, String, i64);
+
+    fn history_rows(conn: &Connection) -> Vec<ExportedRow> {
+        conn.prepare(
+            "SELECT source, session_id, project, prompt, timestamp_ms FROM history \
+             ORDER BY timestamp_ms",
+        )
+        .unwrap()
+        .query_map([], |row| {
+            Ok((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+            ))
+        })
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap()
+    }
+
+    fn history_count(conn: &Connection) -> i64 {
+        conn.query_row("SELECT COUNT(*) FROM history", [], |row| row.get(0))
+            .unwrap()
+    }
+
+    fn fresh_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn a_jsonl_export_round_trips_every_row_into_a_fresh_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let exported_from = fresh_db();
+        seed_exportable_history(&exported_from);
+        let path = dir.path().join("history.jsonl");
+
+        export_history(&exported_from, Some(&path), "jsonl", None, None, None).unwrap();
+
+        // One self-describing JSON object per row, oldest first.
+        let body = fs::read_to_string(&path).unwrap();
+        let lines: Vec<Value> = body
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0]["source"], "claude");
+        assert_eq!(lines[0]["prompt"], "tag the release");
+        assert_eq!(lines[0]["prompt_hash"], prompt_hash("tag the release"));
+        assert_eq!(lines[2]["project"], Value::Null);
+
+        let restored = fresh_db();
+        import_history(&restored, &path, false).unwrap();
+        assert_eq!(history_rows(&restored), history_rows(&exported_from));
+    }
+
+    #[test]
+    fn a_gzipped_export_round_trips_every_row_into_a_fresh_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let exported_from = fresh_db();
+        seed_exportable_history(&exported_from);
+        let path = dir.path().join("history.jsonl.gz");
+
+        export_history(&exported_from, Some(&path), "jsonl", None, None, None).unwrap();
+
+        // Really gzip, not JSONL that happens to be named .gz.
+        assert_eq!(&fs::read(&path).unwrap()[..2], &[0x1f, 0x8b]);
+
+        let restored = fresh_db();
+        import_history(&restored, &path, false).unwrap();
+        assert_eq!(history_rows(&restored), history_rows(&exported_from));
+    }
+
+    #[test]
+    fn a_sqlite_export_is_a_readable_searchable_database_of_the_same_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let exported_from = fresh_db();
+        seed_exportable_history(&exported_from);
+        let dest = dir.path().join("history-export.db");
+
+        export_history(&exported_from, Some(&dest), "sqlite", None, None, None).unwrap();
+
+        let exported = Connection::open(&dest).unwrap();
+        assert_eq!(history_rows(&exported), history_rows(&exported_from));
+        // The export carries the full schema, so search still works on it.
+        let hits: i64 = exported
+            .query_row(
+                "SELECT COUNT(*) FROM history_fts WHERE history_fts MATCH 'release'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(hits, 1);
+
+        // And it imports back like any other export.
+        let restored = fresh_db();
+        import_history(&restored, &dest, false).unwrap();
+        assert_eq!(history_rows(&restored), history_rows(&exported_from));
+    }
+
+    #[test]
+    fn a_sqlite_export_refuses_to_overwrite_the_active_database() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let active = dir.path().join("ai-history.db");
+        let _db_env = EnvVarGuard::set("AI_HIST_DB", &active);
+        let conn = open_db(&active).unwrap();
+        seed_exportable_history(&conn);
+
+        let error = export_history(&conn, Some(&active), "sqlite", None, None, None)
+            .expect_err("exporting over the live database must fail");
+        assert!(
+            error
+                .to_string()
+                .contains("Refusing to export SQLite over the active AI_HIST_DB"),
+            "unexpected error: {error}"
+        );
+
+        // The refusal happens before the destination is truncated, so the live
+        // history is still there.
+        assert_eq!(history_count(&conn), 3);
+    }
+
+    #[test]
+    fn reimporting_the_same_export_adds_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let exported_from = fresh_db();
+        seed_exportable_history(&exported_from);
+        let path = dir.path().join("history.jsonl");
+        export_history(&exported_from, Some(&path), "jsonl", None, None, None).unwrap();
+
+        let restored = fresh_db();
+        import_history(&restored, &path, false).unwrap();
+        assert_eq!(history_count(&restored), 3);
+        import_history(&restored, &path, false).unwrap();
+        assert_eq!(history_count(&restored), 3);
+        assert_eq!(history_rows(&restored), history_rows(&exported_from));
+    }
+
+    #[test]
+    fn a_dry_run_import_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let exported_from = fresh_db();
+        seed_exportable_history(&exported_from);
+        let path = dir.path().join("history.jsonl");
+        export_history(&exported_from, Some(&path), "jsonl", None, None, None).unwrap();
+
+        let restored = fresh_db();
+        import_history(&restored, &path, true).unwrap();
+        assert_eq!(history_count(&restored), 0);
+
+        // The same file without --dry-run does write.
+        import_history(&restored, &path, false).unwrap();
+        assert_eq!(history_count(&restored), 3);
+    }
+
+    #[test]
+    fn imported_rows_missing_a_prompt_hash_get_one_backfilled() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // A hand-written or pre-hash JSONL export.
+        let jsonl = dir.path().join("legacy.jsonl");
+        fs::write(
+            &jsonl,
+            "{\"source\":\"claude\",\"session_id\":\"s1\",\"project\":\"/tmp/p\",\
+             \"prompt\":\"tag the release\",\"timestamp_ms\":1700000000000}\n",
+        )
+        .unwrap();
+        let from_jsonl = fresh_db();
+        import_history(&from_jsonl, &jsonl, false).unwrap();
+        let hash: Option<String> = from_jsonl
+            .query_row("SELECT prompt_hash FROM history", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            hash.as_deref(),
+            Some(prompt_hash("tag the release").as_str())
+        );
+
+        // A SQLite export taken before the prompt_hash column existed.
+        let legacy_db = dir.path().join("legacy.db");
+        let legacy = Connection::open(&legacy_db).unwrap();
+        legacy
+            .execute_batch(
+                "CREATE TABLE history (id INTEGER PRIMARY KEY, source TEXT, session_id TEXT, \
+                 project TEXT, prompt TEXT, timestamp_ms INTEGER); \
+                 INSERT INTO history VALUES (1, 'codex', 's2', '/tmp/q', 'fix the importer', 1700000001000);",
+            )
+            .unwrap();
+        drop(legacy);
+        let from_sqlite = fresh_db();
+        import_history(&from_sqlite, &legacy_db, false).unwrap();
+        let hash: Option<String> = from_sqlite
+            .query_row("SELECT prompt_hash FROM history", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(
+            hash.as_deref(),
+            Some(prompt_hash("fix the importer").as_str())
+        );
+    }
+
+    #[test]
+    fn doctor_reports_a_healthy_database_with_every_field_it_promises() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("ai-history.db");
+        let conn = open_db(&db_path).unwrap();
+        seed_exportable_history(&conn);
+        drop(conn);
+
+        let report = doctor_report(&db_path).to_json(&db_path);
+        assert_eq!(report["db_path"], db_path.display().to_string());
+        assert!(report["db_bytes"].as_u64().unwrap() > 0, "{report}");
+        assert!(report["wal_bytes"].as_u64().is_some(), "{report}");
+        assert!(
+            report["free_bytes"].is_u64() || report["free_bytes"].is_null(),
+            "{report}"
+        );
+        assert_eq!(report["write_lock"], json!("available"));
+        assert_eq!(report["write_capable"], json!(true));
+        assert!(report["holders"].is_array(), "{report}");
+        // Nothing is holding the write lock, so nothing is reported as blocking it.
+        let problems = report["problems"].as_array().expect("problems array");
+        assert!(
+            !problems
+                .iter()
+                .any(|problem| problem.as_str().unwrap_or("").contains("write lock")),
+            "{problems:?}"
+        );
+    }
+
+    /// Reads one request line from `stream` and drains its headers so the
+    /// client sees a complete exchange.
+    fn read_request_line(stream: &mut std::net::TcpStream) -> String {
+        use std::io::{BufRead, BufReader};
+
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut first_line = String::new();
+        reader.read_line(&mut first_line).unwrap();
+        loop {
+            let mut line = String::new();
+            if reader.read_line(&mut line).unwrap() == 0 || line.trim_end().is_empty() {
+                break;
+            }
+        }
+        first_line.trim_end().to_string()
+    }
+
+    /// Answers exactly `count` HTTP requests off `listener` with `respond`, and
+    /// hands back the request lines it saw.
+    fn serve_http(
+        listener: std::net::TcpListener,
+        count: usize,
+        respond: impl Fn(&str) -> (&'static str, String) + Send + 'static,
+    ) -> std::thread::JoinHandle<Vec<String>> {
+        listener.set_nonblocking(true).unwrap();
+        std::thread::spawn(move || {
+            let started = std::time::Instant::now();
+            let mut seen = Vec::new();
+            while seen.len() < count && started.elapsed() < Duration::from_secs(20) {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(connection) => connection,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                        continue;
+                    }
+                    Err(error) => panic!("accept failed: {error}"),
+                };
+                let line = read_request_line(&mut stream);
+                let (status, body) = respond(&line);
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                stream.write_all(response.as_bytes()).unwrap();
+                seen.push(line);
+            }
+            assert_eq!(seen.len(), count, "served {seen:?}");
+            seen
+        })
+    }
+
+    /// A Relaycast messages page holding ids `m{first}`..`m{first + count - 1}`.
+    fn relay_message_page(first: usize, count: usize) -> String {
+        let messages: Vec<Value> = (first..first + count)
+            .map(|n| json!({"id": format!("m{n:03}"), "from_name": "ana", "text": format!("relay message {n:03}")}))
+            .collect();
+        serde_json::to_string(&json!({ "data": messages })).unwrap()
+    }
+
+    fn relaycast_env(base: &str) -> (EnvVarGuard, EnvVarGuard, EnvVarGuard) {
+        (
+            EnvVarGuard::set("RELAYCAST_API_KEY", "rc_test_key"),
+            EnvVarGuard::set("RELAYCAST_WORKSPACE_ID", "ws-e2e"),
+            EnvVarGuard::set("RELAYCAST_BASE_URL", base),
+        )
+    }
+
+    #[test]
+    fn relaycast_sync_pages_through_a_channel_and_saves_the_high_water_mark() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        // channels, messages page 1, messages page 2, dm listing.
+        let server = serve_http(listener, 4, |line| {
+            if line.starts_with("GET /v1/channels ") {
+                ("200 OK", r#"{"data":[{"name":"general"}]}"#.to_string())
+            } else if line.starts_with("GET /v1/channels/general/messages?limit=100&after=m099 ") {
+                ("200 OK", relay_message_page(100, 2))
+            } else if line.starts_with("GET /v1/channels/general/messages?limit=100 ") {
+                // A full page is the signal that another page may follow.
+                ("200 OK", relay_message_page(0, 100))
+            } else if line.starts_with("GET /v1/dm/conversations/all ") {
+                ("200 OK", r#"{"data":[]}"#.to_string())
+            } else {
+                panic!("unexpected request: {line}");
+            }
+        });
+
+        let conn = fresh_db();
+        let mut state = Map::new();
+        let _env = relaycast_env(&format!("http://{addr}"));
+        let inserted = sync_relaycast(&conn, &mut state).unwrap();
+        let requests = server.join().unwrap();
+
+        assert_eq!(inserted, 102);
+        assert_eq!(history_count(&conn), 102);
+        assert!(
+            requests[2].contains("after=m099"),
+            "the second page must continue from the last id of the first: {requests:?}"
+        );
+
+        // Messages are attributed to their sender and the workspace.
+        let (prompt, project, session_id): (String, Option<String>, Option<String>) = conn
+            .query_row(
+                "SELECT prompt, project, session_id FROM history WHERE prompt LIKE '%message 000'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(prompt, "[ana] relay message 000");
+        assert_eq!(project.as_deref(), Some("ws-e2e"));
+        // The channel name is the session; "ch:general" is only the state key.
+        assert_eq!(session_id.as_deref(), Some("#general"));
+
+        // The cursor saved is the highest id seen across both pages.
+        assert_eq!(state["relay"]["ch:general"], json!("m101"));
+    }
+
+    #[test]
+    fn relaycast_sync_resumes_from_the_saved_after_cursor() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = serve_http(listener, 3, |line| {
+            if line.starts_with("GET /v1/channels ") {
+                ("200 OK", r#"{"data":[{"name":"general"}]}"#.to_string())
+            } else if line.starts_with("GET /v1/channels/general/messages?limit=100&after=m050 ") {
+                ("200 OK", relay_message_page(51, 1))
+            } else if line.starts_with("GET /v1/dm/conversations/all ") {
+                ("200 OK", r#"{"data":[]}"#.to_string())
+            } else {
+                panic!("unexpected request: {line}");
+            }
+        });
+
+        let conn = fresh_db();
+        let mut state = Map::new();
+        state.insert("relay".into(), json!({"ch:general": "m050"}));
+        let _env = relaycast_env(&format!("http://{addr}"));
+        let inserted = sync_relaycast(&conn, &mut state).unwrap();
+        let requests = server.join().unwrap();
+
+        // Only the one message after the cursor is asked for, and stored.
+        assert_eq!(inserted, 1);
+        assert_eq!(history_count(&conn), 1);
+        assert!(requests[1].contains("after=m050"), "{requests:?}");
+        assert_eq!(state["relay"]["ch:general"], json!("m051"));
+    }
+
+    #[test]
+    fn relaycast_sync_keeps_channel_rows_when_the_dm_listing_is_forbidden() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = serve_http(listener, 3, |line| {
+            if line.starts_with("GET /v1/channels ") {
+                ("200 OK", r#"{"data":[{"name":"general"}]}"#.to_string())
+            } else if line.starts_with("GET /v1/channels/general/messages?limit=100 ") {
+                ("200 OK", relay_message_page(0, 1))
+            } else if line.starts_with("GET /v1/dm/conversations/all ") {
+                // Plenty of API keys have channel scope but no DM scope.
+                ("403 Forbidden", r#"{"error":"forbidden"}"#.to_string())
+            } else {
+                panic!("unexpected request: {line}");
+            }
+        });
+
+        let conn = fresh_db();
+        let mut state = Map::new();
+        let _env = relaycast_env(&format!("http://{addr}"));
+        let inserted = sync_relaycast(&conn, &mut state).unwrap();
+        server.join().unwrap();
+
+        // The DM refusal is tolerated: the channel rows still land.
+        assert_eq!(inserted, 1);
+        assert_eq!(history_count(&conn), 1);
+        assert_eq!(state["relay"]["ch:general"], json!("m000"));
+    }
+
+    #[test]
+    fn relaycast_sync_is_a_no_op_without_credentials() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+        let conn = fresh_db();
+        let mut state = Map::new();
+        // An unreachable base url proves no request is attempted at all.
+        let _env = (
+            EnvVarGuard::set("RELAYCAST_API_KEY", ""),
+            EnvVarGuard::set("RELAYCAST_WORKSPACE_ID", "ws-e2e"),
+            EnvVarGuard::set("RELAYCAST_BASE_URL", "http://127.0.0.1:1"),
+        );
+        assert_eq!(sync_relaycast(&conn, &mut state).unwrap(), 0);
+        assert_eq!(history_count(&conn), 0);
+        assert!(state.is_empty());
     }
 }

--- a/scripts/verify-e2e.sh
+++ b/scripts/verify-e2e.sh
@@ -6,9 +6,8 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 command -v sqlite3 >/dev/null || { echo "verify-e2e: sqlite3 is required" >&2; exit 1; }
-command -v npm >/dev/null || { echo "verify-e2e: npm is required" >&2; exit 1; }
+command -v node >/dev/null || { echo "verify-e2e: node is required" >&2; exit 1; }
 unset AI_HIST_CLI
-VERIFY_E2E_NPM_CACHE="${NPM_CONFIG_CACHE:-$HOME/.npm}"
 
 assert_eq() {
   local label="$1" actual="$2" expected="$3"
@@ -18,11 +17,20 @@ assert_eq() {
   fi
 }
 
+# Print one field of a --json payload piped on stdin. The argument is a JS
+# expression over `d`, the parsed document -- enough to name a single field
+# without pulling a JSON query tool into the script's dependencies.
+json_field() {
+  node -e '
+    const d = JSON.parse(require("node:fs").readFileSync(0, "utf8"));
+    process.stdout.write(String(eval(process.argv[1])));
+  ' "$1"
+}
+
 export AI_HIST_DB="$TMP/ai-history.db"
 export TRAJECTORY_ROOT="$TMP/trajectories"
 export OPENCODE_DB="$TMP/opencode.db"
 export HOME="$TMP/home"
-export NPM_CONFIG_CACHE="$VERIFY_E2E_NPM_CACHE"
 unset RELAYCAST_API_KEY RELAYCAST_WORKSPACE_ID RELAYCAST_BASE_URL
 mkdir -p "$HOME/.claude/projects/e2e-project" "$HOME/.codex/sessions/2026/06/20" "$TRAJECTORY_ROOT/planner/compacted"
 mkdir -p "$HOME/.grok/sessions/%2Ftmp%2Fe2e%2Fgrok/grok-e2e"
@@ -104,12 +112,25 @@ SQL
 "$ROOT/ai-hist" tag trajectory-e2e release-e2e --source trajectory
 "$ROOT/ai-hist" search release --tag release-e2e --json
 "$ROOT/ai-hist" search --tag release-e2e >/dev/null
-"$ROOT/ai-hist" session claude-e2e --full >/dev/null
-"$ROOT/ai-hist" show 1 --json >/dev/null
-"$ROOT/ai-hist" context 1 >/dev/null
-"$ROOT/ai-hist" pack release --json >/dev/null
-"$ROOT/ai-hist" stats --json >/dev/null
-"$ROOT/ai-hist" tags --sessions --json >/dev/null
+session_prompt=$("$ROOT/ai-hist" session claude-e2e --full --json | json_field 'd.map((e) => e.prompt).join("|")')
+assert_eq "session prompts" "$session_prompt" "e2e claude release tagging prompt"
+
+show_resume=$("$ROOT/ai-hist" show 1 --json | json_field 'd.resume_cmd')
+assert_eq "show resume command" "$show_resume" "cd /tmp/e2e/project && claude --resume claude-e2e"
+
+# `context` has no --json; assert it marks exactly the requested entry.
+context_out=$("$ROOT/ai-hist" context 1)
+context_focus=$(printf '%s\n' "$context_out" | grep -c '>>>' || true)
+assert_eq "context focus rows" "$context_focus" "1"
+
+pack_sources=$("$ROOT/ai-hist" pack release --json | json_field 'd.entries.map((e) => e.source).sort().join(",")')
+assert_eq "pack sources" "$pack_sources" "claude,codex,cursor,grok,opencode,trajectory"
+
+stats_total=$("$ROOT/ai-hist" stats --json | json_field 'd.total')
+assert_eq "stats total" "$stats_total" "6"
+
+tagged_sessions=$("$ROOT/ai-hist" tags --sessions --json | json_field 'd.find((t) => t.name === "release-e2e").session_count')
+assert_eq "tagged session count" "$tagged_sessions" "5"
 
 sources=$(sqlite3 "$AI_HIST_DB" "SELECT DISTINCT source FROM history" | sort)
 expected_sources=$(printf '%s\n' claude codex cursor grok opencode trajectory)
@@ -129,7 +150,5 @@ assert_eq "grok synthetic prompt count" "$synthetic" "0"
 
 "$ROOT/ai-hist" --db "$AI_HIST_DB" tag codex-e2e release-e2e --source codex
 "$ROOT/ai-hist" --db "$AI_HIST_DB" search release --tag release-e2e --json
-
-(cd "$ROOT/sdk-ts" && npm ci && npm test)
 
 echo "E2E verification completed with temp DB: $AI_HIST_DB"


### PR DESCRIPTION
## Why

#71 removed the legacy Python CLI, which was correct — `route_auto()` could never reach it. But its test suite wasn't purely redundant. Four clusters were the **only** coverage of behaviour that still ships in Rust, and none were ported:

| Deleted in #71 | n | Rust code left uncovered |
|---|---:|---|
| `TestCmdExport`, `TestCmdImport` | 17 | `export_history()`, `import_history()` |
| `TestSyncRelaycast` | 13 | `sync_relaycast()` |
| `TestParseCursorLine`, `TestDecodeCursorProject` | 9 | `parse_cursor_text()` |
| `TestCmdShow` (resume hints) | 5 | `resume_command()` |

Separately, six commands were invoked in `verify-e2e.sh` with output sent to `/dev/null`, so the exit code was the entire assertion — a change that made `ai-hist show` print an empty record would have passed CI green.

## What

**18 new Rust unit tests** (`ai-hist-cli` 100 → 112, `ai-hist-core` 31 → 37):

- **export / import** — JSONL and gzip round-trips, SQLite export readable and searchable, the active-database guard, re-import adds nothing, `--dry-run` writes nothing, `prompt_hash` backfilled when absent.
- **relaycast** — pagination with the high-water mark, resume from a saved `after` cursor, a forbidden DM listing keeping channel rows, no-op without credentials. No production change was needed: `sync_relaycast` is gated purely on env vars and `relay_get` shells out to `curl`, so the `TcpListener::bind("127.0.0.1:0")` idiom already in `cloud.rs` applies as-is.
- **cursor parsing** — the `<user_query>` envelope is unwrapped; rows without a user prompt are skipped.
- **`resume_command`** — per-agent CLI and `cd` into the project; the `cd` is dropped without a project and the command is absent without a session.
- **events read path** — `session_events`, `tool_calls` and `file_edits` read back oldest-first and scoped to one source. Nine existing tests cover *writing* transcript events; none covered reading them back.
- **`doctor`** — a healthy database reports every field it promises.

**Six e2e assertions upgraded.** `session`, `show`, `context`, `stats`, `tags` and `pack` each now assert one field of their `--json` payload, via a small `node` helper matching the style `verify-install.sh` already uses. Every assertion was mutation-checked to confirm it isn't vacuously true. `context` has no `--json` flag, so it asserts on text output instead.

**One duplicated CI step removed.** `verify-e2e.sh` ended with `npm ci && npm test`, re-running the entire TypeScript suite that CI already runs as its own step. That line and the npm plumbing serving it are gone; the script now runs in **0.5s instead of ~13s**.

## Production code

One change, refactor only: `doctor()` is split into `doctor_report()` and `DoctorReport::to_json()` so the report can be asserted on without capturing stdout. The `json!` body and the text-branch output are unchanged — both `ai-hist doctor` and `ai-hist doctor --json` produce identical output to before.

## ⚠️ Data-loss bug found — deliberately not fixed here

`export --format sqlite` can **destroy the live database** when `--db` is used.

`export_history()` guards with `dest != default_db_path()` (`lib.rs:1857`), but `main` resolves the database as `cli.db.unwrap_or_else(default_db_path)` (`lib.rs:590`). With `--db`, the guard compares against the *default* path rather than the one actually in use, so it never fires — and the next statement is `let _ = fs::remove_file(dest)`.

Reproduced against the built binary:

```
before:  history 2  tags 1  session_tags 1
$ ai-hist --db mine.db export --format sqlite mine.db
Exported 2 entries to …/mine.db          (exit 0)
after:   history 2  tags 0  session_tags 0
```

`history` survives only because those rows were already in memory. `sessions`, `session_events`, `tool_calls`, `file_edits`, `tags`, `session_tags` and `trajectories` are silently lost, with a success message and exit 0.

No test locks this in — encoding silent data loss as an expected assertion would make the eventual fix look like a regression. The included `a_sqlite_export_refuses_to_overwrite_the_active_database` covers the guard that *does* work (the `AI_HIST_DB` / default path) and will keep passing after a fix. The likely fix is threading the resolved `db_path` into `export_history` instead of re-deriving it. Happy to send that as a follow-up.

## Verification

All run against the final tree:

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --all-targets -- -A clippy::too_many_arguments -D warnings` | zero warnings |
| `cargo test --workspace` | 112 + 2 + 37 passed, 0 failed |
| `./scripts/verify-e2e.sh` | passed, 0.5s |
| `./scripts/verify-install.sh` | passed |

One caveat: the `sqlite3` CLI isn't installable in the environment this was developed in, and `verify-e2e.sh` hard-requires it, so the e2e run used a `python3` shim for `sqlite3`. The Rust tests, clippy, fmt and `verify-install.sh` all ran unshimmed. CI installs the real `sqlite3`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZsnmhbqzdsMXAgR9cUPbb)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

