### PR TITLE
Fast shallow coding-agent session discovery and cache-only session listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ Notable changes to the native `ai-hist` CLI are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- Add `ai-hist sessions list` and `ai-hist sessions discover`: a shallow session
+  catalog over every provider. `discover` enumerates candidates cheaply, orders
+  them globally by recency, and reads only bounded head/tail slices of the
+  winners; `list` serves the cached catalog with one indexed query and no
+  provider I/O. Both emit a versioned contract (`contract_version: 1`) —
+  `list --json` as one object, `discover --json` as JSONL rows, diagnostics, and
+  a closing summary with per-provider counts and operation counters. See
+  `docs/session-catalog.md`.
+- Extend the `sessions` catalog table with `first_prompt`, `models_json`,
+  `originator`, `agent_version`, `repo_url`, `initial_commit`,
+  `workspace_roots_json`, `source_stamp`, and `discovery_state`, plus the
+  `idx_sessions_source_last` and `idx_sessions_raw_path` indexes. Existing
+  databases migrate in place on the next open.
+- Expose `listSessions` and `discoverSessions` from the napi binding, so a Node
+  host can drive the catalog in-process instead of shelling out.
+
 ### Breaking
 
 - Remove the legacy Python CLI and the public `ai-hist-python` and

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ ai-hist context 4521 --window 15   # ±15 min window (default: 5)
 ai-hist session abc-1234-def
 ai-hist session abc-1234-def --full   # no truncation
 
+# Session catalog — "which agent sessions exist here?", without a full index
+ai-hist sessions discover              # refresh the catalog with bounded reads
+ai-hist sessions discover --limit 20   # only the 20 newest, across all providers
+ai-hist sessions list                  # read the catalog back (no provider I/O)
+ai-hist sessions list --source codex --limit 100
+ai-hist sessions list --json           # {"contract_version":1,"sessions":[...]}
+ai-hist sessions discover --json       # JSONL: session rows, diagnostics, summary
+
 # Resume a conversation directly (the exact command is shown by `ai-hist show <id>`)
 cd /path/to/project && claude --resume <session_id>          # claude
 codex resume <session_id>                                     # codex
@@ -138,15 +146,15 @@ Top 10 projects:
 
 ai-hist supports these sources:
 
-| Source | How | Key fields |
-|--------|-----|------------|
-| Claude Code | Local JSONL (`~/.claude/history.jsonl`) | `display`, `timestamp`, `project`, `sessionId` |
-| Codex CLI | Local JSONL (`~/.codex/history.jsonl`) | `text`, `ts`, `session_id` |
-| Cursor | Per-session JSONL (`~/.cursor/projects/<encoded-path>/agent-transcripts/<uuid>/<uuid>.jsonl`) | `role`, `message.content[].text` (user prompts wrapped in `<user_query>...`) |
-| Grok | Per-session JSONL (`~/.grok/sessions/<encoded-path>/<session-id>/chat_history.jsonl`) plus `summary.json` | `type`, `content[].text`, `info.cwd`, `head_branch` |
-| [Agent Relay](https://github.com/AgentWorkforce/relay) | API (`https://api.relaycast.dev/v1`) | `sender`, `content`, `channel`, `timestamp` |
-| Trajectories | Compacted per-run JSON (`$TRAJECTORY_ROOT/**/compacted/*.json`) | `personaId`, `projectId`, `task`, `decisions`, `retrospective` |
-| OpenCode | Local SQLite (`$OPENCODE_DB` or `~/.local/share/opencode/opencode.db`) | user text parts joined to sessions |
+| Source | How | Key fields | Session catalog (`sessions discover`) |
+|--------|-----|------------|---------------------------------------|
+| Claude Code | Local JSONL (`~/.claude/history.jsonl`) | `display`, `timestamp`, `project`, `sessionId` | head + tail of `~/.claude/projects/**/*.jsonl` |
+| Codex CLI | Local JSONL (`~/.codex/history.jsonl`) | `text`, `ts`, `session_id` | first `session_meta` line of `rollout-*.jsonl` (richest metadata) |
+| Cursor | Per-session JSONL (`~/.cursor/projects/<encoded-path>/agent-transcripts/<uuid>/<uuid>.jsonl`) | `role`, `message.content[].text` (user prompts wrapped in `<user_query>...`) | same files; no provider timestamps, so recency is file mtime |
+| Grok | Per-session JSONL (`~/.grok/sessions/<encoded-path>/<session-id>/chat_history.jsonl`) plus `summary.json` | `type`, `content[].text`, `info.cwd`, `head_branch` | `summary.json` + head of `chat_history.jsonl` |
+| [Agent Relay](https://github.com/AgentWorkforce/relay) | API (`https://api.relaycast.dev/v1`) | `sender`, `content`, `channel`, `timestamp` | already-synced local rows only — never the network |
+| Trajectories | Compacted per-run JSON (`$TRAJECTORY_ROOT/**/compacted/*.json`) | `personaId`, `projectId`, `task`, `decisions`, `retrospective` | exempt — derived records, not agent sessions |
+| OpenCode | Local SQLite (`$OPENCODE_DB` or `~/.local/share/opencode/opencode.db`) | user text parts joined to sessions | `session` table on a WAL-safe snapshot |
 
 **Claude Code, Codex, Cursor & Grok** are synced from local JSONL files incrementally. Grok user prompts are read from `chat_history.jsonl`; synthetic reminders are skipped and session metadata comes from `summary.json`.
 
@@ -197,6 +205,22 @@ The runtime contract is one JSON file per completed run:
 Aggregate `trail compact` artifacts are intentionally not the ai-hist interface; ai-hist indexes the runtime-emitted per-run contract files.
 
 All sources are indexed with [FTS5](https://www.sqlite.org/fts5.html) full-text search. Deduplication uses `INSERT OR IGNORE` on a `UNIQUE(source, timestamp_ms, prompt)` constraint.
+
+### Session catalog
+
+`ai-hist sync` is the deep index — every message, tool call and file edit. When
+you only need to answer *"which agent sessions exist here, newest first?"*, the
+**session catalog** is the shallow half: `ai-hist sessions discover` enumerates
+every provider cheaply, reads only bounded head/tail slices of the newest
+candidates, and caches identifying metadata in the `sessions` table.
+`ai-hist sessions list` then reads that cache back with a single indexed query
+and no provider I/O at all — fast enough for a session picker to call on every
+repaint, and unaffected by how much transcript volume sits behind it.
+
+Both emit a versioned, machine-readable contract (`contract_version: 1`).
+Full details — the JSON shapes, which fields each provider can supply, ordering
+and limit semantics, rescan behaviour, and the performance benchmark — are in
+[`docs/session-catalog.md`](docs/session-catalog.md).
 
 ## Database location
 
@@ -449,6 +473,43 @@ CREATE TABLE history (
 -- FTS5 full-text search index
 CREATE VIRTUAL TABLE history_fts USING fts5(prompt, project, content='history', content_rowid='id');
 ```
+
+The `sessions` table is the session catalog — one row per coding-agent session,
+keyed by `(session_id, source)`, written both by full sync and by shallow
+discovery:
+
+```sql
+CREATE TABLE sessions (
+    session_id TEXT NOT NULL,
+    source TEXT NOT NULL,
+    cwd TEXT,
+    git_branch TEXT,
+    first_activity_ms INTEGER,
+    last_activity_ms INTEGER,
+    last_assistant_text TEXT,      -- full indexing only; NULL on a shallow row
+    raw_path TEXT,                 -- provider file, when the source is file-backed
+    parser_version INTEGER NOT NULL DEFAULT 1,
+    first_prompt TEXT,             -- derived: bounded excerpt of the first human turn
+    models_json TEXT,              -- JSON array
+    originator TEXT,
+    agent_version TEXT,
+    repo_url TEXT,
+    initial_commit TEXT,
+    workspace_roots_json TEXT,     -- JSON array
+    source_stamp TEXT,             -- 'v<scanner>:<provider change marker>'
+    discovery_state TEXT,          -- 'shallow' or 'full'
+    PRIMARY KEY (session_id, source)
+);
+
+CREATE INDEX idx_sessions_last ON sessions(last_activity_ms DESC);
+CREATE INDEX idx_sessions_source_last ON sessions(source, last_activity_ms DESC);
+CREATE INDEX idx_sessions_raw_path ON sessions(source, raw_path);
+```
+
+Databases created before the catalog existed are migrated in place on the next
+open, so no manual step is needed. See
+[`docs/session-catalog.md`](docs/session-catalog.md) for field semantics and the
+per-provider capability matrix.
 
 Trajectory sync also maintains a structured `trajectories` table for decisions and retrospectives, while inserting a searchable `source='trajectory'` row into `history`.
 

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -352,6 +352,21 @@ const REQUIRED_TABLES: &[&str] = &[
     "sessions",
 ];
 const REQUIRED_HISTORY_COLUMNS: &[&str] = &["prompt_hash", "git_branch"];
+/// Columns [`init_db`] adds to `sessions` after the original DDL. The shallow
+/// session catalog (`ai-hist sessions list` / `discover`) reads every one of
+/// them, so a read-only handle over a database that predates them would fail
+/// with `no such column` instead of migrating.
+const REQUIRED_SESSIONS_COLUMNS: &[&str] = &[
+    "first_prompt",
+    "models_json",
+    "originator",
+    "agent_version",
+    "repo_url",
+    "initial_commit",
+    "workspace_roots_json",
+    "source_stamp",
+    "discovery_state",
+];
 
 /// Whether this database already has everything [`init_db`] would add.
 ///
@@ -371,9 +386,19 @@ pub fn schema_is_current(conn: &Connection) -> Result<bool> {
         .prepare("SELECT name FROM pragma_table_info('history')")?
         .query_map([], |row| row.get::<_, String>(0))?
         .collect::<rusqlite::Result<_>>()?;
-    Ok(REQUIRED_HISTORY_COLUMNS
+    if !REQUIRED_HISTORY_COLUMNS
         .iter()
-        .all(|needed| columns.contains(*needed)))
+        .all(|needed| columns.contains(*needed))
+    {
+        return Ok(false);
+    }
+    let session_columns: HashSet<String> = conn
+        .prepare("SELECT name FROM pragma_table_info('sessions')")?
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<_>>()?;
+    Ok(REQUIRED_SESSIONS_COLUMNS
+        .iter()
+        .all(|needed| session_columns.contains(*needed)))
 }
 
 /// Open the database for reading only.
@@ -415,10 +440,37 @@ CREATE TABLE IF NOT EXISTS sessions (
     last_assistant_text TEXT,
     raw_path TEXT,
     parser_version INTEGER NOT NULL DEFAULT 1,
+    first_prompt TEXT,
+    models_json TEXT,
+    originator TEXT,
+    agent_version TEXT,
+    repo_url TEXT,
+    initial_commit TEXT,
+    workspace_roots_json TEXT,
+    source_stamp TEXT,
+    discovery_state TEXT,
     PRIMARY KEY (session_id, source)
 );
 "#,
     )?;
+    // `sessions` predates the shallow catalog. Databases created by an older
+    // release keep the original nine columns, so every catalog field is added
+    // here as an ignore-error ALTER; a fresh database gets the same shape from
+    // the CREATE TABLE above and these become no-ops. Both paths converge.
+    // Anything added here must also be listed in REQUIRED_SESSIONS_COLUMNS.
+    for column in [
+        "first_prompt TEXT",
+        "models_json TEXT",
+        "originator TEXT",
+        "agent_version TEXT",
+        "repo_url TEXT",
+        "initial_commit TEXT",
+        "workspace_roots_json TEXT",
+        "source_stamp TEXT",
+        "discovery_state TEXT",
+    ] {
+        let _ = conn.execute(&format!("ALTER TABLE sessions ADD COLUMN {column}"), []);
+    }
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_history_hash ON history(prompt_hash)",
         [],
@@ -450,6 +502,18 @@ CREATE TABLE IF NOT EXISTS sessions (
     )?;
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_sessions_last ON sessions(last_activity_ms DESC)",
+        [],
+    )?;
+    // Source-filtered catalog listing (`sessions list --source codex`) orders by
+    // recency inside one source; without this the planner sorts the whole table.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_source_last ON sessions(source, last_activity_ms DESC)",
+        [],
+    )?;
+    // Shallow discovery keys its "has this file changed?" lookup on the raw
+    // path, because a transcript's session id is not known until it is read.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_raw_path ON sessions(source, raw_path)",
         [],
     )?;
     conn.execute(
@@ -1721,5 +1785,103 @@ mod tests {
             )
             .unwrap();
         assert_eq!(sessions_exists, 1);
+    }
+
+    /// The catalog columns must reach a database that predates them, and a
+    /// read-only handle must refuse to serve that database until they do —
+    /// otherwise `sessions list` fails with `no such column` instead of
+    /// migrating.
+    #[test]
+    fn session_catalog_columns_migrate_onto_a_pre_catalog_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("legacy.db");
+        {
+            let legacy = Connection::open(&db_path).unwrap();
+            legacy.execute_batch(SCHEMA).unwrap();
+            legacy
+                .execute_batch(
+                    "ALTER TABLE history ADD COLUMN git_branch TEXT;
+                     CREATE TABLE sessions (
+                         session_id TEXT NOT NULL,
+                         source TEXT NOT NULL,
+                         cwd TEXT,
+                         git_branch TEXT,
+                         first_activity_ms INTEGER,
+                         last_activity_ms INTEGER,
+                         last_assistant_text TEXT,
+                         raw_path TEXT,
+                         parser_version INTEGER NOT NULL DEFAULT 1,
+                         PRIMARY KEY (session_id, source)
+                     );
+                     INSERT INTO sessions (session_id, source, last_activity_ms)
+                     VALUES ('legacy-1', 'claude', 42);",
+                )
+                .unwrap();
+            assert!(
+                !schema_is_current(&legacy).unwrap(),
+                "a database without the catalog columns must not be served read-only"
+            );
+        }
+
+        let conn = open_db(&db_path).unwrap();
+        assert!(schema_is_current(&conn).unwrap());
+        let columns = conn
+            .prepare("SELECT name FROM pragma_table_info('sessions')")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<HashSet<String>>>()
+            .unwrap();
+        for needed in REQUIRED_SESSIONS_COLUMNS {
+            assert!(columns.contains(*needed), "missing column {needed}");
+        }
+        // Existing rows survive the migration with the new columns null.
+        let (id, state): (String, Option<String>) = conn
+            .query_row(
+                "SELECT session_id, discovery_state FROM sessions",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(id, "legacy-1");
+        assert_eq!(state, None);
+    }
+
+    /// A fresh database and a migrated one must end up with the same `sessions`
+    /// shape, or the CREATE TABLE and the ALTER TABLE list have drifted apart.
+    #[test]
+    fn fresh_and_migrated_session_tables_converge() {
+        let dir = tempfile::tempdir().unwrap();
+        let fresh = open_db(&dir.path().join("fresh.db")).unwrap();
+        let legacy_path = dir.path().join("legacy.db");
+        {
+            let legacy = Connection::open(&legacy_path).unwrap();
+            legacy
+                .execute_batch(
+                    "CREATE TABLE sessions (
+                         session_id TEXT NOT NULL,
+                         source TEXT NOT NULL,
+                         cwd TEXT,
+                         git_branch TEXT,
+                         first_activity_ms INTEGER,
+                         last_activity_ms INTEGER,
+                         last_assistant_text TEXT,
+                         raw_path TEXT,
+                         parser_version INTEGER NOT NULL DEFAULT 1,
+                         PRIMARY KEY (session_id, source)
+                     );",
+                )
+                .unwrap();
+        }
+        let migrated = open_db(&legacy_path).unwrap();
+        let columns = |conn: &Connection| {
+            conn.prepare("SELECT name FROM pragma_table_info('sessions') ORDER BY name")
+                .unwrap()
+                .query_map([], |row| row.get::<_, String>(0))
+                .unwrap()
+                .collect::<rusqlite::Result<Vec<String>>>()
+                .unwrap()
+        };
+        assert_eq!(columns(&fresh), columns(&migrated));
     }
 }

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -350,6 +350,7 @@ const REQUIRED_TABLES: &[&str] = &[
     "tags",
     "session_tags",
     "sessions",
+    "discovery_skips",
 ];
 const REQUIRED_HISTORY_COLUMNS: &[&str] = &["prompt_hash", "git_branch"];
 /// Columns [`init_db`] adds to `sessions` after the original DDL. The shallow
@@ -367,6 +368,16 @@ const REQUIRED_SESSIONS_COLUMNS: &[&str] = &[
     "source_stamp",
     "discovery_state",
 ];
+
+/// Indexes the session catalog's fast paths depend on.
+///
+/// The pre-existing guard checks tables and columns only. These two are listed
+/// because the catalog listing's whole promise is an indexed, sort-free read:
+/// a database that somehow has the columns but not the indexes would be served
+/// read-only with a full scan and a temp b-tree, silently. Missing means "not
+/// current", which routes the caller through the writable open that creates
+/// them.
+const REQUIRED_SESSIONS_INDEXES: &[&str] = &["idx_sessions_recency", "idx_sessions_source_recency"];
 
 /// Whether this database already has everything [`init_db`] would add.
 ///
@@ -396,9 +407,20 @@ pub fn schema_is_current(conn: &Connection) -> Result<bool> {
         .prepare("SELECT name FROM pragma_table_info('sessions')")?
         .query_map([], |row| row.get::<_, String>(0))?
         .collect::<rusqlite::Result<_>>()?;
-    Ok(REQUIRED_SESSIONS_COLUMNS
+    if !REQUIRED_SESSIONS_COLUMNS
         .iter()
-        .all(|needed| session_columns.contains(*needed)))
+        .all(|needed| session_columns.contains(*needed))
+    {
+        return Ok(false);
+    }
+    let mut index =
+        conn.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ? LIMIT 1")?;
+    for name in REQUIRED_SESSIONS_INDEXES {
+        if !index.exists([name])? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 /// Open the database for reading only.
@@ -430,6 +452,14 @@ pub fn init_db(conn: &Connection) -> Result<()> {
     let _ = conn.execute("ALTER TABLE history ADD COLUMN git_branch TEXT", []);
     conn.execute_batch(
         r#"
+CREATE TABLE IF NOT EXISTS discovery_skips (
+    source TEXT NOT NULL,
+    locator TEXT NOT NULL,
+    stamp TEXT NOT NULL,
+    reason TEXT,
+    updated_ms INTEGER,
+    PRIMARY KEY (source, locator)
+);
 CREATE TABLE IF NOT EXISTS sessions (
     session_id TEXT NOT NULL,
     source TEXT NOT NULL,
@@ -457,19 +487,24 @@ CREATE TABLE IF NOT EXISTS sessions (
     // release keep the original nine columns, so every catalog field is added
     // here as an ignore-error ALTER; a fresh database gets the same shape from
     // the CREATE TABLE above and these become no-ops. Both paths converge.
-    // Anything added here must also be listed in REQUIRED_SESSIONS_COLUMNS.
-    for column in [
-        "first_prompt TEXT",
-        "models_json TEXT",
-        "originator TEXT",
-        "agent_version TEXT",
-        "repo_url TEXT",
-        "initial_commit TEXT",
-        "workspace_roots_json TEXT",
-        "source_stamp TEXT",
-        "discovery_state TEXT",
-    ] {
-        let _ = conn.execute(&format!("ALTER TABLE sessions ADD COLUMN {column}"), []);
+    // The list is REQUIRED_SESSIONS_COLUMNS itself rather than a copy of it:
+    // three declarations of the same nine names (CREATE TABLE, this loop, the
+    // read-only guard) is two chances to drift, and every catalog column is
+    // TEXT, so the guard list is the migration list.
+    for column in REQUIRED_SESSIONS_COLUMNS {
+        // "Already there" is the expected outcome on every run after the
+        // first, and the only error worth swallowing. Anything else -- a
+        // read-only file, a corrupt page, a locked database -- means the
+        // migration did not happen, and hiding it here turns one clear failure
+        // at init into `no such column` on the user's first listing.
+        if let Err(error) = conn.execute(
+            &format!("ALTER TABLE sessions ADD COLUMN {column} TEXT"),
+            [],
+        ) {
+            if !error.to_string().contains("duplicate column name") {
+                return Err(error).with_context(|| format!("adding column sessions.{column}"));
+            }
+        }
     }
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_history_hash ON history(prompt_hash)",
@@ -508,6 +543,19 @@ CREATE TABLE IF NOT EXISTS sessions (
     // recency inside one source; without this the planner sorts the whole table.
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_sessions_source_last ON sessions(source, last_activity_ms DESC)",
+        [],
+    )?;
+    // The catalog's total order is (last_activity_ms DESC, source, session_id):
+    // recency alone ties constantly, because every mtime-derived session in one
+    // scan can share a timestamp, and a keyset paginator that cannot break
+    // those ties silently drops rows between pages. These two indexes carry the
+    // whole ORDER BY so the listing is still answered without a sort.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_recency ON sessions(last_activity_ms DESC, source, session_id)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_source_recency ON sessions(source, last_activity_ms DESC, session_id)",
         [],
     )?;
     // Shallow discovery keys its "has this file changed?" lookup on the raw
@@ -1845,6 +1893,27 @@ mod tests {
             .unwrap();
         assert_eq!(id, "legacy-1");
         assert_eq!(state, None);
+    }
+
+    /// The catalog listing's promise is an indexed, sort-free read. A database
+    /// that has the columns but not the indexes would be served read-only with
+    /// degraded plans, silently, so the guard covers them too.
+    #[test]
+    fn a_database_missing_a_catalog_index_is_not_served_read_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("indexless.db");
+        let conn = open_db(&db_path).unwrap();
+        assert!(schema_is_current(&conn).unwrap());
+        for index in REQUIRED_SESSIONS_INDEXES {
+            conn.execute_batch(&format!("DROP INDEX {index}")).unwrap();
+            assert!(
+                !schema_is_current(&conn).unwrap(),
+                "{index} is load-bearing for the catalog listing"
+            );
+            // init_db is idempotent, so the writable path heals it.
+            init_db(&conn).unwrap();
+            assert!(schema_is_current(&conn).unwrap());
+        }
     }
 
     /// A fresh database and a migrated one must end up with the same `sessions`

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -371,13 +371,23 @@ const REQUIRED_SESSIONS_COLUMNS: &[&str] = &[
 
 /// Indexes the session catalog's fast paths depend on.
 ///
-/// The pre-existing guard checks tables and columns only. These two are listed
-/// because the catalog listing's whole promise is an indexed, sort-free read:
-/// a database that somehow has the columns but not the indexes would be served
-/// read-only with a full scan and a temp b-tree, silently. Missing means "not
-/// current", which routes the caller through the writable open that creates
-/// them.
-const REQUIRED_SESSIONS_INDEXES: &[&str] = &["idx_sessions_recency", "idx_sessions_source_recency"];
+/// The pre-existing guard checks tables and columns only. These are listed
+/// because each one carries a promise the catalog makes: the two recency
+/// indexes make a listing an indexed, sort-free read, and `idx_sessions_raw_path`
+/// makes discovery's "has this transcript changed?" lookup a search rather than
+/// a scan of every session on every candidate. A database that somehow has the
+/// columns but not an index would otherwise be served with silently degraded
+/// plans. Missing means "not current", which routes the caller through the
+/// writable open that recreates them.
+///
+/// The older `idx_sessions_cwd` / `idx_sessions_branch` / `idx_sessions_last` /
+/// `idx_sessions_source_last` are deliberately absent: nothing in the catalog
+/// path depends on them any more.
+const REQUIRED_SESSIONS_INDEXES: &[&str] = &[
+    "idx_sessions_recency",
+    "idx_sessions_source_recency",
+    "idx_sessions_raw_path",
+];
 
 /// Whether this database already has everything [`init_db`] would add.
 ///
@@ -1904,6 +1914,20 @@ mod tests {
         let db_path = dir.path().join("indexless.db");
         let conn = open_db(&db_path).unwrap();
         assert!(schema_is_current(&conn).unwrap());
+        // Named explicitly so dropping one from the guard is a deliberate act:
+        // the recency pair carries the listing's sort-free order, and
+        // idx_sessions_raw_path carries discovery's per-candidate "has this
+        // transcript changed?" lookup.
+        for needed in [
+            "idx_sessions_recency",
+            "idx_sessions_source_recency",
+            "idx_sessions_raw_path",
+        ] {
+            assert!(
+                REQUIRED_SESSIONS_INDEXES.contains(&needed),
+                "{needed} is load-bearing and must stay in the guard"
+            );
+        }
         for index in REQUIRED_SESSIONS_INDEXES {
             conn.execute_batch(&format!("DROP INDEX {index}")).unwrap();
             assert!(

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -52,19 +52,46 @@ export interface CatalogSession {
    */
   fromCache: boolean
 }
+/**
+ * A precise continuation point in the catalog's total order,
+ * `(lastActivityMs DESC, source ASC, sessionId ASC)`.
+ *
+ * Recency alone is not a key -- one discovery pass can stamp many sessions
+ * with the same millisecond -- so the identity columns make the cursor total.
+ * `lastActivityMs` is null for the tail of rows whose recency is unknown.
+ */
+export interface CatalogCursor {
+  lastActivityMs?: number
+  source: string
+  sessionId: string
+}
 /** Filters for the cache-only catalog listing. */
 export interface ListSessionsOptions {
   /** Restrict to these sources. Omit for every discoverable source. */
   sources?: Array<string>
-  /** Row cap (default 50). */
+  /** Row cap (default 50). Must not be negative. */
   limit?: number
-  /** Keyset pagination: only sessions older than this epoch-ms cutoff. */
+  /**
+   * Coarse cutoff: only sessions older than this epoch-ms. Cannot separate
+   * sessions sharing a millisecond; use `after` to walk pages. Ignored when
+   * `after` is set.
+   */
   beforeMs?: number
+  /** Precise continuation: the previous page's `nextCursor`. */
+  after?: CatalogCursor
 }
-/** The cache-only catalog listing plus the contract version it was built with. */
+/**
+ * The cache-only catalog listing, the contract version it was built with, and
+ * the cursor that continues it.
+ */
 export interface SessionCatalog {
   contractVersion: number
   sessions: Array<CatalogSession>
+  /**
+   * Pass back as `after` for the next page; null once the catalog is
+   * exhausted (the page came back short of its limit).
+   */
+  nextCursor?: CatalogCursor
 }
 /** Filters for one shallow discovery run. */
 export interface DiscoverSessionsOptions {

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -20,3 +20,116 @@ export declare function syncLocal(): Promise<void>
  * thread so the Node event loop is never blocked.
  */
 export declare function syncAndPush(): Promise<SyncPushResult>
+/**
+ * One coding-agent session as the shallow catalog knows it.
+ *
+ * `firstPrompt` is derived by RelayHistory (a bounded excerpt of the first
+ * substantive human turn); everything else is observed in provider data, and
+ * anything the provider does not record stays null rather than being invented.
+ */
+export interface CatalogSession {
+  source: string
+  sessionId: string
+  cwd?: string
+  gitBranch?: string
+  firstActivityMs?: number
+  lastActivityMs?: number
+  firstPrompt?: string
+  lastAssistantText?: string
+  models: Array<string>
+  originator?: string
+  agentVersion?: string
+  repoUrl?: string
+  initialCommit?: string
+  workspaceRoots: Array<string>
+  rawPath?: string
+  sourceStamp?: string
+  /** `"shallow"` (catalog row only) or `"full"` (full evidence ingested). */
+  discoveryState: string
+  /**
+   * `true` when the row was served from the catalog without re-reading the
+   * provider source.
+   */
+  fromCache: boolean
+}
+/** Filters for the cache-only catalog listing. */
+export interface ListSessionsOptions {
+  /** Restrict to these sources. Omit for every discoverable source. */
+  sources?: Array<string>
+  /** Row cap (default 50). */
+  limit?: number
+  /** Keyset pagination: only sessions older than this epoch-ms cutoff. */
+  beforeMs?: number
+}
+/** The cache-only catalog listing plus the contract version it was built with. */
+export interface SessionCatalog {
+  contractVersion: number
+  sessions: Array<CatalogSession>
+}
+/** Filters for one shallow discovery run. */
+export interface DiscoverSessionsOptions {
+  /** Restrict to these sources. Omit for every adapter. */
+  sources?: Array<string>
+  /** Global cap across all providers, applied by recency. Omit for no cap. */
+  limit?: number
+}
+/**
+ * A non-fatal failure during discovery. One provider (or one malformed
+ * session) failing never blocks the rest of the run.
+ */
+export interface DiscoveryDiagnostic {
+  source: string
+  locator?: string
+  error: string
+}
+/** Per-provider tallies for one discovery run. */
+export interface ProviderSummary {
+  source: string
+  candidates: number
+  discovered: number
+  skippedUnchanged: number
+  failed: boolean
+}
+/** What one discovery run actually did — bounded-work evidence, not timings. */
+export interface DiscoveryCounters {
+  candidatesEnumerated: number
+  shallowReads: number
+  skippedUnchanged: number
+  filesOpened: number
+  bytesRead: number
+}
+/** A source that deliberately has no shallow adapter, and why. */
+export interface SourceExemption {
+  source: string
+  reason: string
+}
+/** Outcome of one shallow discovery run, with the rows collected. */
+export interface DiscoverResult {
+  contractVersion: number
+  sessions: Array<CatalogSession>
+  discovered: number
+  skippedUnchanged: number
+  providers: Array<ProviderSummary>
+  exemptSources: Array<SourceExemption>
+  diagnostics: Array<DiscoveryDiagnostic>
+  counters: DiscoveryCounters
+}
+/**
+ * List the session catalog from the local database only.
+ *
+ * One indexed query over `sessions`: no provider transcript is opened and no
+ * history/event/tool-call table is scanned, so this stays fast on first paint
+ * even with thousands of historical sessions. A database that does not exist
+ * yet is an empty catalog — call `discoverSessions()` to populate it.
+ */
+export declare function listSessions(options?: ListSessionsOptions | undefined | null): Promise<SessionCatalog>
+/**
+ * Discover sessions from the known provider locations with bounded reads.
+ *
+ * Candidates from every provider are merged by recency before the limit is
+ * applied, so a limit is global rather than per-provider. Sources whose bytes
+ * have not changed since the last run are served from the catalog. Rows are
+ * collected rather than streamed; use the CLI's JSONL output for progressive
+ * consumption.
+ */
+export declare function discoverSessions(options?: DiscoverSessionsOptions | undefined | null): Promise<DiscoverResult>

--- a/crates/ai-hist-napi/index.js
+++ b/crates/ai-hist-napi/index.js
@@ -310,7 +310,9 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { syncLocal, syncAndPush } = nativeBinding
+const { syncLocal, syncAndPush, listSessions, discoverSessions } = nativeBinding
 
 module.exports.syncLocal = syncLocal
 module.exports.syncAndPush = syncAndPush
+module.exports.listSessions = listSessions
+module.exports.discoverSessions = discoverSessions

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -99,22 +99,43 @@ impl From<ai_hist_cli::ShallowSession> for CatalogSession {
     }
 }
 
+/// A precise continuation point in the catalog's total order,
+/// `(lastActivityMs DESC, source ASC, sessionId ASC)`.
+///
+/// Recency alone is not a key -- one discovery pass can stamp many sessions
+/// with the same millisecond -- so the identity columns make the cursor total.
+/// `lastActivityMs` is null for the tail of rows whose recency is unknown.
+#[napi(object)]
+pub struct CatalogCursor {
+    pub last_activity_ms: Option<i64>,
+    pub source: String,
+    pub session_id: String,
+}
+
 /// Filters for the cache-only catalog listing.
 #[napi(object)]
 pub struct ListSessionsOptions {
     /// Restrict to these sources. Omit for every discoverable source.
     pub sources: Option<Vec<String>>,
-    /// Row cap (default 50).
+    /// Row cap (default 50). Must not be negative.
     pub limit: Option<i64>,
-    /// Keyset pagination: only sessions older than this epoch-ms cutoff.
+    /// Coarse cutoff: only sessions older than this epoch-ms. Cannot separate
+    /// sessions sharing a millisecond; use `after` to walk pages. Ignored when
+    /// `after` is set.
     pub before_ms: Option<i64>,
+    /// Precise continuation: the previous page's `nextCursor`.
+    pub after: Option<CatalogCursor>,
 }
 
-/// The cache-only catalog listing plus the contract version it was built with.
+/// The cache-only catalog listing, the contract version it was built with, and
+/// the cursor that continues it.
 #[napi(object)]
 pub struct SessionCatalog {
     pub contract_version: u32,
     pub sessions: Vec<CatalogSession>,
+    /// Pass back as `after` for the next page; null once the catalog is
+    /// exhausted (the page came back short of its limit).
+    pub next_cursor: Option<CatalogCursor>,
 }
 
 /// Filters for one shallow discovery run.
@@ -187,20 +208,44 @@ pub async fn list_sessions(options: Option<ListSessionsOptions>) -> napi::Result
         sources: None,
         limit: None,
         before_ms: None,
+        after: None,
     });
+    if let Some(limit) = options.limit {
+        // SQLite reads a negative LIMIT as "unlimited"; reject rather than
+        // silently hand back the whole catalog.
+        if limit < 0 {
+            return Err(napi::Error::from_reason(format!(
+                "limit must not be negative (got {limit})"
+            )));
+        }
+    }
     let request = ai_hist_cli::CatalogListOptions {
         sources: options.sources.unwrap_or_default(),
         limit: options.limit,
         before_ms: options.before_ms,
+        after: options.after.map(|cursor| ai_hist_cli::CatalogCursor {
+            last_activity_ms: cursor.last_activity_ms,
+            source: cursor.source,
+            session_id: cursor.session_id,
+        }),
     };
-    let sessions =
+    let page =
         napi::tokio::task::spawn_blocking(move || ai_hist_cli::list_sessions_local(&request))
             .await
             .map_err(|e| napi::Error::from_reason(format!("worker thread panicked: {e}")))?
             .map_err(|e| napi::Error::from_reason(format!("{e:#}")))?;
     Ok(SessionCatalog {
         contract_version: ai_hist_cli::SESSION_CATALOG_CONTRACT_VERSION,
-        sessions: sessions.into_iter().map(CatalogSession::from).collect(),
+        sessions: page
+            .sessions
+            .into_iter()
+            .map(CatalogSession::from)
+            .collect(),
+        next_cursor: page.next_cursor.map(|cursor| CatalogCursor {
+            last_activity_ms: cursor.last_activity_ms,
+            source: cursor.source,
+            session_id: cursor.session_id,
+        }),
     })
 }
 

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -1,6 +1,8 @@
 //! Native (napi) binding for driving ai-hist in-process — no CLI shell-out.
 //!
-//! Exposes local-only `syncLocal()` and cloud-enabled `syncAndPush()` to Node.
+//! Exposes local-only `syncLocal()` and cloud-enabled `syncAndPush()` to Node,
+//! plus the session catalog: `listSessions()` (cache-only) and
+//! `discoverSessions()` (shallow provider scan).
 #![deny(clippy::all)]
 
 use napi_derive::napi;
@@ -39,5 +41,232 @@ pub async fn sync_and_push() -> napi::Result<SyncPushResult> {
         accepted: outcome.accepted as u32,
         authenticated: outcome.authenticated,
         sync_skipped: outcome.sync_skipped,
+    })
+}
+
+/// One coding-agent session as the shallow catalog knows it.
+///
+/// `firstPrompt` is derived by RelayHistory (a bounded excerpt of the first
+/// substantive human turn); everything else is observed in provider data, and
+/// anything the provider does not record stays null rather than being invented.
+#[napi(object)]
+pub struct CatalogSession {
+    pub source: String,
+    pub session_id: String,
+    pub cwd: Option<String>,
+    pub git_branch: Option<String>,
+    pub first_activity_ms: Option<i64>,
+    pub last_activity_ms: Option<i64>,
+    pub first_prompt: Option<String>,
+    pub last_assistant_text: Option<String>,
+    pub models: Vec<String>,
+    pub originator: Option<String>,
+    pub agent_version: Option<String>,
+    pub repo_url: Option<String>,
+    pub initial_commit: Option<String>,
+    pub workspace_roots: Vec<String>,
+    pub raw_path: Option<String>,
+    pub source_stamp: Option<String>,
+    /// `"shallow"` (catalog row only) or `"full"` (full evidence ingested).
+    pub discovery_state: String,
+    /// `true` when the row was served from the catalog without re-reading the
+    /// provider source.
+    pub from_cache: bool,
+}
+
+impl From<ai_hist_cli::ShallowSession> for CatalogSession {
+    fn from(session: ai_hist_cli::ShallowSession) -> Self {
+        Self {
+            source: session.source,
+            session_id: session.session_id,
+            cwd: session.cwd,
+            git_branch: session.git_branch,
+            first_activity_ms: session.first_activity_ms,
+            last_activity_ms: session.last_activity_ms,
+            first_prompt: session.first_prompt,
+            last_assistant_text: session.last_assistant_text,
+            models: session.models,
+            originator: session.originator,
+            agent_version: session.agent_version,
+            repo_url: session.repo_url,
+            initial_commit: session.initial_commit,
+            workspace_roots: session.workspace_roots,
+            raw_path: session.raw_path,
+            source_stamp: session.source_stamp,
+            discovery_state: session.discovery_state,
+            from_cache: session.from_cache,
+        }
+    }
+}
+
+/// Filters for the cache-only catalog listing.
+#[napi(object)]
+pub struct ListSessionsOptions {
+    /// Restrict to these sources. Omit for every discoverable source.
+    pub sources: Option<Vec<String>>,
+    /// Row cap (default 50).
+    pub limit: Option<i64>,
+    /// Keyset pagination: only sessions older than this epoch-ms cutoff.
+    pub before_ms: Option<i64>,
+}
+
+/// The cache-only catalog listing plus the contract version it was built with.
+#[napi(object)]
+pub struct SessionCatalog {
+    pub contract_version: u32,
+    pub sessions: Vec<CatalogSession>,
+}
+
+/// Filters for one shallow discovery run.
+#[napi(object)]
+pub struct DiscoverSessionsOptions {
+    /// Restrict to these sources. Omit for every adapter.
+    pub sources: Option<Vec<String>>,
+    /// Global cap across all providers, applied by recency. Omit for no cap.
+    pub limit: Option<u32>,
+}
+
+/// A non-fatal failure during discovery. One provider (or one malformed
+/// session) failing never blocks the rest of the run.
+#[napi(object)]
+pub struct DiscoveryDiagnostic {
+    pub source: String,
+    pub locator: Option<String>,
+    pub error: String,
+}
+
+/// Per-provider tallies for one discovery run.
+#[napi(object)]
+pub struct ProviderSummary {
+    pub source: String,
+    pub candidates: u32,
+    pub discovered: u32,
+    pub skipped_unchanged: u32,
+    pub failed: bool,
+}
+
+/// What one discovery run actually did — bounded-work evidence, not timings.
+#[napi(object)]
+pub struct DiscoveryCounters {
+    pub candidates_enumerated: i64,
+    pub shallow_reads: i64,
+    pub skipped_unchanged: i64,
+    pub files_opened: i64,
+    pub bytes_read: i64,
+}
+
+/// A source that deliberately has no shallow adapter, and why.
+#[napi(object)]
+pub struct SourceExemption {
+    pub source: String,
+    pub reason: String,
+}
+
+/// Outcome of one shallow discovery run, with the rows collected.
+#[napi(object)]
+pub struct DiscoverResult {
+    pub contract_version: u32,
+    pub sessions: Vec<CatalogSession>,
+    pub discovered: u32,
+    pub skipped_unchanged: u32,
+    pub providers: Vec<ProviderSummary>,
+    pub exempt_sources: Vec<SourceExemption>,
+    pub diagnostics: Vec<DiscoveryDiagnostic>,
+    pub counters: DiscoveryCounters,
+}
+
+/// List the session catalog from the local database only.
+///
+/// One indexed query over `sessions`: no provider transcript is opened and no
+/// history/event/tool-call table is scanned, so this stays fast on first paint
+/// even with thousands of historical sessions. A database that does not exist
+/// yet is an empty catalog — call `discoverSessions()` to populate it.
+#[napi]
+pub async fn list_sessions(options: Option<ListSessionsOptions>) -> napi::Result<SessionCatalog> {
+    let options = options.unwrap_or(ListSessionsOptions {
+        sources: None,
+        limit: None,
+        before_ms: None,
+    });
+    let request = ai_hist_cli::CatalogListOptions {
+        sources: options.sources.unwrap_or_default(),
+        limit: options.limit,
+        before_ms: options.before_ms,
+    };
+    let sessions =
+        napi::tokio::task::spawn_blocking(move || ai_hist_cli::list_sessions_local(&request))
+            .await
+            .map_err(|e| napi::Error::from_reason(format!("worker thread panicked: {e}")))?
+            .map_err(|e| napi::Error::from_reason(format!("{e:#}")))?;
+    Ok(SessionCatalog {
+        contract_version: ai_hist_cli::SESSION_CATALOG_CONTRACT_VERSION,
+        sessions: sessions.into_iter().map(CatalogSession::from).collect(),
+    })
+}
+
+/// Discover sessions from the known provider locations with bounded reads.
+///
+/// Candidates from every provider are merged by recency before the limit is
+/// applied, so a limit is global rather than per-provider. Sources whose bytes
+/// have not changed since the last run are served from the catalog. Rows are
+/// collected rather than streamed; use the CLI's JSONL output for progressive
+/// consumption.
+#[napi]
+pub async fn discover_sessions(
+    options: Option<DiscoverSessionsOptions>,
+) -> napi::Result<DiscoverResult> {
+    let options = options.unwrap_or(DiscoverSessionsOptions {
+        sources: None,
+        limit: None,
+    });
+    let request = ai_hist_cli::DiscoverOptions {
+        sources: options.sources.unwrap_or_default(),
+        limit: options.limit.map(|limit| limit as usize),
+    };
+    let (sessions, summary) =
+        napi::tokio::task::spawn_blocking(move || ai_hist_cli::discover_sessions_local(&request))
+            .await
+            .map_err(|e| napi::Error::from_reason(format!("worker thread panicked: {e}")))?
+            .map_err(|e| napi::Error::from_reason(format!("{e:#}")))?;
+    Ok(DiscoverResult {
+        contract_version: summary.contract_version,
+        sessions: sessions.into_iter().map(CatalogSession::from).collect(),
+        discovered: summary.discovered as u32,
+        skipped_unchanged: summary.skipped_unchanged as u32,
+        providers: summary
+            .providers
+            .into_iter()
+            .map(|(source, provider)| ProviderSummary {
+                source,
+                candidates: provider.candidates as u32,
+                discovered: provider.discovered as u32,
+                skipped_unchanged: provider.skipped_unchanged as u32,
+                failed: provider.failed,
+            })
+            .collect(),
+        exempt_sources: summary
+            .exempt_sources
+            .into_iter()
+            .map(|exemption| SourceExemption {
+                source: exemption.source.to_string(),
+                reason: exemption.reason.to_string(),
+            })
+            .collect(),
+        diagnostics: summary
+            .diagnostics
+            .into_iter()
+            .map(|diagnostic| DiscoveryDiagnostic {
+                source: diagnostic.source,
+                locator: diagnostic.locator,
+                error: diagnostic.error,
+            })
+            .collect(),
+        counters: DiscoveryCounters {
+            candidates_enumerated: summary.counters.candidates_enumerated as i64,
+            shallow_reads: summary.counters.shallow_reads as i64,
+            skipped_unchanged: summary.counters.skipped_unchanged as i64,
+            files_opened: summary.counters.files_opened as i64,
+            bytes_read: summary.counters.bytes_read as i64,
+        },
     })
 }

--- a/crates/ai-hist/Cargo.toml
+++ b/crates/ai-hist/Cargo.toml
@@ -27,6 +27,7 @@ rusqlite = { version = "0.32", features = ["backup", "bundled", "functions"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+tempfile = "3"
 ureq = { version = "2", features = ["json"] }
 url = "2"
 

--- a/crates/ai-hist/src/discover.rs
+++ b/crates/ai-hist/src/discover.rs
@@ -506,7 +506,26 @@ impl ShallowSessionProvider for ClaudeProvider {
         };
         let mut models = Vec::new();
         let mut session_id = None;
+        // A subagent sidecar transcript is its own file whose records carry the
+        // *parent's* sessionId (see `ingest_claude_transcript`). Enumerating it
+        // as a session would emit the parent twice per run and let the two
+        // files fight over one row's raw_path/source_stamp, so the stamp never
+        // matched again and one of them was re-read forever.
+        let mut identified_records = 0usize;
+        let mut sidechain_records = 0usize;
+        let mut parsed_records = 0usize;
         for value in json_lines(&bounded.head) {
+            parsed_records += 1;
+            if value
+                .get("sessionId")
+                .and_then(Value::as_str)
+                .is_some_and(|id| !id.is_empty())
+            {
+                identified_records += 1;
+                if value.get("isSidechain").and_then(Value::as_bool) == Some(true) {
+                    sidechain_records += 1;
+                }
+            }
             if session_id.is_none() {
                 session_id = value
                     .get("sessionId")
@@ -542,6 +561,26 @@ impl ShallowSessionProvider for ClaudeProvider {
             if let Some(branch) = value.get("gitBranch").and_then(Value::as_str) {
                 session.git_branch = Some(branch.to_string());
             }
+        }
+        // Every identified record in the head belongs to a sidechain: this is a
+        // sidecar for a session whose own transcript is enumerated separately.
+        // A session's primary transcript always opens with non-sidechain turns,
+        // because a subagent can only be spawned by one.
+        if identified_records > 0 && sidechain_records == identified_records {
+            return Ok(None);
+        }
+        // A file with complete records that parse as nothing is corrupt, not a
+        // session. Publishing it under its file stem would put a fabricated
+        // row in the catalog and hide the corruption; a diagnostic names it.
+        // A file with no complete records at all is merely empty (a session
+        // that has just started) and is simply not a session yet.
+        if parsed_records == 0 {
+            anyhow::ensure!(
+                bounded.head.is_empty(),
+                "no parseable JSON records in the first {} record(s)",
+                bounded.head.len()
+            );
+            return Ok(None);
         }
         let Some(session_id) = session_id.or_else(|| {
             path.file_stem()
@@ -1039,24 +1078,24 @@ impl ShallowSessionProvider for OpencodeProvider {
         let Some((directory, created, updated)) = row else {
             return Ok(None);
         };
+        // The excerpt is cut in SQL, not in Rust: a single opencode part can
+        // hold a whole pasted file, and materializing it just to take the
+        // first 4096 characters would break the bounded-read promise for a
+        // catalog entry.
         let first_prompt = conn
             .query_row(
-                "SELECT p.data FROM part p JOIN message m ON m.id = p.message_id \
+                "SELECT substr(json_extract(p.data, '$.text'), 1, ?) \
+                 FROM part p JOIN message m ON m.id = p.message_id \
                  WHERE p.session_id = ? AND json_extract(m.data, '$.role') = 'user' \
                  AND json_extract(p.data, '$.type') = 'text' \
                  ORDER BY COALESCE(p.time_created, m.time_created) ASC LIMIT 1",
-                [&candidate.locator],
-                |row| row.get::<_, String>(0),
+                params![EXCERPT_MAX_CHARS as i64, &candidate.locator],
+                |row| row.get::<_, Option<String>>(0),
             )
             .ok()
-            .and_then(|data| serde_json::from_str::<Value>(&data).ok())
-            .and_then(|value| {
-                value
-                    .get("text")
-                    .and_then(Value::as_str)
-                    .map(excerpt)
-                    .filter(|text| !text.is_empty())
-            });
+            .flatten()
+            .map(|text| excerpt(&text))
+            .filter(|text| !text.is_empty());
         let mut models = Vec::new();
         if let Ok(model) = conn.query_row(
             "SELECT json_extract(data, '$.modelID') FROM message \
@@ -1221,6 +1260,24 @@ fn row_to_session(row: &rusqlite::Row<'_>) -> rusqlite::Result<ShallowSession> {
     })
 }
 
+/// A precise continuation point in the catalog's total order.
+///
+/// The catalog is ordered `(last_activity_ms DESC, source ASC, session_id ASC)`.
+/// Recency alone is not a key: a single discovery pass can stamp dozens of
+/// sessions with the same mtime-derived millisecond, and a cursor that carries
+/// only a timestamp silently drops every row tied with the page boundary. The
+/// identity columns make the cursor total.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CatalogCursor {
+    /// Last activity of the final row on the previous page; `None` for a row
+    /// whose recency is unknown (those sort last, after every dated row).
+    pub last_activity_ms: Option<i64>,
+    /// Source of the final row on the previous page.
+    pub source: String,
+    /// Session id of the final row on the previous page.
+    pub session_id: String,
+}
+
 /// Options for the cache-only catalog listing.
 #[derive(Debug, Clone, Default)]
 pub struct CatalogListOptions {
@@ -1228,20 +1285,30 @@ pub struct CatalogListOptions {
     pub sources: Vec<String>,
     /// Row cap; defaults to [`DEFAULT_CATALOG_LIMIT`].
     pub limit: Option<i64>,
-    /// Keyset pagination cursor: only rows strictly older than this.
+    /// Coarse cutoff: only sessions strictly older than this millisecond.
+    /// Convenient for "show me anything before last Tuesday", but it cannot
+    /// separate rows that share a millisecond — use [`CatalogListOptions::after`]
+    /// to walk pages. Ignored when `after` is set.
     pub before_ms: Option<i64>,
+    /// Precise continuation from the previous page's `next_cursor`.
+    pub after: Option<CatalogCursor>,
 }
 
-/// List the session catalog straight out of the database.
+/// One page of the catalog plus the cursor that continues it.
+#[derive(Debug, Clone, Default)]
+pub struct SessionCatalogPage {
+    /// The rows, newest first.
+    pub sessions: Vec<ShallowSession>,
+    /// Pass as [`CatalogListOptions::after`] for the next page. `None` when
+    /// this page did not fill its limit, i.e. the catalog is exhausted.
+    pub next_cursor: Option<CatalogCursor>,
+}
+
+/// The catalog listing query and its bound arguments.
 ///
-/// Pure SQL over `sessions`: no filesystem access, no provider I/O, and no
-/// scan of `history` / `session_events` / `tool_calls`. `trajectory` rows are
-/// excluded defensively — trajectories are derived records, not sessions, and
-/// must never appear in a session list even if something wrote one.
-pub fn list_session_catalog(
-    conn: &Connection,
-    options: &CatalogListOptions,
-) -> Result<Vec<ShallowSession>> {
+/// Built in one place so the query-plan test asserts the plan of the statement
+/// that actually runs.
+fn catalog_list_query(options: &CatalogListOptions) -> (String, Vec<Box<dyn rusqlite::ToSql>>) {
     let mut sql = format!("SELECT {SESSION_COLUMNS} FROM sessions WHERE source <> 'trajectory'");
     let mut args: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
     if !options.sources.is_empty() {
@@ -1251,12 +1318,59 @@ pub fn list_session_catalog(
             args.push(Box::new(source.clone()));
         }
     }
-    if let Some(before_ms) = options.before_ms {
-        sql.push_str(" AND last_activity_ms < ?");
-        args.push(Box::new(before_ms));
+    match options.after.as_ref() {
+        // Everything strictly after the cursor in the catalog's total order.
+        // Undated rows sort last, so a dated cursor must still reach them.
+        Some(cursor) => match cursor.last_activity_ms {
+            Some(ms) => {
+                sql.push_str(
+                    " AND (last_activity_ms IS NULL OR last_activity_ms < ? \
+                       OR (last_activity_ms = ? \
+                           AND (source > ? OR (source = ? AND session_id > ?))))",
+                );
+                args.push(Box::new(ms));
+                args.push(Box::new(ms));
+                args.push(Box::new(cursor.source.clone()));
+                args.push(Box::new(cursor.source.clone()));
+                args.push(Box::new(cursor.session_id.clone()));
+            }
+            None => {
+                sql.push_str(
+                    " AND last_activity_ms IS NULL \
+                       AND (source > ? OR (source = ? AND session_id > ?))",
+                );
+                args.push(Box::new(cursor.source.clone()));
+                args.push(Box::new(cursor.source.clone()));
+                args.push(Box::new(cursor.session_id.clone()));
+            }
+        },
+        None => {
+            if let Some(before_ms) = options.before_ms {
+                sql.push_str(" AND last_activity_ms < ?");
+                args.push(Box::new(before_ms));
+            }
+        }
     }
-    sql.push_str(" ORDER BY last_activity_ms DESC LIMIT ?");
+    sql.push_str(" ORDER BY last_activity_ms DESC, source ASC, session_id ASC LIMIT ?");
     args.push(Box::new(options.limit.unwrap_or(DEFAULT_CATALOG_LIMIT)));
+    (sql, args)
+}
+
+/// List the session catalog straight out of the database.
+///
+/// Pure SQL over `sessions`: no filesystem access, no provider I/O, and no
+/// scan of `history` / `session_events` / `tool_calls`. `trajectory` rows are
+/// excluded defensively — trajectories are derived records, not sessions, and
+/// must never appear in a session list even if something wrote one.
+///
+/// Rows come back in the catalog's total order:
+/// `(last_activity_ms DESC, source ASC, session_id ASC)`, with rows of unknown
+/// recency last. Use [`list_session_catalog_page`] to paginate.
+pub fn list_session_catalog(
+    conn: &Connection,
+    options: &CatalogListOptions,
+) -> Result<Vec<ShallowSession>> {
+    let (sql, args) = catalog_list_query(options);
     let mut stmt = conn.prepare(&sql)?;
     let params = rusqlite::params_from_iter(args.iter().map(|arg| arg.as_ref()));
     let rows = stmt
@@ -1265,19 +1379,30 @@ pub fn list_session_catalog(
     Ok(rows)
 }
 
-/// The SQL `list_session_catalog` would run, for query-plan assertions.
-#[cfg(test)]
-fn catalog_list_sql(options: &CatalogListOptions) -> String {
-    let mut sql = format!("SELECT {SESSION_COLUMNS} FROM sessions WHERE source <> 'trajectory'");
-    if !options.sources.is_empty() {
-        let placeholders = vec!["?"; options.sources.len()].join(", ");
-        sql.push_str(&format!(" AND source IN ({placeholders})"));
-    }
-    if options.before_ms.is_some() {
-        sql.push_str(" AND last_activity_ms < ?");
-    }
-    sql.push_str(" ORDER BY last_activity_ms DESC LIMIT ?");
-    sql
+/// [`list_session_catalog`] plus the cursor that continues it.
+///
+/// The cursor is `None` once a page comes back short of its limit, so a
+/// caller walks the catalog by following `next_cursor` until it is absent —
+/// no duplicated and no skipped rows, even when a whole page shares one
+/// millisecond.
+pub fn list_session_catalog_page(
+    conn: &Connection,
+    options: &CatalogListOptions,
+) -> Result<SessionCatalogPage> {
+    let sessions = list_session_catalog(conn, options)?;
+    let limit = options.limit.unwrap_or(DEFAULT_CATALOG_LIMIT);
+    let next_cursor = (limit > 0 && sessions.len() as i64 >= limit)
+        .then(|| sessions.last())
+        .flatten()
+        .map(|row| CatalogCursor {
+            last_activity_ms: row.last_activity_ms,
+            source: row.source.clone(),
+            session_id: row.session_id.clone(),
+        });
+    Ok(SessionCatalogPage {
+        sessions,
+        next_cursor,
+    })
 }
 
 fn fetch_catalog_row(
@@ -1303,12 +1428,64 @@ fn fetch_catalog_row_by_path(
         .ok())
 }
 
+/// Whether this source was already examined at this exact stamp and found not
+/// to be a session.
+///
+/// Without this, every codex subagent thread and every claude sidecar — real
+/// files that legitimately produce no catalog row — was re-read on every
+/// single run, because "no row" left nothing for the stamp check to match.
+fn is_known_non_session(
+    conn: &Connection,
+    source: &str,
+    locator: &str,
+    stamp: &str,
+) -> Result<bool> {
+    let known: Option<String> = conn
+        .query_row(
+            "SELECT stamp FROM discovery_skips WHERE source = ? AND locator = ?",
+            params![source, locator],
+            |row| row.get(0),
+        )
+        .ok();
+    Ok(known.as_deref() == Some(stamp))
+}
+
+/// Remember that this source, at this stamp, is not a session.
+fn record_non_session(conn: &Connection, source: &str, locator: &str, stamp: &str) -> Result<()> {
+    conn.execute(
+        "INSERT INTO discovery_skips (source, locator, stamp, reason, updated_ms) \
+         VALUES (?, ?, ?, 'not-a-session', ?) \
+         ON CONFLICT(source, locator) DO UPDATE SET \
+         stamp = excluded.stamp, reason = excluded.reason, updated_ms = excluded.updated_ms",
+        params![source, locator, stamp, now_ms()],
+    )?;
+    Ok(())
+}
+
+/// Drop a stale non-session marker once a source does resolve to a session.
+fn clear_non_session(conn: &Connection, source: &str, locator: &str) -> Result<()> {
+    conn.execute(
+        "DELETE FROM discovery_skips WHERE source = ? AND locator = ?",
+        params![source, locator],
+    )?;
+    Ok(())
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_millis() as i64)
+        .unwrap_or_default()
+}
+
 /// Write a shallow row into the catalog.
 ///
 /// Never nulls out a value the catalog already holds, never lowers
 /// `first_activity_ms` past what a fuller pass observed, and never downgrades
-/// a `discovery_state = 'full'` row to `'shallow'` — a shallow rescan of a
-/// fully indexed session still refreshes its metadata and stamp.
+/// a fully indexed row to `'shallow'` — including a row from a database that
+/// predates `discovery_state`, whose NULL readers deliberately interpret as
+/// `'full'`. A shallow rescan of such a row still refreshes its metadata and
+/// stamp.
 pub fn upsert_shallow_session(conn: &Connection, session: &ShallowSession) -> Result<()> {
     conn.execute(
         "INSERT INTO sessions \
@@ -1338,7 +1515,9 @@ pub fn upsert_shallow_session(conn: &Connection, session: &ShallowSession) -> Re
          initial_commit = COALESCE(excluded.initial_commit, sessions.initial_commit), \
          workspace_roots_json = COALESCE(excluded.workspace_roots_json, sessions.workspace_roots_json), \
          source_stamp = COALESCE(excluded.source_stamp, sessions.source_stamp), \
-         discovery_state = CASE WHEN sessions.discovery_state = 'full' THEN 'full' ELSE 'shallow' END",
+         discovery_state = CASE \
+             WHEN sessions.discovery_state IS NULL OR sessions.discovery_state = 'full' \
+             THEN 'full' ELSE 'shallow' END",
         params![
             session.session_id,
             session.source,
@@ -1417,6 +1596,32 @@ pub struct DiscoverySummary {
     /// Work actually performed.
     pub counters: DiscoveryCounters,
 }
+
+/// Every selected provider failed to enumerate, so the run made no progress.
+///
+/// Carries the run's summary — diagnostics included — so a caller can report
+/// what each provider said before propagating the failure.
+#[derive(Debug)]
+pub struct AllProvidersFailed {
+    /// The run as far as it got, including one diagnostic per failed provider.
+    pub summary: DiscoverySummary,
+}
+
+impl std::fmt::Display for AllProvidersFailed {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "all {} session provider(s) failed; no provider made progress",
+            self.summary
+                .providers
+                .values()
+                .filter(|provider| provider.failed)
+                .count()
+        )
+    }
+}
+
+impl std::error::Error for AllProvidersFailed {}
 
 fn stored_stamp(raw: &str) -> String {
     format!("v{SHALLOW_SCANNER_VERSION}:{raw}")
@@ -1507,9 +1712,12 @@ pub fn discover_sessions_with_env(
         }
     }
     if !providers.is_empty() && failed_providers == providers.len() {
-        anyhow::bail!(
-            "all {failed_providers} session provider(s) failed; no provider made progress"
-        );
+        // Still a failure, but the diagnostics explaining *why* each provider
+        // failed are the useful part. Carrying the summary inside the error
+        // lets a JSONL consumer receive the diagnostic lines and a summary
+        // trailer before the non-zero exit, instead of a bare message.
+        summary.counters = env.counters();
+        return Err(AllProvidersFailed { summary }.into());
     }
 
     // Global recency ordering. Candidates with no recency signal sort last;
@@ -1520,16 +1728,25 @@ pub fn discover_sessions_with_env(
             .then_with(|| a.source.cmp(b.source))
             .then_with(|| a.locator.cmp(&b.locator))
     });
-    if let Some(limit) = options.limit {
-        candidates.truncate(limit);
-    }
-
     let by_source: BTreeMap<&str, &dyn ShallowSessionProvider> = providers
         .iter()
         .map(|provider| (provider.source(), provider.as_ref()))
         .collect();
 
+    // The limit counts *emitted sessions*, not candidates. Truncating the
+    // candidate list up front let a codex subagent thread or a claude sidecar
+    // -- neither of which is a session -- eat a result slot, so `--limit 3`
+    // could hand back two sessions while older valid ones went unread.
+    let limit = options.limit.unwrap_or(usize::MAX);
+    let mut emitted = 0usize;
+    // One session can be reached through more than one file in a single run
+    // (a transcript plus its subagent sidecars). Emit it once.
+    let mut emitted_sessions: BTreeSet<(String, String)> = BTreeSet::new();
+
     for candidate in &candidates {
+        if emitted >= limit {
+            break;
+        }
         let Some(provider) = by_source.get(candidate.source) else {
             continue;
         };
@@ -1544,14 +1761,31 @@ pub fn discover_sessions_with_env(
             if let Some(entry) = summary.providers.get_mut(candidate.source) {
                 entry.skipped_unchanged += 1;
             }
-            on_row(&cached);
+            if emitted_sessions.insert((cached.source.clone(), cached.session_id.clone())) {
+                emitted += 1;
+                on_row(&cached);
+            }
+            continue;
+        }
+        // A source already examined and found not to be a session (a codex
+        // subagent thread, a claude sidecar) is remembered by its stamp, so a
+        // rescan costs a PK lookup instead of a fresh read every single run.
+        if is_known_non_session(conn, candidate.source, &candidate.locator, &expected)? {
+            env.note_skipped();
+            summary.skipped_unchanged += 1;
+            if let Some(entry) = summary.providers.get_mut(candidate.source) {
+                entry.skipped_unchanged += 1;
+            }
             continue;
         }
         env.note_shallow_read();
         let read = provider.read_shallow(env, candidate);
         let session = match read {
             Ok(Some(session)) => session,
-            Ok(None) => continue,
+            Ok(None) => {
+                record_non_session(conn, candidate.source, &candidate.locator, &expected)?;
+                continue;
+            }
             Err(error) => {
                 summary.diagnostics.push(DiscoveryDiagnostic {
                     source: candidate.source.to_string(),
@@ -1580,9 +1814,12 @@ pub fn discover_sessions_with_env(
             });
             continue;
         }
+        // A file that used to be skipped as a non-session (or was never one)
+        // must not keep a stale marker once it resolves to a session.
+        clear_non_session(conn, candidate.source, &candidate.locator)?;
         // Emit the merged catalog row, so what a caller sees is exactly what
         // the catalog now holds (including a preserved `full` state).
-        let emitted = fetch_catalog_row(conn, &session.source, &session.session_id)?
+        let row = fetch_catalog_row(conn, &session.source, &session.session_id)?
             .map(|mut row| {
                 row.from_cache = false;
                 row
@@ -1592,7 +1829,10 @@ pub fn discover_sessions_with_env(
         if let Some(entry) = summary.providers.get_mut(candidate.source) {
             entry.discovered += 1;
         }
-        on_row(&emitted);
+        if emitted_sessions.insert((row.source.clone(), row.session_id.clone())) {
+            emitted += 1;
+            on_row(&row);
+        }
     }
 
     summary.counters = env.counters();

--- a/crates/ai-hist/src/discover.rs
+++ b/crates/ai-hist/src/discover.rs
@@ -1,0 +1,1613 @@
+//! Fast, shallow coding-agent session discovery.
+//!
+//! Two operations live here, and they are deliberately distinct:
+//!
+//! * [`list_session_catalog`] — a cache-only query over the `sessions` table.
+//!   It never touches a provider transcript and never reads `history`,
+//!   `session_events` or `tool_calls`. It is what a desktop app calls on every
+//!   paint.
+//! * [`discover_sessions`] — inspects the known provider locations, extracts
+//!   minimal metadata with *bounded* reads, upserts the `sessions` catalog and
+//!   emits rows progressively in global recency order.
+//!
+//! # Fidelity model
+//!
+//! Every value in [`ShallowSession`] is one of three things, and the
+//! distinction is part of the contract:
+//!
+//! * **Observed** — read straight out of provider data (`session_id`, `cwd`,
+//!   `git_branch`, `originator`, `agent_version`, `repo_url`,
+//!   `initial_commit`, `workspace_roots`, `models`, and any timestamp the
+//!   provider actually records).
+//! * **Derived** — computed deterministically by RelayHistory from provider
+//!   data. `first_prompt` is the only derived field: it is a bounded excerpt
+//!   (see [`EXCERPT_MAX_CHARS`]) of the first *substantive* human turn, with
+//!   provider control/meta turns skipped. `last_activity_ms` is derived from
+//!   the filesystem mtime for providers that record no timestamps (cursor).
+//! * **Unavailable until full indexing** — anything not in this struct. Tool
+//!   calls, file edits, per-message events, token spend, and the full
+//!   transcript body all require `ai-hist sync`. [`ShallowSession::discovery_state`]
+//!   says which of the two a row is: `"shallow"` or `"full"`.
+//!
+//! Absent metadata is `None`. Nothing here is ever invented to fill a column.
+//!
+//! # Product boundary
+//!
+//! Discovery reports *which sessions exist* and identifying metadata. It does
+//! not infer project membership, work status, health, risk, or success, and it
+//! does not summarize outcomes.
+//!
+//! # Concurrency
+//!
+//! Discovery deliberately does **not** take the `sync` advisory lock. Every
+//! write it performs is an idempotent, stamp-guarded upsert into `sessions`,
+//! so a concurrent `ai-hist sync` and a concurrent `discover` converge: the
+//! full-sync path only ever upgrades a row to `discovery_state = 'full'`, and
+//! the shallow path never downgrades one. Writes go through the normal
+//! busy-retry connection.
+
+use std::cell::Cell;
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use ai_hist_core::SOURCE_CHOICES;
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, DatabaseName, OpenFlags};
+use serde::Serialize;
+use serde_json::Value;
+
+/// Version of the machine-readable session-catalog contract.
+///
+/// Bumped when the shape or meaning of [`ShallowSession`] / the CLI JSON
+/// payloads changes in a way a consumer must notice.
+pub const SESSION_CATALOG_CONTRACT_VERSION: u32 = 1;
+
+/// Version of the shallow scanners themselves.
+///
+/// Persisted as the `v{N}:` prefix of `sessions.source_stamp`. Bumping it
+/// invalidates every stored stamp, so a scanner that learns to extract a new
+/// field re-reads sources whose bytes never changed. `parser_version` keeps its
+/// existing meaning (full-ingest parser generation) and is untouched.
+pub const SHALLOW_SCANNER_VERSION: u32 = 1;
+
+/// Most bytes a shallow head read may consume from one transcript.
+pub const HEAD_SCAN_MAX_BYTES: u64 = 256 * 1024;
+/// Most complete JSONL records a shallow head read may consider.
+pub const HEAD_SCAN_MAX_LINES: usize = 400;
+/// Most bytes a shallow tail read may consume from one transcript.
+pub const TAIL_SCAN_MAX_BYTES: u64 = 64 * 1024;
+/// Character cap for stored text excerpts, matching `last_assistant_text`.
+pub const EXCERPT_MAX_CHARS: usize = 4096;
+/// Default row cap for `list_session_catalog` when the caller gives none.
+pub const DEFAULT_CATALOG_LIMIT: i64 = 50;
+
+/// Catalog row: one coding-agent session as shallow discovery knows it.
+///
+/// See the module docs for which fields are observed and which are derived.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct ShallowSession {
+    /// Provider that owns the session (`claude`, `codex`, …). Observed.
+    pub source: String,
+    /// The provider's own session identifier. Observed. Stable across
+    /// rescans; `(source, session_id)` is the catalog primary key, so the same
+    /// native id under two providers is two distinct rows.
+    pub session_id: String,
+    /// Working directory the provider reported for the session. Observed.
+    /// Per provider: claude — `cwd` from the first transcript record; codex —
+    /// `session_meta.payload.cwd`; grok — `summary.json` `info.cwd`/`git_root_dir`,
+    /// else the percent-decoded project directory; cursor — decoded from the
+    /// project directory name; opencode — `session.directory`; relay — none
+    /// (a relay thread has no working directory).
+    pub cwd: Option<String>,
+    /// Git branch the provider reported, last observed value. Observed.
+    pub git_branch: Option<String>,
+    /// Earliest activity timestamp the provider records. Observed. `None`
+    /// when the provider records no timestamps at all (cursor).
+    pub first_activity_ms: Option<i64>,
+    /// Latest activity timestamp. Observed where the provider records one;
+    /// filesystem-derived (file mtime) for cursor, which records none.
+    pub last_activity_ms: Option<i64>,
+    /// Bounded excerpt of the first substantive human prompt. **Derived.**
+    pub first_prompt: Option<String>,
+    /// Bounded excerpt of the last assistant text. Observed; only populated by
+    /// the full-ingest path, so a purely shallow row leaves it `None`.
+    pub last_assistant_text: Option<String>,
+    /// Model ids observed in the bounded read. Observed, best effort: never a
+    /// reason to widen a read, so an empty list means "not seen cheaply", not
+    /// "no model".
+    pub models: Vec<String>,
+    /// Client that originated the session (codex `session_meta.originator`).
+    /// Observed.
+    pub originator: Option<String>,
+    /// Agent CLI version (codex `cli_version`, claude record `version`).
+    /// Observed.
+    pub agent_version: Option<String>,
+    /// Repository remote URL, when the provider records one. Observed.
+    pub repo_url: Option<String>,
+    /// Commit the session started from, when the provider records one. Observed.
+    pub initial_commit: Option<String>,
+    /// Extra workspace roots, when the provider records them. Observed.
+    pub workspace_roots: Vec<String>,
+    /// Path of the provider file this row came from, when it is file-backed.
+    pub raw_path: Option<String>,
+    /// Change stamp of the raw source at scan time, `v{scanner}:{provider stamp}`.
+    pub source_stamp: Option<String>,
+    /// `"shallow"` (catalog row only) or `"full"` (full evidence ingested).
+    pub discovery_state: String,
+    /// `true` when this row was served from the catalog without re-reading the
+    /// provider source — either a cache-only list, or a rescan whose stamp
+    /// matched.
+    pub from_cache: bool,
+}
+
+/// A cheaply enumerated discovery candidate.
+///
+/// Producing one must not read file contents: a directory walk plus `stat`,
+/// or one small indexed query for the database-backed providers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Candidate {
+    /// Provider that produced the candidate.
+    pub source: &'static str,
+    /// Opaque provider-scoped handle: a file path, or a session id for the
+    /// database-backed providers.
+    pub locator: String,
+    /// Session id when enumeration already knows it without reading anything
+    /// (cursor, opencode, relay); `None` when only the shallow read can say.
+    pub session_id: Option<String>,
+    /// Recency signal used for global ordering — a provider timestamp where
+    /// one is available for free, else the file mtime.
+    pub recency_hint_ms: Option<i64>,
+    /// Raw provider change marker; stored as `v{scanner}:{stamp}`.
+    pub stamp: String,
+}
+
+/// Counters describing the work one discovery run actually did.
+///
+/// Exposed so callers (and tests) can assert bounded behaviour without a wall
+/// clock: a limited request must not read the whole archive, a cache-only list
+/// must open zero files, and an unchanged rescan must perform zero shallow
+/// reads.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub struct DiscoveryCounters {
+    /// Candidates produced by enumeration, before the global limit.
+    pub candidates_enumerated: u64,
+    /// Candidates whose source was actually read.
+    pub shallow_reads: u64,
+    /// Candidates served from the catalog because their stamp was unchanged.
+    pub skipped_unchanged: u64,
+    /// Provider files (and database snapshots) opened for reading.
+    pub files_opened: u64,
+    /// Bytes read out of provider sources.
+    pub bytes_read: u64,
+}
+
+/// Environment one discovery run operates in: where the provider data lives,
+/// the catalog connection, and the run's counters.
+pub struct DiscoveryEnv<'a> {
+    /// Home directory the file-backed providers are rooted at.
+    pub home: PathBuf,
+    /// Path to the opencode database.
+    pub opencode_db: PathBuf,
+    conn: &'a Connection,
+    counters: Cell<DiscoveryCounters>,
+}
+
+impl<'a> DiscoveryEnv<'a> {
+    /// Build an environment from the process environment (`HOME`, `OPENCODE_DB`).
+    pub fn new(conn: &'a Connection) -> Self {
+        Self {
+            home: crate::home_dir(),
+            opencode_db: crate::default_opencode_db_path(),
+            conn,
+            counters: Cell::new(DiscoveryCounters::default()),
+        }
+    }
+
+    /// Build an environment with explicit roots, for hosts that keep provider
+    /// data somewhere other than `$HOME` (and for tests, which must not mutate
+    /// process-wide environment variables).
+    pub fn with_roots(conn: &'a Connection, home: PathBuf, opencode_db: PathBuf) -> Self {
+        Self {
+            home,
+            opencode_db,
+            conn,
+            counters: Cell::new(DiscoveryCounters::default()),
+        }
+    }
+
+    /// The catalog connection. `relay` discovers from already-synced local
+    /// rows through this and never opens a socket.
+    pub fn conn(&self) -> &Connection {
+        self.conn
+    }
+
+    /// Counters accumulated so far.
+    pub fn counters(&self) -> DiscoveryCounters {
+        self.counters.get()
+    }
+
+    fn note_open(&self) {
+        let mut counters = self.counters.get();
+        counters.files_opened += 1;
+        self.counters.set(counters);
+    }
+
+    fn note_bytes(&self, bytes: u64) {
+        let mut counters = self.counters.get();
+        counters.bytes_read += bytes;
+        self.counters.set(counters);
+    }
+
+    fn note_candidates(&self, count: u64) {
+        let mut counters = self.counters.get();
+        counters.candidates_enumerated += count;
+        self.counters.set(counters);
+    }
+
+    fn note_shallow_read(&self) {
+        let mut counters = self.counters.get();
+        counters.shallow_reads += 1;
+        self.counters.set(counters);
+    }
+
+    fn note_skipped(&self) {
+        let mut counters = self.counters.get();
+        counters.skipped_unchanged += 1;
+        self.counters.set(counters);
+    }
+}
+
+/// One provider's shallow adapter.
+///
+/// Implementations must be cheap: [`enumerate`](ShallowSessionProvider::enumerate)
+/// may stat but not read, and [`read_shallow`](ShallowSessionProvider::read_shallow)
+/// must stay inside [`HEAD_SCAN_MAX_BYTES`] / [`TAIL_SCAN_MAX_BYTES`] per
+/// source. Returning `Ok(None)` from `read_shallow` means "this candidate is
+/// not a session" (a codex subagent thread, a file with no usable metadata) —
+/// it is not an error.
+pub trait ShallowSessionProvider {
+    /// The `SOURCE_CHOICES` name this adapter covers.
+    fn source(&self) -> &'static str;
+    /// Cheap enumeration: directory walk + stat, or one indexed query.
+    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>>;
+    /// Bounded read of one candidate into a catalog row.
+    fn read_shallow(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        candidate: &Candidate,
+    ) -> Result<Option<ShallowSession>>;
+}
+
+/// A `SOURCE_CHOICES` entry that deliberately has no shallow adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct SourceExemption {
+    /// The exempt source name.
+    pub source: &'static str,
+    /// Why it has no adapter. Shown in machine-readable summaries.
+    pub reason: &'static str,
+}
+
+/// Sources with no shallow adapter, and why.
+///
+/// Paired with [`shallow_providers`] by a registry regression test that
+/// asserts every `SOURCE_CHOICES` entry is covered by exactly one of the two
+/// lists — so adding a provider to `SOURCE_CHOICES` fails the build until
+/// someone decides whether it is discoverable.
+pub const DISCOVERY_EXEMPTIONS: &[SourceExemption] = &[SourceExemption {
+    source: "trajectory",
+    reason: "derived trajectory records, not provider sessions",
+}];
+
+/// Every shallow adapter, one per discoverable source.
+pub fn shallow_providers() -> Vec<Box<dyn ShallowSessionProvider>> {
+    vec![
+        Box::new(ClaudeProvider),
+        Box::new(CodexProvider),
+        Box::new(CursorProvider),
+        Box::new(GrokProvider),
+        Box::new(OpencodeProvider::default()),
+        Box::new(RelayProvider),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// bounded reads
+// ---------------------------------------------------------------------------
+
+/// The complete JSONL records a bounded read recovered from one file.
+///
+/// Only newline-terminated records are returned, matching the project's
+/// incomplete-record convention: a transcript being written right now has a
+/// partial trailing line, and that line is not yet a record.
+struct BoundedJsonl {
+    head: Vec<String>,
+    tail: Vec<String>,
+}
+
+fn complete_lines(buffer: &[u8], drop_leading_fragment: bool) -> Vec<String> {
+    let text = String::from_utf8_lossy(buffer);
+    let mut lines: Vec<String> = text.split_inclusive('\n').map(str::to_string).collect();
+    if lines.last().is_some_and(|line| !line.ends_with('\n')) {
+        lines.pop();
+    }
+    if drop_leading_fragment && !lines.is_empty() {
+        lines.remove(0);
+    }
+    lines
+        .into_iter()
+        .map(|line| line.trim_end_matches(['\n', '\r']).to_string())
+        .filter(|line| !line.trim().is_empty())
+        .collect()
+}
+
+/// Read the head (and, for a large file, the tail) of a JSONL transcript
+/// without ever reading the whole thing.
+///
+/// One file handle regardless of size. Files inside the head budget are read
+/// once and serve as their own tail.
+fn read_bounded_jsonl(env: &DiscoveryEnv<'_>, path: &Path) -> Result<BoundedJsonl> {
+    let mut file = fs::File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    env.note_open();
+    let len = file.metadata()?.len();
+    if len <= HEAD_SCAN_MAX_BYTES {
+        let mut buffer = Vec::with_capacity(len as usize);
+        file.read_to_end(&mut buffer)?;
+        env.note_bytes(buffer.len() as u64);
+        let mut lines = complete_lines(&buffer, false);
+        let tail = lines.clone();
+        lines.truncate(HEAD_SCAN_MAX_LINES);
+        return Ok(BoundedJsonl { head: lines, tail });
+    }
+    let mut head_buffer = vec![0u8; HEAD_SCAN_MAX_BYTES as usize];
+    let mut filled = 0usize;
+    while filled < head_buffer.len() {
+        let read = file.read(&mut head_buffer[filled..])?;
+        if read == 0 {
+            break;
+        }
+        filled += read;
+    }
+    head_buffer.truncate(filled);
+    env.note_bytes(filled as u64);
+    let mut head = complete_lines(&head_buffer, false);
+    head.truncate(HEAD_SCAN_MAX_LINES);
+
+    let tail_start = len.saturating_sub(TAIL_SCAN_MAX_BYTES);
+    file.seek(SeekFrom::Start(tail_start))?;
+    let mut tail_buffer = Vec::with_capacity(TAIL_SCAN_MAX_BYTES as usize);
+    file.take(TAIL_SCAN_MAX_BYTES)
+        .read_to_end(&mut tail_buffer)?;
+    env.note_bytes(tail_buffer.len() as u64);
+    let tail = complete_lines(&tail_buffer, tail_start > 0);
+    Ok(BoundedJsonl { head, tail })
+}
+
+fn excerpt(text: &str) -> String {
+    text.trim().chars().take(EXCERPT_MAX_CHARS).collect()
+}
+
+fn json_lines(lines: &[String]) -> impl Iterator<Item = Value> + '_ {
+    lines
+        .iter()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+}
+
+/// A JSON array column value, or `None` when there is nothing observed to
+/// store. An empty list is never written as `[]` — absent stays absent.
+fn json_array_or_none(values: &[String]) -> Option<String> {
+    (!values.is_empty()).then(|| serde_json::to_string(values).unwrap_or_else(|_| "[]".into()))
+}
+
+fn push_unique(models: &mut Vec<String>, value: Option<&str>) {
+    if let Some(value) = value.map(str::trim).filter(|s| !s.is_empty()) {
+        if !models.iter().any(|existing| existing == value) {
+            models.push(value.to_string());
+        }
+    }
+}
+
+fn text_of(content: Option<&Value>) -> Option<String> {
+    let content = content?;
+    if let Some(text) = content.as_str() {
+        return Some(text.to_string());
+    }
+    let items = content.as_array()?;
+    let parts: Vec<&str> = items
+        .iter()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("text"))
+        .filter_map(|item| item.get("text").and_then(Value::as_str))
+        .collect();
+    (!parts.is_empty()).then(|| parts.join("\n"))
+}
+
+// ---------------------------------------------------------------------------
+// claude
+// ---------------------------------------------------------------------------
+
+struct ClaudeProvider;
+
+/// Wrappers Claude Code writes into the user role that are not human turns.
+const CLAUDE_CONTROL_PREFIXES: &[&str] = &[
+    "<command-name>",
+    "<command-message>",
+    "<command-args>",
+    "<local-command-stdout>",
+    "<local-command-stderr>",
+    "<bash-input>",
+    "<bash-stdout>",
+    "<bash-stderr>",
+    "<user-prompt-submit-hook>",
+    "Caveat: The messages below were generated by the user while running local commands",
+];
+
+fn claude_substantive_prompt(value: &Value) -> Option<String> {
+    let role = value
+        .pointer("/message/role")
+        .and_then(Value::as_str)
+        .or_else(|| value.get("type").and_then(Value::as_str));
+    if role != Some("user") {
+        return None;
+    }
+    // Sidechain rows are the parent agent's own prompts to a subagent, and
+    // meta rows are Claude Code's bookkeeping. Neither is a human turn.
+    if value.get("isSidechain").and_then(Value::as_bool) == Some(true)
+        || value.get("isMeta").and_then(Value::as_bool) == Some(true)
+    {
+        return None;
+    }
+    let text = text_of(value.pointer("/message/content"))?;
+    let trimmed = text.trim();
+    if trimmed.is_empty()
+        || CLAUDE_CONTROL_PREFIXES
+            .iter()
+            .any(|prefix| trimmed.starts_with(prefix))
+    {
+        return None;
+    }
+    Some(excerpt(trimmed))
+}
+
+fn claude_timestamp(value: &Value) -> Option<i64> {
+    value.get("timestamp").and_then(|v| {
+        v.as_str()
+            .and_then(crate::parse_iso_ms)
+            .or_else(|| v.as_i64())
+    })
+}
+
+impl ShallowSessionProvider for ClaudeProvider {
+    fn source(&self) -> &'static str {
+        "claude"
+    }
+
+    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+        file_candidates(
+            "claude",
+            crate::collect_matching_files(&env.home.join(".claude/projects"), "", "jsonl")?,
+            crate::file_stamp,
+        )
+    }
+
+    fn read_shallow(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        candidate: &Candidate,
+    ) -> Result<Option<ShallowSession>> {
+        let path = PathBuf::from(&candidate.locator);
+        let bounded = read_bounded_jsonl(env, &path)?;
+        let mut session = ShallowSession {
+            source: "claude".into(),
+            raw_path: Some(candidate.locator.clone()),
+            ..Default::default()
+        };
+        let mut models = Vec::new();
+        let mut session_id = None;
+        for value in json_lines(&bounded.head) {
+            if session_id.is_none() {
+                session_id = value
+                    .get("sessionId")
+                    .and_then(Value::as_str)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string);
+            }
+            if session.cwd.is_none() {
+                session.cwd = value.get("cwd").and_then(Value::as_str).map(str::to_string);
+            }
+            if let Some(branch) = value.get("gitBranch").and_then(Value::as_str) {
+                session.git_branch = Some(branch.to_string());
+            }
+            if let Some(version) = value.get("version").and_then(Value::as_str) {
+                session.agent_version = Some(version.to_string());
+            }
+            push_unique(
+                &mut models,
+                value.pointer("/message/model").and_then(Value::as_str),
+            );
+            if let Some(ts) = claude_timestamp(&value) {
+                session.first_activity_ms.get_or_insert(ts);
+                session.last_activity_ms = Some(ts);
+            }
+            if session.first_prompt.is_none() {
+                session.first_prompt = claude_substantive_prompt(&value);
+            }
+        }
+        for value in json_lines(&bounded.tail) {
+            if let Some(ts) = claude_timestamp(&value) {
+                session.last_activity_ms = Some(ts);
+            }
+            if let Some(branch) = value.get("gitBranch").and_then(Value::as_str) {
+                session.git_branch = Some(branch.to_string());
+            }
+        }
+        let Some(session_id) = session_id.or_else(|| {
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .map(str::to_string)
+                .filter(|s| !s.is_empty())
+        }) else {
+            return Ok(None);
+        };
+        session.session_id = session_id;
+        session.models = models;
+        Ok(Some(session))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// codex
+// ---------------------------------------------------------------------------
+
+struct CodexProvider;
+
+impl ShallowSessionProvider for CodexProvider {
+    fn source(&self) -> &'static str {
+        "codex"
+    }
+
+    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+        let mut files = Vec::new();
+        for root in [
+            env.home.join(".codex/sessions"),
+            env.home.join(".codex/archived_sessions"),
+        ] {
+            files.extend(crate::collect_matching_files(&root, "rollout-", "jsonl")?);
+        }
+        file_candidates("codex", files, crate::file_stamp)
+    }
+
+    fn read_shallow(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        candidate: &Candidate,
+    ) -> Result<Option<ShallowSession>> {
+        let path = PathBuf::from(&candidate.locator);
+        let bounded = read_bounded_jsonl(env, &path)?;
+        let Some(meta) = bounded.head.first().and_then(|line| {
+            serde_json::from_str::<Value>(line)
+                .ok()
+                .filter(|v| v.get("type").and_then(Value::as_str) == Some("session_meta"))
+        }) else {
+            return Ok(None);
+        };
+        let payload = meta.get("payload");
+        let Some(session_id) = payload
+            .and_then(|p| p.get("id"))
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+        else {
+            return Ok(None);
+        };
+        // Subagent threads are real rollouts but not user sessions; the full
+        // sync excludes them from `sessions` and so does discovery.
+        let is_subagent = payload
+            .and_then(|p| p.get("thread_source"))
+            .and_then(Value::as_str)
+            == Some("subagent")
+            || payload
+                .and_then(|p| p.get("source"))
+                .and_then(Value::as_object)
+                .is_some_and(|s| s.contains_key("subagent"));
+        if is_subagent {
+            return Ok(None);
+        }
+        let git = payload.and_then(|p| p.get("git"));
+        let string_field = |owner: Option<&Value>, key: &str| {
+            owner
+                .and_then(|o| o.get(key))
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+        };
+        let mut models = Vec::new();
+        push_unique(
+            &mut models,
+            payload.and_then(|p| p.get("model")).and_then(Value::as_str),
+        );
+        let mut first_prompt = None;
+        let mut first_activity_ms = claude_timestamp(&meta);
+        let mut last_activity_ms = first_activity_ms;
+        for value in json_lines(&bounded.head) {
+            if let Some(ts) = claude_timestamp(&value) {
+                first_activity_ms.get_or_insert(ts);
+                last_activity_ms = Some(ts);
+            }
+            if value.get("type").and_then(Value::as_str) == Some("turn_context") {
+                push_unique(
+                    &mut models,
+                    value.pointer("/payload/model").and_then(Value::as_str),
+                );
+            }
+            if first_prompt.is_none() {
+                first_prompt = codex_substantive_prompt(&value);
+            }
+        }
+        for value in json_lines(&bounded.tail) {
+            if let Some(ts) = claude_timestamp(&value) {
+                last_activity_ms = Some(ts);
+            }
+        }
+        let mtime = crate::file_modified_ms(&path);
+        Ok(Some(ShallowSession {
+            source: "codex".into(),
+            session_id: session_id.to_string(),
+            cwd: string_field(payload, "cwd"),
+            git_branch: string_field(git, "branch"),
+            first_activity_ms,
+            last_activity_ms: last_activity_ms.or(mtime),
+            first_prompt,
+            models,
+            originator: string_field(payload, "originator"),
+            agent_version: string_field(payload, "cli_version"),
+            repo_url: string_field(git, "repository_url")
+                .or_else(|| string_field(git, "remote_url")),
+            initial_commit: string_field(git, "commit_hash"),
+            workspace_roots: string_list(payload.and_then(|p| p.get("workspace_roots"))),
+            raw_path: Some(candidate.locator.clone()),
+            ..Default::default()
+        }))
+    }
+}
+
+fn codex_substantive_prompt(value: &Value) -> Option<String> {
+    if value.get("type").and_then(Value::as_str) != Some("event_msg") {
+        return None;
+    }
+    let payload = value.get("payload")?;
+    if payload.get("type").and_then(Value::as_str) != Some("user_message") {
+        return None;
+    }
+    let message = payload.get("message").and_then(Value::as_str)?;
+    let trimmed = message.trim();
+    if trimmed.is_empty() || crate::is_codex_control_context(trimmed) {
+        return None;
+    }
+    Some(excerpt(trimmed))
+}
+
+fn string_list(value: Option<&Value>) -> Vec<String> {
+    value
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// cursor
+// ---------------------------------------------------------------------------
+
+struct CursorProvider;
+
+impl ShallowSessionProvider for CursorProvider {
+    fn source(&self) -> &'static str {
+        "cursor"
+    }
+
+    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+        let root = env.home.join(".cursor/projects");
+        let mut out = Vec::new();
+        for project_dir in crate::sorted_dirs(&root)? {
+            let transcripts = project_dir.join("agent-transcripts");
+            if !transcripts.is_dir() {
+                continue;
+            }
+            for session_dir in crate::sorted_dirs(&transcripts)? {
+                let Some(session_id) = session_dir.file_name().and_then(|s| s.to_str()) else {
+                    continue;
+                };
+                let jsonl = session_dir.join(format!("{session_id}.jsonl"));
+                if !jsonl.is_file() {
+                    continue;
+                }
+                let Ok(stamp) = crate::file_stamp(&jsonl) else {
+                    continue;
+                };
+                out.push(Candidate {
+                    source: "cursor",
+                    locator: jsonl.to_string_lossy().into_owned(),
+                    session_id: Some(session_id.to_string()),
+                    recency_hint_ms: crate::file_modified_ms(&jsonl),
+                    stamp,
+                });
+            }
+        }
+        Ok(out)
+    }
+
+    fn read_shallow(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        candidate: &Candidate,
+    ) -> Result<Option<ShallowSession>> {
+        let path = PathBuf::from(&candidate.locator);
+        let Some(session_id) = candidate.session_id.clone() else {
+            return Ok(None);
+        };
+        let bounded = read_bounded_jsonl(env, &path)?;
+        let first_prompt = bounded
+            .head
+            .iter()
+            .filter_map(|line| ai_hist_core::parse_cursor_text(line).ok().flatten())
+            .map(|prompt| excerpt(&prompt))
+            .find(|prompt| !prompt.is_empty());
+        let cwd = path
+            .parent()
+            .and_then(Path::parent)
+            .and_then(Path::parent)
+            .and_then(|p| p.file_name())
+            .and_then(|s| s.to_str())
+            .map(crate::decode_cursor_project);
+        Ok(Some(ShallowSession {
+            source: "cursor".into(),
+            session_id,
+            cwd,
+            // Cursor transcripts carry no per-message timestamps at all. The
+            // file mtime is the only time signal, so it is reported as
+            // last_activity (filesystem-derived) and first_activity stays
+            // NULL rather than being invented.
+            first_activity_ms: None,
+            last_activity_ms: crate::file_modified_ms(&path),
+            first_prompt,
+            raw_path: Some(candidate.locator.clone()),
+            ..Default::default()
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// grok
+// ---------------------------------------------------------------------------
+
+struct GrokProvider;
+
+impl ShallowSessionProvider for GrokProvider {
+    fn source(&self) -> &'static str {
+        "grok"
+    }
+
+    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+        file_candidates(
+            "grok",
+            crate::collect_matching_files(
+                &env.home.join(".grok/sessions"),
+                "chat_history",
+                "jsonl",
+            )?,
+            crate::grok_session_stamp,
+        )
+    }
+
+    fn read_shallow(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        candidate: &Candidate,
+    ) -> Result<Option<ShallowSession>> {
+        let chat = PathBuf::from(&candidate.locator);
+        let summary_path = chat.with_file_name("summary.json");
+        let summary = if summary_path.is_file() {
+            env.note_open();
+            env.note_bytes(fs::metadata(&summary_path).map(|m| m.len()).unwrap_or(0));
+            crate::read_grok_summary(&summary_path)
+        } else {
+            None
+        };
+        let fallback_session = chat
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|s| s.to_str())
+            .unwrap_or_default()
+            .to_string();
+        let session_id = summary
+            .as_ref()
+            .and_then(|s| s.pointer("/info/id"))
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .unwrap_or(fallback_session);
+        if session_id.is_empty() {
+            return Ok(None);
+        }
+        let cwd = summary
+            .as_ref()
+            .and_then(|s| s.pointer("/info/cwd").or_else(|| s.get("git_root_dir")))
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .or_else(|| crate::grok_project_from_path(&chat));
+        let git_branch = summary
+            .as_ref()
+            .and_then(|s| s.get("head_branch"))
+            .and_then(Value::as_str)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        let first_activity_ms = summary
+            .as_ref()
+            .and_then(|s| s.get("created_at"))
+            .and_then(Value::as_str)
+            .and_then(crate::parse_iso_ms);
+        let last_activity_ms = summary
+            .as_ref()
+            .and_then(|s| s.get("updated_at"))
+            .and_then(Value::as_str)
+            .and_then(crate::parse_iso_ms)
+            .or_else(|| crate::file_modified_ms(&chat));
+        let mut models = Vec::new();
+        push_unique(
+            &mut models,
+            summary
+                .as_ref()
+                .and_then(|s| s.pointer("/info/model").or_else(|| s.get("model")))
+                .and_then(Value::as_str),
+        );
+        let mut first_prompt = None;
+        if chat.is_file() {
+            let bounded = read_bounded_jsonl(env, &chat)?;
+            for value in json_lines(&bounded.head) {
+                if let Some(text) = crate::grok_chat_text(&value, "user") {
+                    first_prompt = Some(excerpt(&text));
+                    break;
+                }
+            }
+        }
+        Ok(Some(ShallowSession {
+            source: "grok".into(),
+            session_id,
+            cwd,
+            git_branch,
+            first_activity_ms,
+            last_activity_ms,
+            first_prompt,
+            models,
+            raw_path: Some(candidate.locator.clone()),
+            ..Default::default()
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// opencode
+// ---------------------------------------------------------------------------
+
+/// Shallow adapter over the opencode SQLite store.
+///
+/// Reads the `session` table directly instead of the full sync's
+/// session/message/part join. The database is snapshotted once per run with
+/// `Connection::backup`, exactly as the full sync does, so an in-flight WAL
+/// never yields a torn read.
+#[derive(Default)]
+struct OpencodeProvider {
+    snapshot: RefCell<Option<tempfile::TempPath>>,
+}
+
+impl OpencodeProvider {
+    fn ensure_snapshot(&self, env: &DiscoveryEnv<'_>) -> Result<bool> {
+        if self.snapshot.borrow().is_some() {
+            return Ok(true);
+        }
+        if !env.opencode_db.exists() {
+            return Ok(false);
+        }
+        let tmp = tempfile::NamedTempFile::new()?.into_temp_path();
+        let live = Connection::open_with_flags(
+            &env.opencode_db,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+        )
+        .with_context(|| format!("opening {}", env.opencode_db.display()))?;
+        live.busy_timeout(Duration::from_secs(5))?;
+        live.backup(DatabaseName::Main, &tmp, None)
+            .with_context(|| format!("snapshotting {}", env.opencode_db.display()))?;
+        env.note_open();
+        env.note_bytes(fs::metadata(&env.opencode_db).map(|m| m.len()).unwrap_or(0));
+        *self.snapshot.borrow_mut() = Some(tmp);
+        Ok(true)
+    }
+
+    fn open_snapshot(&self) -> Result<Connection> {
+        let guard = self.snapshot.borrow();
+        let path = guard
+            .as_ref()
+            .context("opencode snapshot was not prepared")?;
+        Ok(Connection::open(path)?)
+    }
+}
+
+fn table_columns(conn: &Connection, table: &str) -> BTreeSet<String> {
+    conn.prepare(&format!("SELECT name FROM pragma_table_info('{table}')"))
+        .and_then(|mut stmt| {
+            stmt.query_map([], |row| row.get::<_, String>(0))?
+                .collect::<rusqlite::Result<BTreeSet<String>>>()
+        })
+        .unwrap_or_default()
+}
+
+impl ShallowSessionProvider for OpencodeProvider {
+    fn source(&self) -> &'static str {
+        "opencode"
+    }
+
+    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+        if !self.ensure_snapshot(env)? {
+            return Ok(Vec::new());
+        }
+        let conn = self.open_snapshot()?;
+        let columns = table_columns(&conn, "session");
+        if !columns.contains("id") {
+            return Ok(Vec::new());
+        }
+        let updated = if columns.contains("time_updated") {
+            "time_updated"
+        } else {
+            "NULL"
+        };
+        let created = if columns.contains("time_created") {
+            "time_created"
+        } else {
+            "NULL"
+        };
+        let sql = format!(
+            "SELECT id, {created}, {updated} FROM session WHERE id IS NOT NULL AND id <> ''"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<i64>>(1)?,
+                    row.get::<_, Option<i64>>(2)?,
+                ))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows
+            .into_iter()
+            .map(|(id, created, updated)| Candidate {
+                source: "opencode",
+                locator: id.clone(),
+                session_id: Some(id),
+                recency_hint_ms: updated.or(created),
+                // Opencode has no file per session; the session's own
+                // created/updated stamps are its change marker.
+                stamp: format!("{}:{}", created.unwrap_or(0), updated.unwrap_or(0)),
+            })
+            .collect())
+    }
+
+    fn read_shallow(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        candidate: &Candidate,
+    ) -> Result<Option<ShallowSession>> {
+        if !self.ensure_snapshot(env)? {
+            return Ok(None);
+        }
+        let conn = self.open_snapshot()?;
+        let columns = table_columns(&conn, "session");
+        let directory = if columns.contains("directory") {
+            "directory"
+        } else {
+            "NULL"
+        };
+        let created = if columns.contains("time_created") {
+            "time_created"
+        } else {
+            "NULL"
+        };
+        let updated = if columns.contains("time_updated") {
+            "time_updated"
+        } else {
+            "NULL"
+        };
+        let sql = format!("SELECT {directory}, {created}, {updated} FROM session WHERE id = ?");
+        let row = conn
+            .query_row(&sql, [&candidate.locator], |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, Option<i64>>(1)?,
+                    row.get::<_, Option<i64>>(2)?,
+                ))
+            })
+            .ok();
+        let Some((directory, created, updated)) = row else {
+            return Ok(None);
+        };
+        let first_prompt = conn
+            .query_row(
+                "SELECT p.data FROM part p JOIN message m ON m.id = p.message_id \
+                 WHERE p.session_id = ? AND json_extract(m.data, '$.role') = 'user' \
+                 AND json_extract(p.data, '$.type') = 'text' \
+                 ORDER BY COALESCE(p.time_created, m.time_created) ASC LIMIT 1",
+                [&candidate.locator],
+                |row| row.get::<_, String>(0),
+            )
+            .ok()
+            .and_then(|data| serde_json::from_str::<Value>(&data).ok())
+            .and_then(|value| {
+                value
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .map(excerpt)
+                    .filter(|text| !text.is_empty())
+            });
+        let mut models = Vec::new();
+        if let Ok(model) = conn.query_row(
+            "SELECT json_extract(data, '$.modelID') FROM message \
+             WHERE session_id = ? AND json_extract(data, '$.modelID') IS NOT NULL LIMIT 1",
+            [&candidate.locator],
+            |row| row.get::<_, Option<String>>(0),
+        ) {
+            push_unique(&mut models, model.as_deref());
+        }
+        Ok(Some(ShallowSession {
+            source: "opencode".into(),
+            session_id: candidate.locator.clone(),
+            cwd: directory,
+            first_activity_ms: created,
+            last_activity_ms: updated.or(created),
+            first_prompt,
+            models,
+            ..Default::default()
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// relay
+// ---------------------------------------------------------------------------
+
+/// Shallow adapter for the network-backed `relay` source.
+///
+/// Relaycast has no local transcript files, and discovery must work with no
+/// network access, so this adapter derives catalog rows from rows a previous
+/// `ai-hist sync` already stored in `history` (indexed by
+/// `idx_history_session`). If nothing was ever synced it discovers nothing —
+/// that is the correct answer, not a failure.
+struct RelayProvider;
+
+impl ShallowSessionProvider for RelayProvider {
+    fn source(&self) -> &'static str {
+        "relay"
+    }
+
+    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+        let mut stmt = env.conn().prepare(
+            "SELECT session_id, MAX(timestamp_ms), COUNT(*) FROM history \
+             WHERE source = 'relay' AND session_id IS NOT NULL AND session_id <> '' \
+             GROUP BY session_id",
+        )?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<i64>>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        Ok(rows
+            .into_iter()
+            .map(|(session_id, last, count)| Candidate {
+                source: "relay",
+                locator: session_id.clone(),
+                session_id: Some(session_id),
+                recency_hint_ms: last,
+                stamp: format!("{}:{count}", last.unwrap_or(0)),
+            })
+            .collect())
+    }
+
+    fn read_shallow(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        candidate: &Candidate,
+    ) -> Result<Option<ShallowSession>> {
+        let bounds = env.conn().query_row(
+            "SELECT MIN(timestamp_ms), MAX(timestamp_ms) FROM history \
+             WHERE source = 'relay' AND session_id = ?",
+            [&candidate.locator],
+            |row| Ok((row.get::<_, Option<i64>>(0)?, row.get::<_, Option<i64>>(1)?)),
+        )?;
+        let first_prompt = env
+            .conn()
+            .query_row(
+                "SELECT prompt FROM history WHERE source = 'relay' AND session_id = ? \
+                 ORDER BY timestamp_ms ASC, id ASC LIMIT 1",
+                [&candidate.locator],
+                |row| row.get::<_, String>(0),
+            )
+            .ok()
+            .map(|prompt| excerpt(&prompt))
+            .filter(|prompt| !prompt.is_empty());
+        Ok(Some(ShallowSession {
+            source: "relay".into(),
+            session_id: candidate.locator.clone(),
+            first_activity_ms: bounds.0,
+            last_activity_ms: bounds.1,
+            first_prompt,
+            ..Default::default()
+        }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// shared enumeration helper
+// ---------------------------------------------------------------------------
+
+fn file_candidates(
+    source: &'static str,
+    files: Vec<PathBuf>,
+    stamp: fn(&Path) -> Result<String>,
+) -> Result<Vec<Candidate>> {
+    let mut out = Vec::with_capacity(files.len());
+    for path in files {
+        // A file that vanished between the walk and the stat is not an error;
+        // the next run will simply not see it.
+        let Ok(stamp) = stamp(&path) else { continue };
+        out.push(Candidate {
+            source,
+            locator: path.to_string_lossy().into_owned(),
+            session_id: None,
+            recency_hint_ms: crate::file_modified_ms(&path),
+            stamp,
+        });
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// catalog reads and writes
+// ---------------------------------------------------------------------------
+
+const SESSION_COLUMNS: &str = "source, session_id, cwd, git_branch, first_activity_ms, \
+     last_activity_ms, first_prompt, last_assistant_text, models_json, originator, \
+     agent_version, repo_url, initial_commit, workspace_roots_json, raw_path, source_stamp, \
+     discovery_state";
+
+fn json_string_list(raw: Option<String>) -> Vec<String> {
+    raw.and_then(|raw| serde_json::from_str::<Vec<String>>(&raw).ok())
+        .unwrap_or_default()
+}
+
+fn row_to_session(row: &rusqlite::Row<'_>) -> rusqlite::Result<ShallowSession> {
+    Ok(ShallowSession {
+        source: row.get(0)?,
+        session_id: row.get(1)?,
+        cwd: row.get(2)?,
+        git_branch: row.get(3)?,
+        first_activity_ms: row.get(4)?,
+        last_activity_ms: row.get(5)?,
+        first_prompt: row.get(6)?,
+        last_assistant_text: row.get(7)?,
+        models: json_string_list(row.get(8)?),
+        originator: row.get(9)?,
+        agent_version: row.get(10)?,
+        repo_url: row.get(11)?,
+        initial_commit: row.get(12)?,
+        workspace_roots: json_string_list(row.get(13)?),
+        raw_path: row.get(14)?,
+        source_stamp: row.get(15)?,
+        discovery_state: row
+            .get::<_, Option<String>>(16)?
+            .unwrap_or_else(|| "full".to_string()),
+        from_cache: true,
+    })
+}
+
+/// Options for the cache-only catalog listing.
+#[derive(Debug, Clone, Default)]
+pub struct CatalogListOptions {
+    /// Restrict to these sources. Empty means every discoverable source.
+    pub sources: Vec<String>,
+    /// Row cap; defaults to [`DEFAULT_CATALOG_LIMIT`].
+    pub limit: Option<i64>,
+    /// Keyset pagination cursor: only rows strictly older than this.
+    pub before_ms: Option<i64>,
+}
+
+/// List the session catalog straight out of the database.
+///
+/// Pure SQL over `sessions`: no filesystem access, no provider I/O, and no
+/// scan of `history` / `session_events` / `tool_calls`. `trajectory` rows are
+/// excluded defensively — trajectories are derived records, not sessions, and
+/// must never appear in a session list even if something wrote one.
+pub fn list_session_catalog(
+    conn: &Connection,
+    options: &CatalogListOptions,
+) -> Result<Vec<ShallowSession>> {
+    let mut sql = format!("SELECT {SESSION_COLUMNS} FROM sessions WHERE source <> 'trajectory'");
+    let mut args: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    if !options.sources.is_empty() {
+        let placeholders = vec!["?"; options.sources.len()].join(", ");
+        sql.push_str(&format!(" AND source IN ({placeholders})"));
+        for source in &options.sources {
+            args.push(Box::new(source.clone()));
+        }
+    }
+    if let Some(before_ms) = options.before_ms {
+        sql.push_str(" AND last_activity_ms < ?");
+        args.push(Box::new(before_ms));
+    }
+    sql.push_str(" ORDER BY last_activity_ms DESC LIMIT ?");
+    args.push(Box::new(options.limit.unwrap_or(DEFAULT_CATALOG_LIMIT)));
+    let mut stmt = conn.prepare(&sql)?;
+    let params = rusqlite::params_from_iter(args.iter().map(|arg| arg.as_ref()));
+    let rows = stmt
+        .query_map(params, row_to_session)?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+/// The SQL `list_session_catalog` would run, for query-plan assertions.
+#[cfg(test)]
+fn catalog_list_sql(options: &CatalogListOptions) -> String {
+    let mut sql = format!("SELECT {SESSION_COLUMNS} FROM sessions WHERE source <> 'trajectory'");
+    if !options.sources.is_empty() {
+        let placeholders = vec!["?"; options.sources.len()].join(", ");
+        sql.push_str(&format!(" AND source IN ({placeholders})"));
+    }
+    if options.before_ms.is_some() {
+        sql.push_str(" AND last_activity_ms < ?");
+    }
+    sql.push_str(" ORDER BY last_activity_ms DESC LIMIT ?");
+    sql
+}
+
+fn fetch_catalog_row(
+    conn: &Connection,
+    source: &str,
+    session_id: &str,
+) -> Result<Option<ShallowSession>> {
+    let sql = format!("SELECT {SESSION_COLUMNS} FROM sessions WHERE source = ? AND session_id = ?");
+    Ok(conn
+        .query_row(&sql, params![source, session_id], row_to_session)
+        .ok())
+}
+
+fn fetch_catalog_row_by_path(
+    conn: &Connection,
+    source: &str,
+    raw_path: &str,
+) -> Result<Option<ShallowSession>> {
+    let sql =
+        format!("SELECT {SESSION_COLUMNS} FROM sessions WHERE source = ? AND raw_path = ? LIMIT 1");
+    Ok(conn
+        .query_row(&sql, params![source, raw_path], row_to_session)
+        .ok())
+}
+
+/// Write a shallow row into the catalog.
+///
+/// Never nulls out a value the catalog already holds, never lowers
+/// `first_activity_ms` past what a fuller pass observed, and never downgrades
+/// a `discovery_state = 'full'` row to `'shallow'` — a shallow rescan of a
+/// fully indexed session still refreshes its metadata and stamp.
+pub fn upsert_shallow_session(conn: &Connection, session: &ShallowSession) -> Result<()> {
+    conn.execute(
+        "INSERT INTO sessions \
+         (session_id, source, cwd, git_branch, first_activity_ms, last_activity_ms, \
+          last_assistant_text, raw_path, parser_version, first_prompt, models_json, originator, \
+          agent_version, repo_url, initial_commit, workspace_roots_json, source_stamp, \
+          discovery_state) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?, 'shallow') \
+         ON CONFLICT(session_id, source) DO UPDATE SET \
+         cwd = COALESCE(excluded.cwd, sessions.cwd), \
+         git_branch = COALESCE(excluded.git_branch, sessions.git_branch), \
+         first_activity_ms = CASE \
+             WHEN excluded.first_activity_ms IS NULL THEN sessions.first_activity_ms \
+             WHEN sessions.first_activity_ms IS NULL THEN excluded.first_activity_ms \
+             ELSE MIN(sessions.first_activity_ms, excluded.first_activity_ms) END, \
+         last_activity_ms = CASE \
+             WHEN excluded.last_activity_ms IS NULL THEN sessions.last_activity_ms \
+             WHEN sessions.last_activity_ms IS NULL THEN excluded.last_activity_ms \
+             ELSE MAX(sessions.last_activity_ms, excluded.last_activity_ms) END, \
+         last_assistant_text = COALESCE(excluded.last_assistant_text, sessions.last_assistant_text), \
+         raw_path = COALESCE(excluded.raw_path, sessions.raw_path), \
+         first_prompt = COALESCE(excluded.first_prompt, sessions.first_prompt), \
+         models_json = COALESCE(excluded.models_json, sessions.models_json), \
+         originator = COALESCE(excluded.originator, sessions.originator), \
+         agent_version = COALESCE(excluded.agent_version, sessions.agent_version), \
+         repo_url = COALESCE(excluded.repo_url, sessions.repo_url), \
+         initial_commit = COALESCE(excluded.initial_commit, sessions.initial_commit), \
+         workspace_roots_json = COALESCE(excluded.workspace_roots_json, sessions.workspace_roots_json), \
+         source_stamp = COALESCE(excluded.source_stamp, sessions.source_stamp), \
+         discovery_state = CASE WHEN sessions.discovery_state = 'full' THEN 'full' ELSE 'shallow' END",
+        params![
+            session.session_id,
+            session.source,
+            session.cwd,
+            session.git_branch,
+            session.first_activity_ms,
+            session.last_activity_ms,
+            session.last_assistant_text,
+            session.raw_path,
+            session.first_prompt,
+            json_array_or_none(&session.models),
+            session.originator,
+            session.agent_version,
+            session.repo_url,
+            session.initial_commit,
+            json_array_or_none(&session.workspace_roots),
+            session.source_stamp,
+        ],
+    )?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// discovery engine
+// ---------------------------------------------------------------------------
+
+/// Options for one discovery run.
+#[derive(Debug, Clone, Default)]
+pub struct DiscoverOptions {
+    /// Restrict to these sources. Empty means every adapter.
+    pub sources: Vec<String>,
+    /// Global cap on emitted rows, applied across providers by recency.
+    /// `None` means no cap.
+    pub limit: Option<usize>,
+}
+
+/// Something one provider (or one session) could not do.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DiscoveryDiagnostic {
+    /// Source the failure belongs to.
+    pub source: String,
+    /// Candidate locator, when the failure was scoped to one session.
+    pub locator: Option<String>,
+    /// Human-readable cause.
+    pub error: String,
+}
+
+/// Per-provider tallies for one run.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub struct ProviderSummary {
+    /// Candidates this provider enumerated (before the global limit).
+    pub candidates: usize,
+    /// Rows emitted after a shallow read.
+    pub discovered: usize,
+    /// Rows served from the catalog because the stamp was unchanged.
+    pub skipped_unchanged: usize,
+    /// `true` when enumeration itself failed.
+    pub failed: bool,
+}
+
+/// Outcome of one discovery run.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct DiscoverySummary {
+    /// [`SESSION_CATALOG_CONTRACT_VERSION`].
+    pub contract_version: u32,
+    /// Rows freshly read and upserted.
+    pub discovered: usize,
+    /// Rows served from the catalog on an unchanged stamp.
+    pub skipped_unchanged: usize,
+    /// Per-provider tallies, keyed by source.
+    pub providers: BTreeMap<String, ProviderSummary>,
+    /// Sources that deliberately have no adapter.
+    pub exempt_sources: Vec<SourceExemption>,
+    /// Non-fatal failures. A provider failing here never blocks another.
+    pub diagnostics: Vec<DiscoveryDiagnostic>,
+    /// Work actually performed.
+    pub counters: DiscoveryCounters,
+}
+
+fn stored_stamp(raw: &str) -> String {
+    format!("v{SHALLOW_SCANNER_VERSION}:{raw}")
+}
+
+fn select_providers(options: &DiscoverOptions) -> Result<Vec<Box<dyn ShallowSessionProvider>>> {
+    for source in &options.sources {
+        if let Some(exempt) = DISCOVERY_EXEMPTIONS
+            .iter()
+            .find(|entry| entry.source == source)
+        {
+            anyhow::bail!(
+                "source '{}' is exempt from session discovery: {}",
+                exempt.source,
+                exempt.reason
+            );
+        }
+        anyhow::ensure!(
+            SOURCE_CHOICES.contains(&source.as_str()),
+            "invalid source '{source}' (choose from {})",
+            SOURCE_CHOICES.join(", ")
+        );
+    }
+    let mut providers = shallow_providers();
+    if !options.sources.is_empty() {
+        providers.retain(|provider| options.sources.iter().any(|s| s == provider.source()));
+    }
+    Ok(providers)
+}
+
+/// Discover sessions across every provider, newest first, emitting rows as
+/// they are produced.
+///
+/// The ordering and the limit are **global**: candidates from all providers
+/// are merged by recency hint and only then truncated, so `--limit 3` over two
+/// providers returns the three newest sessions overall, not three from
+/// whichever provider was enumerated first.
+///
+/// A provider whose enumeration fails contributes a diagnostic and nothing
+/// else; the rest of the run continues. A malformed or unreadable individual
+/// session likewise yields a per-session diagnostic. The call only fails when
+/// *every* selected provider failed.
+pub fn discover_sessions(
+    conn: &Connection,
+    options: &DiscoverOptions,
+    on_row: impl FnMut(&ShallowSession),
+) -> Result<DiscoverySummary> {
+    let env = DiscoveryEnv::new(conn);
+    discover_sessions_with_env(&env, options, on_row)
+}
+
+/// [`discover_sessions`] against an explicitly built [`DiscoveryEnv`].
+pub fn discover_sessions_with_env(
+    env: &DiscoveryEnv<'_>,
+    options: &DiscoverOptions,
+    mut on_row: impl FnMut(&ShallowSession),
+) -> Result<DiscoverySummary> {
+    let conn = env.conn();
+    let providers = select_providers(options)?;
+    let mut summary = DiscoverySummary {
+        contract_version: SESSION_CATALOG_CONTRACT_VERSION,
+        exempt_sources: DISCOVERY_EXEMPTIONS.to_vec(),
+        ..Default::default()
+    };
+
+    let mut candidates: Vec<Candidate> = Vec::new();
+    let mut failed_providers = 0usize;
+    for provider in &providers {
+        let entry = summary
+            .providers
+            .entry(provider.source().to_string())
+            .or_default();
+        match provider.enumerate(env) {
+            Ok(found) => {
+                entry.candidates = found.len();
+                env.note_candidates(found.len() as u64);
+                candidates.extend(found);
+            }
+            Err(error) => {
+                entry.failed = true;
+                failed_providers += 1;
+                summary.diagnostics.push(DiscoveryDiagnostic {
+                    source: provider.source().to_string(),
+                    locator: None,
+                    error: format!("{error:#}"),
+                });
+            }
+        }
+    }
+    if !providers.is_empty() && failed_providers == providers.len() {
+        anyhow::bail!(
+            "all {failed_providers} session provider(s) failed; no provider made progress"
+        );
+    }
+
+    // Global recency ordering. Candidates with no recency signal sort last;
+    // ties break on (source, locator) so a run is reproducible.
+    candidates.sort_by(|a, b| {
+        b.recency_hint_ms
+            .cmp(&a.recency_hint_ms)
+            .then_with(|| a.source.cmp(b.source))
+            .then_with(|| a.locator.cmp(&b.locator))
+    });
+    if let Some(limit) = options.limit {
+        candidates.truncate(limit);
+    }
+
+    let by_source: BTreeMap<&str, &dyn ShallowSessionProvider> = providers
+        .iter()
+        .map(|provider| (provider.source(), provider.as_ref()))
+        .collect();
+
+    for candidate in &candidates {
+        let Some(provider) = by_source.get(candidate.source) else {
+            continue;
+        };
+        let expected = stored_stamp(&candidate.stamp);
+        let cached = match candidate.session_id.as_deref() {
+            Some(session_id) => fetch_catalog_row(conn, candidate.source, session_id)?,
+            None => fetch_catalog_row_by_path(conn, candidate.source, &candidate.locator)?,
+        };
+        if let Some(cached) = cached.filter(|row| row.source_stamp.as_deref() == Some(&expected)) {
+            env.note_skipped();
+            summary.skipped_unchanged += 1;
+            if let Some(entry) = summary.providers.get_mut(candidate.source) {
+                entry.skipped_unchanged += 1;
+            }
+            on_row(&cached);
+            continue;
+        }
+        env.note_shallow_read();
+        let read = provider.read_shallow(env, candidate);
+        let session = match read {
+            Ok(Some(session)) => session,
+            Ok(None) => continue,
+            Err(error) => {
+                summary.diagnostics.push(DiscoveryDiagnostic {
+                    source: candidate.source.to_string(),
+                    locator: Some(candidate.locator.clone()),
+                    error: format!("{error:#}"),
+                });
+                continue;
+            }
+        };
+        if session.session_id.is_empty() {
+            summary.diagnostics.push(DiscoveryDiagnostic {
+                source: candidate.source.to_string(),
+                locator: Some(candidate.locator.clone()),
+                error: "no session id in source".to_string(),
+            });
+            continue;
+        }
+        let mut session = session;
+        session.source_stamp = Some(expected);
+        session.discovery_state = "shallow".to_string();
+        if let Err(error) = upsert_shallow_session(conn, &session) {
+            summary.diagnostics.push(DiscoveryDiagnostic {
+                source: candidate.source.to_string(),
+                locator: Some(candidate.locator.clone()),
+                error: format!("{error:#}"),
+            });
+            continue;
+        }
+        // Emit the merged catalog row, so what a caller sees is exactly what
+        // the catalog now holds (including a preserved `full` state).
+        let emitted = fetch_catalog_row(conn, &session.source, &session.session_id)?
+            .map(|mut row| {
+                row.from_cache = false;
+                row
+            })
+            .unwrap_or(session);
+        summary.discovered += 1;
+        if let Some(entry) = summary.providers.get_mut(candidate.source) {
+            entry.discovered += 1;
+        }
+        on_row(&emitted);
+    }
+
+    summary.counters = env.counters();
+    Ok(summary)
+}
+
+/// [`discover_sessions`] with the rows collected instead of streamed.
+pub fn discover_sessions_collect(
+    conn: &Connection,
+    options: &DiscoverOptions,
+) -> Result<(Vec<ShallowSession>, DiscoverySummary)> {
+    let mut rows = Vec::new();
+    let summary = discover_sessions(conn, options, |session| rows.push(session.clone()))?;
+    Ok((rows, summary))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/ai-hist/src/discover/tests.rs
+++ b/crates/ai-hist/src/discover/tests.rs
@@ -320,6 +320,103 @@ fn an_incomplete_trailing_record_is_ignored_but_the_session_still_appears() {
     );
 }
 
+/// A subagent sidecar is its own file whose records carry the *parent's*
+/// sessionId. Enumerating it as a session emitted the parent twice and let the
+/// two files fight over one row's raw_path/source_stamp, so one of them was
+/// re-read on every run forever.
+#[test]
+fn a_subagent_sidecar_is_not_a_second_copy_of_its_parent_session() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    claude_session(home.path(), "claude-1", CLAUDE_BODY, 1_750_000_000_000);
+    claude_session(
+        home.path(),
+        "agent-sub",
+        concat!(
+            r#"{"type":"user","uuid":"su1","sessionId":"claude-1","isSidechain":true,"cwd":"/work/app","timestamp":"2026-06-20T10:02:00.000Z","message":{"role":"user","content":"Research the repo."}}"#,
+            "\n",
+            r#"{"type":"assistant","uuid":"sa1","sessionId":"claude-1","isSidechain":true,"cwd":"/work/app","timestamp":"2026-06-20T10:03:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Report."}]}}"#,
+            "\n"
+        ),
+        1_750_000_050_000,
+    );
+
+    let first = discover(&conn, home.path(), &only(&["claude"]));
+    assert_eq!(
+        first.ids(),
+        vec!["claude:claude-1"],
+        "the parent session must be emitted exactly once per run"
+    );
+    assert_eq!(first.summary.providers["claude"].candidates, 2);
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(rows, 1);
+    // The row points at the session's own transcript, not at the sidecar.
+    let raw_path: String = conn
+        .query_row(
+            "SELECT raw_path FROM sessions WHERE session_id = 'claude-1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(raw_path.ends_with("claude-1.jsonl"), "{raw_path}");
+
+    let second = discover(&conn, home.path(), &only(&["claude"]));
+    assert_eq!(second.ids(), vec!["claude:claude-1"]);
+    assert_eq!(
+        second.summary.counters.shallow_reads, 0,
+        "neither the transcript nor its sidecar may be re-read when nothing changed"
+    );
+    assert_eq!(second.summary.skipped_unchanged, 2);
+    assert_eq!(
+        second.rows[0].source_stamp, first.rows[0].source_stamp,
+        "the stamp must be stable across rescans"
+    );
+}
+
+/// The same defect class as the claude sidecar: a codex subagent thread is a
+/// real rollout that is not a session, so "no catalog row" left nothing for the
+/// stamp check to match and it was re-read on every run.
+#[test]
+fn a_non_session_source_is_remembered_so_rescans_do_not_reread_it() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    codex_rollout(home.path(), "codex-1", CODEX_BODY, 1_750_000_200_000);
+    codex_rollout(
+        home.path(),
+        "codex-sub",
+        concat!(
+            r#"{"timestamp":"2026-06-20T11:02:00.000Z","type":"session_meta","payload":{"id":"codex-sub","cwd":"/work/api","thread_source":"subagent"}}"#,
+            "\n"
+        ),
+        1_750_000_300_000,
+    );
+
+    let first = discover(&conn, home.path(), &only(&["codex"]));
+    assert_eq!(first.summary.counters.shallow_reads, 2);
+    let second = discover(&conn, home.path(), &only(&["codex"]));
+    assert_eq!(
+        second.summary.counters.shallow_reads, 0,
+        "a source already known not to be a session must not be re-read"
+    );
+    assert_eq!(second.ids(), vec!["codex:codex-1"]);
+
+    // A file that later does become a session drops its marker.
+    codex_rollout(
+        home.path(),
+        "codex-sub",
+        &CODEX_BODY.replace("codex-1", "codex-sub"),
+        1_750_000_400_000,
+    );
+    let third = discover(&conn, home.path(), &only(&["codex"]));
+    assert!(third.ids().contains(&"codex:codex-sub".to_string()));
+    let markers: i64 = conn
+        .query_row("SELECT COUNT(*) FROM discovery_skips", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(markers, 0, "a stale non-session marker must be cleared");
+}
+
 #[test]
 fn a_malformed_transcript_does_not_hide_its_healthy_neighbours() {
     let conn = catalog();
@@ -335,11 +432,54 @@ fn a_malformed_transcript_does_not_hide_its_healthy_neighbours() {
 
     let found = discover(&conn, home.path(), &only(&["claude"]));
     let ids = found.ids();
-    assert!(ids.contains(&"claude:claude-1".to_string()), "{ids:?}");
-    // The unparseable file still has a stable identity from its file name, but
-    // it must never take the healthy session's row with it.
+    assert_eq!(
+        ids,
+        vec!["claude:claude-1"],
+        "a corrupt file must not be published as a session under its file name"
+    );
     assert_eq!(found.summary.providers["claude"].candidates, 2);
-    assert!(found.summary.discovered >= 1);
+    assert_eq!(found.summary.discovered, 1);
+    // The corruption is named rather than silently absorbed.
+    let diagnostic = found
+        .summary
+        .diagnostics
+        .iter()
+        .find(|entry| entry.source == "claude")
+        .expect("a diagnostic for the corrupt transcript");
+    assert!(
+        diagnostic
+            .locator
+            .as_deref()
+            .is_some_and(|locator| locator.ends_with("broken.jsonl")),
+        "the diagnostic must name the broken file: {diagnostic:?}"
+    );
+    assert!(
+        diagnostic.error.contains("no parseable JSON records"),
+        "{diagnostic:?}"
+    );
+    // A row exists for neither the corrupt file's stem nor anything else.
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(rows, 1);
+}
+
+/// An empty transcript is a session that has only just started, not a corrupt
+/// one: nothing to catalog yet, and no diagnostic noise every run.
+#[test]
+fn an_empty_transcript_is_not_a_session_and_not_an_error() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    claude_session(home.path(), "claude-1", CLAUDE_BODY, 1_750_000_000_000);
+    claude_session(home.path(), "starting", "", 1_750_000_100_000);
+
+    let found = discover(&conn, home.path(), &only(&["claude"]));
+    assert_eq!(found.ids(), vec!["claude:claude-1"]);
+    assert!(
+        found.summary.diagnostics.is_empty(),
+        "{:?}",
+        found.summary.diagnostics
+    );
 }
 
 #[test]
@@ -585,6 +725,39 @@ fn opencode_sessions_come_from_the_session_table_with_a_first_prompt() {
     let second = discover(&conn, home.path(), &only(&["opencode"]));
     assert_eq!(second.summary.skipped_unchanged, 1);
     assert_eq!(second.summary.counters.shallow_reads, 0);
+}
+
+/// A single opencode part can hold a whole pasted file. The excerpt is cut in
+/// SQL so only the capped prefix ever crosses into Rust.
+#[test]
+fn a_huge_opencode_part_is_truncated_before_it_reaches_rust() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    let huge = "x".repeat(EXCERPT_MAX_CHARS * 8);
+    opencode_db(
+        home.path(),
+        &format!(
+            r#"INSERT INTO session VALUES ('oc-big', '/work/oc', 1750000600000, 1750000700000);
+               INSERT INTO message VALUES ('m1', 'oc-big', 1750000600000, '{{"role":"user"}}');
+               INSERT INTO part VALUES ('p1', 'm1', 'oc-big', 1750000600000, json_object('type', 'text', 'text', '{huge}'));"#
+        ),
+    );
+
+    let found = discover(&conn, home.path(), &only(&["opencode"]));
+    let prompt = found.row("oc-big").first_prompt.clone().expect("a prompt");
+    assert_eq!(
+        prompt.chars().count(),
+        EXCERPT_MAX_CHARS,
+        "the excerpt must be capped at the documented bound"
+    );
+    let stored: String = conn
+        .query_row(
+            "SELECT first_prompt FROM sessions WHERE session_id = 'oc-big'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(stored.chars().count(), EXCERPT_MAX_CHARS);
 }
 
 // ---------------------------------------------------------------------------
@@ -895,7 +1068,7 @@ fn the_cache_only_listing_survives_the_provider_files_disappearing() {
 
 #[test]
 fn the_catalog_query_reads_only_the_sessions_table() {
-    let sql = catalog_list_sql(&CatalogListOptions::default());
+    let (sql, _) = catalog_list_query(&CatalogListOptions::default());
     assert!(sql.contains("FROM sessions"), "{sql}");
     for forbidden in ["history", "session_events", "tool_calls", "file_edits"] {
         assert!(
@@ -977,12 +1150,182 @@ fn the_catalog_listing_filters_by_source_and_paginates_by_recency() {
     assert_eq!(next[0].session_id, "x1");
 }
 
+fn seed_row(conn: &Connection, source: &str, session_id: &str, last: Option<i64>) {
+    conn.execute(
+        "INSERT INTO sessions (session_id, source, last_activity_ms, discovery_state) \
+         VALUES (?, ?, ?, 'shallow')",
+        params![session_id, source, last],
+    )
+    .unwrap();
+}
+
+/// Walk the whole catalog one page at a time and assert the walk is a
+/// partition: every row exactly once, in the catalog's total order.
+fn walk_pages(conn: &Connection, page_size: i64) -> Vec<(String, String)> {
+    let mut seen = Vec::new();
+    let mut after = None;
+    loop {
+        let page = list_session_catalog_page(
+            conn,
+            &CatalogListOptions {
+                limit: Some(page_size),
+                after: after.clone(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        seen.extend(
+            page.sessions
+                .iter()
+                .map(|row| (row.source.clone(), row.session_id.clone())),
+        );
+        match page.next_cursor {
+            Some(cursor) => after = Some(cursor),
+            None => break,
+        }
+        assert!(seen.len() < 500, "pagination did not terminate");
+    }
+    seen
+}
+
+/// Recency alone is not a key: one discovery pass stamps many sessions with the
+/// same mtime-derived millisecond, and a timestamp-only cursor drops every row
+/// tied with the page boundary.
+#[test]
+fn pagination_walks_tied_timestamps_without_skipping_or_repeating_rows() {
+    let conn = catalog();
+    // Twelve sessions across three timestamps: every page boundary lands in
+    // the middle of a tie group.
+    for (source, index) in [("claude", 0), ("codex", 1), ("cursor", 2), ("grok", 3)] {
+        for (tie, last) in [(0, 300_i64), (1, 200), (2, 100)] {
+            seed_row(
+                &conn,
+                source,
+                &format!("{source}-{tie}-{index}"),
+                Some(last),
+            );
+        }
+    }
+    let total: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(total, 12);
+
+    let all = walk_pages(&conn, 5);
+    assert_eq!(all.len(), 12, "every row must appear exactly once: {all:?}");
+    let unique: BTreeSet<_> = all.iter().cloned().collect();
+    assert_eq!(unique.len(), 12, "no row may repeat across pages: {all:?}");
+
+    // The paged walk must equal one unpaginated read of the whole catalog.
+    let straight: Vec<(String, String)> = list_session_catalog(
+        &conn,
+        &CatalogListOptions {
+            limit: Some(100),
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    .iter()
+    .map(|row| (row.source.clone(), row.session_id.clone()))
+    .collect();
+    assert_eq!(all, straight, "paging must not reorder the catalog");
+}
+
+/// Sessions whose recency is unknown sort after every dated row. A cursor that
+/// only carries a timestamp can never reach them, so the whole undated tail
+/// would be invisible to a paginating client.
+#[test]
+fn pagination_reaches_the_undated_tail() {
+    let conn = catalog();
+    seed_row(&conn, "claude", "dated-a", Some(300));
+    seed_row(&conn, "claude", "dated-b", Some(300));
+    seed_row(&conn, "cursor", "undated-a", None);
+    seed_row(&conn, "cursor", "undated-b", None);
+    seed_row(&conn, "grok", "undated-c", None);
+
+    let all = walk_pages(&conn, 2);
+    assert_eq!(
+        all,
+        vec![
+            ("claude".to_string(), "dated-a".to_string()),
+            ("claude".to_string(), "dated-b".to_string()),
+            ("cursor".to_string(), "undated-a".to_string()),
+            ("cursor".to_string(), "undated-b".to_string()),
+            ("grok".to_string(), "undated-c".to_string()),
+        ],
+        "undated rows sort last but must still be reachable"
+    );
+
+    // Stepping straight from a dated cursor into the undated tail works too.
+    let page = list_session_catalog_page(
+        &conn,
+        &CatalogListOptions {
+            limit: Some(10),
+            after: Some(CatalogCursor {
+                last_activity_ms: Some(300),
+                source: "claude".into(),
+                session_id: "dated-b".into(),
+            }),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(page.sessions.len(), 3);
+    assert!(page
+        .sessions
+        .iter()
+        .all(|row| row.last_activity_ms.is_none()));
+    assert!(
+        page.next_cursor.is_none(),
+        "a short page ends the walk rather than looping"
+    );
+}
+
+#[test]
+fn a_full_page_carries_a_cursor_and_a_short_one_does_not() {
+    let conn = catalog();
+    for index in 0..3 {
+        seed_row(&conn, "claude", &format!("c{index}"), Some(100 - index));
+    }
+    let full = list_session_catalog_page(
+        &conn,
+        &CatalogListOptions {
+            limit: Some(3),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(full.sessions.len(), 3);
+    assert_eq!(
+        full.next_cursor,
+        Some(CatalogCursor {
+            last_activity_ms: Some(98),
+            source: "claude".into(),
+            session_id: "c2".into(),
+        }),
+        "a page that fills its limit hands back its last row as the cursor"
+    );
+    let short = list_session_catalog_page(
+        &conn,
+        &CatalogListOptions {
+            limit: Some(10),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(short.sessions.len(), 3);
+    assert_eq!(short.next_cursor, None);
+}
+
 #[test]
 fn the_catalog_listing_is_served_by_an_index_not_a_table_scan() {
     let conn = catalog();
-    let plan = |options: &CatalogListOptions, args: Vec<Box<dyn rusqlite::ToSql>>| -> String {
-        let sql = format!("EXPLAIN QUERY PLAN {}", catalog_list_sql(options));
-        let mut stmt = conn.prepare(&sql).unwrap();
+    // The plan is taken from the *same* builder the listing runs, so this
+    // cannot pass against a restated copy of the query while the real one
+    // drifts into a table scan.
+    let plan = |options: &CatalogListOptions| -> String {
+        let (sql, args) = catalog_list_query(options);
+        let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).unwrap();
         let params = rusqlite::params_from_iter(args.iter().map(|arg| arg.as_ref()));
         stmt.query_map(params, |row| row.get::<_, String>(3))
             .unwrap()
@@ -991,31 +1334,41 @@ fn the_catalog_listing_is_served_by_an_index_not_a_table_scan() {
             .join(" | ")
     };
 
-    let unfiltered = plan(&CatalogListOptions::default(), vec![Box::new(10_i64)]);
+    let unfiltered = plan(&CatalogListOptions::default());
     assert!(
-        unfiltered.contains("idx_sessions_last"),
-        "the recency ordering must be served by idx_sessions_last: {unfiltered}"
+        unfiltered.contains("idx_sessions_recency"),
+        "the catalog's total order must be served by idx_sessions_recency: {unfiltered}"
     );
     assert!(
         !unfiltered.contains("TEMP B-TREE"),
         "the listing must not sort the table: {unfiltered}"
     );
 
-    let filtered = plan(
-        &CatalogListOptions {
-            sources: vec!["claude".into()],
-            limit: Some(10),
-            before_ms: Some(1),
-        },
-        vec![
-            Box::new("claude".to_string()),
-            Box::new(1_i64),
-            Box::new(10_i64),
-        ],
-    );
+    // The paginated form is the one that runs on every page after the first;
+    // it must stay indexed too, composite cursor predicate and all.
+    let paginated = plan(&CatalogListOptions {
+        limit: Some(10),
+        after: Some(CatalogCursor {
+            last_activity_ms: Some(500),
+            source: "claude".into(),
+            session_id: "c1".into(),
+        }),
+        ..Default::default()
+    });
     assert!(
-        filtered.contains("SEARCH") && filtered.contains("idx_sessions_source_last"),
-        "a source-filtered listing must search idx_sessions_source_last: {filtered}"
+        paginated.contains("idx_sessions_recency") && !paginated.contains("TEMP B-TREE"),
+        "a paginated listing must stay index-ordered: {paginated}"
+    );
+
+    let filtered = plan(&CatalogListOptions {
+        sources: vec!["claude".into()],
+        limit: Some(10),
+        before_ms: Some(1),
+        after: None,
+    });
+    assert!(
+        filtered.contains("idx_sessions_source_recency") && !filtered.contains("TEMP B-TREE"),
+        "a source-filtered listing must be served by idx_sessions_source_recency: {filtered}"
     );
 }
 
@@ -1065,6 +1418,106 @@ fn a_shallow_rescan_never_downgrades_a_fully_indexed_row() {
         "the stamp records which scanner wrote it: {:?}",
         row.source_stamp
     );
+}
+
+/// A row written before `discovery_state` existed carries NULL, which readers
+/// deliberately interpret as fully indexed. The upsert has to agree, or the
+/// first discovery run on an upgraded database quietly demotes every legacy
+/// session to `shallow`.
+#[test]
+fn a_legacy_row_with_no_discovery_state_is_not_demoted_to_shallow() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    let path = claude_session(home.path(), "claude-1", CLAUDE_BODY, 1_750_000_000_000);
+    // Exactly what a pre-catalog database holds: the original nine columns
+    // populated, every column this feature added still NULL.
+    conn.execute(
+        "INSERT INTO sessions \
+         (session_id, source, cwd, git_branch, first_activity_ms, last_activity_ms, \
+          last_assistant_text, raw_path, parser_version) \
+         VALUES ('claude-1', 'claude', '/work/app', 'main', 1, 2, 'legacy tail', ?, 1)",
+        [path.to_string_lossy().as_ref()],
+    )
+    .unwrap();
+    let before: Option<String> = conn
+        .query_row(
+            "SELECT discovery_state FROM sessions WHERE session_id = 'claude-1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(before, None, "the fixture must start as a legacy row");
+
+    let found = discover(&conn, home.path(), &only(&["claude"]));
+    let row = found.row("claude-1");
+    assert_eq!(
+        row.discovery_state, "full",
+        "a NULL discovery_state means fully indexed and must survive a shallow rescan"
+    );
+    let stored: Option<String> = conn
+        .query_row(
+            "SELECT discovery_state FROM sessions WHERE session_id = 'claude-1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(stored.as_deref(), Some("full"));
+    assert_eq!(
+        row.last_assistant_text.as_deref(),
+        Some("legacy tail"),
+        "the legacy row's own evidence must survive too"
+    );
+    assert_eq!(row.first_prompt.as_deref(), Some("the real first prompt"));
+}
+
+/// The limit counts emitted sessions. Truncating candidates up front let a
+/// codex subagent thread -- which is not a session -- eat a result slot.
+#[test]
+fn non_session_candidates_do_not_consume_limit_slots() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    // The two newest candidates are subagent threads; the real sessions are
+    // older, so a candidate-truncating limit returned one session for a limit
+    // of two.
+    for (index, id) in ["sub-a", "sub-b"].iter().enumerate() {
+        codex_rollout(
+            home.path(),
+            id,
+            &format!(
+                concat!(
+                    r#"{{"timestamp":"2026-06-20T11:02:00.000Z","type":"session_meta","payload":{{"id":"{}","cwd":"/work/api","thread_source":"subagent"}}}}"#,
+                    "\n"
+                ),
+                id
+            ),
+            1_750_000_900_000 + index as i64,
+        );
+    }
+    for (index, id) in ["real-a", "real-b", "real-c"].iter().enumerate() {
+        codex_rollout(
+            home.path(),
+            id,
+            &CODEX_BODY.replace("codex-1", id),
+            1_750_000_800_000 + index as i64,
+        );
+    }
+
+    let found = discover(
+        &conn,
+        home.path(),
+        &DiscoverOptions {
+            sources: vec!["codex".into()],
+            limit: Some(2),
+        },
+    );
+    assert_eq!(
+        found.ids(),
+        vec!["codex:real-c".to_string(), "codex:real-b".to_string()],
+        "a limit of 2 must yield 2 real sessions, newest first"
+    );
+    assert_eq!(found.summary.discovered, 2);
+    // The two subagent threads were read (and remembered) but did not count.
+    assert_eq!(found.summary.counters.shallow_reads, 4);
 }
 
 #[test]

--- a/crates/ai-hist/src/discover/tests.rs
+++ b/crates/ai-hist/src/discover/tests.rs
@@ -1,0 +1,1085 @@
+//! Fixture-backed tests for shallow session discovery.
+//!
+//! Every fixture is written inline into a temp directory and reached through an
+//! explicit [`DiscoveryEnv`], so no test mutates process-wide environment
+//! variables and the suite stays parallel-safe.
+//!
+//! Performance claims are asserted through [`DiscoveryCounters`] rather than a
+//! wall clock: bounded reads mean a limited request opens a bounded number of
+//! files and reads a bounded number of bytes no matter how large the archive
+//! is, an unchanged rescan performs zero shallow reads, and the cache-only
+//! listing performs no file I/O at all.
+
+use super::*;
+use ai_hist_core::init_db;
+use std::fs;
+use std::time::{Duration, SystemTime};
+
+// ---------------------------------------------------------------------------
+// fixtures
+// ---------------------------------------------------------------------------
+
+fn catalog() -> Connection {
+    let conn = Connection::open_in_memory().expect("in-memory database");
+    init_db(&conn).expect("schema");
+    conn
+}
+
+fn env_at<'a>(conn: &'a Connection, home: &Path) -> DiscoveryEnv<'a> {
+    DiscoveryEnv::with_roots(conn, home.to_path_buf(), home.join("opencode.db"))
+}
+
+fn write(path: &Path, contents: &str) {
+    fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+    fs::write(path, contents).expect("write fixture");
+}
+
+/// Pin a file's mtime so recency ordering (and the change stamp) is
+/// deterministic instead of depending on how fast the test ran.
+fn set_mtime(path: &Path, ms: i64) {
+    let file = fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .expect("open for mtime");
+    let when = SystemTime::UNIX_EPOCH + Duration::from_millis(ms as u64);
+    file.set_times(fs::FileTimes::new().set_modified(when))
+        .expect("set mtime");
+}
+
+fn claude_session(home: &Path, id: &str, body: &str, mtime_ms: i64) -> PathBuf {
+    let path = home.join(format!(".claude/projects/proj/{id}.jsonl"));
+    write(&path, body);
+    set_mtime(&path, mtime_ms);
+    path
+}
+
+fn codex_rollout(home: &Path, id: &str, body: &str, mtime_ms: i64) -> PathBuf {
+    let path = home.join(format!(".codex/sessions/2026/06/20/rollout-{id}.jsonl"));
+    write(&path, body);
+    set_mtime(&path, mtime_ms);
+    path
+}
+
+fn cursor_session(home: &Path, project: &str, id: &str, body: &str, mtime_ms: i64) -> PathBuf {
+    let path = home.join(format!(
+        ".cursor/projects/{project}/agent-transcripts/{id}/{id}.jsonl"
+    ));
+    write(&path, body);
+    set_mtime(&path, mtime_ms);
+    path
+}
+
+fn grok_session(home: &Path, project: &str, id: &str, summary: &str, chat: &str, mtime_ms: i64) {
+    let dir = home.join(format!(".grok/sessions/{project}/{id}"));
+    write(&dir.join("summary.json"), summary);
+    write(&dir.join("chat_history.jsonl"), chat);
+    set_mtime(&dir.join("summary.json"), mtime_ms);
+    set_mtime(&dir.join("chat_history.jsonl"), mtime_ms);
+}
+
+fn opencode_db(home: &Path, statements: &str) {
+    fs::create_dir_all(home).expect("mkdir");
+    let db = Connection::open(home.join("opencode.db")).expect("opencode db");
+    db.execute_batch(&format!(
+        "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, time_created INTEGER, time_updated INTEGER);
+         CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+         CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+         {statements}"
+    ))
+    .expect("opencode fixture");
+}
+
+/// A realistic Claude transcript: a meta row, a slash-command wrapper, and a
+/// sidechain (subagent) turn all precede the first real human prompt.
+const CLAUDE_BODY: &str = concat!(
+    r#"{"sessionId":"claude-1","cwd":"/work/app","gitBranch":"main","version":"1.2.3","type":"user","isMeta":true,"message":{"role":"user","content":"session bookkeeping"},"timestamp":"2026-06-20T10:00:00.000Z"}"#,
+    "\n",
+    r#"{"sessionId":"claude-1","type":"user","message":{"role":"user","content":"<command-name>/compact</command-name>"},"timestamp":"2026-06-20T10:00:01.000Z"}"#,
+    "\n",
+    r#"{"sessionId":"claude-1","type":"user","isSidechain":true,"message":{"role":"user","content":"subagent instruction"},"timestamp":"2026-06-20T10:00:02.000Z"}"#,
+    "\n",
+    r#"{"sessionId":"claude-1","type":"user","message":{"role":"user","content":[{"type":"text","text":"the real first prompt"}]},"timestamp":"2026-06-20T10:00:03.000Z"}"#,
+    "\n",
+    r#"{"sessionId":"claude-1","type":"assistant","message":{"role":"assistant","model":"claude-opus-4","content":[{"type":"text","text":"working on it"}]},"timestamp":"2026-06-20T10:05:00.000Z"}"#,
+    "\n",
+);
+
+const CODEX_BODY: &str = concat!(
+    r#"{"timestamp":"2026-06-20T11:00:00.000Z","type":"session_meta","payload":{"id":"codex-1","cwd":"/work/api","originator":"codex_cli_rs","cli_version":"0.148.0","git":{"branch":"feature","repository_url":"git@github.com:acme/api.git","commit_hash":"abc1234"}}}"#,
+    "\n",
+    r#"{"timestamp":"2026-06-20T11:00:01.000Z","type":"turn_context","payload":{"model":"gpt-5-codex"}}"#,
+    "\n",
+    r#"{"timestamp":"2026-06-20T11:00:02.000Z","type":"event_msg","payload":{"type":"user_message","message":"<environment_context>ignore me</environment_context>"}}"#,
+    "\n",
+    r#"{"timestamp":"2026-06-20T11:00:03.000Z","type":"event_msg","payload":{"type":"user_message","message":"add a retry to the client"}}"#,
+    "\n",
+    r#"{"timestamp":"2026-06-20T11:09:00.000Z","type":"event_msg","payload":{"type":"agent_message","message":"done"}}"#,
+    "\n",
+);
+
+fn discover(conn: &Connection, home: &Path, options: &DiscoverOptions) -> DiscoveryResultForTest {
+    let env = env_at(conn, home);
+    let mut rows = Vec::new();
+    let summary =
+        discover_sessions_with_env(&env, options, |session| rows.push(session.clone())).unwrap();
+    DiscoveryResultForTest { rows, summary }
+}
+
+struct DiscoveryResultForTest {
+    rows: Vec<ShallowSession>,
+    summary: DiscoverySummary,
+}
+
+impl DiscoveryResultForTest {
+    fn ids(&self) -> Vec<String> {
+        self.rows
+            .iter()
+            .map(|row| format!("{}:{}", row.source, row.session_id))
+            .collect()
+    }
+
+    fn row(&self, session_id: &str) -> &ShallowSession {
+        self.rows
+            .iter()
+            .find(|row| row.session_id == session_id)
+            .unwrap_or_else(|| panic!("no {session_id} in {:?}", self.ids()))
+    }
+}
+
+fn only(sources: &[&str]) -> DiscoverOptions {
+    DiscoverOptions {
+        sources: sources.iter().map(|s| s.to_string()).collect(),
+        limit: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// registry
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_source_is_either_discoverable_or_explicitly_exempt() {
+    let adapters: BTreeSet<&str> = shallow_providers()
+        .iter()
+        .map(|provider| provider.source())
+        .collect();
+    let exempt: BTreeSet<&str> = DISCOVERY_EXEMPTIONS
+        .iter()
+        .map(|entry| entry.source)
+        .collect();
+    assert_eq!(
+        adapters.len(),
+        shallow_providers().len(),
+        "an adapter is registered twice"
+    );
+    for source in SOURCE_CHOICES {
+        let covered = usize::from(adapters.contains(source)) + usize::from(exempt.contains(source));
+        assert_eq!(
+            covered, 1,
+            "source '{source}' must be covered by exactly one of the adapter or exemption lists; \
+             a new provider needs a decision, not a default"
+        );
+    }
+    for source in adapters.iter().chain(exempt.iter()) {
+        assert!(
+            SOURCE_CHOICES.contains(source),
+            "'{source}' is registered but is not a known source"
+        );
+    }
+    assert!(
+        exempt.contains("trajectory"),
+        "trajectories are derived records and must stay out of session discovery"
+    );
+}
+
+#[test]
+fn discovering_an_exempt_source_is_rejected_with_its_reason() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    let env = env_at(&conn, home.path());
+    let error = discover_sessions_with_env(&env, &only(&["trajectory"]), |_| {}).unwrap_err();
+    let message = format!("{error:#}");
+    assert!(message.contains("exempt"), "{message}");
+    assert!(message.contains("derived trajectory records"), "{message}");
+}
+
+#[test]
+fn discovering_an_unknown_source_is_rejected() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    let env = env_at(&conn, home.path());
+    let error = discover_sessions_with_env(&env, &only(&["nope"]), |_| {}).unwrap_err();
+    assert!(format!("{error:#}").contains("invalid source"));
+}
+
+// ---------------------------------------------------------------------------
+// claude
+// ---------------------------------------------------------------------------
+
+#[test]
+fn claude_cold_discovery_extracts_identity_and_skips_non_human_turns() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    claude_session(home.path(), "claude-1", CLAUDE_BODY, 1_750_000_000_000);
+
+    let found = discover(&conn, home.path(), &only(&["claude"]));
+    assert_eq!(found.ids(), vec!["claude:claude-1"]);
+    let row = found.row("claude-1");
+    assert_eq!(row.cwd.as_deref(), Some("/work/app"));
+    assert_eq!(row.git_branch.as_deref(), Some("main"));
+    assert_eq!(row.agent_version.as_deref(), Some("1.2.3"));
+    assert_eq!(row.models, vec!["claude-opus-4".to_string()]);
+    assert_eq!(row.discovery_state, "shallow");
+    assert!(!row.from_cache);
+    // Meta, slash-command wrapper and sidechain turns are not human prompts.
+    assert_eq!(row.first_prompt.as_deref(), Some("the real first prompt"));
+    assert_eq!(
+        row.first_activity_ms,
+        crate::parse_iso_ms("2026-06-20T10:00:00.000Z")
+    );
+    assert_eq!(
+        row.last_activity_ms,
+        crate::parse_iso_ms("2026-06-20T10:05:00.000Z")
+    );
+    assert_eq!(found.summary.discovered, 1);
+    assert_eq!(
+        found.summary.contract_version,
+        SESSION_CATALOG_CONTRACT_VERSION
+    );
+}
+
+#[test]
+fn claude_identity_is_stable_and_an_unchanged_rescan_reparses_nothing() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    claude_session(home.path(), "claude-1", CLAUDE_BODY, 1_750_000_000_000);
+
+    let first = discover(&conn, home.path(), &only(&["claude"]));
+    assert_eq!(first.summary.counters.shallow_reads, 1);
+
+    let second = discover(&conn, home.path(), &only(&["claude"]));
+    assert_eq!(second.ids(), first.ids(), "session identity must be stable");
+    assert_eq!(
+        second.summary.counters.shallow_reads, 0,
+        "an unchanged stamp must skip the read entirely"
+    );
+    assert_eq!(second.summary.skipped_unchanged, 1);
+    assert_eq!(second.summary.counters.files_opened, 0);
+    assert!(second.rows[0].from_cache);
+
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(rows, 1, "a rescan must upsert, never duplicate");
+}
+
+#[test]
+fn claude_append_updates_the_existing_row_without_duplicating_it() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    let path = claude_session(home.path(), "claude-1", CLAUDE_BODY, 1_750_000_000_000);
+    discover(&conn, home.path(), &only(&["claude"]));
+
+    let mut appended = fs::read_to_string(&path).unwrap();
+    appended.push_str(
+        r#"{"sessionId":"claude-1","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"later"}]},"timestamp":"2026-06-20T12:00:00.000Z"}"#,
+    );
+    appended.push('\n');
+    fs::write(&path, appended).unwrap();
+    set_mtime(&path, 1_750_000_500_000);
+
+    let second = discover(&conn, home.path(), &only(&["claude"]));
+    assert_eq!(second.summary.counters.shallow_reads, 1);
+    assert_eq!(
+        second.row("claude-1").last_activity_ms,
+        crate::parse_iso_ms("2026-06-20T12:00:00.000Z")
+    );
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(rows, 1);
+}
+
+#[test]
+fn an_incomplete_trailing_record_is_ignored_but_the_session_still_appears() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    // A transcript being written right now: the final record has no newline.
+    let body = format!(
+        "{CLAUDE_BODY}{}",
+        r#"{"sessionId":"claude-1","type":"user","message":{"role":"user","content":"half-written"#
+    );
+    claude_session(home.path(), "claude-1", &body, 1_750_000_000_000);
+
+    let found = discover(&conn, home.path(), &only(&["claude"]));
+    assert_eq!(found.ids(), vec!["claude:claude-1"]);
+    assert_eq!(
+        found.row("claude-1").last_activity_ms,
+        crate::parse_iso_ms("2026-06-20T10:05:00.000Z"),
+        "a partial trailing record is not yet a record"
+    );
+}
+
+#[test]
+fn a_malformed_transcript_does_not_hide_its_healthy_neighbours() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    claude_session(home.path(), "claude-1", CLAUDE_BODY, 1_750_000_000_000);
+    // Not JSON at all, and no session id anywhere.
+    claude_session(
+        home.path(),
+        "broken",
+        "}}}} not json at all\nalso not json\n",
+        1_750_000_100_000,
+    );
+
+    let found = discover(&conn, home.path(), &only(&["claude"]));
+    let ids = found.ids();
+    assert!(ids.contains(&"claude:claude-1".to_string()), "{ids:?}");
+    // The unparseable file still has a stable identity from its file name, but
+    // it must never take the healthy session's row with it.
+    assert_eq!(found.summary.providers["claude"].candidates, 2);
+    assert!(found.summary.discovered >= 1);
+}
+
+#[test]
+fn absent_optional_metadata_stays_null_instead_of_being_invented() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    claude_session(
+        home.path(),
+        "bare",
+        concat!(
+            r#"{"sessionId":"bare","type":"user","message":{"role":"user","content":"hello"}}"#,
+            "\n"
+        ),
+        1_750_000_000_000,
+    );
+
+    let found = discover(&conn, home.path(), &only(&["claude"]));
+    let row = found.row("bare");
+    assert_eq!(row.cwd, None);
+    assert_eq!(row.git_branch, None);
+    assert_eq!(row.agent_version, None);
+    assert_eq!(row.repo_url, None);
+    assert_eq!(row.initial_commit, None);
+    assert_eq!(row.originator, None);
+    assert_eq!(row.first_activity_ms, None);
+    assert_eq!(row.last_activity_ms, None);
+    assert!(row.models.is_empty());
+    assert!(row.workspace_roots.is_empty());
+    // The columns really are NULL, not empty JSON arrays.
+    let (models, roots): (Option<String>, Option<String>) = conn
+        .query_row(
+            "SELECT models_json, workspace_roots_json FROM sessions WHERE session_id = 'bare'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(models, None);
+    assert_eq!(roots, None);
+}
+
+// ---------------------------------------------------------------------------
+// codex
+// ---------------------------------------------------------------------------
+
+#[test]
+fn codex_session_meta_supplies_originator_version_and_git_provenance() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    codex_rollout(home.path(), "codex-1", CODEX_BODY, 1_750_000_200_000);
+
+    let found = discover(&conn, home.path(), &only(&["codex"]));
+    let row = found.row("codex-1");
+    assert_eq!(row.cwd.as_deref(), Some("/work/api"));
+    assert_eq!(row.git_branch.as_deref(), Some("feature"));
+    assert_eq!(row.originator.as_deref(), Some("codex_cli_rs"));
+    assert_eq!(row.agent_version.as_deref(), Some("0.148.0"));
+    assert_eq!(row.repo_url.as_deref(), Some("git@github.com:acme/api.git"));
+    assert_eq!(row.initial_commit.as_deref(), Some("abc1234"));
+    assert_eq!(row.models, vec!["gpt-5-codex".to_string()]);
+    assert_eq!(
+        row.first_prompt.as_deref(),
+        Some("add a retry to the client"),
+        "the environment_context control turn is not a human prompt"
+    );
+    assert_eq!(
+        row.last_activity_ms,
+        crate::parse_iso_ms("2026-06-20T11:09:00.000Z")
+    );
+}
+
+#[test]
+fn codex_subagent_threads_are_not_sessions() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    codex_rollout(home.path(), "codex-1", CODEX_BODY, 1_750_000_200_000);
+    codex_rollout(
+        home.path(),
+        "codex-sub",
+        concat!(
+            r#"{"timestamp":"2026-06-20T11:02:00.000Z","type":"session_meta","payload":{"id":"codex-sub","cwd":"/work/api","thread_source":"subagent"}}"#,
+            "\n"
+        ),
+        1_750_000_300_000,
+    );
+
+    let found = discover(&conn, home.path(), &only(&["codex"]));
+    assert_eq!(found.ids(), vec!["codex:codex-1"]);
+    assert_eq!(found.summary.providers["codex"].candidates, 2);
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(rows, 1);
+}
+
+#[test]
+fn codex_rescan_is_stamp_guarded_and_identity_stable() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    codex_rollout(home.path(), "codex-1", CODEX_BODY, 1_750_000_200_000);
+    let first = discover(&conn, home.path(), &only(&["codex"]));
+    let second = discover(&conn, home.path(), &only(&["codex"]));
+    assert_eq!(first.ids(), second.ids());
+    assert_eq!(second.summary.counters.shallow_reads, 0);
+    assert_eq!(second.summary.skipped_unchanged, 1);
+}
+
+// ---------------------------------------------------------------------------
+// cursor
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cursor_reports_mtime_as_last_activity_and_leaves_first_activity_null() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    cursor_session(
+        home.path(),
+        "work-app",
+        "cursor-1",
+        concat!(
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"<user_query>\nfix the flaky test\n</user_query>"}]}}"#,
+            "\n",
+            r#"{"role":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}"#,
+            "\n"
+        ),
+        1_750_000_400_000,
+    );
+
+    let found = discover(&conn, home.path(), &only(&["cursor"]));
+    let row = found.row("cursor-1");
+    assert_eq!(row.first_prompt.as_deref(), Some("fix the flaky test"));
+    assert_eq!(row.cwd.as_deref(), Some("/work/app"));
+    // Cursor records no per-message timestamps, so mtime is the only signal
+    // and it is reported as last activity only.
+    assert_eq!(row.last_activity_ms, Some(1_750_000_400_000));
+    assert_eq!(row.first_activity_ms, None);
+}
+
+#[test]
+fn cursor_rescan_keeps_one_row_per_session() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    cursor_session(
+        home.path(),
+        "work-app",
+        "cursor-1",
+        "{\"role\":\"user\",\"message\":{\"content\":\"hi\"}}\n",
+        1_750_000_400_000,
+    );
+    discover(&conn, home.path(), &only(&["cursor"]));
+    let second = discover(&conn, home.path(), &only(&["cursor"]));
+    assert_eq!(second.summary.skipped_unchanged, 1);
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(rows, 1);
+}
+
+// ---------------------------------------------------------------------------
+// grok
+// ---------------------------------------------------------------------------
+
+#[test]
+fn grok_summary_supplies_identity_and_the_chat_head_supplies_the_prompt() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    grok_session(
+        home.path(),
+        "%2Fwork%2Fgrok",
+        "grok-1",
+        r#"{"info":{"id":"grok-1","cwd":"/work/grok"},"created_at":"2026-06-20T09:00:00.000Z","updated_at":"2026-06-20T09:30:00.000Z","head_branch":"trunk"}"#,
+        concat!(
+            r#"{"type":"user","synthetic_reason":"system_reminder","content":[{"type":"text","text":"synthetic"}]}"#,
+            "\n",
+            r#"{"type":"user","content":[{"type":"text","text":"summarize the diff"}]}"#,
+            "\n",
+            r#"{"type":"assistant","content":[{"type":"text","text":"sure"}]}"#,
+            "\n"
+        ),
+        1_750_000_500_000,
+    );
+
+    let found = discover(&conn, home.path(), &only(&["grok"]));
+    let row = found.row("grok-1");
+    assert_eq!(row.cwd.as_deref(), Some("/work/grok"));
+    assert_eq!(row.git_branch.as_deref(), Some("trunk"));
+    assert_eq!(
+        row.first_prompt.as_deref(),
+        Some("summarize the diff"),
+        "synthetic user turns are not human prompts"
+    );
+    assert_eq!(
+        row.first_activity_ms,
+        crate::parse_iso_ms("2026-06-20T09:00:00.000Z")
+    );
+    assert_eq!(
+        row.last_activity_ms,
+        crate::parse_iso_ms("2026-06-20T09:30:00.000Z")
+    );
+}
+
+#[test]
+fn grok_rescan_is_stamp_guarded() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    grok_session(
+        home.path(),
+        "%2Fwork%2Fgrok",
+        "grok-1",
+        r#"{"info":{"id":"grok-1","cwd":"/work/grok"},"created_at":"2026-06-20T09:00:00.000Z"}"#,
+        "{\"type\":\"user\",\"content\":\"hey\"}\n",
+        1_750_000_500_000,
+    );
+    discover(&conn, home.path(), &only(&["grok"]));
+    let second = discover(&conn, home.path(), &only(&["grok"]));
+    assert_eq!(second.summary.counters.shallow_reads, 0);
+    assert_eq!(second.summary.skipped_unchanged, 1);
+}
+
+// ---------------------------------------------------------------------------
+// opencode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn opencode_sessions_come_from_the_session_table_with_a_first_prompt() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    opencode_db(
+        home.path(),
+        r#"INSERT INTO session VALUES ('oc-1', '/work/oc', 1750000600000, 1750000700000);
+           INSERT INTO message VALUES ('m1', 'oc-1', 1750000600000, '{"role":"user","modelID":"claude-sonnet"}');
+           INSERT INTO part VALUES ('p1', 'm1', 'oc-1', 1750000600000, '{"type":"text","text":"port the parser"}');"#,
+    );
+
+    let found = discover(&conn, home.path(), &only(&["opencode"]));
+    let row = found.row("oc-1");
+    assert_eq!(row.cwd.as_deref(), Some("/work/oc"));
+    assert_eq!(row.first_prompt.as_deref(), Some("port the parser"));
+    assert_eq!(row.first_activity_ms, Some(1_750_000_600_000));
+    assert_eq!(row.last_activity_ms, Some(1_750_000_700_000));
+    assert_eq!(row.models, vec!["claude-sonnet".to_string()]);
+    assert_eq!(row.raw_path, None, "opencode sessions are not file-backed");
+
+    let second = discover(&conn, home.path(), &only(&["opencode"]));
+    assert_eq!(second.summary.skipped_unchanged, 1);
+    assert_eq!(second.summary.counters.shallow_reads, 0);
+}
+
+// ---------------------------------------------------------------------------
+// relay
+// ---------------------------------------------------------------------------
+
+#[test]
+fn relay_discovers_from_already_synced_rows_and_never_touches_the_network() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    for (id, prompt, ts) in [
+        ("ch:general", "[ana] deploy is red", 1_750_000_800_000_i64),
+        ("ch:general", "[bo] rolling back", 1_750_000_900_000),
+    ] {
+        ai_hist_core::insert_history(
+            &conn,
+            &ai_hist_core::HistoryEntry {
+                id: 0,
+                source: "relay".into(),
+                session_id: Some(id.into()),
+                project: Some("ws-1".into()),
+                prompt: prompt.into(),
+                prompt_hash: None,
+                timestamp_ms: ts,
+            },
+        )
+        .unwrap();
+    }
+
+    let found = discover(&conn, home.path(), &only(&["relay"]));
+    let row = found.row("ch:general");
+    assert_eq!(row.first_prompt.as_deref(), Some("[ana] deploy is red"));
+    assert_eq!(row.first_activity_ms, Some(1_750_000_800_000));
+    assert_eq!(row.last_activity_ms, Some(1_750_000_900_000));
+    // Relay has no local working directory to report, and inventing one would
+    // be a fabrication.
+    assert_eq!(row.cwd, None);
+    // No local files were opened at all: relay is a database-only adapter.
+    assert_eq!(found.summary.counters.files_opened, 0);
+}
+
+#[test]
+fn relay_with_nothing_synced_discovers_nothing_rather_than_failing() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    let found = discover(&conn, home.path(), &only(&["relay"]));
+    assert!(found.rows.is_empty());
+    assert!(found.summary.diagnostics.is_empty());
+    assert_eq!(found.summary.providers["relay"].candidates, 0);
+}
+
+// ---------------------------------------------------------------------------
+// cross-provider
+// ---------------------------------------------------------------------------
+
+fn three_providers(home: &Path) {
+    claude_session(home, "claude-old", CLAUDE_BODY, 1_000_000_000_000);
+    codex_rollout(home, "codex-mid", CODEX_BODY, 2_000_000_000_000);
+    cursor_session(
+        home,
+        "work-app",
+        "cursor-new",
+        "{\"role\":\"user\",\"message\":{\"content\":\"newest\"}}\n",
+        3_000_000_000_000,
+    );
+}
+
+#[test]
+fn candidates_are_ordered_globally_by_recency_across_providers() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    three_providers(home.path());
+
+    let found = discover(&conn, home.path(), &DiscoverOptions::default());
+    assert_eq!(
+        found.ids(),
+        vec![
+            "cursor:cursor-new".to_string(),
+            "codex:codex-1".to_string(),
+            "claude:claude-1".to_string(),
+        ],
+        "rows must arrive newest-first across providers, not provider by provider"
+    );
+}
+
+#[test]
+fn the_limit_is_global_not_per_provider() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    // Two providers, three sessions each, interleaved in time. The three
+    // newest overall are two claude sessions and one codex session.
+    for (index, id) in ["claude-a", "claude-b", "claude-c"].iter().enumerate() {
+        let body = CLAUDE_BODY.replace("claude-1", id);
+        claude_session(
+            home.path(),
+            id,
+            &body,
+            1_000_000_000_000 + index as i64 * 100,
+        );
+    }
+    for (index, id) in ["codex-a", "codex-b", "codex-c"].iter().enumerate() {
+        let body = CODEX_BODY.replace("codex-1", id);
+        codex_rollout(
+            home.path(),
+            id,
+            &body,
+            1_000_000_000_050 + index as i64 * 100,
+        );
+    }
+
+    let found = discover(
+        &conn,
+        home.path(),
+        &DiscoverOptions {
+            sources: Vec::new(),
+            limit: Some(3),
+        },
+    );
+    assert_eq!(
+        found.ids(),
+        vec![
+            "codex:codex-c".to_string(),
+            "claude:claude-c".to_string(),
+            "codex:codex-b".to_string(),
+        ],
+        "the newest three overall (two codex, one claude), not three from one provider"
+    );
+    assert_eq!(found.summary.counters.candidates_enumerated, 6);
+    assert_eq!(found.summary.counters.shallow_reads, 3);
+}
+
+#[test]
+fn the_same_native_id_under_two_providers_is_two_rows() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    claude_session(
+        home.path(),
+        "shared",
+        &CLAUDE_BODY.replace("claude-1", "shared"),
+        1_000_000_000_000,
+    );
+    codex_rollout(
+        home.path(),
+        "shared",
+        &CODEX_BODY.replace("codex-1", "shared"),
+        1_000_000_000_100,
+    );
+
+    let found = discover(&conn, home.path(), &DiscoverOptions::default());
+    assert_eq!(found.rows.len(), 2);
+    let sources: BTreeSet<&str> = found.rows.iter().map(|row| row.source.as_str()).collect();
+    assert_eq!(sources, ["claude", "codex"].into_iter().collect());
+    let rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sessions WHERE session_id = 'shared'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        rows, 2,
+        "(source, session_id) is the identity, not id alone"
+    );
+}
+
+#[test]
+fn one_broken_provider_does_not_block_the_others() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    claude_session(home.path(), "claude-1", CLAUDE_BODY, 1_750_000_000_000);
+    // Not a SQLite database at all: the opencode snapshot must fail.
+    fs::write(home.path().join("opencode.db"), "definitely not sqlite").unwrap();
+
+    let found = discover(&conn, home.path(), &DiscoverOptions::default());
+    assert_eq!(found.ids(), vec!["claude:claude-1"]);
+    assert!(found.summary.providers["opencode"].failed);
+    assert!(!found.summary.providers["claude"].failed);
+    assert_eq!(found.summary.diagnostics.len(), 1);
+    assert_eq!(found.summary.diagnostics[0].source, "opencode");
+}
+
+#[test]
+fn a_run_fails_only_when_every_provider_fails() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    fs::write(home.path().join("opencode.db"), "definitely not sqlite").unwrap();
+    let env = env_at(&conn, home.path());
+    let error = discover_sessions_with_env(&env, &only(&["opencode"]), |_| {}).unwrap_err();
+    assert!(
+        format!("{error:#}").contains("no provider made progress"),
+        "{error:#}"
+    );
+}
+
+#[test]
+fn bounded_reads_do_not_grow_with_the_size_of_the_archive() {
+    let conn = catalog();
+    let small = tempfile::tempdir().unwrap();
+    claude_session(small.path(), "a", &CLAUDE_BODY.replace("claude-1", "a"), 10);
+    codex_rollout(small.path(), "b", &CODEX_BODY.replace("codex-1", "b"), 20);
+    let limited = DiscoverOptions {
+        sources: Vec::new(),
+        limit: Some(2),
+    };
+    let baseline = discover(&conn, small.path(), &limited);
+
+    let conn = catalog();
+    let big = tempfile::tempdir().unwrap();
+    for index in 0..50 {
+        let id = format!("bulk-{index:02}");
+        claude_session(
+            big.path(),
+            &id,
+            &CLAUDE_BODY.replace("claude-1", &id),
+            1_000 + index as i64,
+        );
+    }
+    claude_session(
+        big.path(),
+        "a",
+        &CLAUDE_BODY.replace("claude-1", "a"),
+        900_000,
+    );
+    codex_rollout(
+        big.path(),
+        "b",
+        &CODEX_BODY.replace("codex-1", "b"),
+        900_010,
+    );
+    let scaled = discover(&conn, big.path(), &limited);
+
+    assert_eq!(scaled.summary.counters.candidates_enumerated, 52);
+    assert_eq!(
+        scaled.summary.counters.shallow_reads, 2,
+        "a limit of 2 must read exactly two sources, whatever the archive holds"
+    );
+    assert_eq!(
+        scaled.summary.counters.files_opened, baseline.summary.counters.files_opened,
+        "file opens must not scale with the archive"
+    );
+    assert_eq!(
+        scaled.summary.counters.bytes_read, baseline.summary.counters.bytes_read,
+        "bytes read must not scale with the archive"
+    );
+    assert_eq!(
+        scaled.ids(),
+        vec!["codex:b".to_string(), "claude:a".to_string()]
+    );
+}
+
+#[test]
+fn a_head_read_stays_inside_its_budget_on_a_very_large_transcript() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    let mut body = String::from(CLAUDE_BODY);
+    let filler = r#"{"sessionId":"claude-1","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"PADDINGPADDINGPADDINGPADDINGPADDINGPADDINGPADDINGPADDING"}]},"timestamp":"2026-06-20T10:06:00.000Z"}"#;
+    while body.len() < 3 * HEAD_SCAN_MAX_BYTES as usize {
+        body.push_str(filler);
+        body.push('\n');
+    }
+    body.push_str(
+        r#"{"sessionId":"claude-1","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"final"}]},"timestamp":"2026-06-20T23:00:00.000Z"}"#,
+    );
+    body.push('\n');
+    let path = claude_session(home.path(), "claude-1", &body, 1_750_000_000_000);
+    let size = fs::metadata(&path).unwrap().len();
+
+    let found = discover(&conn, home.path(), &only(&["claude"]));
+    assert!(
+        found.summary.counters.bytes_read <= HEAD_SCAN_MAX_BYTES + TAIL_SCAN_MAX_BYTES,
+        "read {} bytes of a {size}-byte transcript",
+        found.summary.counters.bytes_read
+    );
+    assert!(found.summary.counters.bytes_read < size);
+    let row = found.row("claude-1");
+    assert_eq!(row.first_prompt.as_deref(), Some("the real first prompt"));
+    assert_eq!(
+        row.last_activity_ms,
+        crate::parse_iso_ms("2026-06-20T23:00:00.000Z"),
+        "the tail read must still find the last timestamp"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// catalog listing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_cache_only_listing_survives_the_provider_files_disappearing() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    three_providers(home.path());
+    discover(&conn, home.path(), &DiscoverOptions::default());
+
+    // Nothing on disk any more: a cache-only list must not care.
+    fs::remove_dir_all(home.path().join(".claude")).unwrap();
+    fs::remove_dir_all(home.path().join(".codex")).unwrap();
+    fs::remove_dir_all(home.path().join(".cursor")).unwrap();
+
+    let rows = list_session_catalog(&conn, &CatalogListOptions::default()).unwrap();
+    assert_eq!(rows.len(), 3);
+    assert!(rows.iter().all(|row| row.from_cache));
+    let recency: Vec<Option<i64>> = rows.iter().map(|row| row.last_activity_ms).collect();
+    let mut sorted = recency.clone();
+    sorted.sort_by(|a, b| b.cmp(a));
+    assert_eq!(recency, sorted, "the catalog lists newest first");
+}
+
+#[test]
+fn the_catalog_query_reads_only_the_sessions_table() {
+    let sql = catalog_list_sql(&CatalogListOptions::default());
+    assert!(sql.contains("FROM sessions"), "{sql}");
+    for forbidden in ["history", "session_events", "tool_calls", "file_edits"] {
+        assert!(
+            !sql.contains(forbidden),
+            "the cache-only listing must not touch {forbidden}: {sql}"
+        );
+    }
+}
+
+#[test]
+fn trajectory_rows_never_appear_in_a_session_listing() {
+    let conn = catalog();
+    conn.execute(
+        "INSERT INTO sessions (session_id, source, last_activity_ms, discovery_state) \
+         VALUES ('traj-1', 'trajectory', 9999999999999, 'full')",
+        [],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO sessions (session_id, source, last_activity_ms, discovery_state) \
+         VALUES ('claude-1', 'claude', 1, 'shallow')",
+        [],
+    )
+    .unwrap();
+    let rows = list_session_catalog(&conn, &CatalogListOptions::default()).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].source, "claude");
+}
+
+#[test]
+fn the_catalog_listing_filters_by_source_and_paginates_by_recency() {
+    let conn = catalog();
+    for (source, id, ts) in [
+        ("claude", "c1", 300_i64),
+        ("claude", "c2", 200),
+        ("codex", "x1", 250),
+    ] {
+        conn.execute(
+            "INSERT INTO sessions (session_id, source, last_activity_ms, discovery_state) \
+             VALUES (?, ?, ?, 'shallow')",
+            params![id, source, ts],
+        )
+        .unwrap();
+    }
+    let claude_only = list_session_catalog(
+        &conn,
+        &CatalogListOptions {
+            sources: vec!["claude".into()],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        claude_only
+            .iter()
+            .map(|row| row.session_id.clone())
+            .collect::<Vec<_>>(),
+        vec!["c1", "c2"]
+    );
+
+    let page = list_session_catalog(
+        &conn,
+        &CatalogListOptions {
+            limit: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(page[0].session_id, "c1");
+    let next = list_session_catalog(
+        &conn,
+        &CatalogListOptions {
+            limit: Some(1),
+            before_ms: page[0].last_activity_ms,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(next[0].session_id, "x1");
+}
+
+#[test]
+fn the_catalog_listing_is_served_by_an_index_not_a_table_scan() {
+    let conn = catalog();
+    let plan = |options: &CatalogListOptions, args: Vec<Box<dyn rusqlite::ToSql>>| -> String {
+        let sql = format!("EXPLAIN QUERY PLAN {}", catalog_list_sql(options));
+        let mut stmt = conn.prepare(&sql).unwrap();
+        let params = rusqlite::params_from_iter(args.iter().map(|arg| arg.as_ref()));
+        stmt.query_map(params, |row| row.get::<_, String>(3))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap()
+            .join(" | ")
+    };
+
+    let unfiltered = plan(&CatalogListOptions::default(), vec![Box::new(10_i64)]);
+    assert!(
+        unfiltered.contains("idx_sessions_last"),
+        "the recency ordering must be served by idx_sessions_last: {unfiltered}"
+    );
+    assert!(
+        !unfiltered.contains("TEMP B-TREE"),
+        "the listing must not sort the table: {unfiltered}"
+    );
+
+    let filtered = plan(
+        &CatalogListOptions {
+            sources: vec!["claude".into()],
+            limit: Some(10),
+            before_ms: Some(1),
+        },
+        vec![
+            Box::new("claude".to_string()),
+            Box::new(1_i64),
+            Box::new(10_i64),
+        ],
+    );
+    assert!(
+        filtered.contains("SEARCH") && filtered.contains("idx_sessions_source_last"),
+        "a source-filtered listing must search idx_sessions_source_last: {filtered}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// full-ingest interaction
+// ---------------------------------------------------------------------------
+
+#[test]
+fn a_shallow_rescan_never_downgrades_a_fully_indexed_row() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    let path = claude_session(home.path(), "claude-1", CLAUDE_BODY, 1_750_000_000_000);
+    // Stand in for the full-sync path having already ingested this session.
+    crate::upsert_session(
+        &conn,
+        "claude-1",
+        "claude",
+        Some("/work/app"),
+        Some("main"),
+        1,
+        2,
+        Some("the assistant's last word"),
+        Some(&path.to_string_lossy()),
+    )
+    .unwrap();
+
+    let found = discover(&conn, home.path(), &only(&["claude"]));
+    let row = found.row("claude-1");
+    assert_eq!(
+        row.discovery_state, "full",
+        "shallow discovery must never claim a fully indexed session is shallow"
+    );
+    assert_eq!(
+        row.last_assistant_text.as_deref(),
+        Some("the assistant's last word"),
+        "a shallow pass must not null out what full indexing established"
+    );
+    assert_eq!(
+        row.first_prompt.as_deref(),
+        Some("the real first prompt"),
+        "a shallow rescan of a full row still refreshes catalog metadata"
+    );
+    assert!(
+        row.source_stamp
+            .as_deref()
+            .is_some_and(|stamp| stamp.starts_with(&format!("v{SHALLOW_SCANNER_VERSION}:"))),
+        "the stamp records which scanner wrote it: {:?}",
+        row.source_stamp
+    );
+}
+
+#[test]
+fn bumping_the_scanner_version_invalidates_stored_stamps() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    claude_session(home.path(), "claude-1", CLAUDE_BODY, 1_750_000_000_000);
+    discover(&conn, home.path(), &only(&["claude"]));
+    // Simulate a database stamped by an older scanner generation.
+    conn.execute(
+        "UPDATE sessions SET source_stamp = 'v0:stale' WHERE session_id = 'claude-1'",
+        [],
+    )
+    .unwrap();
+    let rescan = discover(&conn, home.path(), &only(&["claude"]));
+    assert_eq!(rescan.summary.counters.shallow_reads, 1);
+    assert_eq!(rescan.summary.skipped_unchanged, 0);
+}

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -512,7 +512,11 @@ enum SessionsAction {
         /// Precise continuation: `last_activity_ms` of the previous page's last
         /// row. Omit (with --after-source/--after-session-id given) to continue
         /// through the rows whose recency is unknown.
-        #[arg(long)]
+        ///
+        /// Requires --after-source (which in turn requires --after-session-id):
+        /// a timestamp alone is not a cursor, and silently ignoring it would
+        /// restart the walk at page one instead of continuing it.
+        #[arg(long, requires = "after_source")]
         after_ms: Option<i64>,
         /// Emit `{"contract_version":N,"sessions":[...],"next_cursor":…}` as one
         /// JSON object.
@@ -1438,13 +1442,13 @@ fn run_session_discovery(
     // followed by an opaque exit code.
     let (summary, failure) = match outcome {
         Ok(summary) => (summary, None),
-        Err(error) => match error.downcast::<AllProvidersFailed>() {
-            Ok(failed) => {
-                let summary = failed.summary.clone();
-                (summary, Some(anyhow::Error::from(failed)))
-            }
-            Err(error) => return Err(error),
-        },
+        // `downcast`'s Err arm carries the original error untouched, so `?`
+        // propagates any other failure exactly as it arrived.
+        Err(error) => {
+            let failed = error.downcast::<AllProvidersFailed>()?;
+            let summary = failed.summary.clone();
+            (summary, Some(anyhow::Error::from(failed)))
+        }
     };
     for diagnostic in &summary.diagnostics {
         if as_json {

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -22,7 +22,18 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 mod cloud;
+/// Fast, shallow coding-agent session discovery and the cache-only catalog
+/// listing that backs it.
+pub mod discover;
 mod learn;
+
+pub use discover::{
+    discover_sessions, discover_sessions_collect, discover_sessions_with_env, list_session_catalog,
+    shallow_providers, Candidate, CatalogListOptions, DiscoverOptions, DiscoveryCounters,
+    DiscoveryDiagnostic, DiscoveryEnv, DiscoverySummary, ProviderSummary, ShallowSession,
+    ShallowSessionProvider, SourceExemption, DEFAULT_CATALOG_LIMIT, DISCOVERY_EXEMPTIONS,
+    SESSION_CATALOG_CONTRACT_VERSION, SHALLOW_SCANNER_VERSION,
+};
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering as AtomicOrdering};
 
@@ -108,6 +119,37 @@ pub fn sync_and_push() -> Result<SyncPushOutcome> {
         authenticated: true,
         sync_skipped,
     })
+}
+
+/// Cache-only session catalog listing against the default database.
+///
+/// The in-process equivalent of `ai-hist sessions list`: one indexed query
+/// over `sessions`, no provider I/O. A database that does not exist yet is an
+/// empty catalog, not an error — the caller is expected to run discovery next.
+pub fn list_sessions_local(options: &CatalogListOptions) -> Result<Vec<ShallowSession>> {
+    let db_path = default_db_path();
+    if !db_path.exists() {
+        return Ok(Vec::new());
+    }
+    let conn = match open_db_readonly(&db_path) {
+        Ok(conn) if schema_is_current(&conn).unwrap_or(false) => conn,
+        // Missing migration (a read-only handle skips init_db) or an
+        // unreadable handle: let the writable open sort it out.
+        _ => open_db(&db_path)?,
+    };
+    list_session_catalog(&conn, options)
+}
+
+/// Shallow discovery against the default database, with the rows collected.
+///
+/// The in-process equivalent of `ai-hist sessions discover`. Upsert-only and
+/// stamp-guarded, so it does not take the sync lock and is safe to run beside
+/// `sync_local`.
+pub fn discover_sessions_local(
+    options: &DiscoverOptions,
+) -> Result<(Vec<ShallowSession>, DiscoverySummary)> {
+    let conn = open_db(&default_db_path())?;
+    discover_sessions_collect(&conn, options)
 }
 
 #[derive(Parser)]
@@ -432,6 +474,51 @@ enum Command {
         #[command(subcommand)]
         action: LearnAction,
     },
+    /// Coding-agent session catalog — cache-only listing and shallow discovery.
+    Sessions {
+        #[command(subcommand)]
+        action: SessionsAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum SessionsAction {
+    /// List the session catalog from the database only.
+    ///
+    /// Never opens a provider transcript and never scans history, events, or
+    /// tool calls: one indexed query over `sessions`. Run `sessions discover`
+    /// first to populate a fresh database.
+    List {
+        /// Restrict to a source (repeatable). Defaults to every discoverable source.
+        #[arg(long)]
+        source: Vec<String>,
+        /// Maximum rows (default 50).
+        #[arg(long)]
+        limit: Option<i64>,
+        /// Keyset pagination: only sessions older than this epoch-ms cutoff.
+        #[arg(long)]
+        before_ms: Option<i64>,
+        /// Emit `{"contract_version":N,"sessions":[...]}` as one JSON object.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Discover sessions from provider locations with bounded reads.
+    ///
+    /// Enumerates every provider, orders candidates globally by recency, reads
+    /// only what the catalog needs, and upserts rows as it goes. Sources whose
+    /// bytes have not changed since the last run are served from the catalog.
+    Discover {
+        /// Restrict to a source (repeatable). Defaults to every discoverable source.
+        #[arg(long)]
+        source: Vec<String>,
+        /// Global cap across all providers, applied by recency. Unlimited when omitted.
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Emit JSONL progressively: one `session`/`diagnostic` object per line,
+        /// then a final `summary`.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -560,6 +647,12 @@ fn is_read_only(command: &Command) -> bool {
             // Listing it here keeps it off the write lock, so running it does not contend
             // with the 60s `sync` service.
             | Command::Coverage { .. }
+            // `sessions list` is cache-only by construction: one indexed query
+            // over `sessions` and no provider I/O at all. `sessions discover`
+            // upserts, so it is deliberately absent.
+            | Command::Sessions {
+                action: SessionsAction::List { .. }
+            }
     )
 }
 
@@ -1175,7 +1268,153 @@ pub fn run() -> Result<()> {
                 Ok(())
             }
         },
+        Command::Sessions { action } => match action {
+            SessionsAction::List {
+                source,
+                limit,
+                before_ms,
+                json,
+            } => {
+                for source in &source {
+                    validate_source(Some(source))?;
+                }
+                let rows = list_session_catalog(
+                    &conn,
+                    &CatalogListOptions {
+                        sources: source,
+                        limit,
+                        before_ms,
+                    },
+                )?;
+                print_session_catalog(&rows, json)
+            }
+            SessionsAction::Discover {
+                source,
+                limit,
+                json,
+            } => run_session_discovery(&conn, source, limit, json),
+        },
     }
+}
+
+/// Render `ai-hist sessions list`.
+///
+/// The JSON form is one object, not a bare array, so the contract version
+/// travels with the payload: `{"contract_version":1,"sessions":[…]}`.
+fn print_session_catalog(rows: &[ShallowSession], as_json: bool) -> Result<()> {
+    if as_json {
+        println!(
+            "{}",
+            json!({
+                "contract_version": SESSION_CATALOG_CONTRACT_VERSION,
+                "sessions": rows,
+            })
+        );
+        return Ok(());
+    }
+    if rows.is_empty() {
+        println!("No sessions in the catalog. Run `ai-hist sessions discover` to populate it.");
+        return Ok(());
+    }
+    for row in rows {
+        println!("{}", fmt_session_row(row));
+    }
+    println!("  {} session(s)", rows.len());
+    Ok(())
+}
+
+fn fmt_session_row(row: &ShallowSession) -> String {
+    let when = row
+        .last_activity_ms
+        .and_then(|ms| Local.timestamp_millis_opt(ms).single())
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_else(|| "------ --:--".to_string());
+    let cwd = row.cwd.as_deref().unwrap_or("-");
+    let prompt = row
+        .first_prompt
+        .as_deref()
+        .map(|text| {
+            let flat = text.replace('\n', " ");
+            if flat.chars().count() > 80 {
+                format!("{}...", flat.chars().take(80).collect::<String>())
+            } else {
+                flat
+            }
+        })
+        .unwrap_or_default();
+    format!(
+        "  {when}  {:<8} {:<8} {:<38} {cwd}  {prompt}",
+        row.source, row.discovery_state, row.session_id
+    )
+}
+
+/// Render `ai-hist sessions discover`, streaming rows as they are produced.
+///
+/// JSON mode is JSONL (the `events` command's precedent): one
+/// `{"type":"session",…}` per row, `{"type":"diagnostic",…}` per failure, and a
+/// closing `{"type":"summary",…}`. Per-provider failures are reported but do
+/// not change the exit code; only an every-provider failure does.
+fn run_session_discovery(
+    conn: &Connection,
+    sources: Vec<String>,
+    limit: Option<usize>,
+    as_json: bool,
+) -> Result<()> {
+    let options = DiscoverOptions { sources, limit };
+    let mut count = 0usize;
+    let summary = discover_sessions(conn, &options, |session| {
+        count += 1;
+        if as_json {
+            match serde_json::to_value(session) {
+                Ok(Value::Object(mut map)) => {
+                    map.insert("type".to_string(), json!("session"));
+                    println!("{}", Value::Object(map));
+                }
+                _ => eprintln!(
+                    "ai-hist: could not serialize session {}",
+                    session.session_id
+                ),
+            }
+        } else {
+            println!("{}", fmt_session_row(session));
+        }
+    })?;
+    for diagnostic in &summary.diagnostics {
+        if as_json {
+            println!(
+                "{}",
+                json!({
+                    "type": "diagnostic",
+                    "source": diagnostic.source,
+                    "locator": diagnostic.locator,
+                    "error": diagnostic.error,
+                })
+            );
+        } else {
+            let scope = diagnostic.locator.as_deref().unwrap_or("(provider)");
+            eprintln!(
+                "ai-hist: [{}] {scope}: {}",
+                diagnostic.source, diagnostic.error
+            );
+        }
+    }
+    if as_json {
+        let mut payload = serde_json::to_value(&summary)?;
+        if let Value::Object(map) = &mut payload {
+            map.insert("type".to_string(), json!("summary"));
+            map.remove("diagnostics");
+        }
+        println!("{payload}");
+    } else {
+        println!(
+            "  {count} session(s): {} discovered, {} unchanged ({} file(s) opened, {} shallow read(s))",
+            summary.discovered,
+            summary.skipped_unchanged,
+            summary.counters.files_opened,
+            summary.counters.shallow_reads
+        );
+    }
+    Ok(())
 }
 
 /// Best-effort `git remote get-url origin` for project scoping (None if not a repo).
@@ -6152,6 +6391,10 @@ fn count_patch_text(text: &str) -> (i64, i64) {
     (added, removed)
 }
 
+/// Register a session whose full evidence (`session_events`, `tool_calls`, …)
+/// has just been ingested, so the row is marked `discovery_state = 'full'`.
+/// Shallow discovery writes through [`discover::upsert_shallow_session`]
+/// instead and never downgrades a `'full'` row.
 #[allow(clippy::too_many_arguments)]
 fn upsert_session(
     conn: &Connection,
@@ -6166,8 +6409,8 @@ fn upsert_session(
 ) -> Result<()> {
     conn.execute(
         "INSERT INTO sessions \
-         (session_id, source, cwd, git_branch, first_activity_ms, last_activity_ms, last_assistant_text, raw_path, parser_version) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1) \
+         (session_id, source, cwd, git_branch, first_activity_ms, last_activity_ms, last_assistant_text, raw_path, parser_version, discovery_state) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, 'full') \
          ON CONFLICT(session_id, source) DO UPDATE SET \
          cwd = COALESCE(excluded.cwd, sessions.cwd), \
          git_branch = COALESCE(excluded.git_branch, sessions.git_branch), \
@@ -6175,7 +6418,8 @@ fn upsert_session(
          last_activity_ms = MAX(COALESCE(sessions.last_activity_ms, excluded.last_activity_ms), excluded.last_activity_ms), \
          last_assistant_text = COALESCE(excluded.last_assistant_text, sessions.last_assistant_text), \
          raw_path = COALESCE(excluded.raw_path, sessions.raw_path), \
-         parser_version = excluded.parser_version",
+         parser_version = excluded.parser_version, \
+         discovery_state = 'full'",
         params![
             session_id,
             source,

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -29,10 +29,11 @@ mod learn;
 
 pub use discover::{
     discover_sessions, discover_sessions_collect, discover_sessions_with_env, list_session_catalog,
-    shallow_providers, Candidate, CatalogListOptions, DiscoverOptions, DiscoveryCounters,
-    DiscoveryDiagnostic, DiscoveryEnv, DiscoverySummary, ProviderSummary, ShallowSession,
-    ShallowSessionProvider, SourceExemption, DEFAULT_CATALOG_LIMIT, DISCOVERY_EXEMPTIONS,
-    SESSION_CATALOG_CONTRACT_VERSION, SHALLOW_SCANNER_VERSION,
+    list_session_catalog_page, shallow_providers, AllProvidersFailed, Candidate, CatalogCursor,
+    CatalogListOptions, DiscoverOptions, DiscoveryCounters, DiscoveryDiagnostic, DiscoveryEnv,
+    DiscoverySummary, ProviderSummary, SessionCatalogPage, ShallowSession, ShallowSessionProvider,
+    SourceExemption, DEFAULT_CATALOG_LIMIT, DISCOVERY_EXEMPTIONS, SESSION_CATALOG_CONTRACT_VERSION,
+    SHALLOW_SCANNER_VERSION,
 };
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering as AtomicOrdering};
@@ -126,10 +127,10 @@ pub fn sync_and_push() -> Result<SyncPushOutcome> {
 /// The in-process equivalent of `ai-hist sessions list`: one indexed query
 /// over `sessions`, no provider I/O. A database that does not exist yet is an
 /// empty catalog, not an error — the caller is expected to run discovery next.
-pub fn list_sessions_local(options: &CatalogListOptions) -> Result<Vec<ShallowSession>> {
+pub fn list_sessions_local(options: &CatalogListOptions) -> Result<SessionCatalogPage> {
     let db_path = default_db_path();
     if !db_path.exists() {
-        return Ok(Vec::new());
+        return Ok(SessionCatalogPage::default());
     }
     let conn = match open_db_readonly(&db_path) {
         Ok(conn) if schema_is_current(&conn).unwrap_or(false) => conn,
@@ -137,7 +138,7 @@ pub fn list_sessions_local(options: &CatalogListOptions) -> Result<Vec<ShallowSe
         // unreadable handle: let the writable open sort it out.
         _ => open_db(&db_path)?,
     };
-    list_session_catalog(&conn, options)
+    list_session_catalog_page(&conn, options)
 }
 
 /// Shallow discovery against the default database, with the rows collected.
@@ -492,13 +493,29 @@ enum SessionsAction {
         /// Restrict to a source (repeatable). Defaults to every discoverable source.
         #[arg(long)]
         source: Vec<String>,
-        /// Maximum rows (default 50).
+        /// Maximum rows (default 50). Must not be negative.
         #[arg(long)]
         limit: Option<i64>,
-        /// Keyset pagination: only sessions older than this epoch-ms cutoff.
+        /// Coarse cutoff: only sessions older than this epoch-ms. Cannot
+        /// separate sessions that share a millisecond — pass the previous
+        /// page's `next_cursor` fields to walk pages exactly.
         #[arg(long)]
         before_ms: Option<i64>,
-        /// Emit `{"contract_version":N,"sessions":[...]}` as one JSON object.
+        /// Precise continuation: `source` of the previous page's last row.
+        /// Requires --after-session-id.
+        #[arg(long, requires = "after_session_id")]
+        after_source: Option<String>,
+        /// Precise continuation: `session_id` of the previous page's last row.
+        /// Requires --after-source.
+        #[arg(long, requires = "after_source")]
+        after_session_id: Option<String>,
+        /// Precise continuation: `last_activity_ms` of the previous page's last
+        /// row. Omit (with --after-source/--after-session-id given) to continue
+        /// through the rows whose recency is unknown.
+        #[arg(long)]
+        after_ms: Option<i64>,
+        /// Emit `{"contract_version":N,"sessions":[...],"next_cursor":…}` as one
+        /// JSON object.
         #[arg(long)]
         json: bool,
     },
@@ -1273,20 +1290,40 @@ pub fn run() -> Result<()> {
                 source,
                 limit,
                 before_ms,
+                after_source,
+                after_session_id,
+                after_ms,
                 json,
             } => {
                 for source in &source {
                     validate_source(Some(source))?;
                 }
-                let rows = list_session_catalog(
+                // SQLite reads a negative LIMIT as "no limit", so `--limit -1`
+                // would quietly dump the entire catalog instead of erroring.
+                if let Some(limit) = limit {
+                    anyhow::ensure!(limit >= 0, "--limit must not be negative (got {limit})");
+                }
+                // clap's `requires` already pairs the two identity flags; the
+                // timestamp is optional because the rows whose recency is
+                // unknown sort last and are continued through without one.
+                let after = match (after_source, after_session_id) {
+                    (Some(source), Some(session_id)) => Some(CatalogCursor {
+                        last_activity_ms: after_ms,
+                        source,
+                        session_id,
+                    }),
+                    _ => None,
+                };
+                let page = list_session_catalog_page(
                     &conn,
                     &CatalogListOptions {
                         sources: source,
                         limit,
                         before_ms,
+                        after,
                     },
                 )?;
-                print_session_catalog(&rows, json)
+                print_session_catalog(&page, json)
             }
             SessionsAction::Discover {
                 source,
@@ -1299,15 +1336,20 @@ pub fn run() -> Result<()> {
 
 /// Render `ai-hist sessions list`.
 ///
-/// The JSON form is one object, not a bare array, so the contract version
-/// travels with the payload: `{"contract_version":1,"sessions":[…]}`.
-fn print_session_catalog(rows: &[ShallowSession], as_json: bool) -> Result<()> {
+/// The JSON form is one object, not a bare array, so the contract version and
+/// the pagination cursor travel with the payload:
+/// `{"contract_version":1,"sessions":[…],"next_cursor":{…}|null}`. Feed
+/// `next_cursor` back as `--after-ms/--after-source/--after-session-id` to get
+/// the next page; it is null once the catalog is exhausted.
+fn print_session_catalog(page: &SessionCatalogPage, as_json: bool) -> Result<()> {
+    let rows = &page.sessions;
     if as_json {
         println!(
             "{}",
             json!({
                 "contract_version": SESSION_CATALOG_CONTRACT_VERSION,
                 "sessions": rows,
+                "next_cursor": page.next_cursor,
             })
         );
         return Ok(());
@@ -1320,6 +1362,17 @@ fn print_session_catalog(rows: &[ShallowSession], as_json: bool) -> Result<()> {
         println!("{}", fmt_session_row(row));
     }
     println!("  {} session(s)", rows.len());
+    if let Some(cursor) = &page.next_cursor {
+        println!(
+            "  more available: --after-source {} --after-session-id {}{}",
+            cursor.source,
+            cursor.session_id,
+            cursor
+                .last_activity_ms
+                .map(|ms| format!(" --after-ms {ms}"))
+                .unwrap_or_default()
+        );
+    }
     Ok(())
 }
 
@@ -1362,7 +1415,7 @@ fn run_session_discovery(
 ) -> Result<()> {
     let options = DiscoverOptions { sources, limit };
     let mut count = 0usize;
-    let summary = discover_sessions(conn, &options, |session| {
+    let outcome = discover_sessions(conn, &options, |session| {
         count += 1;
         if as_json {
             match serde_json::to_value(session) {
@@ -1378,7 +1431,21 @@ fn run_session_discovery(
         } else {
             println!("{}", fmt_session_row(session));
         }
-    })?;
+    });
+    // An every-provider failure is still a failure, but the diagnostics are
+    // the reason a caller ran this at all. Render the collected stream and the
+    // summary trailer first, so a JSONL consumer never sees a truncated stream
+    // followed by an opaque exit code.
+    let (summary, failure) = match outcome {
+        Ok(summary) => (summary, None),
+        Err(error) => match error.downcast::<AllProvidersFailed>() {
+            Ok(failed) => {
+                let summary = failed.summary.clone();
+                (summary, Some(anyhow::Error::from(failed)))
+            }
+            Err(error) => return Err(error),
+        },
+    };
     for diagnostic in &summary.diagnostics {
         if as_json {
             println!(
@@ -1413,6 +1480,9 @@ fn run_session_discovery(
             summary.counters.files_opened,
             summary.counters.shallow_reads
         );
+    }
+    if let Some(failure) = failure {
+        return Err(failure);
     }
     Ok(())
 }

--- a/crates/ai-hist/tests/discovery_bench.rs
+++ b/crates/ai-hist/tests/discovery_bench.rs
@@ -1,0 +1,884 @@
+//! Performance validation for the shallow session catalog.
+//!
+//! This is a measurement harness, not a pass/fail timing gate. It builds a
+//! synthetic multi-provider archive in a temp directory (the isolated-`HOME`
+//! pattern `session_discovery.rs` established), exercises the two catalog
+//! operations against it, and prints a table of what each one actually cost.
+//!
+//! Run it with:
+//!
+//! ```text
+//! cargo test -p ai-hist-cli --test discovery_bench -- --ignored --nocapture
+//! ```
+//!
+//! It is `#[ignore]`d because it writes tens of megabytes of fixtures and runs
+//! a full `ai-hist sync` for comparison — too slow for the default suite, and
+//! its headline numbers are wall clocks that vary by machine.
+//!
+//! # What is asserted, and what is only printed
+//!
+//! Every assertion here is an **operation count** — bytes read, files opened,
+//! shallow reads, rows returned — because those are properties of the
+//! algorithm and hold on any machine. Wall clocks are printed for the human
+//! reading the table and are never asserted against a threshold; a loaded CI
+//! box would fail such a check without anything having regressed.
+//!
+//! The four claims this harness validates:
+//!
+//! 1. **Cached listing scales with the rows you ask for, not with the archive.**
+//!    Timings across catalog sizes and event volumes, at three limits. The
+//!    structural half of this claim — the query is served by
+//!    `idx_sessions_last` / `idx_sessions_source_last` and never sorts the
+//!    table — is asserted with `EXPLAIN QUERY PLAN` by the unit test
+//!    `discover::tests::the_catalog_listing_is_served_by_an_index_not_a_table_scan`.
+//! 2. **A cached listing reads zero provider files.** Structurally true
+//!    (`list_session_catalog` takes only a `Connection`), and demonstrated here
+//!    by deleting the entire archive and listing it anyway. The unit tests
+//!    `the_cache_only_listing_survives_the_provider_files_disappearing` and
+//!    `the_catalog_query_reads_only_the_sessions_table` pin the same property.
+//! 3. **Shallow discovery does far less work than full indexing.** Same
+//!    archive, `sessions discover` versus `sync`, compared on wall time, bytes
+//!    read, and rows written.
+//! 4. **A bounded request does not parse the archive.** `--limit 5` reads the
+//!    same bytes from a 5x larger archive.
+
+use ai_hist_cli::discover::{HEAD_SCAN_MAX_BYTES, TAIL_SCAN_MAX_BYTES};
+use ai_hist_cli::{
+    discover_sessions_with_env, list_session_catalog, CatalogListOptions, DiscoverOptions,
+    DiscoveryEnv, DiscoverySummary,
+};
+use ai_hist_core::open_db;
+use rusqlite::Connection;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+// ---------------------------------------------------------------------------
+// archive fixtures
+// ---------------------------------------------------------------------------
+
+/// Roughly how large the "ordinary" synthetic transcripts are.
+const SMALL_TRANSCRIPT_BYTES: usize = 24 * 1024;
+/// Roughly how large the "long-running session" transcripts are — comfortably
+/// past the head budget, so bounded reads have something to be bounded against.
+const LONG_TRANSCRIPT_BYTES: usize = 900 * 1024;
+
+fn write(path: &Path, contents: &str, mtime_ms: u64) {
+    fs::create_dir_all(path.parent().expect("fixture parent")).expect("mkdir");
+    fs::write(path, contents).expect("write fixture");
+    // Recency ordering is mtime-driven, so pin it instead of letting the order
+    // the fixtures happened to be written decide which sessions win.
+    let file = fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .expect("open for mtime");
+    let when = std::time::UNIX_EPOCH + Duration::from_millis(mtime_ms);
+    file.set_times(fs::FileTimes::new().set_modified(when))
+        .expect("set mtime");
+}
+
+fn claude_transcript(id: &str, target_bytes: usize) -> String {
+    let mut body = String::with_capacity(target_bytes + 512);
+    body.push_str(&format!(
+        r#"{{"sessionId":"{id}","cwd":"/work/{id}","gitBranch":"main","version":"1.2.3","type":"user","message":{{"role":"user","content":"first human prompt for {id}"}},"timestamp":"2026-06-20T10:00:00.000Z"}}"#
+    ));
+    body.push('\n');
+    let mut turn = 0usize;
+    while body.len() < target_bytes {
+        body.push_str(&format!(
+            r#"{{"sessionId":"{id}","type":"assistant","message":{{"role":"assistant","model":"claude-opus-4","content":[{{"type":"text","text":"turn {turn} PADDINGPADDINGPADDINGPADDINGPADDINGPADDINGPADDINGPADDINGPADDINGPADDING"}}]}},"timestamp":"2026-06-20T11:00:00.000Z"}}"#
+        ));
+        body.push('\n');
+        turn += 1;
+    }
+    body.push_str(&format!(
+        r#"{{"sessionId":"{id}","type":"assistant","message":{{"role":"assistant","content":[{{"type":"text","text":"final"}}]}},"timestamp":"2026-06-20T23:00:00.000Z"}}"#
+    ));
+    body.push('\n');
+    body
+}
+
+fn codex_rollout(id: &str, target_bytes: usize) -> String {
+    let mut body = String::with_capacity(target_bytes + 512);
+    body.push_str(&format!(
+        r#"{{"timestamp":"2026-06-21T11:00:00.000Z","type":"session_meta","payload":{{"id":"{id}","cwd":"/work/{id}","originator":"codex_cli_rs","cli_version":"0.148.0","workspace_roots":["/work/{id}"],"git":{{"branch":"dev","repository_url":"git@github.com:acme/{id}.git","commit_hash":"abc1234"}}}}}}"#
+    ));
+    body.push('\n');
+    body.push_str(
+        r#"{"timestamp":"2026-06-21T11:00:01.000Z","type":"turn_context","payload":{"model":"gpt-5-codex"}}"#,
+    );
+    body.push('\n');
+    body.push_str(&format!(
+        r#"{{"timestamp":"2026-06-21T11:00:03.000Z","type":"event_msg","payload":{{"type":"user_message","message":"first human prompt for {id}"}}}}"#
+    ));
+    body.push('\n');
+    let mut turn = 0usize;
+    while body.len() < target_bytes {
+        body.push_str(&format!(
+            r#"{{"timestamp":"2026-06-21T12:00:00.000Z","type":"event_msg","payload":{{"type":"agent_message","message":"turn {turn} PADDINGPADDINGPADDINGPADDINGPADDINGPADDINGPADDINGPADDINGPADDING"}}}}"#
+        ));
+        body.push('\n');
+        turn += 1;
+    }
+    body
+}
+
+fn cursor_transcript(id: &str, target_bytes: usize) -> String {
+    let mut body = format!(
+        "{{\"role\":\"user\",\"message\":{{\"content\":[{{\"type\":\"text\",\"text\":\"<user_query>\\nfirst human prompt for {id}\\n</user_query>\"}}]}}}}\n"
+    );
+    while body.len() < target_bytes {
+        body.push_str(
+            r#"{"role":"assistant","message":{"content":[{"type":"text","text":"PADDINGPADDINGPADDINGPADDINGPADDINGPADDINGPADDING"}]}}"#,
+        );
+        body.push('\n');
+    }
+    body
+}
+
+fn grok_chat(id: &str, target_bytes: usize) -> String {
+    let mut body = format!(
+        r#"{{"type":"user","content":[{{"type":"text","text":"first human prompt for {id}"}}]}}"#
+    );
+    body.push('\n');
+    while body.len() < target_bytes {
+        body.push_str(
+            r#"{"type":"assistant","content":[{"type":"text","text":"PADDINGPADDINGPADDINGPADDINGPADDINGPADDING"}]}"#,
+        );
+        body.push('\n');
+    }
+    body
+}
+
+/// One session's worth of files, written under the fake home.
+struct ArchiveBuilder {
+    home: PathBuf,
+}
+
+impl ArchiveBuilder {
+    fn claude(&self, index: usize, bytes: usize, mtime_ms: u64) {
+        let id = format!("claude-{index:04}");
+        write(
+            &self.home.join(format!(".claude/projects/app/{id}.jsonl")),
+            &claude_transcript(&id, bytes),
+            mtime_ms,
+        );
+    }
+
+    fn codex(&self, index: usize, bytes: usize, mtime_ms: u64) {
+        let id = format!("codex-{index:04}");
+        write(
+            &self
+                .home
+                .join(format!(".codex/sessions/2026/06/21/rollout-{id}.jsonl")),
+            &codex_rollout(&id, bytes),
+            mtime_ms,
+        );
+    }
+
+    fn cursor(&self, index: usize, bytes: usize, mtime_ms: u64) {
+        let id = format!("cursor-{index:04}");
+        write(
+            &self.home.join(format!(
+                ".cursor/projects/work-app/agent-transcripts/{id}/{id}.jsonl"
+            )),
+            &cursor_transcript(&id, bytes),
+            mtime_ms,
+        );
+    }
+
+    fn grok(&self, index: usize, bytes: usize, mtime_ms: u64) {
+        let id = format!("grok-{index:04}");
+        let dir = self
+            .home
+            .join(format!(".grok/sessions/%2Fwork%2Fgrok/{id}"));
+        write(
+            &dir.join("summary.json"),
+            &format!(
+                r#"{{"info":{{"id":"{id}","cwd":"/work/grok"}},"created_at":"2026-06-20T09:00:00.000Z","updated_at":"2026-06-20T09:30:00.000Z","head_branch":"trunk"}}"#
+            ),
+            mtime_ms,
+        );
+        write(
+            &dir.join("chat_history.jsonl"),
+            &grok_chat(&id, bytes),
+            mtime_ms,
+        );
+    }
+
+    fn opencode(&self, sessions: usize) {
+        let db = Connection::open(self.home.join("opencode.db")).expect("opencode db");
+        db.execute_batch(
+            "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, time_created INTEGER, time_updated INTEGER);
+             CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+             CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);",
+        )
+        .expect("opencode schema");
+        for index in 0..sessions {
+            let id = format!("oc-{index:04}");
+            let created = 1_600_000_000_000i64 + index as i64;
+            db.execute(
+                "INSERT INTO session VALUES (?, ?, ?, ?)",
+                rusqlite::params![id, "/work/oc", created, created + 1_000],
+            )
+            .expect("opencode session");
+            db.execute(
+                "INSERT INTO message VALUES (?, ?, ?, ?)",
+                rusqlite::params![
+                    format!("m-{index}"),
+                    id,
+                    created,
+                    r#"{"role":"user","modelID":"claude-sonnet"}"#
+                ],
+            )
+            .expect("opencode message");
+            db.execute(
+                "INSERT INTO part VALUES (?, ?, ?, ?, ?)",
+                rusqlite::params![
+                    format!("p-{index}"),
+                    format!("m-{index}"),
+                    id,
+                    created,
+                    format!(r#"{{"type":"text","text":"first human prompt for {id}"}}"#)
+                ],
+            )
+            .expect("opencode part");
+        }
+    }
+}
+
+/// Total bytes of provider data under a fake home.
+fn archive_bytes(root: &Path) -> u64 {
+    let mut total = 0;
+    let Ok(entries) = fs::read_dir(root) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            total += archive_bytes(&path);
+        } else if let Ok(meta) = path.metadata() {
+            total += meta.len();
+        }
+    }
+    total
+}
+
+// ---------------------------------------------------------------------------
+// measurement helpers
+// ---------------------------------------------------------------------------
+
+fn median(mut samples: Vec<Duration>) -> Duration {
+    samples.sort();
+    samples[samples.len() / 2]
+}
+
+fn time_repeated<T>(runs: usize, mut body: impl FnMut() -> T) -> (Duration, T) {
+    let mut last = body(); // warm the page cache / prepared-statement path
+    let mut samples = Vec::with_capacity(runs);
+    for _ in 0..runs {
+        let start = Instant::now();
+        last = body();
+        samples.push(start.elapsed());
+    }
+    (median(samples), last)
+}
+
+fn micros(duration: Duration) -> String {
+    format!("{:.3} ms", duration.as_secs_f64() * 1_000.0)
+}
+
+fn bytes(value: u64) -> String {
+    const UNITS: [&str; 4] = ["B", "KB", "MB", "GB"];
+    let mut scaled = value as f64;
+    let mut unit = 0;
+    while scaled >= 1024.0 && unit + 1 < UNITS.len() {
+        scaled /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{value} B")
+    } else {
+        format!("{scaled:.1} {}", UNITS[unit])
+    }
+}
+
+fn table(title: &str, headers: &[&str], rows: &[Vec<String>]) {
+    let mut widths: Vec<usize> = headers.iter().map(|header| header.len()).collect();
+    for row in rows {
+        for (index, cell) in row.iter().enumerate() {
+            widths[index] = widths[index].max(cell.len());
+        }
+    }
+    let line = |cells: &[String]| {
+        let rendered: Vec<String> = cells
+            .iter()
+            .enumerate()
+            .map(|(index, cell)| format!("{cell:<width$}", width = widths[index]))
+            .collect();
+        println!("  {}", rendered.join("  "));
+    };
+    println!("\n{title}");
+    line(&headers.iter().map(|h| h.to_string()).collect::<Vec<_>>());
+    line(
+        &widths
+            .iter()
+            .map(|width| "-".repeat(*width))
+            .collect::<Vec<_>>(),
+    );
+    for row in rows {
+        line(row);
+    }
+}
+
+fn cli(home: &Path, db_path: &Path, args: &[&str]) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ai-hist"));
+    command
+        .arg("--db")
+        .arg(db_path)
+        .args(args)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("XDG_DATA_HOME", home.join("xdg"))
+        .env("OPENCODE_DB", home.join("opencode.db"))
+        .env_remove("AI_HIST_DB")
+        .env_remove("TRAJECTORY_ROOT")
+        .env_remove("RELAYCAST_API_KEY")
+        .env_remove("RELAYCAST_WORKSPACE_ID");
+    command
+}
+
+/// Run one CLI invocation, returning its wall time and stdout.
+fn run_cli(home: &Path, db_path: &Path, args: &[&str]) -> (Duration, String) {
+    let start = Instant::now();
+    let output = cli(home, db_path, args).output().expect("spawn ai-hist");
+    let elapsed = start.elapsed();
+    assert!(
+        output.status.success(),
+        "`ai-hist {}` failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    (
+        elapsed,
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+    )
+}
+
+/// The trailing `{"type":"summary",…}` line of a `sessions discover --json` run.
+fn discover_summary(stdout: &str) -> Value {
+    let last = stdout
+        .lines()
+        .rfind(|line| !line.trim().is_empty())
+        .expect("a summary line");
+    let value: Value = serde_json::from_str(last).expect("summary is JSON");
+    assert_eq!(value["type"], "summary");
+    value
+}
+
+fn counter(summary: &Value, name: &str) -> u64 {
+    summary["counters"][name].as_u64().unwrap_or_else(|| {
+        panic!("counter {name} missing from {summary}");
+    })
+}
+
+// ---------------------------------------------------------------------------
+// the benchmark
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "benchmark: writes a multi-megabyte archive and runs a full sync"]
+fn session_catalog_performance_report() {
+    println!("\n=== RelayHistory session catalog — performance validation ===");
+    measure_cached_listing_scaling();
+    let home = tempfile::tempdir().expect("fake home");
+    let counts = build_archive(home.path());
+    measure_bounded_request(home.path(), &counts);
+    measure_shallow_versus_full(home.path());
+    measure_cache_only_listing(home.path());
+    println!(
+        "\nAll assertions above are operation counts. Timings are reported, never asserted.\n"
+    );
+}
+
+/// The archive as first built, before `grow_archive` adds older sessions.
+struct ArchiveCounts {
+    sessions: usize,
+    bytes: u64,
+}
+
+fn build_archive(home: &Path) -> ArchiveCounts {
+    let builder = ArchiveBuilder {
+        home: home.to_path_buf(),
+    };
+    // The five newest sessions are long-running transcripts, so a bounded read
+    // has something to be bounded against. They keep the newest mtimes in both
+    // the small and the grown archive, so a `--limit 5` request selects exactly
+    // these five either way.
+    for index in 0..3 {
+        builder.claude(
+            9_000 + index,
+            LONG_TRANSCRIPT_BYTES,
+            1_800_000_000_000 + index as u64,
+        );
+    }
+    for index in 0..2 {
+        builder.codex(
+            9_000 + index,
+            LONG_TRANSCRIPT_BYTES,
+            1_800_000_010_000 + index as u64,
+        );
+    }
+    // An ordinary spread across every file-backed provider.
+    for index in 0..40 {
+        builder.claude(
+            index,
+            SMALL_TRANSCRIPT_BYTES,
+            1_700_000_000_000 + index as u64,
+        );
+    }
+    for index in 0..20 {
+        builder.codex(
+            index,
+            SMALL_TRANSCRIPT_BYTES,
+            1_700_000_100_000 + index as u64,
+        );
+    }
+    for index in 0..10 {
+        builder.cursor(
+            index,
+            SMALL_TRANSCRIPT_BYTES,
+            1_700_000_200_000 + index as u64,
+        );
+    }
+    for index in 0..5 {
+        builder.grok(
+            index,
+            SMALL_TRANSCRIPT_BYTES,
+            1_700_000_300_000 + index as u64,
+        );
+    }
+    builder.opencode(10);
+    ArchiveCounts {
+        sessions: 3 + 2 + 40 + 20 + 10 + 5 + 10,
+        bytes: archive_bytes(home),
+    }
+}
+
+/// Add older sessions to an existing archive. They are older than everything
+/// already there, so the newest-N winners do not change.
+fn grow_archive(home: &Path, added: usize) -> u64 {
+    let builder = ArchiveBuilder {
+        home: home.to_path_buf(),
+    };
+    for index in 0..added {
+        builder.claude(
+            1_000 + index,
+            SMALL_TRANSCRIPT_BYTES,
+            1_600_000_000_000 + index as u64,
+        );
+    }
+    archive_bytes(home)
+}
+
+// --- 1. cached listing -----------------------------------------------------
+
+/// The cache-only listing's cost tracks the rows requested, not the size of
+/// the catalog and not the volume of transcript/event data beside it.
+fn measure_cached_listing_scaling() {
+    let temp = tempfile::tempdir().expect("catalog dir");
+    let db_path = temp.path().join("catalog.db");
+    let conn = open_db(&db_path).expect("catalog db");
+
+    let mut rows = Vec::new();
+    let mut sessions_so_far = 0usize;
+    let mut events_so_far = 0usize;
+    for (target_sessions, target_events) in [(1_000usize, 5_000usize), (20_000, 100_000)] {
+        seed_catalog(&conn, sessions_so_far, target_sessions);
+        seed_event_volume(&conn, events_so_far, target_events);
+        sessions_so_far = target_sessions;
+        events_so_far = target_events;
+
+        for limit in [20i64, 200, 2_000] {
+            let options = CatalogListOptions {
+                limit: Some(limit),
+                ..Default::default()
+            };
+            let (elapsed, listed) = time_repeated(15, || {
+                list_session_catalog(&conn, &options).expect("catalog listing")
+            });
+            let expected = (limit as usize).min(target_sessions);
+            assert_eq!(
+                listed.len(),
+                expected,
+                "the listing must return exactly the rows requested"
+            );
+            assert!(
+                listed.iter().all(|row| row.from_cache),
+                "every cache-only row is served from the catalog"
+            );
+            rows.push(vec![
+                target_sessions.to_string(),
+                target_events.to_string(),
+                limit.to_string(),
+                listed.len().to_string(),
+                micros(elapsed),
+            ]);
+        }
+    }
+
+    table(
+        "1. Cached listing — cost tracks the rows requested, not the archive",
+        &[
+            "catalog rows",
+            "history+event rows",
+            "limit",
+            "returned",
+            "median",
+        ],
+        &rows,
+    );
+    println!(
+        "  index use is asserted structurally by \
+         `discover::tests::the_catalog_listing_is_served_by_an_index_not_a_table_scan`"
+    );
+}
+
+fn seed_catalog(conn: &Connection, from: usize, to: usize) {
+    conn.execute_batch("BEGIN").expect("begin");
+    {
+        let mut stmt = conn
+            .prepare(
+                "INSERT INTO sessions \
+                 (session_id, source, cwd, first_activity_ms, last_activity_ms, first_prompt, \
+                  discovery_state) \
+                 VALUES (?, 'claude', '/work/app', ?, ?, ?, 'shallow')",
+            )
+            .expect("prepare catalog insert");
+        for index in from..to {
+            let ts = 1_700_000_000_000i64 + index as i64;
+            stmt.execute(rusqlite::params![
+                format!("bench-{index:06}"),
+                ts,
+                ts,
+                format!("synthetic prompt {index}")
+            ])
+            .expect("catalog insert");
+        }
+    }
+    conn.execute_batch("COMMIT").expect("commit");
+}
+
+/// Transcript-shaped volume beside the catalog: `history` rows (which carry an
+/// FTS index) and `session_events` rows. The cache-only listing must not care
+/// that these exist.
+fn seed_event_volume(conn: &Connection, from: usize, to: usize) {
+    conn.execute_batch("BEGIN").expect("begin");
+    {
+        let mut history = conn
+            .prepare(
+                "INSERT OR IGNORE INTO history (source, session_id, project, prompt, timestamp_ms) \
+                 VALUES ('claude', ?, '/work/app', ?, ?)",
+            )
+            .expect("prepare history insert");
+        let mut events = conn
+            .prepare(
+                "INSERT INTO session_events \
+                 (source, session_id, ts_ms, role, kind, text, event_uid) \
+                 VALUES ('claude', ?, ?, 'assistant', 'text', ?, ?)",
+            )
+            .expect("prepare event insert");
+        for index in from..to {
+            let ts = 1_700_000_000_000i64 + index as i64;
+            let session = format!("bench-{:06}", index % 1_000);
+            history
+                .execute(rusqlite::params![
+                    session,
+                    format!("synthetic history row {index} with some searchable words"),
+                    ts
+                ])
+                .expect("history insert");
+            events
+                .execute(rusqlite::params![
+                    session,
+                    ts,
+                    format!("synthetic assistant turn {index}"),
+                    format!("uid-{index}")
+                ])
+                .expect("event insert");
+        }
+    }
+    conn.execute_batch("COMMIT").expect("commit");
+}
+
+// --- 2. bounded request ----------------------------------------------------
+
+/// A `--limit 5` request reads five sessions' worth of bounded head/tail, and
+/// reads exactly the same bytes when the archive around it grows 5x.
+fn measure_bounded_request(home: &Path, counts: &ArchiveCounts) {
+    let temp = tempfile::tempdir().expect("db dir");
+    let limit = 5usize;
+
+    let db_small = temp.path().join("small.db");
+    let (elapsed_small, stdout_small) = run_cli(
+        home,
+        &db_small,
+        &["sessions", "discover", "--json", "--limit", "5"],
+    );
+    let small = discover_summary(&stdout_small);
+
+    let bytes_grown = grow_archive(home, counts.sessions * 4);
+    let db_grown = temp.path().join("grown.db");
+    let (elapsed_grown, stdout_grown) = run_cli(
+        home,
+        &db_grown,
+        &["sessions", "discover", "--json", "--limit", "5"],
+    );
+    let grown = discover_summary(&stdout_grown);
+
+    let budget = (HEAD_SCAN_MAX_BYTES + TAIL_SCAN_MAX_BYTES) * limit as u64;
+    for (label, summary, archive) in [
+        ("small", &small, counts.bytes),
+        ("grown", &grown, bytes_grown),
+    ] {
+        assert_eq!(
+            counter(summary, "shallow_reads"),
+            limit as u64,
+            "{label}: a limit of {limit} must read exactly {limit} sources"
+        );
+        assert!(
+            counter(summary, "bytes_read") < archive,
+            "{label}: a bounded request must not read the whole archive"
+        );
+    }
+    assert_eq!(
+        counter(&small, "bytes_read"),
+        counter(&grown, "bytes_read"),
+        "growing the archive must not change what a limit-5 request reads"
+    );
+    assert!(
+        counter(&small, "bytes_read") <= budget + 64 * 1024,
+        "five bounded reads must stay inside {} plus the opencode snapshot",
+        bytes(budget)
+    );
+    assert!(
+        counter(&grown, "candidates_enumerated") > counter(&small, "candidates_enumerated"),
+        "the grown archive must actually be larger"
+    );
+
+    let row = |label: &str, summary: &Value, archive: u64, elapsed: Duration| {
+        let read = counter(summary, "bytes_read");
+        vec![
+            label.to_string(),
+            counter(summary, "candidates_enumerated").to_string(),
+            bytes(archive),
+            counter(summary, "shallow_reads").to_string(),
+            counter(summary, "files_opened").to_string(),
+            bytes(read),
+            format!("{:.1}%", read as f64 * 100.0 / archive as f64),
+            micros(elapsed),
+        ]
+    };
+    table(
+        "2. Bounded request (--limit 5) — work is set by the limit, not the archive",
+        &[
+            "archive",
+            "candidates",
+            "archive bytes",
+            "shallow reads",
+            "files opened",
+            "bytes read",
+            "share of archive",
+            "wall",
+        ],
+        &[
+            row("small", &small, counts.bytes, elapsed_small),
+            row("grown (5x sessions)", &grown, bytes_grown, elapsed_grown),
+        ],
+    );
+}
+
+// --- 3. shallow discovery versus full indexing -----------------------------
+
+/// The same archive, discovered shallowly and then indexed fully.
+fn measure_shallow_versus_full(home: &Path) {
+    let temp = tempfile::tempdir().expect("db dir");
+    let archive = archive_bytes(home);
+
+    let discover_db = temp.path().join("discover.db");
+    let (cold, cold_stdout) = run_cli(home, &discover_db, &["sessions", "discover", "--json"]);
+    let cold_summary = discover_summary(&cold_stdout);
+    let discovered = cold_summary["discovered"].as_u64().expect("discovered");
+
+    // A rescan over unchanged bytes: every candidate is served from the
+    // catalog on its stamp, so no source is opened at all.
+    let (warm, warm_stdout) = run_cli(home, &discover_db, &["sessions", "discover", "--json"]);
+    let warm_summary = discover_summary(&warm_stdout);
+    assert_eq!(
+        counter(&warm_summary, "shallow_reads"),
+        0,
+        "an unchanged rescan must reparse nothing"
+    );
+    assert_eq!(
+        warm_summary["skipped_unchanged"].as_u64(),
+        Some(discovered),
+        "every session discovered cold must be served from the catalog warm"
+    );
+
+    let sync_db = temp.path().join("sync.db");
+    let (full, _) = run_cli(home, &sync_db, &["sync"]);
+    let sync_conn = open_db(&sync_db).expect("sync db");
+    let full_rows: i64 = sync_conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM history) + (SELECT COUNT(*) FROM session_events)",
+            [],
+            |row| row.get(0),
+        )
+        .expect("full ingest rows");
+    let shallow_conn = open_db(&discover_db).expect("discover db");
+    let shallow_rows: i64 = shallow_conn
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM history) + (SELECT COUNT(*) FROM session_events)",
+            [],
+            |row| row.get(0),
+        )
+        .expect("shallow rows");
+
+    assert!(
+        counter(&cold_summary, "bytes_read") < archive,
+        "shallow discovery must read less than the archive it catalogs"
+    );
+    assert_eq!(
+        shallow_rows, 0,
+        "shallow discovery writes catalog rows only — no history, no events"
+    );
+    assert!(
+        full_rows > 0,
+        "the full sync must actually have ingested the archive"
+    );
+
+    table(
+        "3. Shallow discovery vs full indexing — same archive",
+        &[
+            "operation",
+            "bytes read",
+            "files opened",
+            "sessions",
+            "history+event rows",
+            "wall",
+        ],
+        &[
+            vec![
+                "sessions discover (cold)".into(),
+                bytes(counter(&cold_summary, "bytes_read")),
+                counter(&cold_summary, "files_opened").to_string(),
+                discovered.to_string(),
+                shallow_rows.to_string(),
+                micros(cold),
+            ],
+            vec![
+                "sessions discover (rescan)".into(),
+                bytes(counter(&warm_summary, "bytes_read")),
+                counter(&warm_summary, "files_opened").to_string(),
+                warm_summary["skipped_unchanged"].to_string(),
+                "0".into(),
+                micros(warm),
+            ],
+            vec![
+                "sync (full ingest)".into(),
+                format!(">= {}", bytes(archive)),
+                "all".into(),
+                "-".into(),
+                full_rows.to_string(),
+                micros(full),
+            ],
+        ],
+    );
+    println!(
+        "  archive: {}; full ingest reads every transcript end to end, so its byte",
+        bytes(archive)
+    );
+    println!("  figure is a floor rather than a measurement.");
+}
+
+// --- 4. cache-only listing reads nothing -----------------------------------
+
+/// The catalog listing opens no provider file — demonstrated by deleting every
+/// provider directory and listing the catalog anyway.
+fn measure_cache_only_listing(home: &Path) {
+    let temp = tempfile::tempdir().expect("db dir");
+    let db_path = temp.path().join("catalog.db");
+    let conn = open_db(&db_path).expect("catalog db");
+    let env = DiscoveryEnv::with_roots(&conn, home.to_path_buf(), home.join("opencode.db"));
+    let mut discovered = 0usize;
+    let summary: DiscoverySummary =
+        discover_sessions_with_env(&env, &DiscoverOptions::default(), |_| discovered += 1)
+            .expect("discovery");
+    assert!(discovered > 0, "the archive must yield sessions");
+
+    let options = CatalogListOptions {
+        limit: Some(50),
+        ..Default::default()
+    };
+    let (before, listed_before) = time_repeated(15, || {
+        list_session_catalog(&conn, &options).expect("listing")
+    });
+
+    for provider in [".claude", ".codex", ".cursor", ".grok"] {
+        fs::remove_dir_all(home.join(provider)).expect("remove provider dir");
+    }
+    fs::remove_file(home.join("opencode.db")).expect("remove opencode db");
+
+    let (after, listed_after) = time_repeated(15, || {
+        list_session_catalog(&conn, &options).expect("listing after deletion")
+    });
+    assert_eq!(
+        listed_before.len(),
+        listed_after.len(),
+        "a cache-only listing cannot depend on provider files"
+    );
+    assert_eq!(
+        listed_before
+            .iter()
+            .map(|row| (
+                row.source.clone(),
+                row.session_id.clone(),
+                row.first_prompt.clone()
+            ))
+            .collect::<Vec<_>>(),
+        listed_after
+            .iter()
+            .map(|row| (
+                row.source.clone(),
+                row.session_id.clone(),
+                row.first_prompt.clone()
+            ))
+            .collect::<Vec<_>>(),
+        "the same rows, with the same derived prompts, after the archive is gone"
+    );
+
+    table(
+        "4. Cache-only listing — zero provider reads",
+        &["archive on disk", "rows listed", "median"],
+        &[
+            vec![
+                "present".into(),
+                listed_before.len().to_string(),
+                micros(before),
+            ],
+            vec![
+                "deleted".into(),
+                listed_after.len().to_string(),
+                micros(after),
+            ],
+        ],
+    );
+    println!(
+        "  discovery that populated this catalog: {} row(s), {} file(s) opened, {} read",
+        summary.discovered,
+        summary.counters.files_opened,
+        bytes(summary.counters.bytes_read)
+    );
+}

--- a/crates/ai-hist/tests/session_discovery.rs
+++ b/crates/ai-hist/tests/session_discovery.rs
@@ -233,6 +233,67 @@ fn list_paginates_with_the_cursor_it_hands_back() {
     );
 }
 
+/// A timestamp alone is not a cursor. Accepting one and ignoring it restarted
+/// the walk at page one while reporting success, so a paginating client would
+/// loop over the first page forever.
+#[test]
+fn an_incomplete_pagination_cursor_is_rejected_rather_than_ignored() {
+    let temp = fake_home();
+    let db_path = temp.path().join("history.db");
+    assert!(isolated(&temp, &db_path, &["sessions", "discover"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    for incomplete in [
+        vec!["--after-ms=1782039603000"],
+        vec!["--after-source", "codex"],
+        vec!["--after-session-id", "codex-cli"],
+        vec![
+            "--after-ms=1782039603000",
+            "--after-session-id",
+            "codex-cli",
+        ],
+    ] {
+        let mut args = vec!["sessions", "list", "--json"];
+        args.extend(incomplete.iter().copied());
+        let output = isolated(&temp, &db_path, &args).output().unwrap();
+        assert!(
+            !output.status.success(),
+            "an incomplete cursor must be rejected: {args:?}"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("required") || stderr.contains("requires"),
+            "clap must name the missing flag for {args:?}: {stderr}"
+        );
+    }
+
+    // The complete triple is still accepted.
+    let output = isolated(
+        &temp,
+        &db_path,
+        &[
+            "sessions",
+            "list",
+            "--json",
+            "--after-ms=1782039603000",
+            "--after-source",
+            "codex",
+            "--after-session-id",
+            "codex-cli",
+        ],
+    )
+    .output()
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn a_negative_limit_is_rejected_rather_than_dumping_the_catalog() {
     let temp = fake_home();

--- a/crates/ai-hist/tests/session_discovery.rs
+++ b/crates/ai-hist/tests/session_discovery.rs
@@ -166,6 +166,9 @@ fn list_serves_the_catalog_after_the_provider_files_are_gone() {
     assert_eq!(sessions[1]["session_id"], "claude-cli");
     assert!(sessions.iter().all(|row| row["from_cache"] == true));
 
+    // A page that did not fill its limit ends the walk.
+    assert_eq!(payload["next_cursor"], Value::Null);
+
     let filtered = isolated(
         &temp,
         &db_path,
@@ -176,6 +179,132 @@ fn list_serves_the_catalog_after_the_provider_files_are_gone() {
     let payload: Value = serde_json::from_slice(&filtered.stdout).unwrap();
     assert_eq!(payload["sessions"].as_array().unwrap().len(), 1);
     assert_eq!(payload["sessions"][0]["source"], "claude");
+}
+
+#[test]
+fn list_paginates_with_the_cursor_it_hands_back() {
+    let temp = fake_home();
+    let db_path = temp.path().join("history.db");
+    assert!(isolated(&temp, &db_path, &["sessions", "discover"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    let first = isolated(
+        &temp,
+        &db_path,
+        &["sessions", "list", "--json", "--limit", "1"],
+    )
+    .output()
+    .unwrap();
+    let page: Value = serde_json::from_slice(&first.stdout).unwrap();
+    assert_eq!(page["sessions"].as_array().unwrap().len(), 1);
+    assert_eq!(page["sessions"][0]["session_id"], "codex-cli");
+    let cursor = &page["next_cursor"];
+    assert_eq!(cursor["source"], "codex");
+    assert_eq!(cursor["session_id"], "codex-cli");
+    assert!(cursor["last_activity_ms"].is_i64());
+
+    let second = isolated(
+        &temp,
+        &db_path,
+        &[
+            "sessions",
+            "list",
+            "--json",
+            "--limit",
+            "1",
+            "--after-ms",
+            &cursor["last_activity_ms"].as_i64().unwrap().to_string(),
+            "--after-source",
+            cursor["source"].as_str().unwrap(),
+            "--after-session-id",
+            cursor["session_id"].as_str().unwrap(),
+        ],
+    )
+    .output()
+    .unwrap();
+    let page: Value = serde_json::from_slice(&second.stdout).unwrap();
+    assert_eq!(page["sessions"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        page["sessions"][0]["session_id"], "claude-cli",
+        "the second page continues where the first stopped"
+    );
+}
+
+#[test]
+fn a_negative_limit_is_rejected_rather_than_dumping_the_catalog() {
+    let temp = fake_home();
+    let db_path = temp.path().join("history.db");
+    assert!(isolated(&temp, &db_path, &["sessions", "discover"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    // SQLite reads a negative LIMIT as "unlimited".
+    let output = isolated(
+        &temp,
+        &db_path,
+        // `--limit=-1` rather than `--limit -1`: clap reads a bare `-1` as a
+        // flag, so the equals form is what actually reaches the guard.
+        &["sessions", "list", "--json", "--limit=-1"],
+    )
+    .output()
+    .unwrap();
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--limit must not be negative"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // `discover --limit` is unsigned, so clap rejects it before it reaches us.
+    let discover = isolated(
+        &temp,
+        &db_path,
+        &["sessions", "discover", "--json", "--limit=-1"],
+    )
+    .output()
+    .unwrap();
+    assert!(!discover.status.success());
+}
+
+#[test]
+fn an_every_provider_failure_still_emits_its_diagnostics_and_summary() {
+    let temp = fake_home();
+    let db_path = temp.path().join("history.db");
+    fs::write(temp.path().join("opencode.db"), "definitely not sqlite").unwrap();
+
+    // Only the broken provider is selected, so the whole run fails -- but a
+    // JSONL consumer must still receive the reason before the exit code.
+    let output = isolated(
+        &temp,
+        &db_path,
+        &["sessions", "discover", "--json", "--source", "opencode"],
+    )
+    .output()
+    .unwrap();
+    assert!(
+        !output.status.success(),
+        "an every-provider failure is an error"
+    );
+    let lines = jsonl(&String::from_utf8_lossy(&output.stdout));
+    let diagnostics: Vec<&Value> = lines
+        .iter()
+        .filter(|line| line["type"] == "diagnostic")
+        .collect();
+    assert_eq!(diagnostics.len(), 1, "{lines:#?}");
+    assert_eq!(diagnostics[0]["source"], "opencode");
+    let summary = lines.last().expect("a summary trailer");
+    assert_eq!(summary["type"], "summary");
+    assert_eq!(summary["providers"]["opencode"]["failed"], true);
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("no provider made progress"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]

--- a/crates/ai-hist/tests/session_discovery.rs
+++ b/crates/ai-hist/tests/session_discovery.rs
@@ -1,0 +1,301 @@
+//! End-to-end contract tests for `ai-hist sessions list` / `sessions discover`.
+//!
+//! These drive the real binary against an isolated HOME (the pattern
+//! `sync_resilience.rs` established) so the CLI output contract — the JSON
+//! shapes a desktop app parses — is asserted from outside the library.
+
+use ai_hist_core::open_db;
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn isolated(temp: &tempfile::TempDir, db_path: &Path, args: &[&str]) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_ai-hist"));
+    command
+        .arg("--db")
+        .arg(db_path)
+        .args(args)
+        .env("HOME", temp.path())
+        .env("USERPROFILE", temp.path())
+        .env("XDG_DATA_HOME", temp.path().join("xdg"))
+        .env("OPENCODE_DB", temp.path().join("opencode.db"))
+        .env_remove("AI_HIST_DB")
+        .env_remove("RELAYCAST_API_KEY")
+        .env_remove("RELAYCAST_WORKSPACE_ID");
+    command
+}
+
+fn write(path: &Path, contents: &str, mtime_ms: u64) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+    // Recency ordering is driven by mtime, so pin it rather than letting the
+    // order the fixtures happened to be written decide the assertions.
+    let file = fs::OpenOptions::new().write(true).open(path).unwrap();
+    let when = std::time::UNIX_EPOCH + std::time::Duration::from_millis(mtime_ms);
+    file.set_times(fs::FileTimes::new().set_modified(when))
+        .unwrap();
+}
+
+fn fake_home() -> tempfile::TempDir {
+    let temp = tempfile::tempdir().unwrap();
+    write(
+        &temp.path().join(".claude/projects/app/claude-cli.jsonl"),
+        concat!(
+            r#"{"sessionId":"claude-cli","cwd":"/work/app","gitBranch":"main","version":"1.2.3","type":"user","message":{"role":"user","content":"first human prompt"},"timestamp":"2026-06-20T10:00:00.000Z"}"#,
+            "\n",
+            r#"{"sessionId":"claude-cli","type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"ack"}]},"timestamp":"2026-06-20T10:05:00.000Z"}"#,
+            "\n"
+        ),
+        1_750_000_000_000,
+    );
+    write(
+        &temp
+            .path()
+            .join(".codex/sessions/2026/06/21/rollout-codex-cli.jsonl"),
+        concat!(
+            r#"{"timestamp":"2026-06-21T11:00:00.000Z","type":"session_meta","payload":{"id":"codex-cli","cwd":"/work/api","originator":"codex_cli_rs","cli_version":"0.148.0","git":{"branch":"dev"}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-06-21T11:00:03.000Z","type":"event_msg","payload":{"type":"user_message","message":"add a retry"}}"#,
+            "\n"
+        ),
+        1_750_000_100_000,
+    );
+    temp
+}
+
+fn jsonl(stdout: &str) -> Vec<Value> {
+    stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<Value>(line).expect("each discover line is JSON"))
+        .collect()
+}
+
+#[test]
+fn discover_streams_jsonl_rows_then_a_summary() {
+    let temp = fake_home();
+    let db_path = temp.path().join("history.db");
+
+    let output = isolated(&temp, &db_path, &["sessions", "discover", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let lines = jsonl(&String::from_utf8_lossy(&output.stdout));
+    let sessions: Vec<&Value> = lines
+        .iter()
+        .filter(|line| line["type"] == "session")
+        .collect();
+    assert_eq!(sessions.len(), 2, "{lines:#?}");
+    // Newest first, globally across providers.
+    assert_eq!(sessions[0]["session_id"], "codex-cli");
+    assert_eq!(sessions[0]["source"], "codex");
+    assert_eq!(sessions[0]["originator"], "codex_cli_rs");
+    assert_eq!(sessions[0]["agent_version"], "0.148.0");
+    assert_eq!(sessions[0]["first_prompt"], "add a retry");
+    assert_eq!(sessions[0]["discovery_state"], "shallow");
+    assert_eq!(sessions[1]["session_id"], "claude-cli");
+    assert_eq!(sessions[1]["cwd"], "/work/app");
+    assert_eq!(sessions[1]["repo_url"], Value::Null);
+
+    let summary = lines.last().expect("a summary line");
+    assert_eq!(summary["type"], "summary");
+    assert_eq!(summary["contract_version"], 1);
+    assert_eq!(summary["discovered"], 2);
+    assert_eq!(summary["skipped_unchanged"], 0);
+    assert_eq!(summary["providers"]["claude"]["discovered"], 1);
+    assert_eq!(summary["providers"]["codex"]["discovered"], 1);
+    assert_eq!(summary["exempt_sources"][0]["source"], "trajectory");
+}
+
+#[test]
+fn a_global_limit_is_shared_across_providers() {
+    let temp = fake_home();
+    let db_path = temp.path().join("history.db");
+    let output = isolated(
+        &temp,
+        &db_path,
+        &["sessions", "discover", "--json", "--limit", "1"],
+    )
+    .output()
+    .unwrap();
+    assert!(output.status.success());
+    let lines = jsonl(&String::from_utf8_lossy(&output.stdout));
+    let sessions: Vec<&Value> = lines
+        .iter()
+        .filter(|line| line["type"] == "session")
+        .collect();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0]["session_id"], "codex-cli");
+    let summary = lines.last().unwrap();
+    assert_eq!(summary["counters"]["shallow_reads"], 1);
+    assert_eq!(summary["counters"]["candidates_enumerated"], 2);
+}
+
+#[test]
+fn list_serves_the_catalog_after_the_provider_files_are_gone() {
+    let temp = fake_home();
+    let db_path = temp.path().join("history.db");
+    assert!(isolated(&temp, &db_path, &["sessions", "discover"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    // A cache-only list must not depend on any provider file existing.
+    fs::remove_dir_all(temp.path().join(".claude")).unwrap();
+    fs::remove_dir_all(temp.path().join(".codex")).unwrap();
+
+    let output = isolated(&temp, &db_path, &["sessions", "list", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["contract_version"], 1);
+    let sessions = payload["sessions"].as_array().unwrap();
+    assert_eq!(sessions.len(), 2);
+    assert_eq!(sessions[0]["session_id"], "codex-cli");
+    assert_eq!(sessions[1]["session_id"], "claude-cli");
+    assert!(sessions.iter().all(|row| row["from_cache"] == true));
+
+    let filtered = isolated(
+        &temp,
+        &db_path,
+        &["sessions", "list", "--json", "--source", "claude"],
+    )
+    .output()
+    .unwrap();
+    let payload: Value = serde_json::from_slice(&filtered.stdout).unwrap();
+    assert_eq!(payload["sessions"].as_array().unwrap().len(), 1);
+    assert_eq!(payload["sessions"][0]["source"], "claude");
+}
+
+#[test]
+fn list_reads_through_a_handle_that_cannot_contend_with_a_writer() {
+    let temp = fake_home();
+    let db_path = temp.path().join("history.db");
+    assert!(isolated(&temp, &db_path, &["sessions", "discover"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    // Hold the write lock: a cache-only list is routed to a read-only handle,
+    // so it must complete rather than wait out the busy handler.
+    let holder = open_db(&db_path).unwrap();
+    holder.execute_batch("BEGIN IMMEDIATE").unwrap();
+    let output = isolated(&temp, &db_path, &["sessions", "list", "--json"])
+        .output()
+        .unwrap();
+    holder.execute_batch("ROLLBACK").unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["sessions"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn one_broken_provider_is_a_diagnostic_not_a_failed_run() {
+    let temp = fake_home();
+    let db_path = temp.path().join("history.db");
+    // Not a SQLite database: the opencode adapter must fail on its own.
+    fs::write(temp.path().join("opencode.db"), "definitely not sqlite").unwrap();
+
+    let output = isolated(&temp, &db_path, &["sessions", "discover", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "a single broken provider must not fail the run: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let lines = jsonl(&String::from_utf8_lossy(&output.stdout));
+    assert_eq!(
+        lines
+            .iter()
+            .filter(|line| line["type"] == "session")
+            .count(),
+        2
+    );
+    let diagnostics: Vec<&Value> = lines
+        .iter()
+        .filter(|line| line["type"] == "diagnostic")
+        .collect();
+    assert_eq!(diagnostics.len(), 1, "{lines:#?}");
+    assert_eq!(diagnostics[0]["source"], "opencode");
+    let summary = lines.last().unwrap();
+    assert_eq!(summary["providers"]["opencode"]["failed"], true);
+}
+
+#[test]
+fn a_rescan_reparses_nothing_and_keeps_one_row_per_session() {
+    let temp = fake_home();
+    let db_path = temp.path().join("history.db");
+    assert!(isolated(&temp, &db_path, &["sessions", "discover"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    let output = isolated(&temp, &db_path, &["sessions", "discover", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let lines = jsonl(&String::from_utf8_lossy(&output.stdout));
+    let summary = lines.last().unwrap();
+    assert_eq!(summary["skipped_unchanged"], 2);
+    assert_eq!(summary["counters"]["shallow_reads"], 0);
+    assert_eq!(summary["counters"]["files_opened"], 0);
+
+    let conn = open_db(&db_path).unwrap();
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(rows, 2);
+}
+
+#[test]
+fn discovery_leaves_a_fully_synced_session_marked_full() {
+    let temp = fake_home();
+    let db_path = temp.path().join("history.db");
+    assert!(isolated(&temp, &db_path, &["sync"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+    assert!(isolated(&temp, &db_path, &["sessions", "discover"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    let output = isolated(&temp, &db_path, &["sessions", "list", "--json"])
+        .output()
+        .unwrap();
+    let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let claude = payload["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["source"] == "claude")
+        .expect("the claude session");
+    assert_eq!(
+        claude["discovery_state"], "full",
+        "a shallow rescan must not downgrade a fully indexed session"
+    );
+    assert_eq!(
+        claude["first_prompt"], "first human prompt",
+        "the shallow pass still enriches a fully indexed row"
+    );
+}

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -115,7 +115,7 @@ ai-hist sessions list --json                  # cached read: one indexed query, 
 
 Both emit a versioned contract (`contract_version: 1`) — parse it and fail loudly on a version you don't know. `discover --json` is JSONL: session rows in global recency order, then per-provider `diagnostic` lines, then a closing `summary` carrying operation counters (`files_opened`, `bytes_read`, …) so you can verify the run stayed cheap. Rows are identity only — `session_id`, `cwd`, branch, first prompt, models, provenance. Events, tool calls, token usage and full transcripts still require `ai-hist sync`; `discovery_state` on each row tells you which you have.
 
-The same operations are available in-process through the napi binding (`listSessions` / `discoverSessions`) and as an MCP tool, so an agent can enumerate recent work without shelling out.
+Both operations are available in-process through the napi binding (`listSessions` / `discoverSessions`) and the TypeScript SDK (`listSessionCatalog` / `listSessionCatalogPage` and the top-level `discoverSessions`); over MCP, only the cached listing is exposed, as the read-only `list_sessions` tool. So an agent can enumerate recent work without shelling out, and refresh the catalog wherever it has more than the MCP surface.
 
 > Full contract, per-provider capability matrix, and ordering/limit semantics: [`session-catalog.md`](session-catalog.md).
 

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -104,7 +104,24 @@ Empty result → `{"decision":"allow","warnings":[]}` → the hook no-ops cleanl
 
 ---
 
-## 6. Quick reference
+## 6. Enumerate sessions without indexing them
+
+Before you can reason about a session you have to know it exists. The **session catalog** answers that locally and cheaply, and it is a separate surface from the cloud loop above — no auth, no network, no full index:
+
+```bash
+ai-hist sessions discover --json --limit 20   # bounded scan of every provider, newest first
+ai-hist sessions list --json                  # cached read: one indexed query, zero provider I/O
+```
+
+Both emit a versioned contract (`contract_version: 1`) — parse it and fail loudly on a version you don't know. `discover --json` is JSONL: session rows in global recency order, then per-provider `diagnostic` lines, then a closing `summary` carrying operation counters (`files_opened`, `bytes_read`, …) so you can verify the run stayed cheap. Rows are identity only — `session_id`, `cwd`, branch, first prompt, models, provenance. Events, tool calls, token usage and full transcripts still require `ai-hist sync`; `discovery_state` on each row tells you which you have.
+
+The same operations are available in-process through the napi binding (`listSessions` / `discoverSessions`) and as an MCP tool, so an agent can enumerate recent work without shelling out.
+
+> Full contract, per-provider capability matrix, and ordering/limit semantics: [`session-catalog.md`](session-catalog.md).
+
+---
+
+## 7. Quick reference
 
 ```bash
 # one-time: build + authenticate (see docs/cloud-sync.md)
@@ -114,6 +131,10 @@ ai-hist admin-mint --base-url <dev-url> --org <org> --user "$USER"   # dev only;
 # every session
 ai-hist push --json                                          # sync your work
 ai-hist pair check --file <path> --task "<summary>" --json   # ask for warnings before a risky step
+
+# local session discovery (no auth, no network)
+ai-hist sessions discover --json --limit 20                  # refresh the catalog
+ai-hist sessions list --json                                 # read it back
 ```
 
-See also: `docs/cloud-sync.md` (human setup), `docs/pair-hooks.md` (hook/MCP wiring), and the `trajectories` repo `docs/convergence-integration.md` (full event-mapping contract).
+See also: `docs/cloud-sync.md` (human setup), `docs/pair-hooks.md` (hook/MCP wiring), `docs/session-catalog.md` (local session discovery), and the `trajectories` repo `docs/convergence-integration.md` (full event-mapping contract).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,6 +60,16 @@ ai-hist search "auth" # confirm it captured something
 
 The local DB lives at `~/.local/share/ai-hist/ai-history.db`. This is what `push` sends.
 
+To see *which* agent sessions this machine has — without waiting for a full index —
+use the session catalog:
+
+```bash
+ai-hist sessions discover --limit 20   # refresh the catalog, newest 20 across all tools
+ai-hist sessions list                  # read it back instantly (no provider files touched)
+```
+
+> Full reference: [`session-catalog.md`](session-catalog.md).
+
 ---
 
 ## Step 3 — Cloud sync

--- a/docs/session-catalog.md
+++ b/docs/session-catalog.md
@@ -87,13 +87,22 @@ One object, never a bare array, so the version travels with the payload:
       "discovery_state": "shallow",
       "from_cache": true
     }
-  ]
+  ],
+  "next_cursor": {
+    "last_activity_ms": 1782039603000,
+    "source": "codex",
+    "session_id": "0198c2ad-codex"
+  }
 }
 ```
 
 Keys are `snake_case`. `models` and `workspace_roots` are always arrays
 (possibly empty); every other absent value is `null`, never an invented
 placeholder or an empty string.
+
+`next_cursor` is the continuation for the next page, or `null` once the catalog
+is exhausted (the page came back short of its limit). See
+[Pagination](#pagination).
 
 ### `sessions discover --json`
 
@@ -107,7 +116,8 @@ command's precedent). Three line types, in this order:
 // 0..n non-fatal failures — one provider or one malformed session
 {"type": "diagnostic", "source": "grok", "locator": "/Users/you/.grok/sessions/…/chat_history.jsonl", "error": "…"}
 
-// exactly one closing summary
+// exactly one closing summary — emitted even when every provider failed,
+// so a consumer always sees the reason before the non-zero exit
 {
   "type": "summary",
   "contract_version": 1,
@@ -226,13 +236,19 @@ How each adapter works:
   branch, `version`, models and the first human prompt; tail for the last
   timestamp and the final branch. Meta rows, slash-command wrappers, bash
   wrappers and sidechain (subagent) turns are skipped when picking
-  `first_prompt`.
+  `first_prompt`. A subagent *sidecar* — a separate file whose records all
+  carry the parent's `sessionId` — is not a session of its own: it is detected
+  in the head read and skipped, so a session is emitted once per run and its
+  row keeps pointing at its own transcript. A transcript whose complete records
+  parse as nothing is reported as a diagnostic rather than published under its
+  file name; an empty one is simply not a session yet.
 - **codex** — `rollout-*.jsonl` under `~/.codex/sessions` and
   `~/.codex/archived_sessions`. The first line is a `session_meta` record, which
   makes codex the richest source: originator, `cli_version`, git remote, initial
   commit, workspace roots and model all come from it. Subagent threads are real
   rollouts but not user sessions, so they are excluded — exactly as the full
-  sync excludes them.
+  sync excludes them — and remembered in `discovery_skips` so a rescan does not
+  re-read them.
 - **cursor** — `~/.cursor/projects/<encoded-path>/agent-transcripts/<id>/<id>.jsonl`.
   Cursor transcripts carry **no timestamps at all**, so `first_activity_ms` is
   always `null` and `last_activity_ms` is the file mtime. `cwd` is decoded from
@@ -283,9 +299,32 @@ Files inside the head budget are read once and serve as their own tail. Only
 newline-terminated records are parsed: a transcript being appended to right now
 has a partial trailing line, and that line is not yet a record.
 
-`sessions list` paginates by recency instead: `--limit` plus `--before-ms`
-(keyset), served by `idx_sessions_last`, or `idx_sessions_source_last` when
-`--source` is given.
+<a id="pagination"></a>
+
+`sessions list` paginates by recency instead. The catalog's total order is
+
+```sql
+ORDER BY last_activity_ms DESC, source ASC, session_id ASC
+```
+
+with rows of unknown recency (`last_activity_ms IS NULL`, e.g. a cursor session
+whose file has no mtime) last. Recency alone is not a key — one discovery pass
+stamps many sessions with the same mtime-derived millisecond — so the cursor
+carries the identity columns too:
+
+```jsonc
+{"last_activity_ms": 1782039603000, "source": "codex", "session_id": "0198c2ad-codex"}
+```
+
+Feed it back as `--after-ms` / `--after-source` / `--after-session-id` (the two
+identity flags are required together; omit `--after-ms` to continue through the
+undated tail). `--before-ms` still works as a coarse "older than" cutoff, but it
+cannot separate rows that share a millisecond, so it is not a paging key; it is
+ignored when a cursor is given.
+
+The whole order is carried by `idx_sessions_recency`, or
+`idx_sessions_source_recency` when `--source` is given, so a page is an indexed
+read with no sort.
 
 ---
 
@@ -322,7 +361,9 @@ stamp-guarded upsert into `sessions`:
 
 - the shallow upsert never nulls a value the catalog already holds, never
   raises `first_activity_ms` above what a fuller pass observed, and never
-  downgrades `discovery_state = 'full'`;
+  downgrades a fully indexed row to `'shallow'` — including a row from a
+  database that predates `discovery_state`, whose `NULL` readers interpret as
+  `'full'`;
 - the full-sync path only ever upgrades a row to `'full'`;
 - writes go through the normal busy-retry connection, and the opencode
   provider reads a WAL-safe snapshot rather than the live database.
@@ -338,7 +379,12 @@ the schema is current: it cannot block the writer and cannot be blocked by it.
 The catalog lives in the existing `sessions` table, extended with
 `first_prompt`, `models_json`, `originator`, `agent_version`, `repo_url`,
 `initial_commit`, `workspace_roots_json`, `source_stamp` and `discovery_state`,
-plus the `idx_sessions_source_last` and `idx_sessions_raw_path` indexes.
+plus the `idx_sessions_source_last`, `idx_sessions_raw_path`,
+`idx_sessions_recency` and `idx_sessions_source_recency` indexes. A companion
+`discovery_skips` table remembers sources already examined and found not to be
+sessions (a codex subagent thread, a Claude subagent sidecar), keyed by
+`(source, locator)` with the stamp, so a rescan costs a primary-key lookup
+instead of re-reading them every run.
 Databases created by an older release are migrated in place by ignore-error
 `ALTER TABLE`s in `init_db`, and `schema_is_current` knows about the new
 columns, so a read-only handle over an old database is upgraded instead of
@@ -372,11 +418,11 @@ discoverable".
 ## Programmatic access
 
 - **Native (napi)** — `listSessions(options?)` returns
-  `{contractVersion, sessions}`; `discoverSessions(options?)` runs a shallow
+  `{contractVersion, sessions, nextCursor}`; `discoverSessions(options?)` runs a shallow
   scan and returns the rows plus the summary (collected rather than streamed —
   use the CLI's JSONL output when you want progressive rendering). Both run on
-  a blocking worker thread and accept `sources` / `limit`, with `beforeMs` on
-  the listing.
+  a blocking worker thread and accept `sources` / `limit`, with `beforeMs` and
+  `after` (the previous page's `nextCursor`) on the listing.
 - **TypeScript SDK** — `listSessionCatalog()` / `discoverSessions()` wrap the
   same contract for Node consumers; see the SDK's own documentation for the
   exact signatures.

--- a/docs/session-catalog.md
+++ b/docs/session-catalog.md
@@ -1,0 +1,438 @@
+# Session Catalog — shallow coding-agent session discovery
+
+**Answer "which coding-agent sessions exist on this machine, newest first?" in milliseconds, without indexing a single transcript.**
+
+`ai-hist sync` builds the deep index: every message, tool call, file edit and
+full-text row. That is the right thing for search, and the wrong thing for a
+session picker — it reads every transcript end to end. The **session catalog**
+is the shallow half: it enumerates provider sessions cheaply, extracts only the
+metadata needed to *identify* a session, and caches the result in the `sessions`
+table so the next listing touches no provider file at all.
+
+The two layers coexist. Discovery never blocks or downgrades a full sync, and a
+fully indexed session keeps its richer state when discovery re-reads it.
+
+---
+
+## The two operations
+
+| | `ai-hist sessions list` | `ai-hist sessions discover` |
+|---|---|---|
+| Reads | the `sessions` table only | provider locations, with bounded reads |
+| Provider I/O | none | head/tail of the newest candidates |
+| Writes | nothing (read-only handle when the schema is current) | upserts `sessions` rows |
+| Output | one JSON object | JSONL, streamed as rows are produced |
+| Use it for | every repaint of a session picker | refreshing the catalog |
+
+Use **`list`** whenever you are rendering: it is a single indexed query, it
+cannot contend with a running `sync`, and it still works when the provider
+files have been deleted.
+
+Use **`discover`** when the catalog may be stale — on app launch, on a manual
+refresh, or on a timer. It is safe to run beside `ai-hist sync`.
+
+```bash
+# Refresh the catalog from every provider, newest first.
+ai-hist sessions discover
+
+# Just the 20 most recent sessions across all providers (bounded work).
+ai-hist sessions discover --limit 20
+
+# Read back what the catalog holds — no provider file is opened.
+ai-hist sessions list
+ai-hist sessions list --limit 100 --source codex --source claude
+
+# Page backwards by recency (keyset, not OFFSET).
+ai-hist sessions list --limit 50 --before-ms 1781949900000
+
+# Machine-readable forms.
+ai-hist sessions list --json          # one JSON object
+ai-hist sessions discover --json      # JSONL: sessions, diagnostics, summary
+```
+
+---
+
+## The output contract
+
+Both operations carry `contract_version` — currently **1**
+(`SESSION_CATALOG_CONTRACT_VERSION`). It is bumped whenever the shape or the
+meaning of a row changes in a way a consumer must notice, so parse it and fail
+loudly on a version you do not know rather than guessing.
+
+### `sessions list --json`
+
+One object, never a bare array, so the version travels with the payload:
+
+```jsonc
+{
+  "contract_version": 1,
+  "sessions": [
+    {
+      "source": "codex",
+      "session_id": "0198c2ad-codex",
+      "cwd": "/Users/you/Projects/api",
+      "git_branch": "feature/retries",
+      "first_activity_ms": 1782039600000,
+      "last_activity_ms": 1782039603000,
+      "first_prompt": "make the backoff configurable",
+      "last_assistant_text": null,
+      "models": ["gpt-5-codex"],
+      "originator": "codex_cli_rs",
+      "agent_version": "0.148.0",
+      "repo_url": "git@github.com:acme/api.git",
+      "initial_commit": "abc1234def",
+      "workspace_roots": ["/Users/you/Projects/api"],
+      "raw_path": "/Users/you/.codex/sessions/2026/06/21/rollout-codex.jsonl",
+      "source_stamp": "v1:1788042670103317900:569",
+      "discovery_state": "shallow",
+      "from_cache": true
+    }
+  ]
+}
+```
+
+Keys are `snake_case`. `models` and `workspace_roots` are always arrays
+(possibly empty); every other absent value is `null`, never an invented
+placeholder or an empty string.
+
+### `sessions discover --json`
+
+JSONL, one object per line, streamed as the run progresses (the `events`
+command's precedent). Three line types, in this order:
+
+```jsonc
+// 0..n session rows, in global recency order (newest first)
+{"type": "session", "source": "codex", "session_id": "0198c2ad-codex", "from_cache": false, /* …same fields as above… */ }
+
+// 0..n non-fatal failures — one provider or one malformed session
+{"type": "diagnostic", "source": "grok", "locator": "/Users/you/.grok/sessions/…/chat_history.jsonl", "error": "…"}
+
+// exactly one closing summary
+{
+  "type": "summary",
+  "contract_version": 1,
+  "discovered": 2,
+  "skipped_unchanged": 0,
+  "providers": {
+    "claude":   {"candidates": 1, "discovered": 1, "skipped_unchanged": 0, "failed": false},
+    "codex":    {"candidates": 1, "discovered": 1, "skipped_unchanged": 0, "failed": false},
+    "cursor":   {"candidates": 0, "discovered": 0, "skipped_unchanged": 0, "failed": false},
+    "grok":     {"candidates": 0, "discovered": 0, "skipped_unchanged": 0, "failed": false},
+    "opencode": {"candidates": 0, "discovered": 0, "skipped_unchanged": 0, "failed": false},
+    "relay":    {"candidates": 0, "discovered": 0, "skipped_unchanged": 0, "failed": false}
+  },
+  "exempt_sources": [
+    {"source": "trajectory", "reason": "derived trajectory records, not provider sessions"}
+  ],
+  "counters": {
+    "candidates_enumerated": 2,
+    "shallow_reads": 2,
+    "skipped_unchanged": 0,
+    "files_opened": 2,
+    "bytes_read": 978
+  }
+}
+```
+
+`counters` is the run's bill of work, and it is the honest way to check that
+discovery stayed cheap — `bytes_read` and `files_opened` are what a bounded
+request bounds, and `shallow_reads` is `0` on a rescan where nothing changed.
+
+Diagnostics are their own lines and never appear inside the `summary` object,
+so a consumer that only wants the tally can read the last line and stop. In
+human (non-`--json`) mode they go to stderr instead, leaving stdout clean:
+
+```text
+  2026-06-21 11:00  codex    shallow  0198c2ad-codex   /Users/you/Projects/api  make the backoff configurable
+  2026-06-20 10:05  claude   shallow  3f6c1b7a-claude  /Users/you/Projects/api  add a retry to the http client
+  2 session(s): 0 discovered, 2 unchanged (0 file(s) opened, 0 shallow read(s))
+```
+
+A provider that fails contributes a `diagnostic` and nothing else; the run
+continues and exits `0`. The command fails only when **every** selected
+provider failed.
+
+---
+
+## Field semantics
+
+Every value is one of three things, and the distinction is part of the
+contract:
+
+| Field | Kind | Notes |
+|---|---|---|
+| `source` | observed | `claude`, `codex`, `cursor`, `grok`, `opencode`, `relay` |
+| `session_id` | observed | provider-native; `(source, session_id)` is the primary key, so the same native id under two providers is two rows |
+| `cwd` | observed | working directory the provider recorded |
+| `git_branch` | observed | last branch the provider recorded |
+| `first_activity_ms` | observed | `null` when the provider records no timestamps at all |
+| `last_activity_ms` | observed, or filesystem-derived | file mtime for providers that record no timestamps |
+| `first_prompt` | **derived** | bounded excerpt (≤ 4096 chars) of the first *substantive* human turn; provider control/meta/sidechain turns are skipped |
+| `last_assistant_text` | observed | **only** written by full indexing — always `null` on a shallow-only row |
+| `models` | observed, best effort | model ids seen inside the bounded read; empty means "not seen cheaply", not "no model" |
+| `originator` | observed | the client that started the session (codex only) |
+| `agent_version` | observed | agent CLI version |
+| `repo_url` | observed | remote URL, when the provider records one |
+| `initial_commit` | observed | commit the session started from |
+| `workspace_roots` | observed | extra workspace roots, when the provider records them |
+| `raw_path` | observed | provider file this row came from; `null` for database- and network-backed sources |
+| `source_stamp` | internal | change marker; see [rescan behaviour](#rescans-and-source-stamps) |
+| `discovery_state` | internal | `"shallow"` or `"full"` |
+| `from_cache` | per-response | `true` when the row was served without re-reading the source |
+
+Absent metadata stays `null`. Nothing is ever invented to fill a column.
+
+### What the catalog deliberately does not have
+
+These require `ai-hist sync`, for every provider, without exception:
+
+- per-message events (`session_events`), tool calls, file edits
+- token usage and cost
+- session → commit links
+- full-text search over transcripts
+- the full transcript body, and `last_assistant_text`
+
+`discovery_state` tells you which you have: `"full"` means a full ingest has
+run for that session, `"shallow"` means catalog metadata only. Full ingest
+always wins — a shallow rescan refreshes a `full` row's metadata and stamp but
+never downgrades its state.
+
+### Product boundary
+
+Discovery reports *which sessions exist* and identifying metadata. It does not
+infer project membership, work status, health, risk or success, and it does not
+summarize outcomes.
+
+---
+
+## Per-provider capability matrix
+
+What each adapter can actually extract from a cheap read. `✓` = populated when
+the provider recorded it; `–` = the provider does not expose it to a shallow
+read.
+
+| Source | `session_id` | `cwd` | `git_branch` | `first_activity` | `last_activity` | `first_prompt` | `models` | `originator` | `agent_version` | `repo_url` | `initial_commit` | `workspace_roots` |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| **claude** | ✓ | ✓ | ✓ | ✓ | ✓ (tail) | ✓ | ✓ (head) | – | ✓ (record `version`) | – | – | – |
+| **codex** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **cursor** | ✓ (dir name) | ✓ (decoded path) | – | – (never) | mtime-derived | ✓ | – | – | – | – | – | – |
+| **grok** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ (if present) | – | – | – | – | – |
+| **opencode** | ✓ | ✓ (directory) | – | ✓ | ✓ | ✓ | ✓ | – | – | – | – | – |
+| **relay** | ✓ | – (never) | – | ✓ (synced min ts) | ✓ (synced max ts) | ✓ (earliest synced prompt) | – | – | – | – | – | – |
+
+How each adapter works:
+
+- **claude** — `~/.claude/projects/**/*.jsonl`. Head for identity, `cwd`,
+  branch, `version`, models and the first human prompt; tail for the last
+  timestamp and the final branch. Meta rows, slash-command wrappers, bash
+  wrappers and sidechain (subagent) turns are skipped when picking
+  `first_prompt`.
+- **codex** — `rollout-*.jsonl` under `~/.codex/sessions` and
+  `~/.codex/archived_sessions`. The first line is a `session_meta` record, which
+  makes codex the richest source: originator, `cli_version`, git remote, initial
+  commit, workspace roots and model all come from it. Subagent threads are real
+  rollouts but not user sessions, so they are excluded — exactly as the full
+  sync excludes them.
+- **cursor** — `~/.cursor/projects/<encoded-path>/agent-transcripts/<id>/<id>.jsonl`.
+  Cursor transcripts carry **no timestamps at all**, so `first_activity_ms` is
+  always `null` and `last_activity_ms` is the file mtime. `cwd` is decoded from
+  the project directory name.
+- **grok** — `~/.grok/sessions/<encoded-path>/<id>/`. Identity, `cwd`, branch and
+  both timestamps come from `summary.json`; the first prompt comes from the head
+  of `chat_history.jsonl`, skipping synthetic reminder turns.
+- **opencode** — the SQLite store at `$OPENCODE_DB` (default
+  `~/.local/share/opencode/opencode.db`). The database is snapshotted once per
+  run with SQLite's backup API, exactly as the full sync does, so an in-flight
+  WAL never yields a torn read. Enumeration is one query over `session`; the
+  shallow read adds two bounded single-row lookups for the first user text part
+  and a model id, rather than the full session/message/part join the sync does.
+- **relay** — a **network** source with no local transcript, and discovery must
+  work offline. The adapter therefore derives rows only from `history` rows a
+  previous `ai-hist sync` already stored locally; it opens no socket. If nothing
+  was ever synced it discovers nothing, which is the correct answer rather than
+  a failure. A relay thread has no working directory, so `cwd` is always `null`.
+
+---
+
+## Ordering and limits
+
+The ordering and the limit are **global**, not per provider:
+
+1. Every selected provider enumerates its candidates **cheaply** — a directory
+   walk plus `stat`, or one indexed query. No file content is read.
+2. Candidates from all providers are merged and sorted by recency hint,
+   descending. Candidates with no recency signal sort last; ties break on
+   `(source, locator)` so a run is reproducible.
+3. The global `--limit` truncates that merged list.
+4. Only the survivors get a bounded shallow read.
+
+So `--limit 3` across two providers returns the three newest sessions
+*overall*, not three from whichever provider happened to be enumerated first —
+and the cost of a limited request is set by the limit, not by the size of the
+archive.
+
+Read budgets per source, so one enormous transcript cannot dominate a run:
+
+| Budget | Value |
+|---|---|
+| head read | ≤ 256 KB and ≤ 400 complete JSONL records |
+| tail read | ≤ 64 KB |
+| text excerpt (`first_prompt`) | ≤ 4096 characters |
+
+Files inside the head budget are read once and serve as their own tail. Only
+newline-terminated records are parsed: a transcript being appended to right now
+has a partial trailing line, and that line is not yet a record.
+
+`sessions list` paginates by recency instead: `--limit` plus `--before-ms`
+(keyset), served by `idx_sessions_last`, or `idx_sessions_source_last` when
+`--source` is given.
+
+---
+
+## Rescans and source stamps
+
+Each row stores a `source_stamp` — `v{scanner version}:{provider change marker}`:
+
+| Source | Change marker |
+|---|---|
+| claude, codex, cursor | `{mtime nanoseconds}:{file length}` |
+| grok | the chat file's marker, `\|`, the `summary.json` marker |
+| opencode | `{time_created}:{time_updated}` |
+| relay | `{newest synced timestamp}:{synced row count}` |
+
+On a rescan, a candidate whose stamp matches the stored one is served straight
+from the catalog: no read, no parse, `skipped_unchanged` incremented,
+`from_cache: true` on the emitted row. In the benchmark below, a rescan of 450
+unchanged sessions performs **zero** shallow reads.
+
+The `v{N}` prefix is the *scanner* version (`SHALLOW_SCANNER_VERSION`), separate
+from `parser_version` (the full-ingest parser generation). Bumping it
+invalidates every stored stamp, so a scanner taught to extract a new field
+re-reads sources whose bytes never changed.
+
+---
+
+## Concurrency
+
+Discovery deliberately does **not** take the `sync` advisory lock, so a session
+picker refreshing itself never has to wait behind a 60-second background sync.
+
+That is safe because every write discovery performs is an idempotent,
+stamp-guarded upsert into `sessions`:
+
+- the shallow upsert never nulls a value the catalog already holds, never
+  raises `first_activity_ms` above what a fuller pass observed, and never
+  downgrades `discovery_state = 'full'`;
+- the full-sync path only ever upgrades a row to `'full'`;
+- writes go through the normal busy-retry connection, and the opencode
+  provider reads a WAL-safe snapshot rather than the live database.
+
+A concurrent `sync` and `discover` therefore converge on the same row rather
+than fighting over it.
+
+`sessions list` is classified read-only, so it takes a read-only handle when
+the schema is current: it cannot block the writer and cannot be blocked by it.
+
+### Schema
+
+The catalog lives in the existing `sessions` table, extended with
+`first_prompt`, `models_json`, `originator`, `agent_version`, `repo_url`,
+`initial_commit`, `workspace_roots_json`, `source_stamp` and `discovery_state`,
+plus the `idx_sessions_source_last` and `idx_sessions_raw_path` indexes.
+Databases created by an older release are migrated in place by ignore-error
+`ALTER TABLE`s in `init_db`, and `schema_is_current` knows about the new
+columns, so a read-only handle over an old database is upgraded instead of
+failing with `no such column`.
+
+---
+
+## Adding a provider
+
+Every entry in `SOURCE_CHOICES` must be covered by **exactly one** of:
+
+- an adapter in `shallow_providers()` — implement `ShallowSessionProvider`
+  (`enumerate` may stat but not read; `read_shallow` stays inside the head/tail
+  budgets and returns `Ok(None)` for "this candidate is not a session"), or
+- an entry in `DISCOVERY_EXEMPTIONS`, which is machine-readable and carries a
+  reason.
+
+A registry test enforces the pairing, so adding a source without deciding which
+list it belongs to fails the build. Today the only exemption is `trajectory`
+("derived trajectory records, not provider sessions"). It is enforced at both
+ends: `sessions discover --source trajectory` fails with that reason, and
+`sessions list` filters `trajectory` rows out defensively, so a trajectory can
+never be presented as a session.
+
+The exemption list also travels in the `summary` line as `exempt_sources`, so a
+consumer can tell "this source has no sessions" apart from "this source is not
+discoverable".
+
+---
+
+## Programmatic access
+
+- **Native (napi)** — `listSessions(options?)` returns
+  `{contractVersion, sessions}`; `discoverSessions(options?)` runs a shallow
+  scan and returns the rows plus the summary (collected rather than streamed —
+  use the CLI's JSONL output when you want progressive rendering). Both run on
+  a blocking worker thread and accept `sources` / `limit`, with `beforeMs` on
+  the listing.
+- **TypeScript SDK** — `listSessionCatalog()` / `discoverSessions()` wrap the
+  same contract for Node consumers; see the SDK's own documentation for the
+  exact signatures.
+- **MCP** — the stdio server exposes the cache-only listing as a `list_sessions`
+  tool, so an agent can enumerate recent sessions without triggering any
+  provider I/O. See the MCP package's documentation for its arguments.
+
+Whatever the surface, `contract_version` means the same thing: check it, and
+fail loudly on a version you do not know.
+
+---
+
+## Performance validation
+
+The claims above are validated by a benchmark harness rather than by wall-clock
+assertions in the test suite:
+
+```bash
+cargo test -p ai-hist-cli --test discovery_bench -- --ignored --nocapture
+```
+
+It builds a synthetic multi-provider archive in a temp directory, runs both
+catalog operations plus a full `ai-hist sync` against it, and prints a
+measurement table. Every assertion it makes is an *operation count* — bytes
+read, files opened, shallow reads, rows returned — because those hold on any
+machine; timings are printed for the reader and never asserted.
+
+Representative numbers from one run (debug build, 450-session archive, 14.7 MB):
+
+| Measurement | Result |
+|---|---|
+| Cached listing, `--limit 20` at 1 000 catalog rows | 0.13 ms |
+| Cached listing, `--limit 20` at 20 000 catalog rows + 100 000 history/event rows | 0.13 ms |
+| Cached listing, `--limit 2000` at 20 000 rows | 8.6 ms |
+| `discover --limit 5` over a 90-session / 6.2 MB archive | 5 shallow reads, 1.6 MB read (26% of the archive) |
+| `discover --limit 5` over the same archive grown to 450 sessions / 14.7 MB | 5 shallow reads, **the same 1.6 MB** (11%) |
+| `sessions discover` (cold, whole archive) | 11.9 MB read, 450 rows, ~1.7 s |
+| `sessions discover` (rescan, nothing changed) | 0 shallow reads, 28 KB read, ~0.08 s |
+| `ai-hist sync` (full ingest, same archive) | reads all 14.7 MB, writes 62 451 history/event rows, ~46 s |
+| Cached listing after the entire archive is deleted | same 50 rows, 0.41 ms |
+
+The shape is what matters, not the absolute numbers: the cached listing tracks
+the rows you asked for and ignores both catalog size and event volume; a
+bounded request's cost is fixed by its limit; and a shallow refresh of a whole
+archive cost roughly 1/27th of a full ingest of the same archive — while a
+rescan of unchanged bytes is nearly free (the 28 KB is the one-per-run opencode
+snapshot, which enumeration always takes).
+
+Complementary structural coverage lives in the unit tests:
+`the_catalog_listing_is_served_by_an_index_not_a_table_scan` (EXPLAIN QUERY
+PLAN), `the_catalog_query_reads_only_the_sessions_table`,
+`bounded_reads_do_not_grow_with_the_size_of_the_archive`, and
+`a_head_read_stays_inside_its_budget_on_a_very_large_transcript`.
+
+---
+
+See also: [`getting-started.md`](getting-started.md) (human setup) ·
+[`agent-integration.md`](agent-integration.md) (agent-facing surfaces) ·
+the `Schema` section of the top-level `README.md`.

--- a/mcp-package/README.md
+++ b/mcp-package/README.md
@@ -42,6 +42,7 @@ The MCP server exposes:
 
 - `search_history`
 - `recent_entries`
+- `list_sessions`
 - `get_session`
 - `get_context`
 - `stats`

--- a/scripts/verify-e2e.sh
+++ b/scripts/verify-e2e.sh
@@ -27,6 +27,16 @@ json_field() {
   ' "$1"
 }
 
+# Print one field of a JSONL stream piped on stdin (the `sessions discover`
+# shape). The argument is a JS expression over `d`, the array of parsed lines.
+jsonl_field() {
+  node -e '
+    const d = require("node:fs").readFileSync(0, "utf8")
+      .split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    process.stdout.write(String(eval(process.argv[1])));
+  ' "$1"
+}
+
 export AI_HIST_DB="$TMP/ai-history.db"
 export TRAJECTORY_ROOT="$TMP/trajectories"
 export OPENCODE_DB="$TMP/opencode.db"
@@ -147,6 +157,95 @@ assert_eq "grok session metadata" "$grok_session" "/tmp/e2e/grok|main|grok assis
 
 synthetic=$(sqlite3 "$AI_HIST_DB" "SELECT COUNT(*) FROM history WHERE source='grok' AND prompt LIKE '%synthetic prompt%'")
 assert_eq "grok synthetic prompt count" "$synthetic" "0"
+
+# --- session catalog -------------------------------------------------------
+# Shallow discovery over the same multi-provider fake HOME, then the cache-only
+# listing a desktop app paints from. Both carry the catalog contract version.
+discover_json=$("$ROOT/ai-hist" sessions discover --json)
+
+discovered_sources=$(printf '%s\n' "$discover_json" | jsonl_field \
+  'd.filter((l) => l.type === "session").map((l) => l.source).sort().join(",")')
+assert_eq "discovered sources" "$discovered_sources" "claude,codex,cursor,grok,opencode"
+
+discover_contract=$(printf '%s\n' "$discover_json" | jsonl_field \
+  'd.find((l) => l.type === "summary").contract_version')
+assert_eq "discover contract version" "$discover_contract" "1"
+
+discover_trailer=$(printf '%s\n' "$discover_json" | jsonl_field 'd[d.length - 1].type')
+assert_eq "discover trailer" "$discover_trailer" "summary"
+
+discover_exempt=$(printf '%s\n' "$discover_json" | jsonl_field \
+  'd.find((l) => l.type === "summary").exempt_sources.map((e) => e.source).join(",")')
+assert_eq "discover exemptions" "$discover_exempt" "trajectory"
+
+# Trajectories are derived records, never sessions.
+discover_trajectories=$(printf '%s\n' "$discover_json" | jsonl_field \
+  'd.filter((l) => l.type === "session" && l.source === "trajectory").length')
+assert_eq "discovered trajectories" "$discover_trajectories" "0"
+
+# Codex session_meta provenance is observed, not invented.
+codex_branch=$(printf '%s\n' "$discover_json" | jsonl_field \
+  'String(d.find((l) => l.type === "session" && l.source === "codex").git_branch)')
+assert_eq "codex discovered branch" "$codex_branch" "main"
+codex_repo=$(printf '%s\n' "$discover_json" | jsonl_field \
+  'String(d.find((l) => l.type === "session" && l.source === "codex").repo_url)')
+assert_eq "codex discovered repo url" "$codex_repo" "null"
+
+# Cursor records no per-message timestamps: mtime is reported as last activity
+# and first activity stays null rather than being fabricated.
+cursor_first=$(printf '%s\n' "$discover_json" | jsonl_field \
+  'String(d.find((l) => l.type === "session" && l.source === "cursor").first_activity_ms)')
+assert_eq "cursor first activity" "$cursor_first" "null"
+cursor_last=$(printf '%s\n' "$discover_json" | jsonl_field \
+  'String(d.find((l) => l.type === "session" && l.source === "cursor").last_activity_ms !== null)')
+assert_eq "cursor last activity present" "$cursor_last" "true"
+
+# A rescan re-reads nothing: unchanged stamps are served from the catalog.
+rescan_reads=$("$ROOT/ai-hist" sessions discover --json | jsonl_field \
+  'd.find((l) => l.type === "summary").counters.shallow_reads')
+assert_eq "rescan shallow reads" "$rescan_reads" "0"
+rescan_skipped=$("$ROOT/ai-hist" sessions discover --json | jsonl_field \
+  'd.find((l) => l.type === "summary").skipped_unchanged')
+assert_eq "rescan skipped unchanged" "$rescan_skipped" "5"
+
+# The global limit is shared across providers, not applied per provider.
+limited=$("$ROOT/ai-hist" sessions discover --json --limit 2 | jsonl_field \
+  'd.filter((l) => l.type === "session").length')
+assert_eq "global discover limit" "$limited" "2"
+
+list_json=$("$ROOT/ai-hist" sessions list --json)
+list_contract=$(printf '%s\n' "$list_json" | json_field 'd.contract_version')
+assert_eq "sessions list contract version" "$list_contract" "1"
+
+list_sessions=$(printf '%s\n' "$list_json" | json_field \
+  'd.sessions.map((s) => `${s.source}:${s.session_id}`).sort().join(",")')
+assert_eq "sessions list rows" "$list_sessions" \
+  "claude:claude-e2e,codex:codex-e2e,cursor:cursor-e2e,grok:grok-e2e,opencode:opencode-e2e"
+
+# The catalog lists newest first.
+list_ordered=$(printf '%s\n' "$list_json" | json_field \
+  'JSON.stringify(d.sessions.map((s) => s.last_activity_ms)) === JSON.stringify(d.sessions.map((s) => s.last_activity_ms).slice().sort((a, b) => b - a))')
+assert_eq "sessions list ordering" "$list_ordered" "true"
+
+# Sessions the full sync already ingested stay marked `full`; the ones only
+# shallow discovery knows about are `shallow`.
+claude_state=$(printf '%s\n' "$list_json" | json_field \
+  'd.sessions.find((s) => s.source === "claude").discovery_state')
+assert_eq "claude discovery state" "$claude_state" "full"
+cursor_state=$(printf '%s\n' "$list_json" | json_field \
+  'd.sessions.find((s) => s.source === "cursor").discovery_state')
+assert_eq "cursor discovery state" "$cursor_state" "shallow"
+
+# The derived first-prompt excerpt skips synthetic/control turns.
+grok_prompt=$(printf '%s\n' "$list_json" | json_field \
+  'd.sessions.find((s) => s.source === "grok").first_prompt')
+assert_eq "grok first prompt" "$grok_prompt" "e2e grok release tagging prompt"
+
+list_filtered=$("$ROOT/ai-hist" sessions list --json --source codex --limit 5 | json_field \
+  'd.sessions.map((s) => s.source).join(",")')
+assert_eq "sessions list source filter" "$list_filtered" "codex"
+
+"$ROOT/ai-hist" sessions list >/dev/null
 
 "$ROOT/ai-hist" --db "$AI_HIST_DB" tag codex-e2e release-e2e --source codex
 "$ROOT/ai-hist" --db "$AI_HIST_DB" search release --tag release-e2e --json

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `listSessionCatalog({ sources?, limit?, beforeMs? })` — the materialized
+- `listSessionCatalog({ sources?, limit?, beforeMs?, after? })` — the materialized
   session catalog, newest first, as one indexed query over the `sessions` table.
   No provider transcript is opened and neither `history` nor `session_events` is
   scanned, so it stays fast on first paint with thousands of sessions. Rows come
@@ -20,11 +20,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   catalog and reads as `'full'`). `source = 'trajectory'` rows are excluded
   defensively — trajectories are derived records, not sessions. Ordering is
   `last_activity_ms DESC` with null timestamps last, then `source` and
-  `session_id` so `beforeMs` keyset pagination is stable. A configured
-  `projectScope` constrains rows by `cwd`, as `getHandoff` does, so sources with
-  no working directory (relay) drop out of a scoped listing. Returns `[]` in
-  JSONL fallback mode: the fallback scan builds `history` only, and just the
-  native discovery engine writes the catalog.
+  `session_id` — the catalog's total order. Recency alone is not a key: one
+  discovery pass can stamp many sessions with the same mtime-derived
+  millisecond, so a cursor that carries only a timestamp drops every row tied
+  with a page boundary. A configured `projectScope` constrains rows by `cwd`, as
+  `getHandoff` does, so sources with no working directory (relay) drop out of a
+  scoped listing. A negative `limit` throws a `RangeError` — SQLite reads a
+  negative `LIMIT` as "unlimited", so it would otherwise dump the whole catalog.
+  Returns `[]` in JSONL fallback mode: the fallback scan builds `history` only,
+  and just the native discovery engine writes the catalog.
+- `listSessionCatalogPage(options)` → `{ sessions, nextCursor }` — the same
+  listing plus the cursor that continues it, mirroring the native
+  `list_session_catalog_page` and the CLI's `next_cursor`. `nextCursor` is
+  a `CatalogCursor` (`{ lastActivityMs, source, sessionId }`) and is non-null
+  only when the page filled its limit, so following it until `null` walks the
+  whole catalog with no skipped and no repeated rows — even across a page
+  boundary that lands inside a group of tied timestamps, and through the tail of
+  rows whose recency is unknown, which stays reachable from a dated cursor.
+  `ListCatalogOptions` gains `after` for that cursor; `beforeMs` survives as a
+  coarse cutoff and is ignored when `after` is set.
 - **In-memory catalog migration** — the catalog columns (`first_prompt`,
   `models_json`, `originator`, `agent_version`, `repo_url`, `initial_commit`,
   `workspace_roots_json`, `source_stamp`, `discovery_state`) landed after 0.5.0,
@@ -32,8 +46,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ALTER TABLE ... ADD COLUMN` against the in-memory copy sql.js holds — the same
   trick already used for `history.git_branch`. Without it every catalog read on
   a pre-0.6 file would fail with `no such column`; with it the missing values
-  simply read as `NULL`. The file on disk is never modified. The two new indexes
-  (`idx_sessions_source_last`, `idx_sessions_raw_path`) are created on the copy too.
+  simply read as `NULL`. The file on disk is never modified. The catalog
+  indexes are created on the copy too — `idx_sessions_source_last`,
+  `idx_sessions_raw_path`, and the two composite indexes that carry the whole
+  total order (`idx_sessions_recency`, `idx_sessions_source_recency`) — so a
+  query here plans the way it does natively. The `discovery_skips` table
+  (`source`, `locator`, `stamp`, …), which native discovery uses to remember
+  that a file is not a session, is created for shape parity; the SDK never
+  reads it.
 - `discoverSessions({ sources?, limit?, onSession?, onDiagnostic?, binPath?, env? })`
   — a top-level async function (not an `AiHist` method) that drives
   `ai-hist sessions discover --json` and parses its JSONL stream into
@@ -43,27 +63,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot see the rows it just wrote, so re-open before listing. The limit is
   global across providers and applied by recency, matching the native engine.
   Binary discovery reuses `resolveAiHistBinary` from the cloud-push path
-  (`$AI_HIST_RUST_BIN` → the install.sh location → `ai-hist` on `PATH`). Failure
-  behavior mirrors the CLI: a provider that fails contributes a diagnostic and
-  the run still resolves; the promise rejects only when the binary cannot be run
-  (with an error naming `AI_HIST_RUST_BIN`) or on a non-zero exit, whose stderr
-  is included. Unparseable or unknown JSONL lines are skipped rather than
-  failing the run, so a newer binary's extra line types are forward-compatible.
+  (`$AI_HIST_RUST_BIN` → the install.sh location → `ai-hist` on `PATH`).
+  Unparseable or unknown JSONL lines are skipped rather than failing the run, so
+  a newer binary's extra line types are forward-compatible.
+- **`DiscoveryError`, with the run's own evidence attached.** A provider that
+  fails still only contributes a diagnostic and the run resolves; the promise
+  rejects when the binary cannot be run (the message names `AI_HIST_RUST_BIN`),
+  when the run exits non-zero because every provider failed, or when the closing
+  summary is missing or announces a contract version this SDK does not
+  implement. The native command writes its diagnostics and the summary trailer
+  even on an all-provider failure, so the error carries `diagnostics`,
+  `summary`, `stderr`, and `exitCode` rather than an opaque exit status.
+  Checking `contractVersion` is no longer left to the caller: a mismatch (or an
+  absent trailer, which the contract makes mandatory) means the rows cannot be
+  interpreted safely, so it is refused instead of half-parsed. `DiscoverResult.summary`
+  is therefore non-optional.
+- **Callback exceptions no longer escape the stream.** An error thrown by
+  `onSession` or `onDiagnostic` used to surface as an unhandled exception inside
+  the stdout handler, which can take a host process down. It now aborts the run:
+  the child is killed and the promise rejects with the caller's own error.
 - `SESSION_CATALOG_CONTRACT_VERSION` (currently `1`), mirroring the native
   constant, plus the `CatalogSession`, `ListCatalogOptions`,
   `DiscoverSessionsOptions`, `DiscoverResult`, `DiscoverySummary`,
   `DiscoveryDiagnostic`, `DiscoveryCounters`, `ProviderDiscoverySummary`, and
   `SourceExemption` types.
 - **MCP tool `list_sessions`** (read-only) — `sources?`, `limit` (default 20,
-  max 200), `before_ms`; returns the catalog rows as JSON alongside
+  max 200), `before_ms`, and `after` (the previous reply's `nextCursor` object);
+  returns the catalog rows plus `nextCursor` as JSON alongside
   `contractVersion`, `sourceKind`, `dbPath`, and `projectScope`. Its `sources`
-  enum omits `trajectory`, which the catalog never contains.
+  enum omits `trajectory`, which the catalog never contains. With no SQLite
+  database present the tool answers `{ sessions: [], nextCursor: null,
+  sourceKind: "none", note }` **without** opening the reader: the catalog only
+  ever lives in SQLite, so building the JSONL fallback there would walk every
+  local provider file — seconds of I/O — to produce a guaranteed-empty catalog.
+  Every other tool keeps the fallback behavior it had.
 
 ### Changed
 
 - `listSessions` is unchanged and still derives sessions from `history`; its doc
   comment now points at `listSessionCatalog` as the fast and complete path
   (the catalog also holds sessions that only shallow discovery has seen).
+- A cursor missing `source` or `sessionId` throws a `TypeError`. A timestamp
+  alone cannot separate rows that share a millisecond, and quietly ignoring the
+  half-cursor would restart the walk at page one — the same half-cursor the
+  native CLI refuses.
 
 ## [0.5.0] - 2026-08-20
 

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `listSessionCatalog({ sources?, limit?, beforeMs? })` — the materialized
+  session catalog, newest first, as one indexed query over the `sessions` table.
+  No provider transcript is opened and neither `history` nor `session_events` is
+  scanned, so it stays fast on first paint with thousands of sessions. Rows come
+  back as `CatalogSession`: cwd, git branch, first/last activity, derived
+  `firstPrompt`, observed `models`, originator, agent version, repo identity,
+  `sourceStamp`, and `discoveryState` (`'shallow'` for a catalog-only row,
+  `'full'` once a sync ingested the transcript; a `NULL` column predates the
+  catalog and reads as `'full'`). `source = 'trajectory'` rows are excluded
+  defensively — trajectories are derived records, not sessions. Ordering is
+  `last_activity_ms DESC` with null timestamps last, then `source` and
+  `session_id` so `beforeMs` keyset pagination is stable. A configured
+  `projectScope` constrains rows by `cwd`, as `getHandoff` does, so sources with
+  no working directory (relay) drop out of a scoped listing. Returns `[]` in
+  JSONL fallback mode: the fallback scan builds `history` only, and just the
+  native discovery engine writes the catalog.
+- **In-memory catalog migration** — the catalog columns (`first_prompt`,
+  `models_json`, `originator`, `agent_version`, `repo_url`, `initial_commit`,
+  `workspace_roots_json`, `source_stamp`, `discovery_state`) landed after 0.5.0,
+  so opening an older database file now backfills each one best-effort with
+  `ALTER TABLE ... ADD COLUMN` against the in-memory copy sql.js holds — the same
+  trick already used for `history.git_branch`. Without it every catalog read on
+  a pre-0.6 file would fail with `no such column`; with it the missing values
+  simply read as `NULL`. The file on disk is never modified. The two new indexes
+  (`idx_sessions_source_last`, `idx_sessions_raw_path`) are created on the copy too.
+- `discoverSessions({ sources?, limit?, onSession?, onDiagnostic?, binPath?, env? })`
+  — a top-level async function (not an `AiHist` method) that drives
+  `ai-hist sessions discover --json` and parses its JSONL stream into
+  `{ sessions, diagnostics, summary }`, invoking `onSession` progressively as
+  rows arrive. It is top-level because discovery **writes** the on-disk database
+  while an `AiHist` is an in-memory snapshot: a method would return a reader that
+  cannot see the rows it just wrote, so re-open before listing. The limit is
+  global across providers and applied by recency, matching the native engine.
+  Binary discovery reuses `resolveAiHistBinary` from the cloud-push path
+  (`$AI_HIST_RUST_BIN` → the install.sh location → `ai-hist` on `PATH`). Failure
+  behavior mirrors the CLI: a provider that fails contributes a diagnostic and
+  the run still resolves; the promise rejects only when the binary cannot be run
+  (with an error naming `AI_HIST_RUST_BIN`) or on a non-zero exit, whose stderr
+  is included. Unparseable or unknown JSONL lines are skipped rather than
+  failing the run, so a newer binary's extra line types are forward-compatible.
+- `SESSION_CATALOG_CONTRACT_VERSION` (currently `1`), mirroring the native
+  constant, plus the `CatalogSession`, `ListCatalogOptions`,
+  `DiscoverSessionsOptions`, `DiscoverResult`, `DiscoverySummary`,
+  `DiscoveryDiagnostic`, `DiscoveryCounters`, `ProviderDiscoverySummary`, and
+  `SourceExemption` types.
+- **MCP tool `list_sessions`** (read-only) — `sources?`, `limit` (default 20,
+  max 200), `before_ms`; returns the catalog rows as JSON alongside
+  `contractVersion`, `sourceKind`, `dbPath`, and `projectScope`. Its `sources`
+  enum omits `trajectory`, which the catalog never contains.
+
+### Changed
+
+- `listSessions` is unchanged and still derives sessions from `history`; its doc
+  comment now points at `listSessionCatalog` as the fast and complete path
+  (the catalog also holds sessions that only shallow discovery has seen).
+
 ## [0.5.0] - 2026-08-20
 
 ### Added

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -49,7 +49,7 @@ npm run build
 node dist/mcp-server.js
 ```
 
-The MCP server exposes tools for search, recent history, session lookup, temporal context, evidence packing, stats, trajectory search, and task WHY lookup over stdio. It runs on the user's machine and uses the same data-opening behavior as the SDK: SQLite first, then local fallback scanning.
+The MCP server exposes tools for search, recent history, the session catalog, session lookup, temporal context, evidence packing, stats, trajectory search, and task WHY lookup over stdio. It runs on the user's machine and uses the same data-opening behavior as the SDK: SQLite first, then local fallback scanning.
 
 To expose only one project through MCP, pass a project scope when launching the server. Exact project matches and child paths are included.
 
@@ -67,6 +67,48 @@ Contract tools:
 - `stats()`
 - `search_trajectories(query, limit?)`
 - `why_for_task(query)`
+- `list_sessions(sources?, limit?, before_ms?)`
+
+## Session catalog
+
+`sessions` is a materialized catalog of every coding-agent session ai-hist knows about — one row per `(source, session_id)`, with cwd, git branch, first/last activity, the first prompt, observed models, originator, agent version, and repo identity. It is populated by shallow discovery (cheap, metadata only) and upgraded in place by a full `ai-hist sync`. `discoveryState` says which you are looking at: `'shallow'` for a catalog row whose transcript has not been ingested, `'full'` once it has (rows written before the catalog existed store `NULL` and read as `'full'`).
+
+Reading it is one indexed query over a single table — no provider transcript is opened and no prompt history is scanned — so it is the fast path for "which sessions exist?" on first paint:
+
+```ts
+import { openAiHist, discoverSessions, SESSION_CATALOG_CONTRACT_VERSION } from 'ai-hist';
+
+const hist = await openAiHist();
+const sessions = hist.listSessionCatalog({ limit: 20 });
+for (const s of sessions) {
+  console.log(s.lastActivityMs, s.source, s.sessionId, s.cwd, s.firstPrompt);
+}
+
+// Paginate with a keyset cursor.
+const older = hist.listSessionCatalog({
+  limit: 20,
+  beforeMs: sessions.at(-1)!.lastActivityMs!,
+});
+```
+
+Ordering is `lastActivityMs` descending, rows with no timestamp last, then `source` and `sessionId` so pages are stable. `trajectory` rows are excluded — trajectories are derived records, not sessions. A configured `projectScope` constrains rows by `cwd`, so sources with no working directory (relay) drop out of a scoped listing. In JSONL fallback mode (no SQLite database) the catalog is empty and the method returns `[]`; only the native discovery engine writes it.
+
+To populate or refresh the catalog, run shallow discovery. It scans the known provider locations with bounded reads, orders candidates globally by recency before applying the limit, and skips sources whose bytes have not changed since the last run:
+
+```ts
+const { sessions, diagnostics, summary } = await discoverSessions({
+  sources: ['claude', 'codex'],   // omit for every discoverable source
+  limit: 50,                      // global across providers, by recency
+  onSession: (s) => render(s),    // streams as rows arrive
+});
+
+console.log(summary?.discovered, summary?.skippedUnchanged, summary?.counters.bytesRead);
+for (const d of diagnostics) console.warn(`[${d.source}] ${d.locator ?? ''}: ${d.error}`);
+```
+
+`discoverSessions` is a top-level function, not an `AiHist` method: it drives `ai-hist sessions discover --json` (binary discovery is `$AI_HIST_RUST_BIN` → the install.sh location → `ai-hist` on `PATH`, the same as `pushToCloud`), and that writes the on-disk database. An `AiHist` instance is an in-memory snapshot taken at open time, so re-open it before listing to see freshly discovered rows.
+
+Failure behavior matches the CLI's: one provider blowing up yields a diagnostic and the run still resolves; the promise rejects only when the binary cannot be run at all (the error names `AI_HIST_RUST_BIN`) or when every selected provider failed. Unparseable JSONL lines are skipped rather than failing the run. `summary.contractVersion` is the native output-contract version; compare it against the exported `SESSION_CATALOG_CONTRACT_VERSION` (currently `1`) when a mismatch matters to you.
 
 ## API
 
@@ -83,7 +125,8 @@ hist.sourceKind: 'sqlite' | 'jsonl'
 hist.projectScope: string | undefined
 
 hist.recent(opts?): HistoryEntry[]            // newest prompts first
-hist.listSessions(opts?): SessionSummary[]    // grouped by session_id, last activity DESC
+hist.listSessions(opts?): SessionSummary[]    // grouped from history by session_id, last activity DESC
+hist.listSessionCatalog(opts?): CatalogSession[] // the sessions catalog: cache-only, one indexed query
 hist.getSession(sessionId): HistoryEntry[]    // all prompts in a session, oldest first
 hist.getSessionEvents(sessionId): SessionEvent[] // full transcript: text, thinking, tool calls/results, token usage
 hist.getToolCalls(sessionId): SessionToolCall[]  // the session's tool invocations
@@ -97,9 +140,13 @@ hist.stats(): Stats                           // counts + date range
 
 All list-style methods accept `{ source?, project?, limit?, beforeMs? }`. `beforeMs` is the cursor for paginating older results.
 
+`listSessionCatalog` takes `{ sources?, limit?, beforeMs? }` instead — it filters on the catalog's own `source` column, not on project.
+
 ```ts
 resumeCommand(entry): string | null           // shell command per source; null for relay
 defaultDbPath(): string                       // resolve env / OS default
+discoverSessions(opts?): Promise<DiscoverResult>  // drives `ai-hist sessions discover --json`
+SESSION_CATALOG_CONTRACT_VERSION: number      // native session-catalog output contract (1)
 ```
 
 ## Trajectories
@@ -162,7 +209,34 @@ CREATE TABLE history (
 );
 
 CREATE VIRTUAL TABLE history_fts USING fts5(prompt, project, content='history', content_rowid='id');
+
+CREATE TABLE sessions (
+  session_id TEXT NOT NULL,
+  source TEXT NOT NULL,
+  cwd TEXT,
+  git_branch TEXT,
+  first_activity_ms INTEGER,
+  last_activity_ms INTEGER,
+  last_assistant_text TEXT,
+  raw_path TEXT,
+  parser_version INTEGER NOT NULL DEFAULT 1,
+  first_prompt TEXT,
+  models_json TEXT,
+  originator TEXT,
+  agent_version TEXT,
+  repo_url TEXT,
+  initial_commit TEXT,
+  workspace_roots_json TEXT,
+  source_stamp TEXT,
+  discovery_state TEXT,
+  PRIMARY KEY (session_id, source)
+);
+
+CREATE INDEX idx_sessions_source_last ON sessions(source, last_activity_ms DESC);
+CREATE INDEX idx_sessions_raw_path ON sessions(source, raw_path);
 ```
+
+`models_json` and `workspace_roots_json` hold JSON string arrays or `NULL` (never `[]`); the SDK parses both into arrays. The catalog columns were added after 0.5.0, so when the SDK opens an older database file it backfills the missing columns on its in-memory copy with `ALTER TABLE` — the file on disk is not touched, and the absent values read as `NULL`.
 
 Trajectory sync also creates a structured `trajectories` table and inserts each per-run compact file into `history` with `source='trajectory'`, so general history search and WHY-specific lookup both work.
 

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -67,7 +67,7 @@ Contract tools:
 - `stats()`
 - `search_trajectories(query, limit?)`
 - `why_for_task(query)`
-- `list_sessions(sources?, limit?, before_ms?)`
+- `list_sessions(sources?, limit?, before_ms?, after?)`
 
 ## Session catalog
 
@@ -79,19 +79,26 @@ Reading it is one indexed query over a single table — no provider transcript i
 import { openAiHist, discoverSessions, SESSION_CATALOG_CONTRACT_VERSION } from 'ai-hist';
 
 const hist = await openAiHist();
-const sessions = hist.listSessionCatalog({ limit: 20 });
-for (const s of sessions) {
+for (const s of hist.listSessionCatalog({ limit: 20 })) {
   console.log(s.lastActivityMs, s.source, s.sessionId, s.cwd, s.firstPrompt);
 }
-
-// Paginate with a keyset cursor.
-const older = hist.listSessionCatalog({
-  limit: 20,
-  beforeMs: sessions.at(-1)!.lastActivityMs!,
-});
 ```
 
-Ordering is `lastActivityMs` descending, rows with no timestamp last, then `source` and `sessionId` so pages are stable. `trajectory` rows are excluded — trajectories are derived records, not sessions. A configured `projectScope` constrains rows by `cwd`, so sources with no working directory (relay) drop out of a scoped listing. In JSONL fallback mode (no SQLite database) the catalog is empty and the method returns `[]`; only the native discovery engine writes it.
+The catalog's total order is `(lastActivityMs DESC, source ASC, sessionId ASC)`, with rows of unknown recency last. Recency alone is not a key: one discovery pass can stamp many sessions with the same mtime-derived millisecond, so paginate with `listSessionCatalogPage` and follow its cursor, which carries all three columns:
+
+```ts
+let after;
+for (;;) {
+  const page = hist.listSessionCatalogPage({ limit: 20, after });
+  render(page.sessions);
+  if (!page.nextCursor) break;   // null once the catalog is exhausted
+  after = page.nextCursor;       // { lastActivityMs, source, sessionId }
+}
+```
+
+`nextCursor` is non-null only when the page filled its limit, so the loop terminates on an empty catalog and on a null-timestamp tail alike — both cases where a `beforeMs`-only walk either spins forever or silently drops the rows tied with a page boundary. `beforeMs` survives as a *coarse* cutoff ("anything before last Tuesday") and is ignored when `after` is set. The same contract is available from the CLI as the `next_cursor` field of `sessions list --json`, fed back as `--after-source` + `--after-session-id` (both required together, and `--after-ms` alone is refused — a timestamp is not a cursor). Omit `--after-ms` to continue through the undated tail.
+
+`trajectory` rows are excluded — trajectories are derived records, not sessions. A configured `projectScope` constrains rows by `cwd`, so sources with no working directory (relay) drop out of a scoped listing. A negative `limit` throws (SQLite would read it as "unlimited"). In JSONL fallback mode (no SQLite database) the catalog is empty and the methods return no rows; only the native discovery engine writes it.
 
 To populate or refresh the catalog, run shallow discovery. It scans the known provider locations with bounded reads, orders candidates globally by recency before applying the limit, and skips sources whose bytes have not changed since the last run:
 
@@ -102,13 +109,15 @@ const { sessions, diagnostics, summary } = await discoverSessions({
   onSession: (s) => render(s),    // streams as rows arrive
 });
 
-console.log(summary?.discovered, summary?.skippedUnchanged, summary?.counters.bytesRead);
+console.log(summary.discovered, summary.skippedUnchanged, summary.counters.bytesRead);
 for (const d of diagnostics) console.warn(`[${d.source}] ${d.locator ?? ''}: ${d.error}`);
 ```
 
 `discoverSessions` is a top-level function, not an `AiHist` method: it drives `ai-hist sessions discover --json` (binary discovery is `$AI_HIST_RUST_BIN` → the install.sh location → `ai-hist` on `PATH`, the same as `pushToCloud`), and that writes the on-disk database. An `AiHist` instance is an in-memory snapshot taken at open time, so re-open it before listing to see freshly discovered rows.
 
-Failure behavior matches the CLI's: one provider blowing up yields a diagnostic and the run still resolves; the promise rejects only when the binary cannot be run at all (the error names `AI_HIST_RUST_BIN`) or when every selected provider failed. Unparseable JSONL lines are skipped rather than failing the run. `summary.contractVersion` is the native output-contract version; compare it against the exported `SESSION_CATALOG_CONTRACT_VERSION` (currently `1`) when a mismatch matters to you.
+Failure behavior matches the CLI's: one provider blowing up yields a diagnostic and the run still resolves. The promise rejects with a `DiscoveryError` when the binary cannot be run at all (the message names `AI_HIST_RUST_BIN`), when the run exits non-zero because every selected provider failed, or when the closing summary is missing or announces a contract version this SDK does not implement — the version is checked for you against `SESSION_CATALOG_CONTRACT_VERSION` rather than left as a field to remember. The native command writes its diagnostics and summary trailer even on an all-provider failure, so a `DiscoveryError` carries `diagnostics`, `summary`, `stderr`, and `exitCode`. Unparseable or unrecognized JSONL lines are skipped rather than failing the run.
+
+An exception thrown by `onSession` or `onDiagnostic` aborts the run: the child process is killed and the promise rejects with your error, instead of escaping the stream handler as an uncaught exception in the host.
 
 ## API
 
@@ -126,7 +135,8 @@ hist.projectScope: string | undefined
 
 hist.recent(opts?): HistoryEntry[]            // newest prompts first
 hist.listSessions(opts?): SessionSummary[]    // grouped from history by session_id, last activity DESC
-hist.listSessionCatalog(opts?): CatalogSession[] // the sessions catalog: cache-only, one indexed query
+hist.listSessionCatalog(opts?): CatalogSession[]      // the sessions catalog: cache-only, one indexed query
+hist.listSessionCatalogPage(opts?): SessionCatalogPage // the same page plus its nextCursor
 hist.getSession(sessionId): HistoryEntry[]    // all prompts in a session, oldest first
 hist.getSessionEvents(sessionId): SessionEvent[] // full transcript: text, thinking, tool calls/results, token usage
 hist.getToolCalls(sessionId): SessionToolCall[]  // the session's tool invocations
@@ -140,13 +150,14 @@ hist.stats(): Stats                           // counts + date range
 
 All list-style methods accept `{ source?, project?, limit?, beforeMs? }`. `beforeMs` is the cursor for paginating older results.
 
-`listSessionCatalog` takes `{ sources?, limit?, beforeMs? }` instead — it filters on the catalog's own `source` column, not on project.
+The catalog methods take `{ sources?, limit?, beforeMs?, after? }` instead — they filter on the catalog's own `source` column, not on project, and `after` is the cursor for paging.
 
 ```ts
 resumeCommand(entry): string | null           // shell command per source; null for relay
 defaultDbPath(): string                       // resolve env / OS default
 discoverSessions(opts?): Promise<DiscoverResult>  // drives `ai-hist sessions discover --json`
 SESSION_CATALOG_CONTRACT_VERSION: number      // native session-catalog output contract (1)
+DiscoveryError                                // thrown by discoverSessions; carries diagnostics + summary
 ```
 
 ## Trajectories
@@ -232,8 +243,19 @@ CREATE TABLE sessions (
   PRIMARY KEY (session_id, source)
 );
 
+CREATE INDEX idx_sessions_recency ON sessions(last_activity_ms DESC, source, session_id);
+CREATE INDEX idx_sessions_source_recency ON sessions(source, last_activity_ms DESC, session_id);
 CREATE INDEX idx_sessions_source_last ON sessions(source, last_activity_ms DESC);
 CREATE INDEX idx_sessions_raw_path ON sessions(source, raw_path);
+
+CREATE TABLE discovery_skips (
+  source TEXT NOT NULL,
+  locator TEXT NOT NULL,
+  stamp TEXT NOT NULL,
+  reason TEXT,
+  updated_ms INTEGER,
+  PRIMARY KEY (source, locator)
+);
 ```
 
 `models_json` and `workspace_roots_json` hold JSON string arrays or `NULL` (never `[]`); the SDK parses both into arrays. The catalog columns were added after 0.5.0, so when the SDK opens an older database file it backfills the missing columns on its in-memory copy with `ALTER TABLE` — the file on disk is not touched, and the absent values read as `NULL`.

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -27,6 +27,21 @@ import {
   type TrajectoryDecision,
   type TrajectoryRetrospective,
 } from './trajectory-sources.js';
+import { catalogSessionFromJson, type CatalogSession, type ListCatalogOptions } from './session-catalog.js';
+
+export {
+  SESSION_CATALOG_CONTRACT_VERSION,
+  discoverSessions,
+  type CatalogSession,
+  type ListCatalogOptions,
+  type DiscoverSessionsOptions,
+  type DiscoverResult,
+  type DiscoverySummary,
+  type DiscoveryDiagnostic,
+  type DiscoveryCounters,
+  type ProviderDiscoverySummary,
+  type SourceExemption,
+} from './session-catalog.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -42,6 +57,12 @@ export interface HistoryEntry {
   gitBranch: string | null;
 }
 
+/**
+ * The pre-catalog `sessions` row shape, kept for backward compatibility.
+ * New code wants {@link CatalogSession} (via `listSessionCatalog`), which
+ * covers the whole catalog row: first prompt, models, originator, repo
+ * identity, and discovery state.
+ */
 export interface SessionMeta {
   sessionId: string;
   source: Source;
@@ -219,6 +240,51 @@ function getSqlJs(): Promise<SqlJsStatic> {
   return _sqlPromise;
 }
 
+/**
+ * Every non-key column of the session catalog, in the order the native schema
+ * declares them. Used both to create the table and to backfill it column by
+ * column on a database snapshot written before the catalog existed.
+ */
+const SESSION_CATALOG_COLUMNS: ReadonlyArray<readonly [string, string]> = [
+  ['cwd', 'TEXT'],
+  ['git_branch', 'TEXT'],
+  ['first_activity_ms', 'INTEGER'],
+  ['last_activity_ms', 'INTEGER'],
+  ['last_assistant_text', 'TEXT'],
+  ['raw_path', 'TEXT'],
+  ['parser_version', 'INTEGER NOT NULL DEFAULT 1'],
+  ['first_prompt', 'TEXT'],
+  ['models_json', 'TEXT'],
+  ['originator', 'TEXT'],
+  ['agent_version', 'TEXT'],
+  ['repo_url', 'TEXT'],
+  ['initial_commit', 'TEXT'],
+  ['workspace_roots_json', 'TEXT'],
+  ['source_stamp', 'TEXT'],
+  ['discovery_state', 'TEXT'],
+];
+
+/** Run a statement whose only expected failure is "already there". */
+function tryRun(db: Database, sql: string): void {
+  try {
+    db.run(sql);
+  } catch {
+    /* column/index already exists, or the table shape rules it out */
+  }
+}
+
+/**
+ * Ensure the in-memory copy has the current `sessions` shape.
+ *
+ * The catalog columns (`first_prompt`, `models_json`, `discovery_state`, …)
+ * were added after 0.5.0, so a database file written by an older CLI has the
+ * old nine-column table. `CREATE TABLE IF NOT EXISTS` would leave that table
+ * untouched and every catalog read would fail with `no such column`, so each
+ * column is also added best-effort with `ALTER TABLE` — the same trick used for
+ * `history.git_branch` in `openAiHist`. The writes land only in the in-memory
+ * copy sql.js holds; the file on disk is untouched and the missing columns
+ * simply read as `NULL`.
+ */
 function ensureSessionsSchema(db: Database): void {
   db.run(`CREATE TABLE IF NOT EXISTS sessions (
     session_id TEXT NOT NULL,
@@ -230,11 +296,28 @@ function ensureSessionsSchema(db: Database): void {
     last_assistant_text TEXT,
     raw_path TEXT,
     parser_version INTEGER NOT NULL DEFAULT 1,
+    first_prompt TEXT,
+    models_json TEXT,
+    originator TEXT,
+    agent_version TEXT,
+    repo_url TEXT,
+    initial_commit TEXT,
+    workspace_roots_json TEXT,
+    source_stamp TEXT,
+    discovery_state TEXT,
     PRIMARY KEY (session_id, source)
   )`);
-  db.run('CREATE INDEX IF NOT EXISTS idx_sessions_cwd ON sessions(cwd)');
-  db.run('CREATE INDEX IF NOT EXISTS idx_sessions_branch ON sessions(git_branch)');
-  db.run('CREATE INDEX IF NOT EXISTS idx_sessions_last ON sessions(last_activity_ms DESC)');
+  for (const [name, decl] of SESSION_CATALOG_COLUMNS) {
+    tryRun(db, `ALTER TABLE sessions ADD COLUMN ${name} ${decl}`);
+  }
+  tryRun(db, 'CREATE INDEX IF NOT EXISTS idx_sessions_cwd ON sessions(cwd)');
+  tryRun(db, 'CREATE INDEX IF NOT EXISTS idx_sessions_branch ON sessions(git_branch)');
+  tryRun(db, 'CREATE INDEX IF NOT EXISTS idx_sessions_last ON sessions(last_activity_ms DESC)');
+  tryRun(
+    db,
+    'CREATE INDEX IF NOT EXISTS idx_sessions_source_last ON sessions(source, last_activity_ms DESC)',
+  );
+  tryRun(db, 'CREATE INDEX IF NOT EXISTS idx_sessions_raw_path ON sessions(source, raw_path)');
 }
 
 function ensureTrajectorySchema(db: Database): void {
@@ -955,6 +1038,14 @@ export class AiHist {
    * Group history into sessions, ordered by last activity (newest first).
    * Sessions without a `session_id` are skipped.
    *
+   * This derives sessions from the `history` table, so it only ever sees
+   * sessions a full `ai-hist sync` has ingested, and it pays a window-function
+   * pass over history to do it. For the fast and complete path — every session
+   * the catalog knows, including ones only shallow discovery has seen, with
+   * cwd, branch, models, originator and repo identity attached — use
+   * {@link AiHist.listSessionCatalog}. This method stays as-is for callers
+   * that want prompt counts and the project-derived grouping.
+   *
    * Implementation note: this used to use a correlated scalar subquery
    * to pick `first_prompt`, which ran in O(sessions × rows) — ~19s on a
    * 35K-row DB. Switched to `ROW_NUMBER() OVER (PARTITION BY session_id
@@ -1020,6 +1111,68 @@ export class AiHist {
       firstActivityMs: row.first_activity_ms,
       promptCount: row.prompt_count,
     }));
+  }
+
+  /**
+   * The session catalog, newest first — one indexed query over `sessions` and
+   * nothing else.
+   *
+   * No provider transcript is opened and neither `history` nor
+   * `session_events` is touched, so this stays fast on first paint even with
+   * thousands of historical sessions. It is the read side of the native
+   * `ai-hist sessions list`; populate the catalog with `discoverSessions()`
+   * (or a full `ai-hist sync`).
+   *
+   * Details worth knowing:
+   *   - `trajectory` rows are excluded defensively — trajectories are derived
+   *     records, not sessions, and must never appear in a session list.
+   *   - Ordering is `last_activity_ms` descending, with rows that have no
+   *     timestamp last, then `source` and `session_id` so pagination is
+   *     stable across pages.
+   *   - `beforeMs` is a keyset cursor: pass the `lastActivityMs` of the last
+   *     row of the previous page. Rows with a null timestamp never come back
+   *     from a `beforeMs` query (`NULL < x` is unknown), which is what keyset
+   *     pagination wants.
+   *   - A configured `projectScope` constrains rows by `cwd`, like
+   *     `getHandoff`. Sources with no working directory (relay) therefore drop
+   *     out of a scoped listing.
+   *   - In JSONL fallback mode (no SQLite database) the catalog is empty and
+   *     this returns `[]`: the fallback scan builds `history` rows only, and
+   *     only the native discovery engine writes the catalog.
+   */
+  listSessionCatalog(opts: ListCatalogOptions = {}): CatalogSession[] {
+    if (!tableExists(this.db, 'sessions')) return [];
+    const limit = opts.limit ?? 50;
+    const clauses: string[] = ["source != 'trajectory'"];
+    const params: unknown[] = [];
+
+    const sources = [...(opts.sources ?? [])].map((source) => String(source));
+    if (sources.length > 0) {
+      clauses.push(`source IN (${sources.map(() => '?').join(', ')})`);
+      params.push(...sources);
+    }
+    if (typeof opts.beforeMs === 'number') {
+      clauses.push('last_activity_ms < ?');
+      params.push(opts.beforeMs);
+    }
+    if (this._projectScope) {
+      const scope = scopedPathClause('cwd', this._projectScope);
+      clauses.push(scope.sql);
+      params.push(...scope.params);
+    }
+
+    return runQuery<Record<string, unknown>>(
+      this.db,
+      `SELECT source, session_id, cwd, git_branch, first_activity_ms, last_activity_ms,
+              first_prompt, last_assistant_text, models_json, originator, agent_version,
+              repo_url, initial_commit, workspace_roots_json, raw_path, source_stamp,
+              discovery_state, parser_version
+       FROM sessions
+       WHERE ${clauses.join(' AND ')}
+       ORDER BY last_activity_ms IS NULL, last_activity_ms DESC, source ASC, session_id ASC
+       LIMIT ?`,
+      [...params, limit],
+    ).map((row) => catalogSessionFromJson({ ...row, from_cache: true }));
   }
 
   /** All prompts in a session, ordered oldest → newest. */

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -27,12 +27,20 @@ import {
   type TrajectoryDecision,
   type TrajectoryRetrospective,
 } from './trajectory-sources.js';
-import { catalogSessionFromJson, type CatalogSession, type ListCatalogOptions } from './session-catalog.js';
+import {
+  catalogSessionFromJson,
+  type CatalogSession,
+  type ListCatalogOptions,
+  type SessionCatalogPage,
+} from './session-catalog.js';
 
 export {
   SESSION_CATALOG_CONTRACT_VERSION,
+  DiscoveryError,
   discoverSessions,
   type CatalogSession,
+  type CatalogCursor,
+  type SessionCatalogPage,
   type ListCatalogOptions,
   type DiscoverSessionsOptions,
   type DiscoverResult,
@@ -317,7 +325,39 @@ function ensureSessionsSchema(db: Database): void {
     db,
     'CREATE INDEX IF NOT EXISTS idx_sessions_source_last ON sessions(source, last_activity_ms DESC)',
   );
+  // The catalog's total order is (last_activity_ms DESC, source, session_id) —
+  // recency alone ties constantly, since one discovery pass can stamp many
+  // sessions with the same mtime-derived millisecond. These two carry the whole
+  // ORDER BY, so the listing is answered without a sort here as it is natively.
+  tryRun(
+    db,
+    'CREATE INDEX IF NOT EXISTS idx_sessions_recency ON sessions(last_activity_ms DESC, source, session_id)',
+  );
+  tryRun(
+    db,
+    'CREATE INDEX IF NOT EXISTS idx_sessions_source_recency ON sessions(source, last_activity_ms DESC, session_id)',
+  );
   tryRun(db, 'CREATE INDEX IF NOT EXISTS idx_sessions_raw_path ON sessions(source, raw_path)');
+}
+
+/**
+ * Mirror the discovery bookkeeping table.
+ *
+ * Shallow discovery records here that a given source was examined at a given
+ * stamp and found not to be a session (a subagent sidecar, say), so a rescan
+ * costs a primary-key lookup instead of a re-read. The SDK never reads it; the
+ * table is created so an in-memory copy has the same shape as the file the
+ * native tool writes.
+ */
+function ensureDiscoverySkipsSchema(db: Database): void {
+  db.run(`CREATE TABLE IF NOT EXISTS discovery_skips (
+    source TEXT NOT NULL,
+    locator TEXT NOT NULL,
+    stamp TEXT NOT NULL,
+    reason TEXT,
+    updated_ms INTEGER,
+    PRIMARY KEY (source, locator)
+  )`);
 }
 
 function ensureTrajectorySchema(db: Database): void {
@@ -410,6 +450,7 @@ export async function openAiHist(opts: OpenOptions = {}): Promise<AiHist> {
     ensureTrajectorySchema(db);
     ensureTagSchema(db);
     ensureSessionsSchema(db);
+    ensureDiscoverySkipsSchema(db);
     // Add git_branch to history if missing (pre-handoff DBs lack this column).
     try { db.run('ALTER TABLE history ADD COLUMN git_branch TEXT'); } catch { /* already exists */ }
     // Older database schemas don't contain `idx_history_session` or
@@ -452,6 +493,7 @@ export async function openAiHist(opts: OpenOptions = {}): Promise<AiHist> {
   ensureTrajectorySchema(db);
   ensureTagSchema(db);
   ensureSessionsSchema(db);
+  ensureDiscoverySkipsSchema(db);
 
   // scanLocalSources is async with yields between sources so the event
   // loop stays responsive while we scan many MB of JSONL.
@@ -1126,13 +1168,17 @@ export class AiHist {
    * Details worth knowing:
    *   - `trajectory` rows are excluded defensively — trajectories are derived
    *     records, not sessions, and must never appear in a session list.
-   *   - Ordering is `last_activity_ms` descending, with rows that have no
-   *     timestamp last, then `source` and `session_id` so pagination is
-   *     stable across pages.
-   *   - `beforeMs` is a keyset cursor: pass the `lastActivityMs` of the last
-   *     row of the previous page. Rows with a null timestamp never come back
-   *     from a `beforeMs` query (`NULL < x` is unknown), which is what keyset
-   *     pagination wants.
+   *   - The catalog's total order is
+   *     `(last_activity_ms DESC, source ASC, session_id ASC)`. SQLite sorts
+   *     NULL lowest, so rows of unknown recency land last under `DESC` without
+   *     a helper expression. Recency alone is not a key: one discovery pass can
+   *     stamp many sessions with the same mtime-derived millisecond, which is
+   *     why the identity columns are part of the order.
+   *   - To page, use {@link AiHist.listSessionCatalogPage} and follow its
+   *     `nextCursor`. `beforeMs` is only a *coarse* cutoff ("anything before
+   *     last Tuesday"): it cannot separate rows sharing a millisecond, so a
+   *     walk built on it drops every row tied with a page boundary. It is
+   *     ignored when `after` is set.
    *   - A configured `projectScope` constrains rows by `cwd`, like
    *     `getHandoff`. Sources with no working directory (relay) therefore drop
    *     out of a scoped listing.
@@ -1142,6 +1188,11 @@ export class AiHist {
    */
   listSessionCatalog(opts: ListCatalogOptions = {}): CatalogSession[] {
     if (!tableExists(this.db, 'sessions')) return [];
+    // SQLite reads a negative LIMIT as "unlimited", so a negative cap would
+    // quietly dump the whole catalog. The native CLI rejects it; so do we.
+    if (typeof opts.limit === 'number' && opts.limit < 0) {
+      throw new RangeError(`limit must not be negative (got ${opts.limit})`);
+    }
     const limit = opts.limit ?? 50;
     const clauses: string[] = ["source != 'trajectory'"];
     const params: unknown[] = [];
@@ -1151,7 +1202,33 @@ export class AiHist {
       clauses.push(`source IN (${sources.map(() => '?').join(', ')})`);
       params.push(...sources);
     }
-    if (typeof opts.beforeMs === 'number') {
+    if (opts.after) {
+      // Everything strictly after the cursor in the catalog's total order.
+      // Undated rows sort last, so a dated cursor must still reach them.
+      const { lastActivityMs, source, sessionId } = opts.after;
+      // A timestamp alone is not a cursor: without the identity columns the
+      // predicate cannot separate rows sharing a millisecond, and silently
+      // dropping the cursor would restart the walk at page one. The native CLI
+      // rejects the same half-cursor; so does this, rather than looping.
+      if (typeof source !== 'string' || source.length === 0 || typeof sessionId !== 'string' || sessionId.length === 0) {
+        throw new TypeError(
+          'after must carry both source and sessionId — pass the whole nextCursor object from the previous page',
+        );
+      }
+      if (typeof lastActivityMs === 'number') {
+        clauses.push(
+          `(last_activity_ms IS NULL OR last_activity_ms < ?
+             OR (last_activity_ms = ?
+                 AND (source > ? OR (source = ? AND session_id > ?))))`,
+        );
+        params.push(lastActivityMs, lastActivityMs, source, source, sessionId);
+      } else {
+        clauses.push(
+          `last_activity_ms IS NULL AND (source > ? OR (source = ? AND session_id > ?))`,
+        );
+        params.push(source, source, sessionId);
+      }
+    } else if (typeof opts.beforeMs === 'number') {
       clauses.push('last_activity_ms < ?');
       params.push(opts.beforeMs);
     }
@@ -1169,10 +1246,30 @@ export class AiHist {
               discovery_state, parser_version
        FROM sessions
        WHERE ${clauses.join(' AND ')}
-       ORDER BY last_activity_ms IS NULL, last_activity_ms DESC, source ASC, session_id ASC
+       ORDER BY last_activity_ms DESC, source ASC, session_id ASC
        LIMIT ?`,
       [...params, limit],
     ).map((row) => catalogSessionFromJson({ ...row, from_cache: true }));
+  }
+
+  /**
+   * {@link AiHist.listSessionCatalog} plus the cursor that continues it.
+   *
+   * Follow `nextCursor` until it comes back `null` to walk the whole catalog:
+   * no skipped and no duplicated rows, even when a whole page shares one
+   * millisecond, and the undated tail stays reachable from a dated cursor.
+   * `nextCursor` is non-null only when the page filled its limit, mirroring
+   * the native `list_session_catalog_page` and the CLI's `next_cursor`.
+   */
+  listSessionCatalogPage(opts: ListCatalogOptions = {}): SessionCatalogPage {
+    const sessions = this.listSessionCatalog(opts);
+    const limit = opts.limit ?? 50;
+    const last = sessions[sessions.length - 1];
+    const nextCursor =
+      limit > 0 && sessions.length >= limit && last
+        ? { lastActivityMs: last.lastActivityMs, source: last.source, sessionId: last.sessionId }
+        : null;
+    return { sessions, nextCursor };
   }
 
   /** All prompts in a session, ordered oldest → newest. */

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -13,7 +13,14 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { resolve } from "node:path";
 import { z } from "zod";
-import { openAiHist, resumeCommand, type AiHist, type TrajectoryEntry, type HandoffCandidate } from "./index.js";
+import {
+  openAiHist,
+  resumeCommand,
+  SESSION_CATALOG_CONTRACT_VERSION,
+  type AiHist,
+  type TrajectoryEntry,
+  type HandoffCandidate,
+} from "./index.js";
 import { formatPairWarnings, pairCheck } from "./pair-client.js";
 
 // ---------------------------------------------------------------------------
@@ -105,6 +112,9 @@ const READ_ONLY = { readOnlyHint: true, idempotentHint: true, openWorldHint: fal
 const WRITE_LOCAL = { readOnlyHint: false, idempotentHint: true, openWorldHint: false } as const;
 const REMOTE_READ_ONLY = { readOnlyHint: true, idempotentHint: true, openWorldHint: true } as const;
 const SOURCE_SCHEMA = z.enum(["claude", "codex", "cursor", "grok", "relay", "trajectory", "opencode"]);
+// The session catalog holds provider sessions only: trajectories are derived
+// records and never appear in a session listing.
+const CATALOG_SOURCE_SCHEMA = z.enum(["claude", "codex", "cursor", "grok", "relay", "opencode"]);
 
 // ---------------------------------------------------------------------------
 // Server
@@ -148,6 +158,12 @@ Grok, OpenCode, Agent Relay, and trajectories — all searchable in a single ind
 
 - **recent_history** — Browse what was worked on recently across all agents, or
   filter by source and project.
+
+- **list_sessions** — List sessions from the local session catalog, newest first:
+  source, session_id, cwd, git branch, first/last activity, first prompt, models,
+  and discovery_state. Cache-only — it reads one indexed table and never opens a
+  transcript, so prefer it over recent_history when the question is "which sessions
+  exist?" rather than "which prompts mention X?".
 
 - **pack_evidence** — Assemble a concise, token-budget-aware summary of the most
   relevant past sessions before starting a new task. Each entry includes a resume
@@ -439,6 +455,68 @@ server.tool(
         lines.push(`[${dt}] #${e.id}\n${e.prompt}`);
       }
       return { content: [{ type: "text", text: lines.join("\n\n") }] };
+    } catch (err) {
+      return { content: [{ type: "text", text: `Error: ${String(err)}` }], isError: true };
+    }
+  },
+);
+
+server.tool(
+  "list_sessions",
+  "List coding-agent sessions from the local session catalog, newest first. " +
+    "This is a cache-only read of the `sessions` table: it never opens a provider " +
+    "transcript and never scans prompt history, so it is the cheapest way to answer " +
+    '"what sessions exist?" or "what was I working on in this repo?". Each row carries ' +
+    "source, session_id, cwd, git branch, first/last activity, the first prompt, observed " +
+    "models, originator, agent version, repo identity, and discovery_state ('shallow' = " +
+    "catalog metadata only, 'full' = transcript ingested). Populate or refresh the catalog " +
+    "with `ai-hist sessions discover`; run `ai-hist sync` for full transcripts. Trajectories " +
+    "are not sessions and never appear here — use search_trajectories for those.",
+  {
+    sources: z
+      .array(CATALOG_SOURCE_SCHEMA)
+      .optional()
+      .describe("Restrict to these agent sources. Omit for every source in the catalog."),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(200)
+      .optional()
+      .default(20)
+      .describe("Maximum number of sessions to return. Default: 20."),
+    before_ms: z
+      .number()
+      .int()
+      .optional()
+      .describe(
+        "Keyset pagination cursor: only sessions whose last activity is strictly older than " +
+          "this epoch-ms value. Pass the last_activity_ms of the final row of the previous page.",
+      ),
+  },
+  READ_ONLY,
+  async ({ sources, limit, before_ms }) => {
+    try {
+      const hist = await getHist();
+      const sessions = hist.listSessionCatalog({ sources, limit, beforeMs: before_ms });
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                contractVersion: SESSION_CATALOG_CONTRACT_VERSION,
+                sessions,
+                sourceKind: hist.sourceKind,
+                dbPath: hist.dbPath,
+                projectScope: hist.projectScope,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
     } catch (err) {
       return { content: [{ type: "text", text: `Error: ${String(err)}` }], isError: true };
     }

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -11,9 +11,11 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { z } from "zod";
 import {
+  defaultDbPath,
   openAiHist,
   resumeCommand,
   SESSION_CATALOG_CONTRACT_VERSION,
@@ -65,6 +67,21 @@ function getHist(): Promise<AiHist> {
     });
   }
   return _histPromise;
+}
+
+/**
+ * The reader for a catalog read, or `null` when there is nothing to read.
+ *
+ * The session catalog lives only in the SQLite database: the JSONL fallback
+ * scan builds prompt history and never writes a catalog row. So when no
+ * database exists, opening the reader would walk every local provider file —
+ * seconds of I/O — only to answer with an empty catalog. Short-circuit instead,
+ * unless another tool has already paid for the reader, in which case reuse it.
+ */
+async function getCatalogHist(): Promise<AiHist | null> {
+  if (_histPromise) return getHist();
+  if (!existsSync(defaultDbPath())) return null;
+  return getHist();
 }
 
 function fmtEntry(
@@ -490,15 +507,60 @@ server.tool(
       .int()
       .optional()
       .describe(
-        "Keyset pagination cursor: only sessions whose last activity is strictly older than " +
-          "this epoch-ms value. Pass the last_activity_ms of the final row of the previous page.",
+        "Coarse cutoff: only sessions whose last activity is strictly older than this epoch-ms " +
+          "value. It cannot separate sessions that share a millisecond, so use `after` to page. " +
+          "Ignored when `after` is given.",
+      ),
+    after: z
+      .object({
+        lastActivityMs: z
+          .number()
+          .int()
+          .nullable()
+          .optional()
+          .describe("Null or omitted to continue through sessions whose recency is unknown."),
+        source: z.string(),
+        sessionId: z.string(),
+      })
+      .optional()
+      .describe(
+        "Precise pagination cursor: pass back the `nextCursor` object from the previous call. " +
+          "Keep calling until nextCursor is null to walk the whole catalog with no skipped or " +
+          "repeated sessions, even when many share one timestamp.",
       ),
   },
   READ_ONLY,
-  async ({ sources, limit, before_ms }) => {
+  async ({ sources, limit, before_ms, after }) => {
     try {
-      const hist = await getHist();
-      const sessions = hist.listSessionCatalog({ sources, limit, beforeMs: before_ms });
+      const hist = await getCatalogHist();
+      // No database yet: the catalog lives only in SQLite, so this is an empty
+      // answer rather than a reason to scan every provider file.
+      if (!hist) {
+        const dbPath = defaultDbPath();
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  contractVersion: SESSION_CATALOG_CONTRACT_VERSION,
+                  sessions: [],
+                  nextCursor: null,
+                  sourceKind: "none",
+                  dbPath,
+                  note:
+                    `No ai-hist database at ${dbPath}. The session catalog is empty until ` +
+                    "`ai-hist sessions discover` (or `ai-hist sync`) writes one — the JSONL " +
+                    "fallback scan only builds prompt history, so other tools still work.",
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+      const page = hist.listSessionCatalogPage({ sources, limit, beforeMs: before_ms, after });
       return {
         content: [
           {
@@ -506,7 +568,8 @@ server.tool(
             text: JSON.stringify(
               {
                 contractVersion: SESSION_CATALOG_CONTRACT_VERSION,
-                sessions,
+                sessions: page.sessions,
+                nextCursor: page.nextCursor,
                 sourceKind: hist.sourceKind,
                 dbPath: hist.dbPath,
                 projectScope: hist.projectScope,

--- a/sdk-ts/src/mcp-smoke.test.ts
+++ b/sdk-ts/src/mcp-smoke.test.ts
@@ -416,6 +416,100 @@ test('MCP server exposes history and trajectory tools over stdio', async () => {
   }
 });
 
+test('list_sessions answers without a database instead of scanning provider files', async () => {
+  // No SQLite database exists, and the catalog only ever lives in one. Opening
+  // the reader here would walk every local provider file to build the JSONL
+  // fallback — seconds of I/O for a guaranteed-empty catalog. The tool must
+  // short-circuit, which shows up as sourceKind "none" rather than "jsonl".
+  const root = await realpath(await mkdtemp(join(tmpdir(), 'ai-hist-mcp-nodb-')));
+  const home = join(root, 'home');
+  await mkdir(home, { recursive: true });
+  const child = spawn(process.execPath, [new URL('./mcp-server.js', import.meta.url).pathname], {
+    cwd: root,
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      AI_HIST_DB: join(root, 'missing.db'),
+      TRAJECTORY_ROOT: join(root, 'missing-trajectories'),
+      OPENCODE_DB: join(root, 'missing-opencode.db'),
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  const stderr: Buffer[] = [];
+  child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+
+  try {
+    const payload = await new Promise<{ sourceKind?: string; sessions?: unknown[]; nextCursor?: unknown; note?: string }>(
+      (resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('timed out waiting for list_sessions')), 10_000);
+        let buffer = '';
+        child.stdout.on('data', (chunk: Buffer) => {
+          buffer += chunk.toString('utf8');
+          while (true) {
+            const marker = buffer.indexOf('\n');
+            if (marker === -1) return;
+            const body = buffer.slice(0, marker).trim();
+            buffer = buffer.slice(marker + 1);
+            if (!body) continue;
+            const message = JSON.parse(body) as {
+              id?: number;
+              result?: { content?: Array<{ type: string; text?: string }> };
+              error?: unknown;
+            };
+            if (message.error) {
+              clearTimeout(timer);
+              reject(new Error(`MCP error: ${JSON.stringify(message.error)}`));
+              return;
+            }
+            if (message.id === 2) {
+              clearTimeout(timer);
+              const text = message.result?.content?.find((item) => item.type === 'text')?.text ?? '{}';
+              resolve(JSON.parse(text));
+              return;
+            }
+          }
+        });
+        child.on('error', (err) => {
+          clearTimeout(timer);
+          reject(err);
+        });
+        child.on('exit', (code) => {
+          if (code !== null && code !== 0) {
+            clearTimeout(timer);
+            reject(new Error(`MCP server exited ${code}: ${Buffer.concat(stderr).toString('utf8')}`));
+          }
+        });
+
+        writeJsonRpc(child.stdin, {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            clientInfo: { name: 'ai-hist-smoke', version: '0.0.0' },
+          },
+        });
+        writeJsonRpc(child.stdin, { jsonrpc: '2.0', method: 'notifications/initialized', params: {} });
+        writeJsonRpc(child.stdin, {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/call',
+          params: { name: 'list_sessions', arguments: {} },
+        });
+      },
+    );
+
+    assert.equal(payload.sourceKind, 'none');
+    assert.deepEqual(payload.sessions, []);
+    assert.equal(payload.nextCursor, null);
+    assert.match(payload.note ?? '', /sessions discover/);
+  } finally {
+    child.kill();
+  }
+});
+
 function writeJsonRpc(stdin: NodeJS.WritableStream, payload: unknown): void {
   stdin.write(`${JSON.stringify(payload)}\n`);
 }

--- a/sdk-ts/src/mcp-smoke.test.ts
+++ b/sdk-ts/src/mcp-smoke.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { execFile, spawn } from 'node:child_process';
 import { mkdtemp, mkdir, realpath, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { test } from 'node:test';
 import initSqlJs from 'sql.js';
 import { openAiHist } from './index.js';
@@ -291,11 +291,20 @@ test('MCP server exposes history and trajectory tools over stdio', async () => {
   child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
 
   try {
-    const { tools, stats } = await new Promise<{ tools: Set<string>; stats: { projectScope?: string } }>((resolve, reject) => {
+    type CatalogPayload = {
+      contractVersion?: number;
+      sessions?: Array<{ sessionId: string; source: string; models: string[]; discoveryState: string }>;
+    };
+    const { tools, stats, catalog } = await new Promise<{
+      tools: Set<string>;
+      stats: { projectScope?: string };
+      catalog: CatalogPayload;
+    }>((resolve, reject) => {
       const timer = setTimeout(() => reject(new Error('timed out waiting for MCP responses')), 5000);
       let buffer = '';
       let tools: Set<string> | null = null;
       let stats: { projectScope?: string } | null = null;
+      let catalog: CatalogPayload | null = null;
 
       child.stdout.on('data', (chunk: Buffer) => {
         buffer += chunk.toString('utf8');
@@ -322,9 +331,13 @@ test('MCP server exposes history and trajectory tools over stdio', async () => {
             const text = message.result?.content?.find((item) => item.type === 'text')?.text ?? '{}';
             stats = JSON.parse(text) as { projectScope?: string };
           }
-          if (tools && stats) {
+          if (message.id === 4) {
+            const text = message.result?.content?.find((item) => item.type === 'text')?.text ?? '{}';
+            catalog = JSON.parse(text) as CatalogPayload;
+          }
+          if (tools && stats && catalog) {
             clearTimeout(timer);
-            resolve({ tools, stats });
+            resolve({ tools, stats, catalog });
           }
         }
       });
@@ -367,6 +380,12 @@ test('MCP server exposes history and trajectory tools over stdio', async () => {
         method: 'tools/call',
         params: { name: 'stats', arguments: {} },
       });
+      writeJsonRpc(child.stdin, {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: { name: 'list_sessions', arguments: { limit: 5 } },
+      });
     });
 
     for (const name of [
@@ -382,10 +401,16 @@ test('MCP server exposes history and trajectory tools over stdio', async () => {
       'why_for_task',
       'get_handoff',
       'pair_check',
+      'list_sessions',
     ]) {
       assert.ok(tools.has(name), `missing MCP tool ${name}`);
     }
     assert.equal(stats.projectScope, root);
+    // The catalog tool serves the sessions table, with trajectories excluded.
+    assert.equal(catalog.contractVersion, 1);
+    assert.deepEqual(catalog.sessions?.map((session) => session.sessionId), ['catalog-codex']);
+    assert.deepEqual(catalog.sessions?.[0]?.models, ['gpt-5.4']);
+    assert.equal(catalog.sessions?.[0]?.discoveryState, 'shallow');
   } finally {
     child.kill();
   }
@@ -418,8 +443,38 @@ async function writeScopeFixtureDb(dbPath: string): Promise<void> {
       last_assistant_text TEXT,
       raw_path TEXT,
       parser_version INTEGER NOT NULL DEFAULT 1,
+      first_prompt TEXT,
+      models_json TEXT,
+      originator TEXT,
+      agent_version TEXT,
+      repo_url TEXT,
+      initial_commit TEXT,
+      workspace_roots_json TEXT,
+      source_stamp TEXT,
+      discovery_state TEXT,
       PRIMARY KEY (session_id, source)
     )`);
+    // Catalog rows live in the database's own directory so a project-scoped
+    // server (the MCP smoke test scopes to that directory) can see them.
+    const sessionCwd = dirname(dbPath);
+    const insertSession = db.prepare(
+      `INSERT INTO sessions (session_id, source, cwd, git_branch, first_activity_ms,
+         last_activity_ms, last_assistant_text, raw_path, parser_version, first_prompt,
+         models_json, discovery_state)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    try {
+      insertSession.run([
+        'catalog-codex', 'codex', sessionCwd, 'main', 1_000, 2_000, null, '/raw/codex.jsonl', 1,
+        'catalog codex prompt', '["gpt-5.4"]', 'shallow',
+      ]);
+      insertSession.run([
+        'catalog-traj', 'trajectory', sessionCwd, null, 9_000, 9_000, null, null, 1,
+        null, null, 'full',
+      ]);
+    } finally {
+      insertSession.free();
+    }
     db.run(`CREATE TABLE trajectories (
       id TEXT PRIMARY KEY,
       version INTEGER,

--- a/sdk-ts/src/session-catalog.test.ts
+++ b/sdk-ts/src/session-catalog.test.ts
@@ -1,16 +1,22 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { promisify } from 'node:util';
 import initSqlJs from 'sql.js';
 import {
   SESSION_CATALOG_CONTRACT_VERSION,
+  DiscoveryError,
   discoverSessions,
   openAiHist,
+  type CatalogCursor,
   type CatalogSession,
 } from './index.js';
+
+const execFileAsync = promisify(execFile);
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -124,8 +130,44 @@ async function writeCatalogDb(dbPath: string): Promise<void> {
   });
 }
 
+/**
+ * A catalog where one discovery pass stamped many sessions with the same
+ * millisecond, plus an undated tail — the shape a recency-only cursor drops
+ * rows from.
+ */
+async function writeTiedCatalogDb(dbPath: string): Promise<void> {
+  await writeDb(dbPath, (db) => {
+    db.run(NEW_SHAPE_DDL);
+    const insert = db.prepare(
+      `INSERT INTO sessions (session_id, source, last_activity_ms, discovery_state)
+       VALUES (?, ?, ?, 'shallow')`,
+    );
+    try {
+      const rows: Array<[string, string, number | null]> = [
+        ['tie-a', 'claude', 2_000],
+        ['tie-b', 'claude', 2_000],
+        ['tie-c', 'codex', 2_000],
+        ['tie-d', 'codex', 2_000],
+        ['old-a', 'claude', 1_000],
+        ['old-b', 'cursor', 1_000],
+        ['undated-a', 'claude', null],
+        ['undated-b', 'codex', null],
+        ['undated-c', 'codex', null],
+      ];
+      for (const row of rows) insert.run(row);
+    } finally {
+      insert.free();
+    }
+  });
+}
+
 function ids(sessions: CatalogSession[]): string[] {
   return sessions.map((session) => session.sessionId);
+}
+
+/** Identity of a row in the catalog's total order. */
+function keys(sessions: CatalogSession[]): string[] {
+  return sessions.map((session) => `${session.source}:${session.sessionId}`);
 }
 
 async function withCatalog(
@@ -224,6 +266,146 @@ test('listSessionCatalog filters by source and limit, and paginates with beforeM
   });
 });
 
+test('listSessionCatalogPage walks tied and undated rows exactly once', async () => {
+  await withCatalog('ai-hist-catalog-page-', writeTiedCatalogDb, async (dbPath) => {
+    const hist = await openAiHist({ dbPath });
+    try {
+      const everything = hist.listSessionCatalog({ limit: 100 });
+      assert.equal(everything.length, 9);
+      // Total order: recency first, then source, then session id; undated last.
+      assert.deepEqual(ids(everything), [
+        'tie-a',
+        'tie-b',
+        'tie-c',
+        'tie-d',
+        'old-a',
+        'old-b',
+        'undated-a',
+        'undated-b',
+        'undated-c',
+      ]);
+
+      // A walk in pages of two must reproduce that list exactly: a page
+      // boundary lands inside a group of tied rows, which is where a
+      // recency-only cursor loses (or repeats) rows.
+      const walked: string[] = [];
+      let after: CatalogCursor | undefined;
+      let pages = 0;
+      for (;;) {
+        const page = hist.listSessionCatalogPage({ limit: 2, after });
+        walked.push(...keys(page.sessions));
+        pages += 1;
+        assert.ok(pages < 20, 'pagination did not terminate');
+        if (!page.nextCursor) break;
+        after = page.nextCursor;
+      }
+      assert.deepEqual(walked, keys(everything));
+      assert.equal(new Set(walked).size, walked.length, 'a row was returned twice');
+      assert.equal(pages, 5); // 2+2+2+2+1
+    } finally {
+      hist.close();
+    }
+  });
+});
+
+test('a dated cursor still reaches the undated tail', async () => {
+  await withCatalog('ai-hist-catalog-tail-', writeTiedCatalogDb, async (dbPath) => {
+    const hist = await openAiHist({ dbPath });
+    try {
+      const fromLastDated = hist.listSessionCatalog({
+        after: { lastActivityMs: 1_000, source: 'cursor', sessionId: 'old-b' },
+      });
+      assert.deepEqual(ids(fromLastDated), ['undated-a', 'undated-b', 'undated-c']);
+
+      // And an undated cursor continues within the tail, by identity alone.
+      const withinTail = hist.listSessionCatalog({
+        after: { lastActivityMs: null, source: 'claude', sessionId: 'undated-a' },
+      });
+      assert.deepEqual(ids(withinTail), ['undated-b', 'undated-c']);
+
+      // A cursor sitting on a tie returns the rest of the tie, not the next
+      // timestamp — the failure mode `before_ms` alone cannot avoid.
+      const midTie = hist.listSessionCatalog({
+        limit: 2,
+        after: { lastActivityMs: 2_000, source: 'claude', sessionId: 'tie-b' },
+      });
+      assert.deepEqual(ids(midTie), ['tie-c', 'tie-d']);
+    } finally {
+      hist.close();
+    }
+  });
+});
+
+test('nextCursor is set only when a page fills its limit', async () => {
+  await withCatalog('ai-hist-catalog-cursor-', writeTiedCatalogDb, async (dbPath) => {
+    const hist = await openAiHist({ dbPath });
+    try {
+      // Short page: the catalog is exhausted, so there is nothing to continue.
+      const short = hist.listSessionCatalogPage({ limit: 50 });
+      assert.equal(short.sessions.length, 9);
+      assert.equal(short.nextCursor, null);
+
+      // Exactly-full page: the cursor is handed out even though the next page
+      // turns out to be empty — the same fill rule the native page uses.
+      const exact = hist.listSessionCatalogPage({ limit: 9 });
+      assert.deepEqual(exact.nextCursor, {
+        lastActivityMs: null,
+        source: 'codex',
+        sessionId: 'undated-c',
+      });
+      const beyond = hist.listSessionCatalogPage({ limit: 9, after: exact.nextCursor! });
+      assert.deepEqual(beyond.sessions, []);
+      assert.equal(beyond.nextCursor, null);
+
+      // The cursor carries the last row of the page, ties included.
+      const first = hist.listSessionCatalogPage({ limit: 2 });
+      assert.deepEqual(first.nextCursor, {
+        lastActivityMs: 2_000,
+        source: 'claude',
+        sessionId: 'tie-b',
+      });
+    } finally {
+      hist.close();
+    }
+  });
+});
+
+test('a negative limit is rejected rather than dumping the catalog', async () => {
+  await withCatalog('ai-hist-catalog-limit-', writeTiedCatalogDb, async (dbPath) => {
+    const hist = await openAiHist({ dbPath });
+    try {
+      assert.throws(() => hist.listSessionCatalog({ limit: -1 }), RangeError);
+      assert.throws(() => hist.listSessionCatalogPage({ limit: -1 }), RangeError);
+    } finally {
+      hist.close();
+    }
+  });
+});
+
+test('a half-built cursor is rejected rather than silently restarting the walk', async () => {
+  await withCatalog('ai-hist-catalog-halfcursor-', writeTiedCatalogDb, async (dbPath) => {
+    const hist = await openAiHist({ dbPath });
+    try {
+      // A timestamp on its own cannot separate tied rows; dropping it would
+      // hand back page one forever.
+      assert.throws(
+        () => hist.listSessionCatalog({ after: { lastActivityMs: 2_000 } as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => hist.listSessionCatalog({ after: { lastActivityMs: 2_000, source: 'claude' } as never }),
+        TypeError,
+      );
+      assert.throws(
+        () => hist.listSessionCatalog({ after: { source: '', sessionId: 'tie-a' } }),
+        TypeError,
+      );
+    } finally {
+      hist.close();
+    }
+  });
+});
+
 test('listSessionCatalog reads a pre-catalog database through the in-memory migration', async () => {
   const writeOld = (dbPath: string) =>
     writeDb(dbPath, (db) => {
@@ -273,28 +455,39 @@ test('a project scope constrains the catalog listing by cwd', async () => {
 });
 
 test('the catalog is empty in JSONL fallback mode', async () => {
+  // The fallback scanner resolves ~/.claude, ~/.codex, ~/.cursor and ~/.grok
+  // from os.homedir() at module load, so overriding HOME inside this process
+  // would come too late and the scan would read the developer's real history.
+  // Run it in a child with an empty HOME instead: fully isolated, and it also
+  // proves the fallback path builds no catalog rather than merely finding none.
   const dir = await mkdtemp(join(tmpdir(), 'ai-hist-catalog-fallback-'));
-  const previousDb = process.env.AI_HIST_DB;
-  const previousTrajectory = process.env.TRAJECTORY_ROOT;
-  const previousOpenCode = process.env.OPENCODE_DB;
-  process.env.AI_HIST_DB = join(dir, 'missing.db');
-  process.env.TRAJECTORY_ROOT = join(dir, 'missing-trajectories');
-  process.env.OPENCODE_DB = join(dir, 'missing-opencode.db');
+  const home = join(dir, 'home');
+  await mkdir(home, { recursive: true });
+  const probe = join(dir, 'probe.mjs');
+  const indexUrl = new URL('./index.js', import.meta.url).href;
+  await writeFile(
+    probe,
+    `import { openAiHist } from ${JSON.stringify(indexUrl)};\n` +
+      `const hist = await openAiHist({ dbPath: process.env.AI_HIST_DB });\n` +
+      `console.log(JSON.stringify({ kind: hist.sourceKind, catalog: hist.listSessionCatalog() }));\n` +
+      `hist.close();\n`,
+  );
   try {
-    const hist = await openAiHist({ dbPath: join(dir, 'missing.db') });
-    try {
-      assert.equal(hist.sourceKind, 'jsonl');
-      assert.deepEqual(hist.listSessionCatalog(), []);
-    } finally {
-      hist.close();
-    }
+    const { stdout } = await execFileAsync(process.execPath, [probe], {
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        AI_HIST_DB: join(dir, 'missing.db'),
+        TRAJECTORY_ROOT: join(dir, 'missing-trajectories'),
+        OPENCODE_DB: join(dir, 'missing-opencode.db'),
+      },
+      timeout: 30_000,
+    });
+    const result = JSON.parse(stdout) as { kind: string; catalog: unknown[] };
+    assert.equal(result.kind, 'jsonl');
+    assert.deepEqual(result.catalog, []);
   } finally {
-    if (previousDb === undefined) delete process.env.AI_HIST_DB;
-    else process.env.AI_HIST_DB = previousDb;
-    if (previousTrajectory === undefined) delete process.env.TRAJECTORY_ROOT;
-    else process.env.TRAJECTORY_ROOT = previousTrajectory;
-    if (previousOpenCode === undefined) delete process.env.OPENCODE_DB;
-    else process.env.OPENCODE_DB = previousOpenCode;
     await rm(dir, { recursive: true, force: true });
   }
 });
@@ -491,17 +684,91 @@ test('discoverSessions rejects with a clear install hint when the binary is miss
   );
 });
 
-test('discoverSessions rejects on a non-zero exit and surfaces stderr', async () => {
-  const { spawnFn } = fakeSpawn({ code: 2, stderr: 'every provider failed' });
+test('discoverSessions rejects on a non-zero exit, carrying the diagnostics and summary', async () => {
+  // Every provider failed: the CLI still writes its diagnostics and the summary
+  // trailer before exiting non-zero, so the error must keep them.
+  const { spawnFn } = fakeSpawn({
+    chunks: [`${DISCOVER_DIAGNOSTIC_LINE}\n${DISCOVER_SUMMARY_LINE}\n`],
+    code: 2,
+    stderr: 'every provider failed',
+  });
   await assert.rejects(
     discoverSessions({ binPath: '/bin/echo', spawnFn }),
-    /ai-hist sessions discover failed \(exit 2\).*every provider failed/,
+    (err: unknown) => {
+      assert.ok(err instanceof DiscoveryError);
+      assert.match(err.message, /ai-hist sessions discover failed \(exit 2\).*every provider failed/);
+      assert.equal(err.exitCode, 2);
+      assert.deepEqual(err.diagnostics.map((d) => d.source), ['grok']);
+      assert.equal(err.summary?.providers.grok?.failed, true);
+      return true;
+    },
   );
 });
 
-test('discoverSessions returns a null summary when the binary emits none', async () => {
+test('discoverSessions rejects when the run produces no summary trailer', async () => {
   const { spawnFn } = fakeSpawn({ chunks: [`${DISCOVER_SESSION_LINE}\n`] });
-  const result = await discoverSessions({ binPath: '/bin/echo', spawnFn });
-  assert.equal(result.summary, null);
-  assert.equal(result.sessions.length, 1);
+  await assert.rejects(
+    discoverSessions({ binPath: '/bin/echo', spawnFn }),
+    /produced no summary line/,
+  );
+});
+
+test('discoverSessions rejects a summary from an unsupported contract version', async () => {
+  const future = JSON.stringify({
+    ...(JSON.parse(DISCOVER_SUMMARY_LINE) as Record<string, unknown>),
+    contract_version: 2,
+  });
+  const { spawnFn } = fakeSpawn({ chunks: [`${DISCOVER_SESSION_LINE}\n${future}\n`] });
+  await assert.rejects(
+    discoverSessions({ binPath: '/bin/echo', spawnFn }),
+    (err: unknown) => {
+      assert.ok(err instanceof DiscoveryError);
+      assert.match(err.message, /unsupported session-catalog contract version 2/);
+      // The rows the run did emit are still on the error's summary.
+      assert.equal(err.summary?.discovered, 1);
+      return true;
+    },
+  );
+
+  // A summary with no contract_version at all is equally unusable.
+  const versionless = JSON.stringify({ type: 'summary', discovered: 0 });
+  const { spawnFn: spawnVersionless } = fakeSpawn({ chunks: [`${versionless}\n`] });
+  await assert.rejects(
+    discoverSessions({ binPath: '/bin/echo', spawnFn: spawnVersionless }),
+    /unsupported session-catalog contract version 0/,
+  );
+});
+
+test('an exception from onSession aborts the run instead of escaping the stream', async () => {
+  const { spawnFn } = fakeSpawn({
+    chunks: [`${DISCOVER_SESSION_LINE}\n${DISCOVER_SUMMARY_LINE}\n`],
+  });
+  const boom = new Error('host render failed');
+  await assert.rejects(
+    discoverSessions({
+      binPath: '/bin/echo',
+      spawnFn,
+      onSession: () => {
+        throw boom;
+      },
+    }),
+    (err: unknown) => err === boom,
+  );
+});
+
+test('an exception from onDiagnostic aborts the run too', async () => {
+  const { spawnFn } = fakeSpawn({
+    chunks: [`${DISCOVER_DIAGNOSTIC_LINE}\n${DISCOVER_SUMMARY_LINE}\n`],
+  });
+  const boom = new Error('host logger failed');
+  await assert.rejects(
+    discoverSessions({
+      binPath: '/bin/echo',
+      spawnFn,
+      onDiagnostic: () => {
+        throw boom;
+      },
+    }),
+    (err: unknown) => err === boom,
+  );
 });

--- a/sdk-ts/src/session-catalog.test.ts
+++ b/sdk-ts/src/session-catalog.test.ts
@@ -1,0 +1,507 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import initSqlJs from 'sql.js';
+import {
+  SESSION_CATALOG_CONTRACT_VERSION,
+  discoverSessions,
+  openAiHist,
+  type CatalogSession,
+} from './index.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NEW_SHAPE_DDL = `CREATE TABLE sessions (
+  session_id TEXT NOT NULL,
+  source TEXT NOT NULL,
+  cwd TEXT,
+  git_branch TEXT,
+  first_activity_ms INTEGER,
+  last_activity_ms INTEGER,
+  last_assistant_text TEXT,
+  raw_path TEXT,
+  parser_version INTEGER NOT NULL DEFAULT 1,
+  first_prompt TEXT,
+  models_json TEXT,
+  originator TEXT,
+  agent_version TEXT,
+  repo_url TEXT,
+  initial_commit TEXT,
+  workspace_roots_json TEXT,
+  source_stamp TEXT,
+  discovery_state TEXT,
+  PRIMARY KEY (session_id, source)
+)`;
+
+/** The pre-catalog `sessions` table, as an ai-hist 0.5.0 database has it. */
+const OLD_SHAPE_DDL = `CREATE TABLE sessions (
+  session_id TEXT NOT NULL,
+  source TEXT NOT NULL,
+  cwd TEXT,
+  git_branch TEXT,
+  first_activity_ms INTEGER,
+  last_activity_ms INTEGER,
+  last_assistant_text TEXT,
+  raw_path TEXT,
+  parser_version INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (session_id, source)
+)`;
+
+const HISTORY_DDL = `CREATE TABLE history (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source TEXT NOT NULL,
+  session_id TEXT,
+  project TEXT,
+  prompt TEXT NOT NULL,
+  timestamp_ms INTEGER NOT NULL,
+  git_branch TEXT
+)`;
+
+async function writeDb(dbPath: string, build: (db: import('sql.js').Database) => void): Promise<void> {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  try {
+    db.run(HISTORY_DDL);
+    build(db);
+    await writeFile(dbPath, Buffer.from(db.export()));
+  } finally {
+    db.close();
+  }
+}
+
+/** A catalog covering every quirk the native contract calls out. */
+async function writeCatalogDb(dbPath: string): Promise<void> {
+  await writeDb(dbPath, (db) => {
+    db.run(NEW_SHAPE_DDL);
+    const insert = db.prepare(
+      `INSERT INTO sessions (session_id, source, cwd, git_branch, first_activity_ms,
+         last_activity_ms, last_assistant_text, raw_path, parser_version, first_prompt,
+         models_json, originator, agent_version, repo_url, initial_commit,
+         workspace_roots_json, source_stamp, discovery_state)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    try {
+      // Newest. Fully ingested, with models and workspace roots.
+      insert.run([
+        'codex-1', 'codex', '/work/api', 'dev', 3_000, 5_000, 'done', '/raw/codex-1.jsonl', 2,
+        'add a retry', '["gpt-5.4","gpt-5.4-mini"]', 'codex_cli_rs', '0.148.0',
+        'git@github.com:acme/api.git', 'abc123', '["/work/api","/work/shared"]',
+        'v1:mtime-1', 'full',
+      ]);
+      // Shallow-only: no last_assistant_text, no models.
+      insert.run([
+        'claude-1', 'claude', '/work/app', 'main', 1_000, 4_000, null, '/raw/claude-1.jsonl', 1,
+        'first human prompt', null, null, '1.2.3', null, null, null, 'v1:mtime-2', 'shallow',
+      ]);
+      // Cursor: never a first_activity_ms; last_activity_ms is mtime-derived.
+      insert.run([
+        'cursor-1', 'cursor', '/work/app', null, null, 2_000, null, '/raw/cursor-1.db', 1,
+        null, 'not json at all', null, null, null, null, null, 'v1:mtime-3', 'shallow',
+      ]);
+      // Relay: no cwd, and a legacy NULL discovery_state.
+      insert.run([
+        'relay-1', 'relay', null, null, 500, 1_000, 'relay reply', null, 1,
+        'relay thread', null, null, null, null, null, null, null, null,
+      ]);
+      // No timestamps at all — must sort last, and must not surface via beforeMs.
+      insert.run([
+        'grok-1', 'grok', '/work/app', null, null, null, null, null, 1,
+        null, null, null, null, null, null, null, null, 'shallow',
+      ]);
+      // Trajectories are derived records, not sessions: never listed.
+      insert.run([
+        'traj-1', 'trajectory', '/work/app', null, 9_000, 9_000, null, null, 1,
+        null, null, null, null, null, null, null, null, 'full',
+      ]);
+    } finally {
+      insert.free();
+    }
+  });
+}
+
+function ids(sessions: CatalogSession[]): string[] {
+  return sessions.map((session) => session.sessionId);
+}
+
+async function withCatalog(
+  prefix: string,
+  write: (dbPath: string) => Promise<void>,
+  body: (dbPath: string) => Promise<void>,
+): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  const dbPath = join(dir, 'history.db');
+  try {
+    await write(dbPath);
+    await body(dbPath);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// listSessionCatalog
+// ---------------------------------------------------------------------------
+
+test('listSessionCatalog orders by recency, excludes trajectories, and parses JSON columns', async () => {
+  await withCatalog('ai-hist-catalog-', writeCatalogDb, async (dbPath) => {
+    const hist = await openAiHist({ dbPath });
+    try {
+      const rows = hist.listSessionCatalog();
+      assert.deepEqual(ids(rows), ['codex-1', 'claude-1', 'cursor-1', 'relay-1', 'grok-1']);
+      assert.ok(!rows.some((row) => row.source === 'trajectory'));
+
+      const codex = rows[0]!;
+      assert.deepEqual(codex, {
+        source: 'codex',
+        sessionId: 'codex-1',
+        cwd: '/work/api',
+        gitBranch: 'dev',
+        firstActivityMs: 3_000,
+        lastActivityMs: 5_000,
+        firstPrompt: 'add a retry',
+        lastAssistantText: 'done',
+        models: ['gpt-5.4', 'gpt-5.4-mini'],
+        originator: 'codex_cli_rs',
+        agentVersion: '0.148.0',
+        repoUrl: 'git@github.com:acme/api.git',
+        initialCommit: 'abc123',
+        workspaceRoots: ['/work/api', '/work/shared'],
+        rawPath: '/raw/codex-1.jsonl',
+        sourceStamp: 'v1:mtime-1',
+        discoveryState: 'full',
+        fromCache: true,
+        parserVersion: 2,
+      });
+
+      // NULL and malformed JSON columns both mean "nothing observed".
+      const claude = rows[1]!;
+      assert.deepEqual(claude.models, []);
+      assert.deepEqual(claude.workspaceRoots, []);
+      assert.equal(claude.lastAssistantText, null);
+      assert.equal(claude.discoveryState, 'shallow');
+      assert.deepEqual(rows[2]!.models, []);
+
+      // Provider quirks: cursor has no first activity, relay has no cwd.
+      assert.equal(rows[2]!.firstActivityMs, null);
+      assert.equal(rows[3]!.cwd, null);
+      // A NULL discovery_state predates the catalog and reads as 'full'.
+      assert.equal(rows[3]!.discoveryState, 'full');
+      // Rows with no last activity sort last.
+      assert.equal(rows[4]!.lastActivityMs, null);
+    } finally {
+      hist.close();
+    }
+  });
+});
+
+test('listSessionCatalog filters by source and limit, and paginates with beforeMs', async () => {
+  await withCatalog('ai-hist-catalog-filter-', writeCatalogDb, async (dbPath) => {
+    const hist = await openAiHist({ dbPath });
+    try {
+      assert.deepEqual(ids(hist.listSessionCatalog({ sources: ['claude'] })), ['claude-1']);
+      assert.deepEqual(ids(hist.listSessionCatalog({ sources: ['claude', 'codex'] })), [
+        'codex-1',
+        'claude-1',
+      ]);
+      // A trajectory filter cannot smuggle trajectory rows back in.
+      assert.deepEqual(hist.listSessionCatalog({ sources: ['trajectory'] }), []);
+
+      assert.deepEqual(ids(hist.listSessionCatalog({ limit: 2 })), ['codex-1', 'claude-1']);
+
+      const page1 = hist.listSessionCatalog({ limit: 2 });
+      const page2 = hist.listSessionCatalog({ limit: 2, beforeMs: page1[1]!.lastActivityMs! });
+      assert.deepEqual(ids(page2), ['cursor-1', 'relay-1']);
+      // Keyset pagination never resurfaces null-timestamp rows.
+      assert.deepEqual(ids(hist.listSessionCatalog({ beforeMs: 1_000 })), []);
+    } finally {
+      hist.close();
+    }
+  });
+});
+
+test('listSessionCatalog reads a pre-catalog database through the in-memory migration', async () => {
+  const writeOld = (dbPath: string) =>
+    writeDb(dbPath, (db) => {
+      db.run(OLD_SHAPE_DDL);
+      db.run(
+        `INSERT INTO sessions (session_id, source, cwd, git_branch, first_activity_ms,
+           last_activity_ms, last_assistant_text, raw_path, parser_version)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ['legacy-1', 'claude', '/work/app', 'main', 1_000, 2_000, 'older reply', '/raw/legacy.jsonl', 1],
+      );
+    });
+
+  await withCatalog('ai-hist-catalog-legacy-', writeOld, async (dbPath) => {
+    const hist = await openAiHist({ dbPath });
+    try {
+      const rows = hist.listSessionCatalog();
+      assert.equal(rows.length, 1);
+      const row = rows[0]!;
+      // Old columns still read.
+      assert.equal(row.sessionId, 'legacy-1');
+      assert.equal(row.cwd, '/work/app');
+      assert.equal(row.lastAssistantText, 'older reply');
+      // Columns the ALTER added exist and read as "nothing observed".
+      assert.equal(row.firstPrompt, null);
+      assert.equal(row.originator, null);
+      assert.deepEqual(row.models, []);
+      assert.deepEqual(row.workspaceRoots, []);
+      assert.equal(row.sourceStamp, null);
+      // A row written before discovery existed is a fully ingested row.
+      assert.equal(row.discoveryState, 'full');
+    } finally {
+      hist.close();
+    }
+  });
+});
+
+test('a project scope constrains the catalog listing by cwd', async () => {
+  await withCatalog('ai-hist-catalog-scope-', writeCatalogDb, async (dbPath) => {
+    const scoped = await openAiHist({ dbPath, projectScope: '/work/app' });
+    try {
+      // /work/api is outside the scope; relay has no cwd, so it drops out too.
+      assert.deepEqual(ids(scoped.listSessionCatalog()), ['claude-1', 'cursor-1', 'grok-1']);
+    } finally {
+      scoped.close();
+    }
+  });
+});
+
+test('the catalog is empty in JSONL fallback mode', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'ai-hist-catalog-fallback-'));
+  const previousDb = process.env.AI_HIST_DB;
+  const previousTrajectory = process.env.TRAJECTORY_ROOT;
+  const previousOpenCode = process.env.OPENCODE_DB;
+  process.env.AI_HIST_DB = join(dir, 'missing.db');
+  process.env.TRAJECTORY_ROOT = join(dir, 'missing-trajectories');
+  process.env.OPENCODE_DB = join(dir, 'missing-opencode.db');
+  try {
+    const hist = await openAiHist({ dbPath: join(dir, 'missing.db') });
+    try {
+      assert.equal(hist.sourceKind, 'jsonl');
+      assert.deepEqual(hist.listSessionCatalog(), []);
+    } finally {
+      hist.close();
+    }
+  } finally {
+    if (previousDb === undefined) delete process.env.AI_HIST_DB;
+    else process.env.AI_HIST_DB = previousDb;
+    if (previousTrajectory === undefined) delete process.env.TRAJECTORY_ROOT;
+    else process.env.TRAJECTORY_ROOT = previousTrajectory;
+    if (previousOpenCode === undefined) delete process.env.OPENCODE_DB;
+    else process.env.OPENCODE_DB = previousOpenCode;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// discoverSessions
+// ---------------------------------------------------------------------------
+
+/** Minimal fake child process that scripts stdout/stderr/exit for one run. */
+function fakeSpawn(script: { chunks?: string[]; stderr?: string; code?: number; errorCode?: string }) {
+  const calls: Array<{ bin: string; args: string[] }> = [];
+  const spawnFn = ((bin: string, args: string[]) => {
+    calls.push({ bin, args });
+    const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    setImmediate(() => {
+      if (script.errorCode) {
+        const err = new Error('spawn failed') as NodeJS.ErrnoException;
+        err.code = script.errorCode;
+        child.emit('error', err);
+        return;
+      }
+      for (const chunk of script.chunks ?? []) child.stdout.emit('data', Buffer.from(chunk, 'utf8'));
+      if (script.stderr) child.stderr.emit('data', script.stderr);
+      child.emit('close', script.code ?? 0);
+    });
+    return child;
+  }) as unknown as typeof import('node:child_process').spawn;
+  return { spawnFn, calls };
+}
+
+const DISCOVER_SESSION_LINE = JSON.stringify({
+  type: 'session',
+  source: 'codex',
+  session_id: 'codex-cli',
+  cwd: '/work/api',
+  git_branch: 'dev',
+  first_activity_ms: 1_000,
+  last_activity_ms: 2_000,
+  first_prompt: 'add a retry',
+  last_assistant_text: null,
+  models: ['gpt-5.4'],
+  originator: 'codex_cli_rs',
+  agent_version: '0.148.0',
+  repo_url: null,
+  initial_commit: null,
+  workspace_roots: [],
+  raw_path: '/raw/codex.jsonl',
+  source_stamp: 'v1:stamp',
+  discovery_state: 'shallow',
+  from_cache: false,
+});
+
+const DISCOVER_SUMMARY_LINE = JSON.stringify({
+  type: 'summary',
+  contract_version: 1,
+  discovered: 1,
+  skipped_unchanged: 1,
+  providers: {
+    codex: { candidates: 2, discovered: 1, skipped_unchanged: 1, failed: false },
+    grok: { candidates: 0, discovered: 0, skipped_unchanged: 0, failed: true },
+  },
+  exempt_sources: [{ source: 'trajectory', reason: 'derived trajectory records, not provider sessions' }],
+  counters: {
+    candidates_enumerated: 2,
+    shallow_reads: 1,
+    skipped_unchanged: 1,
+    files_opened: 1,
+    bytes_read: 4096,
+  },
+});
+
+const DISCOVER_DIAGNOSTIC_LINE = JSON.stringify({
+  type: 'diagnostic',
+  source: 'grok',
+  locator: '/raw/broken.json',
+  error: 'unreadable',
+});
+
+test('discoverSessions parses the JSONL stream into sessions, diagnostics, and a summary', async () => {
+  // Split mid-line so the incremental line buffering is exercised.
+  const stream = `${DISCOVER_SESSION_LINE}\n${DISCOVER_DIAGNOSTIC_LINE}\n${DISCOVER_SUMMARY_LINE}\n`;
+  const split = Math.floor(DISCOVER_SESSION_LINE.length / 2);
+  const { spawnFn, calls } = fakeSpawn({ chunks: [stream.slice(0, split), stream.slice(split)] });
+
+  const streamed: string[] = [];
+  const result = await discoverSessions({
+    binPath: '/bin/echo',
+    spawnFn,
+    sources: ['codex', 'grok'],
+    limit: 5,
+    onSession: (session) => streamed.push(session.sessionId),
+  });
+
+  assert.deepEqual(calls[0]!.args, [
+    'sessions',
+    'discover',
+    '--json',
+    '--source',
+    'codex',
+    '--source',
+    'grok',
+    '--limit',
+    '5',
+  ]);
+  assert.deepEqual(streamed, ['codex-cli']);
+  assert.equal(result.sessions.length, 1);
+  assert.deepEqual(result.sessions[0], {
+    source: 'codex',
+    sessionId: 'codex-cli',
+    cwd: '/work/api',
+    gitBranch: 'dev',
+    firstActivityMs: 1_000,
+    lastActivityMs: 2_000,
+    firstPrompt: 'add a retry',
+    lastAssistantText: null,
+    models: ['gpt-5.4'],
+    originator: 'codex_cli_rs',
+    agentVersion: '0.148.0',
+    repoUrl: null,
+    initialCommit: null,
+    workspaceRoots: [],
+    rawPath: '/raw/codex.jsonl',
+    sourceStamp: 'v1:stamp',
+    discoveryState: 'shallow',
+    fromCache: false,
+  });
+  assert.deepEqual(result.diagnostics, [
+    { source: 'grok', locator: '/raw/broken.json', error: 'unreadable' },
+  ]);
+  assert.equal(result.summary?.contractVersion, SESSION_CATALOG_CONTRACT_VERSION);
+  assert.equal(result.summary?.discovered, 1);
+  assert.equal(result.summary?.skippedUnchanged, 1);
+  assert.deepEqual(result.summary?.providers.codex, {
+    candidates: 2,
+    discovered: 1,
+    skippedUnchanged: 1,
+    failed: false,
+  });
+  assert.equal(result.summary?.providers.grok?.failed, true);
+  assert.deepEqual(result.summary?.exemptSources, [
+    { source: 'trajectory', reason: 'derived trajectory records, not provider sessions' },
+  ]);
+  assert.deepEqual(result.summary?.counters, {
+    candidatesEnumerated: 2,
+    shallowReads: 1,
+    skippedUnchanged: 1,
+    filesOpened: 1,
+    bytesRead: 4096,
+  });
+});
+
+test('discoverSessions skips unparseable and unknown lines instead of failing', async () => {
+  const { spawnFn, calls } = fakeSpawn({
+    chunks: [
+      `{ truncated\n`,
+      `${JSON.stringify({ type: 'future_line_type', hello: 'world' })}\n`,
+      `\n`,
+      // No trailing newline: the last line still has to be parsed on close.
+      `${DISCOVER_SESSION_LINE}\n${DISCOVER_SUMMARY_LINE}`,
+    ],
+  });
+  const result = await discoverSessions({ binPath: '/bin/echo', spawnFn });
+  assert.deepEqual(calls[0]!.args, ['sessions', 'discover', '--json']);
+  assert.deepEqual(
+    result.sessions.map((session) => session.sessionId),
+    ['codex-cli'],
+  );
+  assert.equal(result.summary?.discovered, 1);
+});
+
+test('discoverSessions resolves with diagnostics when a provider fails but the run exits 0', async () => {
+  const { spawnFn } = fakeSpawn({
+    chunks: [`${DISCOVER_DIAGNOSTIC_LINE}\n${DISCOVER_SUMMARY_LINE}\n`],
+    code: 0,
+  });
+  const seen: string[] = [];
+  const result = await discoverSessions({
+    binPath: '/bin/echo',
+    spawnFn,
+    onDiagnostic: (diagnostic) => seen.push(diagnostic.source),
+  });
+  assert.deepEqual(result.sessions, []);
+  assert.deepEqual(seen, ['grok']);
+  assert.equal(result.summary?.providers.grok?.failed, true);
+});
+
+test('discoverSessions rejects with a clear install hint when the binary is missing', async () => {
+  const { spawnFn } = fakeSpawn({ errorCode: 'ENOENT' });
+  await assert.rejects(
+    discoverSessions({ binPath: '/nope/ai-hist', spawnFn }),
+    /could not run the ai-hist binary.*AI_HIST_RUST_BIN/s,
+  );
+});
+
+test('discoverSessions rejects on a non-zero exit and surfaces stderr', async () => {
+  const { spawnFn } = fakeSpawn({ code: 2, stderr: 'every provider failed' });
+  await assert.rejects(
+    discoverSessions({ binPath: '/bin/echo', spawnFn }),
+    /ai-hist sessions discover failed \(exit 2\).*every provider failed/,
+  );
+});
+
+test('discoverSessions returns a null summary when the binary emits none', async () => {
+  const { spawnFn } = fakeSpawn({ chunks: [`${DISCOVER_SESSION_LINE}\n`] });
+  const result = await discoverSessions({ binPath: '/bin/echo', spawnFn });
+  assert.equal(result.summary, null);
+  assert.equal(result.sessions.length, 1);
+});

--- a/sdk-ts/src/session-catalog.test.ts
+++ b/sdk-ts/src/session-catalog.test.ts
@@ -496,14 +496,31 @@ test('the catalog is empty in JSONL fallback mode', async () => {
 // discoverSessions
 // ---------------------------------------------------------------------------
 
-/** Minimal fake child process that scripts stdout/stderr/exit for one run. */
+/**
+ * Minimal fake child process that scripts stdout/stderr/exit for one run.
+ *
+ * `kill` is real rather than absent: an aborted run has to actually stop the
+ * child, and a fake without the method would swallow `child.kill?.()` as a
+ * no-op, so the abort tests would keep passing if the implementation quietly
+ * stopped killing it. Recorded in `kills`, and a killed child stops producing
+ * output the way a real one does.
+ */
 function fakeSpawn(script: { chunks?: string[]; stderr?: string; code?: number; errorCode?: string }) {
   const calls: Array<{ bin: string; args: string[] }> = [];
+  const kills: Array<NodeJS.Signals | number | undefined> = [];
   const spawnFn = ((bin: string, args: string[]) => {
     calls.push({ bin, args });
-    const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: (signal?: NodeJS.Signals | number) => boolean;
+    };
     child.stdout = new EventEmitter();
     child.stderr = new EventEmitter();
+    child.kill = (signal?: NodeJS.Signals | number) => {
+      kills.push(signal);
+      return true;
+    };
     setImmediate(() => {
       if (script.errorCode) {
         const err = new Error('spawn failed') as NodeJS.ErrnoException;
@@ -511,13 +528,16 @@ function fakeSpawn(script: { chunks?: string[]; stderr?: string; code?: number; 
         child.emit('error', err);
         return;
       }
-      for (const chunk of script.chunks ?? []) child.stdout.emit('data', Buffer.from(chunk, 'utf8'));
+      for (const chunk of script.chunks ?? []) {
+        if (kills.length > 0) break; // Killed: no more output from this child.
+        child.stdout.emit('data', Buffer.from(chunk, 'utf8'));
+      }
       if (script.stderr) child.stderr.emit('data', script.stderr);
       child.emit('close', script.code ?? 0);
     });
     return child;
   }) as unknown as typeof import('node:child_process').spawn;
-  return { spawnFn, calls };
+  return { spawnFn, calls, kills };
 }
 
 const DISCOVER_SESSION_LINE = JSON.stringify({
@@ -572,7 +592,7 @@ test('discoverSessions parses the JSONL stream into sessions, diagnostics, and a
   // Split mid-line so the incremental line buffering is exercised.
   const stream = `${DISCOVER_SESSION_LINE}\n${DISCOVER_DIAGNOSTIC_LINE}\n${DISCOVER_SUMMARY_LINE}\n`;
   const split = Math.floor(DISCOVER_SESSION_LINE.length / 2);
-  const { spawnFn, calls } = fakeSpawn({ chunks: [stream.slice(0, split), stream.slice(split)] });
+  const { spawnFn, calls, kills } = fakeSpawn({ chunks: [stream.slice(0, split), stream.slice(split)] });
 
   const streamed: string[] = [];
   const result = await discoverSessions({
@@ -639,6 +659,8 @@ test('discoverSessions parses the JSONL stream into sessions, diagnostics, and a
     filesOpened: 1,
     bytesRead: 4096,
   });
+  // A run that completes is never killed — only an aborted one is.
+  assert.deepEqual(kills, []);
 });
 
 test('discoverSessions skips unparseable and unknown lines instead of failing', async () => {
@@ -740,8 +762,8 @@ test('discoverSessions rejects a summary from an unsupported contract version', 
 });
 
 test('an exception from onSession aborts the run instead of escaping the stream', async () => {
-  const { spawnFn } = fakeSpawn({
-    chunks: [`${DISCOVER_SESSION_LINE}\n${DISCOVER_SUMMARY_LINE}\n`],
+  const { spawnFn, kills } = fakeSpawn({
+    chunks: [`${DISCOVER_SESSION_LINE}\n`, `${DISCOVER_SUMMARY_LINE}\n`],
   });
   const boom = new Error('host render failed');
   await assert.rejects(
@@ -754,11 +776,14 @@ test('an exception from onSession aborts the run instead of escaping the stream'
     }),
     (err: unknown) => err === boom,
   );
+  // Rejecting is only half of it: the child has to be stopped, or an aborted
+  // run leaves a process reading the user's disk with nobody listening.
+  assert.equal(kills.length, 1);
 });
 
 test('an exception from onDiagnostic aborts the run too', async () => {
-  const { spawnFn } = fakeSpawn({
-    chunks: [`${DISCOVER_DIAGNOSTIC_LINE}\n${DISCOVER_SUMMARY_LINE}\n`],
+  const { spawnFn, kills } = fakeSpawn({
+    chunks: [`${DISCOVER_DIAGNOSTIC_LINE}\n`, `${DISCOVER_SUMMARY_LINE}\n`],
   });
   const boom = new Error('host logger failed');
   await assert.rejects(
@@ -771,4 +796,5 @@ test('an exception from onDiagnostic aborts the run too', async () => {
     }),
     (err: unknown) => err === boom,
   );
+  assert.equal(kills.length, 1);
 });

--- a/sdk-ts/src/session-catalog.ts
+++ b/sdk-ts/src/session-catalog.ts
@@ -1,0 +1,405 @@
+/**
+ * Session catalog: the materialized shallow index of coding-agent sessions.
+ *
+ * Two halves, deliberately split by who owns the write:
+ *
+ *   - **Cache-only listing** — `AiHist.listSessionCatalog()` in `index.ts`
+ *     reads the `sessions` table and nothing else. No provider file is opened,
+ *     no `history` / `session_events` scan happens. This module supplies the
+ *     row type and the raw-row → `CatalogSession` mapping it uses.
+ *   - **Shallow discovery** — `discoverSessions()` here drives
+ *     `ai-hist sessions discover --json`, which scans the known provider
+ *     locations with bounded reads and upserts the catalog. It is a top-level
+ *     function rather than an `AiHist` method because discovery *writes* the
+ *     on-disk database, and an `AiHist` instance is an in-memory snapshot taken
+ *     at open time — a method would hand back a reader that cannot see the rows
+ *     it just wrote. Re-open (or `openAiHist` again) afterwards to read them.
+ *
+ * The Rust CLI stays the single source of truth for discovery (provider
+ * locations, bounded reads, global recency ordering, stamp comparison), exactly
+ * as `cloud-push.ts` defers to `ai-hist push` for the push pipeline.
+ */
+
+import { spawn, type SpawnOptions } from 'node:child_process';
+import { StringDecoder } from 'node:string_decoder';
+
+import { resolveAiHistBinary } from './cloud-push.js';
+import type { Source } from './index.js';
+
+/**
+ * Version of the session-catalog output contract this SDK understands.
+ * Mirrors the native `SESSION_CATALOG_CONTRACT_VERSION`; a `summary` whose
+ * `contractVersion` differs came from a binary that speaks a different dialect.
+ */
+export const SESSION_CATALOG_CONTRACT_VERSION = 1;
+
+/**
+ * One row of the session catalog — a coding-agent session as shallow
+ * discovery knows it.
+ *
+ * Most fields are *observed* (read straight out of provider data);
+ * `firstPrompt` is *derived* — a bounded excerpt of the first substantive human
+ * prompt. Provider quirks worth knowing:
+ *
+ *   - `cursor` rows never have a `firstActivityMs` (the provider records no
+ *     timestamps) and their `lastActivityMs` comes from the file mtime.
+ *   - `relay` rows never have a `cwd` (a relay thread has no working
+ *     directory) and only exist for threads a previous sync pulled down.
+ *   - `lastAssistantText` is only written by a full ingest (`ai-hist sync`), so
+ *     it is `null` on rows that have only ever been discovered shallowly.
+ *   - `models` / `workspaceRoots` are best effort: `[]` means "not seen in a
+ *     bounded read", not "none exist".
+ */
+export interface CatalogSession {
+  /** Provider that owns the session. `trajectory` never appears here. */
+  source: Source;
+  /** The provider's own session id. `(source, sessionId)` is the catalog key. */
+  sessionId: string;
+  cwd: string | null;
+  gitBranch: string | null;
+  firstActivityMs: number | null;
+  lastActivityMs: number | null;
+  /** Derived: bounded excerpt of the first substantive human prompt. */
+  firstPrompt: string | null;
+  /** Full-ingest only; `null` on shallow-only rows. */
+  lastAssistantText: string | null;
+  /** Parsed from `models_json`; `[]` when nothing was observed. */
+  models: string[];
+  originator: string | null;
+  agentVersion: string | null;
+  repoUrl: string | null;
+  initialCommit: string | null;
+  /** Parsed from `workspace_roots_json`; `[]` when nothing was observed. */
+  workspaceRoots: string[];
+  rawPath: string | null;
+  /** Change stamp of the raw source at scan time (`v{scanner}:{provider stamp}`). */
+  sourceStamp: string | null;
+  /**
+   * `'shallow'` (catalog row only) or `'full'` (full evidence ingested).
+   * Rows written before the catalog existed store `NULL` and are reported as
+   * `'full'`, matching the native reader.
+   */
+  discoveryState: 'shallow' | 'full';
+  /** `true` when the row was served from the catalog without re-reading the source. */
+  fromCache: boolean;
+  /** Parser generation that wrote the row; absent on rows streamed by discovery. */
+  parserVersion?: number;
+}
+
+/** Filters for the cache-only catalog listing. */
+export interface ListCatalogOptions {
+  /** Restrict to these sources. Omit for every discoverable source. */
+  sources?: Iterable<Source | string>;
+  /** Row cap. Default 50, mirroring the native `DEFAULT_CATALOG_LIMIT`. */
+  limit?: number;
+  /** Keyset pagination: only sessions strictly older than this epoch-ms cutoff. */
+  beforeMs?: number;
+}
+
+/** A non-fatal failure during discovery: one provider, or one bad session. */
+export interface DiscoveryDiagnostic {
+  source: string;
+  /** File path or provider-scoped handle, when the failure has one. */
+  locator: string | null;
+  error: string;
+}
+
+/** Per-provider tallies for one discovery run. */
+export interface ProviderDiscoverySummary {
+  /** Candidates enumerated, before the global limit. */
+  candidates: number;
+  /** Rows emitted after a shallow read. */
+  discovered: number;
+  /** Rows served from the catalog because the stamp was unchanged. */
+  skippedUnchanged: number;
+  /** `true` when enumeration itself failed. */
+  failed: boolean;
+}
+
+/** Work one discovery run actually performed — bounded-work evidence. */
+export interface DiscoveryCounters {
+  candidatesEnumerated: number;
+  shallowReads: number;
+  skippedUnchanged: number;
+  filesOpened: number;
+  bytesRead: number;
+}
+
+/** A source that deliberately has no shallow adapter, and why. */
+export interface SourceExemption {
+  source: string;
+  reason: string;
+}
+
+/** The closing `summary` line of a discovery run. */
+export interface DiscoverySummary {
+  /** Compare against {@link SESSION_CATALOG_CONTRACT_VERSION}. */
+  contractVersion: number;
+  discovered: number;
+  skippedUnchanged: number;
+  /** Per-provider tallies, keyed by source name. */
+  providers: Record<string, ProviderDiscoverySummary>;
+  exemptSources: SourceExemption[];
+  counters: DiscoveryCounters;
+}
+
+/** Everything one `discoverSessions()` run produced. */
+export interface DiscoverResult {
+  /** Rows in the order the CLI streamed them: newest first, globally. */
+  sessions: CatalogSession[];
+  /** Non-fatal per-provider / per-session failures. Never throws on these. */
+  diagnostics: DiscoveryDiagnostic[];
+  /** `null` only when the binary produced no summary line (unexpected). */
+  summary: DiscoverySummary | null;
+}
+
+export interface DiscoverSessionsOptions {
+  /** Explicit path to the ai-hist binary (overrides discovery). */
+  binPath?: string;
+  /** Restrict to these sources (forwarded as repeated `--source`). */
+  sources?: Iterable<Source | string>;
+  /**
+   * Global cap across all providers, applied by recency (`--limit`). The
+   * native ordering is global, so a limit of 3 returns the three newest
+   * sessions overall, not three per provider.
+   */
+  limit?: number;
+  /** Called for each session row as it streams, before the promise resolves. */
+  onSession?: (session: CatalogSession) => void;
+  /** Called for each diagnostic line as it streams. */
+  onDiagnostic?: (diagnostic: DiscoveryDiagnostic) => void;
+  /** Extra environment for the spawned binary (merged over `process.env`). */
+  env?: NodeJS.ProcessEnv;
+  /** Injectable spawn for testing. */
+  spawnFn?: typeof spawn;
+}
+
+const AI_HIST_RUST_BIN_ENV = 'AI_HIST_RUST_BIN';
+/** Spawn failures that all mean the same thing: no usable binary. */
+const MISSING_BINARY_CODES = new Set(['ENOENT', 'EACCES', 'EPERM', 'ENOTDIR', 'EISDIR']);
+
+function str(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function num(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function count(value: unknown): number {
+  return num(value) ?? 0;
+}
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+/**
+ * Parse a JSON string array column (`models_json`, `workspace_roots_json`).
+ * `NULL`, `''`, and malformed JSON all mean "nothing observed" → `[]`; the
+ * column never stores `[]` itself.
+ */
+export function parseJsonStringList(raw: string | null | undefined): string[] {
+  if (typeof raw !== 'string' || raw.length === 0) return [];
+  try {
+    return stringList(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+}
+
+/** `NULL` `discovery_state` predates the catalog and means a fully ingested row. */
+export function normalizeDiscoveryState(raw: unknown): 'shallow' | 'full' {
+  return raw === 'shallow' ? 'shallow' : 'full';
+}
+
+/** Map one snake_case CLI/`sessions`-row object onto a {@link CatalogSession}. */
+export function catalogSessionFromJson(raw: Record<string, unknown>): CatalogSession {
+  return {
+    source: (str(raw.source) ?? '') as Source,
+    sessionId: str(raw.session_id) ?? '',
+    cwd: str(raw.cwd),
+    gitBranch: str(raw.git_branch),
+    firstActivityMs: num(raw.first_activity_ms),
+    lastActivityMs: num(raw.last_activity_ms),
+    firstPrompt: str(raw.first_prompt),
+    lastAssistantText: str(raw.last_assistant_text),
+    // Discovery emits parsed arrays; a raw table row carries the JSON text.
+    models: Array.isArray(raw.models) ? stringList(raw.models) : parseJsonStringList(str(raw.models_json)),
+    originator: str(raw.originator),
+    agentVersion: str(raw.agent_version),
+    repoUrl: str(raw.repo_url),
+    initialCommit: str(raw.initial_commit),
+    workspaceRoots: Array.isArray(raw.workspace_roots)
+      ? stringList(raw.workspace_roots)
+      : parseJsonStringList(str(raw.workspace_roots_json)),
+    rawPath: str(raw.raw_path),
+    sourceStamp: str(raw.source_stamp),
+    discoveryState: normalizeDiscoveryState(raw.discovery_state),
+    fromCache: raw.from_cache === true,
+    ...(num(raw.parser_version) != null ? { parserVersion: num(raw.parser_version) as number } : {}),
+  };
+}
+
+function diagnosticFromJson(raw: Record<string, unknown>): DiscoveryDiagnostic {
+  return {
+    source: str(raw.source) ?? '',
+    locator: str(raw.locator),
+    error: str(raw.error) ?? '',
+  };
+}
+
+function providerSummaryFromJson(raw: unknown): ProviderDiscoverySummary {
+  const obj = (typeof raw === 'object' && raw !== null ? raw : {}) as Record<string, unknown>;
+  return {
+    candidates: count(obj.candidates),
+    discovered: count(obj.discovered),
+    skippedUnchanged: count(obj.skipped_unchanged),
+    failed: obj.failed === true,
+  };
+}
+
+function summaryFromJson(raw: Record<string, unknown>): DiscoverySummary {
+  const providersRaw = (typeof raw.providers === 'object' && raw.providers !== null
+    ? raw.providers
+    : {}) as Record<string, unknown>;
+  const providers: Record<string, ProviderDiscoverySummary> = {};
+  for (const [source, value] of Object.entries(providersRaw)) {
+    providers[source] = providerSummaryFromJson(value);
+  }
+  const countersRaw = (typeof raw.counters === 'object' && raw.counters !== null
+    ? raw.counters
+    : {}) as Record<string, unknown>;
+  return {
+    contractVersion: count(raw.contract_version),
+    discovered: count(raw.discovered),
+    skippedUnchanged: count(raw.skipped_unchanged),
+    providers,
+    exemptSources: Array.isArray(raw.exempt_sources)
+      ? raw.exempt_sources
+          .filter((item): item is Record<string, unknown> => typeof item === 'object' && item !== null)
+          .map((item) => ({ source: str(item.source) ?? '', reason: str(item.reason) ?? '' }))
+      : [],
+    counters: {
+      candidatesEnumerated: count(countersRaw.candidates_enumerated),
+      shallowReads: count(countersRaw.shallow_reads),
+      skippedUnchanged: count(countersRaw.skipped_unchanged),
+      filesOpened: count(countersRaw.files_opened),
+      bytesRead: count(countersRaw.bytes_read),
+    },
+  };
+}
+
+/**
+ * Run shallow session discovery by driving `ai-hist sessions discover --json`.
+ *
+ * The CLI streams JSONL — one `session` object per discovered row, a
+ * `diagnostic` per non-fatal failure, then a closing `summary` — and this
+ * parses it as it arrives, so `onSession` fires progressively rather than only
+ * once the whole run finishes.
+ *
+ * Discovery **writes the on-disk database**. An `AiHist` opened before the run
+ * is a snapshot and will not contain the new rows; re-open (or call
+ * `openAiHist` again) before `listSessionCatalog()` to see them.
+ *
+ * Failure behavior mirrors the CLI's: a provider that blows up contributes a
+ * diagnostic and the run still resolves (exit 0). This rejects only when the
+ * binary cannot be run at all, when every selected provider failed (non-zero
+ * exit), or when the process errors for some other reason. Individual
+ * unparseable lines are skipped rather than failing the run — a future binary
+ * may add line types this SDK does not know.
+ */
+export function discoverSessions(opts: DiscoverSessionsOptions = {}): Promise<DiscoverResult> {
+  const spawnFn = opts.spawnFn ?? spawn;
+  const bin = resolveAiHistBinary(opts.binPath);
+
+  const args = ['sessions', 'discover', '--json'];
+  for (const source of opts.sources ?? []) args.push('--source', String(source));
+  if (opts.limit != null) args.push('--limit', String(opts.limit));
+
+  const spawnOpts: SpawnOptions = {
+    env: { ...process.env, ...opts.env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  };
+
+  return new Promise((resolve, reject) => {
+    const sessions: CatalogSession[] = [];
+    const diagnostics: DiscoveryDiagnostic[] = [];
+    let summary: DiscoverySummary | null = null;
+    let stderr = '';
+    let pending = '';
+    const decoder = new StringDecoder('utf8');
+
+    const handleLine = (line: string): void => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        return; // Tolerant: skip a line we cannot read rather than failing the run.
+      }
+      if (typeof parsed !== 'object' || parsed === null) return;
+      const obj = parsed as Record<string, unknown>;
+      switch (obj.type) {
+        case 'session': {
+          const session = catalogSessionFromJson(obj);
+          sessions.push(session);
+          opts.onSession?.(session);
+          break;
+        }
+        case 'diagnostic': {
+          const diagnostic = diagnosticFromJson(obj);
+          diagnostics.push(diagnostic);
+          opts.onDiagnostic?.(diagnostic);
+          break;
+        }
+        case 'summary':
+          summary = summaryFromJson(obj);
+          break;
+        default:
+          break; // Unknown line type from a newer binary.
+      }
+    };
+
+    const child = spawnFn(bin, args, spawnOpts);
+
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      pending += typeof chunk === 'string' ? chunk : decoder.write(chunk);
+      let newline = pending.indexOf('\n');
+      while (newline !== -1) {
+        handleLine(pending.slice(0, newline));
+        pending = pending.slice(newline + 1);
+        newline = pending.indexOf('\n');
+      }
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      if (MISSING_BINARY_CODES.has(err.code ?? '')) {
+        reject(
+          new Error(
+            `could not run the ai-hist binary (${bin}): ${err.code}. Install ai-hist, ` +
+              `or set ${AI_HIST_RUST_BIN_ENV} to its path.`,
+          ),
+        );
+        return;
+      }
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      handleLine(pending + decoder.end());
+      pending = '';
+      if (code !== 0) {
+        reject(
+          new Error(`ai-hist sessions discover failed (exit ${code}): ${stderr.trim().slice(0, 300)}`),
+        );
+        return;
+      }
+      resolve({ sessions, diagnostics, summary });
+    });
+  });
+}

--- a/sdk-ts/src/session-catalog.ts
+++ b/sdk-ts/src/session-catalog.ts
@@ -86,14 +86,47 @@ export interface CatalogSession {
   parserVersion?: number;
 }
 
+/**
+ * A precise continuation point in the catalog's total order,
+ * `(lastActivityMs DESC, source ASC, sessionId ASC)`.
+ *
+ * Recency alone is not a key — one discovery pass can stamp many sessions with
+ * the same mtime-derived millisecond, and a cursor carrying only a timestamp
+ * silently drops every row tied with the page boundary — so the identity
+ * columns make the cursor total. `lastActivityMs` is null/absent for the tail
+ * of rows whose recency is unknown; those sort after every dated row.
+ */
+export interface CatalogCursor {
+  lastActivityMs?: number | null;
+  source: string;
+  sessionId: string;
+}
+
 /** Filters for the cache-only catalog listing. */
 export interface ListCatalogOptions {
   /** Restrict to these sources. Omit for every discoverable source. */
   sources?: Iterable<Source | string>;
   /** Row cap. Default 50, mirroring the native `DEFAULT_CATALOG_LIMIT`. */
   limit?: number;
-  /** Keyset pagination: only sessions strictly older than this epoch-ms cutoff. */
+  /**
+   * Coarse cutoff: only sessions strictly older than this epoch-ms. Convenient
+   * for "anything before last Tuesday", but it cannot separate rows that share
+   * a millisecond — use `after` to walk pages. Ignored when `after` is set.
+   */
   beforeMs?: number;
+  /** Precise continuation from the previous page's `nextCursor`. */
+  after?: CatalogCursor;
+}
+
+/** One page of the catalog plus the cursor that continues it. */
+export interface SessionCatalogPage {
+  /** The rows, newest first. */
+  sessions: CatalogSession[];
+  /**
+   * Pass as {@link ListCatalogOptions.after} for the next page. `null` when
+   * the page did not fill its limit, i.e. the catalog is exhausted.
+   */
+  nextCursor: CatalogCursor | null;
 }
 
 /** A non-fatal failure during discovery: one provider, or one bad session. */
@@ -149,8 +182,41 @@ export interface DiscoverResult {
   sessions: CatalogSession[];
   /** Non-fatal per-provider / per-session failures. Never throws on these. */
   diagnostics: DiscoveryDiagnostic[];
-  /** `null` only when the binary produced no summary line (unexpected). */
-  summary: DiscoverySummary | null;
+  /** The closing summary. Always present: a run without one is rejected. */
+  summary: DiscoverySummary;
+}
+
+/**
+ * A discovery run that could not be completed or trusted.
+ *
+ * The native command emits its diagnostics and the summary trailer even when
+ * every provider fails, so a failed run still carries everything it managed to
+ * learn: `diagnostics` says which sources broke and why, and `summary` (when
+ * the trailer arrived) says what the run actually did. `stderr` and `exitCode`
+ * carry the process-level detail.
+ */
+export class DiscoveryError extends Error {
+  readonly exitCode: number | null;
+  readonly stderr: string;
+  readonly diagnostics: DiscoveryDiagnostic[];
+  readonly summary: DiscoverySummary | null;
+
+  constructor(
+    message: string,
+    details: {
+      exitCode?: number | null;
+      stderr?: string;
+      diagnostics?: DiscoveryDiagnostic[];
+      summary?: DiscoverySummary | null;
+    } = {},
+  ) {
+    super(message);
+    this.name = 'DiscoveryError';
+    this.exitCode = details.exitCode ?? null;
+    this.stderr = details.stderr ?? '';
+    this.diagnostics = details.diagnostics ?? [];
+    this.summary = details.summary ?? null;
+  }
 }
 
 export interface DiscoverSessionsOptions {
@@ -303,11 +369,24 @@ function summaryFromJson(raw: Record<string, unknown>): DiscoverySummary {
  * `openAiHist` again) before `listSessionCatalog()` to see them.
  *
  * Failure behavior mirrors the CLI's: a provider that blows up contributes a
- * diagnostic and the run still resolves (exit 0). This rejects only when the
- * binary cannot be run at all, when every selected provider failed (non-zero
- * exit), or when the process errors for some other reason. Individual
- * unparseable lines are skipped rather than failing the run — a future binary
- * may add line types this SDK does not know.
+ * diagnostic and the run still resolves (exit 0). Individual unparseable or
+ * unrecognized lines are skipped rather than failing the run, so a newer
+ * binary's extra line types stay forward-compatible. The promise rejects with
+ * a {@link DiscoveryError} when:
+ *
+ *   - the binary cannot be run at all (the message names `AI_HIST_RUST_BIN`);
+ *   - the run exits non-zero — every selected provider failed. The native
+ *     command still writes its diagnostics and the summary trailer before
+ *     exiting, so the error carries both alongside `stderr` and `exitCode`;
+ *   - no summary line arrived, or its `contractVersion` is not the one this
+ *     SDK understands. The trailer is mandatory in the native contract, so a
+ *     run without one (or with a version this SDK cannot read) means the rows
+ *     are not safe to interpret — better to say so than to hand back a
+ *     half-understood catalog.
+ *
+ * An exception thrown by `onSession` or `onDiagnostic` aborts the run: the
+ * child is killed and the promise rejects with that exception, rather than
+ * escaping the stream handler as an uncaught error in the host process.
  */
 export function discoverSessions(opts: DiscoverSessionsOptions = {}): Promise<DiscoverResult> {
   const spawnFn = opts.spawnFn ?? spawn;
@@ -328,7 +407,34 @@ export function discoverSessions(opts: DiscoverSessionsOptions = {}): Promise<Di
     let summary: DiscoverySummary | null = null;
     let stderr = '';
     let pending = '';
+    let settled = false;
     const decoder = new StringDecoder('utf8');
+
+    const child = spawnFn(bin, args, spawnOpts);
+
+    const succeed = (result: DiscoverResult): void => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    const fail = (err: unknown): void => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    };
+    /**
+     * A host callback that throws must not take the process down with it, and
+     * must not leave the child running: stop consuming, end the run, surface
+     * the caller's own error.
+     */
+    const abort = (err: unknown): void => {
+      try {
+        child.kill?.();
+      } catch {
+        /* already gone */
+      }
+      fail(err);
+    };
 
     const handleLine = (line: string): void => {
       const trimmed = line.trim();
@@ -345,13 +451,25 @@ export function discoverSessions(opts: DiscoverSessionsOptions = {}): Promise<Di
         case 'session': {
           const session = catalogSessionFromJson(obj);
           sessions.push(session);
-          opts.onSession?.(session);
+          if (opts.onSession) {
+            try {
+              opts.onSession(session);
+            } catch (err) {
+              abort(err);
+            }
+          }
           break;
         }
         case 'diagnostic': {
           const diagnostic = diagnosticFromJson(obj);
           diagnostics.push(diagnostic);
-          opts.onDiagnostic?.(diagnostic);
+          if (opts.onDiagnostic) {
+            try {
+              opts.onDiagnostic(diagnostic);
+            } catch (err) {
+              abort(err);
+            }
+          }
           break;
         }
         case 'summary':
@@ -362,12 +480,11 @@ export function discoverSessions(opts: DiscoverSessionsOptions = {}): Promise<Di
       }
     };
 
-    const child = spawnFn(bin, args, spawnOpts);
-
     child.stdout?.on('data', (chunk: Buffer | string) => {
+      if (settled) return;
       pending += typeof chunk === 'string' ? chunk : decoder.write(chunk);
       let newline = pending.indexOf('\n');
-      while (newline !== -1) {
+      while (newline !== -1 && !settled) {
         handleLine(pending.slice(0, newline));
         pending = pending.slice(newline + 1);
         newline = pending.indexOf('\n');
@@ -379,27 +496,57 @@ export function discoverSessions(opts: DiscoverSessionsOptions = {}): Promise<Di
 
     child.on('error', (err: NodeJS.ErrnoException) => {
       if (MISSING_BINARY_CODES.has(err.code ?? '')) {
-        reject(
-          new Error(
+        fail(
+          new DiscoveryError(
             `could not run the ai-hist binary (${bin}): ${err.code}. Install ai-hist, ` +
               `or set ${AI_HIST_RUST_BIN_ENV} to its path.`,
           ),
         );
         return;
       }
-      reject(err);
+      fail(err);
     });
 
     child.on('close', (code) => {
+      if (settled) return;
       handleLine(pending + decoder.end());
       pending = '';
+      if (settled) return; // A callback threw on the final line.
+      const trailer = summary as DiscoverySummary | null;
       if (code !== 0) {
-        reject(
-          new Error(`ai-hist sessions discover failed (exit ${code}): ${stderr.trim().slice(0, 300)}`),
+        // The native command emits its diagnostics and the summary trailer
+        // before exiting non-zero, so the failure carries what the run learned.
+        fail(
+          new DiscoveryError(
+            `ai-hist sessions discover failed (exit ${code}): ${stderr.trim().slice(0, 300)}`,
+            { exitCode: code, stderr, diagnostics, summary: trailer },
+          ),
         );
         return;
       }
-      resolve({ sessions, diagnostics, summary });
+      if (!trailer) {
+        fail(
+          new DiscoveryError(
+            'ai-hist sessions discover produced no summary line — the closing summary is ' +
+              'part of the output contract, so the stream was truncated or the binary is too old.',
+            { exitCode: code, stderr, diagnostics, summary: null },
+          ),
+        );
+        return;
+      }
+      if (trailer.contractVersion !== SESSION_CATALOG_CONTRACT_VERSION) {
+        fail(
+          new DiscoveryError(
+            `unsupported session-catalog contract version ${trailer.contractVersion} ` +
+              `(this SDK understands ${SESSION_CATALOG_CONTRACT_VERSION}) — upgrade the ai-hist ` +
+              'package or the ai-hist binary so the two agree. A version of 0 means the summary ' +
+              'carried no contract_version at all.',
+            { exitCode: code, stderr, diagnostics, summary: trailer },
+          ),
+        );
+        return;
+      }
+      succeed({ sessions, diagnostics, summary: trailer });
     });
   });
 }


### PR DESCRIPTION
Adds a supported, versioned API for shallowly discovering and listing coding-agent sessions without fully indexing their transcripts, so a desktop app can render a recent-sessions list immediately — even on first launch with no database and thousands of historical sessions across providers.

## Public APIs and CLI commands added

**CLI**
- `ai-hist sessions list [--json] [--source <s>]... [--limit N] [--before-ms X]` — cache-only: a single indexed query over the `sessions` catalog (routed through the read-only connection path); never touches provider files or `history`/`session_events`/`tool_calls`. `--json` emits `{"contract_version":1,"sessions":[...]}`.
- `ai-hist sessions discover [--json] [--source <s>]... [--limit N]` — shallow discovery: streams JSONL progressively (`{"type":"session"}` rows in global recency order, `{"type":"diagnostic"}` per failure, final `{"type":"summary"}` with per-provider counts, exemptions, and operation counters). Exit 0 with per-provider diagnostics; non-zero only when every selected provider fails.

**Rust (`ai_hist_cli`)** — `discover_sessions` (progressive callback), `discover_sessions_collect`, `list_session_catalog`, `list_sessions_local` / `discover_sessions_local`, plus the `ShallowSession` / `DiscoverySummary` / `DiscoveryDiagnostic` types, `SESSION_CATALOG_CONTRACT_VERSION`, and `DISCOVERY_EXEMPTIONS`.

**napi (`ai-hist-native`)** — `listSessions(options?)` and `discoverSessions(options?)` (camelCase, collected results; regenerated `index.d.ts` committed).

**TypeScript SDK (`ai-hist`)** — `AiHist.listSessionCatalog(options)` (pure SQL over the catalog, works on pre-catalog DBs via in-memory column backfill), top-level `discoverSessions(options)` (drives the CLI's JSONL contract with `onSession`/`onDiagnostic` streaming callbacks), and a read-only `list_sessions` MCP tool. The existing history-derived `listSessions` is unchanged for compatibility and now documents the catalog path as the fast/complete alternative.

## Catalog schema and migration

`sessions` becomes the materialized shallow catalog. New nullable columns: `first_prompt`, `models_json`, `originator`, `agent_version`, `repo_url`, `initial_commit`, `workspace_roots_json`, `source_stamp`, `discovery_state`; new indexes `idx_sessions_source_last(source, last_activity_ms DESC)` and `idx_sessions_raw_path(source, raw_path)`.

Migration follows the repo's established mechanism: idempotent ignore-error `ALTER TABLE`s in `init_db` for existing databases, identical columns in the fresh-DB `CREATE TABLE`, and registration in a new `REQUIRED_SESSIONS_COLUMNS` guard so `schema_is_current` refuses to serve a pre-catalog DB read-only and falls back to the migrating writable open. Tests assert the two paths converge to the same shape. The TS SDK applies the same columns to its in-memory sql.js copy, so older on-disk databases keep working unmodified.

`discovery_state` distinguishes `'shallow'` (catalog-only row) from `'full'` (full evidence ingested); full ingest always wins and shallow rescans never downgrade it. `source_stamp` (`v{SHALLOW_SCANNER_VERSION}:` + a provider-specific change marker) makes unchanged sources skippable and gives a global invalidation knob.

## Provider coverage and per-provider strategy

A shared `ShallowSessionProvider` contract (cheap `enumerate` with no content reads, then bounded `read_shallow`) with one adapter per provider, plus a machine-readable exemption list. A registry test asserts every entry in `SOURCE_CHOICES` is covered by exactly one of adapter-or-exemption, so adding a provider fails tests until its author supplies an implementation or a declared exemption.

| Source | Strategy | Notable fields |
|---|---|---|
| claude | bounded head (≤256&nbsp;KB/400 lines) + tail (≤64&nbsp;KB) of `~/.claude/projects/**/*.jsonl`; skips meta/command/sidechain rows for the first prompt | id, cwd, branch, first/last activity, first prompt, models, agent version |
| codex | first-line `session_meta` of `rollout-*.jsonl` (sessions + archived); subagent threads excluded; bounded scan for first prompt | richest set: adds originator, cli version, repo URL, initial commit, workspace roots |
| cursor | dir-structure enumeration of agent transcripts; head read for first prompt | id, cwd; **no provider timestamps exist** — `first_activity_ms` stays null, `last_activity_ms` is documented as file-mtime-derived |
| grok | sibling `summary.json` + head of `chat_history.jsonl` | id, cwd, branch, created/updated, first prompt, model when present |
| opencode | WAL-safe backup snapshot of `opencode.db`; one query over `session` + bounded single-row lookups for first prompt and model | id, directory, created/updated, first prompt, model |
| relay | network source — shallow adapter derives only from already-synced local `history` rows (indexed GROUP BY); **no network access** | id, first/last synced activity, earliest synced prompt; `cwd` always null |
| trajectory | **exempt** — derived trajectory records, not provider sessions; never appears in listings (also filtered defensively in SQL) |

No values are fabricated: absent metadata stays null, `first_prompt` is documented as derived (bounded 4096-char excerpt), and filesystem-derived timestamps are called out per provider. Everything still requiring full indexing (`session_events`, `tool_calls`, `file_edits`, token usage, commit links, FTS, `last_assistant_text`) is documented in `docs/session-catalog.md`.

## Global cross-provider ordering and limiting

All providers are enumerated first (stat/dir-walk or cheap SQL only; each wrapped so a provider failure becomes a diagnostic, not an abort). Candidates merge into one list sorted by recency hint with a deterministic tie-break, the limit is applied globally **after** the merge, and only the winning candidates get bounded shallow reads — so `--limit 100` returns the 100 newest sessions across all providers, not 100 from whichever provider was scanned first. A test proves the limit is global, not per-provider. Unchanged winners (stamp match) are emitted from cache with `from_cache: true` and zero reads.

## Robustness

- Incomplete final JSONL records: only newline-terminated records are treated as complete (existing convention), so actively-appended files parse safely.
- A malformed session becomes a per-session diagnostic; a failing provider becomes a per-provider diagnostic; neither blocks other results.
- Discovery is upsert-only, stamp-guarded, and busy-retry-backed, so it coexists with concurrent `sync` without taking the sync lock; the opencode read uses a backup snapshot for WAL safety.
- Appends update the existing `(session_id, source)` row — identity is stable across rescans, no duplicates.

## Tests and benchmark results

New coverage: 33 discovery unit tests (per-provider cold discovery, identity, metadata, prompt selection, recency, limits, incremental updates, unchanged-source skipping, incomplete/malformed data, missing-optional-metadata; cross-provider ordering/limit/duplicate-id/one-provider-failing/all-failing; counter-based bounded-read assertions; query-plan check that cached listing uses an index), 7 CLI integration tests pinning the output contract, 2 core migration tests, 11 TS SDK tests plus MCP smoke coverage, and new `verify-e2e.sh` assertions. Full suite: **145 + 39 + 7 + 2 Rust tests pass, 29/29 TS tests pass**, fmt/clippy clean, napi `index.d.ts` in sync, installer and e2e scripts pass.

Benchmark (`cargo test -p ai-hist-cli --test discovery_bench -- --ignored --nocapture`; timings printed, only operation counts asserted):

- Cached 20-row listing is flat at ~0.13 ms whether the catalog holds 1,000 or 20,000 sessions (5,000 vs 100,000 history/event rows), and identical with the raw archive deleted — zero provider reads.
- `discover --limit 5` reads an identical 1.6 MB whether the archive holds 90 or 450 sessions.
- Cold full-archive shallow discovery: 11.9 MB read / 1.7 s vs full `sync` of the same archive at ≥14.7 MB / 46.2 s and 62k evidence rows — ~1/27th the wall time with zero `history`/`session_events` rows written. An unchanged rescan does zero shallow reads (28 KB total, the unavoidable opencode snapshot).

## Docs

`docs/session-catalog.md` documents the versioned contract (both output shapes with real captured examples), observed-vs-derived-vs-full-indexing field semantics, the per-provider capability matrix, ordering/limit/rescan behavior, concurrency notes, and the exemption mechanism. README usage/schema sections, `docs/agent-integration.md`, `docs/getting-started.md`, root and SDK changelogs updated.

## Recommended follow-up (not in this PR)

- On-demand full indexing of a single session (e.g. `ai-hist sync --session <id>`) so a consumer can hydrate one catalog row to full evidence without a whole-archive sync.
- Optionally teaching full `sync` to reuse catalog stamps so a discover-then-sync flow shares work.
- A napi streaming callback for progressive discovery in-process (the CLI JSONL path already streams).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpsbS2gQJpobcjtoj8zDTs

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpsbS2gQJpobcjtoj8zDTs)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

