### PR TITLE
Pin the publish workflows' npm upgrade to the 11.x major

### DIFF
--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -137,11 +137,12 @@ jobs:
         run: npx napi create-npm-dir -t . && npx napi artifacts --dir artifacts
       # npm >= 11.5 is required for the OIDC trusted-publisher flow (the runner's
       # bundled npm 10.x can't mint OIDC tokens, so publish fails unauthenticated).
-      # Pinned to the 11.x major: npm@latest (12+) raised its Node engine floor
-      # above the Node this workflow pins, breaking the publish (EBADENGINE).
+      # Pinned to an exact version: npm@latest (12+) raised its Node engine floor
+      # above the Node this workflow pins, breaking the publish (EBADENGINE), and
+      # an exact pin keeps publishes reproducible.
       - name: Upgrade npm for OIDC
         if: ${{ !inputs.dry_run }}
-        run: npm install -g npm@11
+        run: npm install -g npm@11.19.1
       - name: Publish
         env:
           DRY_RUN: ${{ inputs.dry_run }}

--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -137,9 +137,11 @@ jobs:
         run: npx napi create-npm-dir -t . && npx napi artifacts --dir artifacts
       # npm >= 11.5 is required for the OIDC trusted-publisher flow (the runner's
       # bundled npm 10.x can't mint OIDC tokens, so publish fails unauthenticated).
+      # Pinned to the 11.x major: npm@latest (12+) raised its Node engine floor
+      # above the Node this workflow pins, breaking the publish (EBADENGINE).
       - name: Upgrade npm for OIDC
         if: ${{ !inputs.dry_run }}
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
       - name: Publish
         env:
           DRY_RUN: ${{ inputs.dry_run }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -355,10 +355,11 @@ jobs:
           fi
 
       # npm >= 11.5.1 is required for the OIDC trusted-publisher flow. Pinned to
-      # the 11.x major: npm@latest (12+) raised its Node engine floor above the
-      # Node this workflow pins, so chasing latest breaks the publish (EBADENGINE).
+      # an exact version: npm@latest (12+) raised its Node engine floor above the
+      # Node this workflow pins, so chasing latest breaks the publish (EBADENGINE),
+      # and an exact pin keeps publishes reproducible.
       - name: Install npm 11
-        run: npm install -g npm@11
+        run: npm install -g npm@11.19.1
 
       # Authentication note: this workflow does NOT use an NPM_TOKEN. It relies
       # on npm's OIDC trusted-publisher flow — the `id-token: write` permission

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -354,9 +354,11 @@ jobs:
             git commit -m "chore(release): ${{ steps.bump.outputs.npm_name }}@${{ steps.bump.outputs.version }}"
           fi
 
-      # npm >= 11.5.1 is required for the OIDC trusted-publisher flow.
-      - name: Install latest npm
-        run: npm install -g npm@latest
+      # npm >= 11.5.1 is required for the OIDC trusted-publisher flow. Pinned to
+      # the 11.x major: npm@latest (12+) raised its Node engine floor above the
+      # Node this workflow pins, so chasing latest breaks the publish (EBADENGINE).
+      - name: Install npm 11
+        run: npm install -g npm@11
 
       # Authentication note: this workflow does NOT use an NPM_TOKEN. It relies
       # on npm's OIDC trusted-publisher flow — the `id-token: write` permission


### PR DESCRIPTION
Fixes the publish failure in [run 33282709252](https://github.com/AgentWorkforce/relayhistory/actions/runs/33282709252).

## What broke

Both publish workflows pin Node `22.14.0` but run `npm install -g npm@latest` before publishing. npm's latest is now **12.0.2**, whose Node engine floor (`^22.22.2 || ^24.15.0 || >=26.0.0`) is above the pinned Node, so the upgrade step fails with `EBADENGINE` and the job dies before anything is pushed, tagged, or published. This was a time bomb, not a regression — any publish attempted after npm 12 shipped would have failed identically.

The step can't simply be removed: the runner's bundled npm 10.9.2 can't mint OIDC tokens for the trusted-publisher flow, which requires npm ≥ 11.5 (per the workflows' own comments).

## The fix

Pin the upgrade to the 11.x major in both `publish.yml` and `publish-napi.yml`:

```yaml
run: npm install -g npm@11
```

npm 11 satisfies the OIDC requirement (current 11.19.1 ≥ 11.5) and its engine range `^20.17.0 || >=22.9.0` accepts the pinned Node 22.14.0 (verified against the registry). Pinning the major removes this failure class instead of deferring it to npm's next engine-floor bump; comments in both workflows record the rationale.

## After merge

Re-running the publish dispatch should proceed cleanly — the failed run's version bump and release commit existed only on the dead runner, so nothing was partially published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JpsbS2gQJpobcjtoj8zDTs

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpsbS2gQJpobcjtoj8zDTs)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

