### PR TITLE
feat(cli): new-version notice on --version, with --no-warning opt-out

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -158,9 +158,26 @@ jobs:
         run: |
           set -euo pipefail
           VERSION='${{ steps.bump.outputs.version }}'
+          # First `version = "..."` line in the manifest is the package's own
+          # (the lines above it are the [package] header, name, and comments).
           sed -i "0,/^version = \".*\"/s//version = \"$VERSION\"/" crates/ai-hist/Cargo.toml
-          grep -q "^version = \"$VERSION\"" crates/ai-hist/Cargo.toml
-          cargo update --workspace --offline
+          grep -q "^version = \"$VERSION\"$" crates/ai-hist/Cargo.toml
+          # Keep Cargo.lock in step by rewriting the one line that changed,
+          # rather than running cargo: this job installs no Rust toolchain and
+          # has no registry cache, so `cargo update --offline` cannot resolve
+          # the graph, and an online `cargo update` would fold unrelated
+          # dependency upgrades into the release commit. `ai-hist-cli` is a
+          # path-only workspace member that nothing depends on by version
+          # requirement, so its own `version` is the whole delta.
+          awk -v ver="$VERSION" '
+            /^\[\[package\]\]$/ { in_pkg = 0 }
+            /^name = "ai-hist-cli"$/ { in_pkg = 1 }
+            in_pkg && /^version = / { print "version = \"" ver "\""; in_pkg = 0; next }
+            { print }
+          ' Cargo.lock > Cargo.lock.synced
+          mv Cargo.lock.synced Cargo.lock
+          LOCKED=$(awk '/^name = "ai-hist-cli"$/ { getline; print; exit }' Cargo.lock)
+          test "$LOCKED" = "version = \"$VERSION\""
 
       # CHANGELOG.md generation. If `## [Unreleased]` contains hand-curated
       # content, promote it verbatim into the new `## [x.y.z] - DATE` block.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -471,6 +471,12 @@ jobs:
         uses: taiki-e/install-action@cross
 
       - name: Build binary
+        env:
+          # Stamped into the binary (see CLI_VERSION in crates/ai-hist/src/lib.rs)
+          # so `--version` reports the release version and can compare itself
+          # against the latest GitHub release. Cross.toml passes it through to
+          # the cross container.
+          AI_HIST_RELEASE_VERSION: ${{ needs.publish.outputs.version }}
         run: |
           set -euo pipefail
           if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
@@ -484,7 +490,11 @@ jobs:
 
       - name: Verify binary
         if: matrix.run_binary
-        run: "./${{ matrix.asset }} --version"
+        run: |
+          set -euo pipefail
+          OUT="$(./${{ matrix.asset }} --version --no-warning)"
+          echo "$OUT"
+          test "$OUT" = "ai-hist ${{ needs.publish.outputs.version }}"
 
       - name: Inspect binary
         if: ${{ !matrix.run_binary }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -149,6 +149,19 @@ jobs:
           writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
           NODE
 
+      # The `ai-hist` binary reports the crate version (see CLI_VERSION in
+      # crates/ai-hist/src/lib.rs), so keep it in lockstep with the release
+      # version — otherwise source-built installs report a stale version and
+      # the --version update check misfires.
+      - name: Sync CLI crate version
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          VERSION='${{ steps.bump.outputs.version }}'
+          sed -i "0,/^version = \".*\"/s//version = \"$VERSION\"/" crates/ai-hist/Cargo.toml
+          grep -q "^version = \"$VERSION\"" crates/ai-hist/Cargo.toml
+          cargo update --workspace --offline
+
       # CHANGELOG.md generation. If `## [Unreleased]` contains hand-curated
       # content, promote it verbatim into the new `## [x.y.z] - DATE` block.
       # Otherwise infer from git log since the last `sdk-ts-v*` tag. Skips
@@ -343,6 +356,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add sdk-ts/package.json
           git add mcp-package/package.json
+          git add crates/ai-hist/Cargo.toml Cargo.lock
           # CHANGELOG only exists once there's been at least one release with
           # Unreleased content or a prior tag — skip silently on first publish.
           if [ -f sdk-ts/CHANGELOG.md ]; then

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -65,8 +65,16 @@ jobs:
         uses: taiki-e/install-action@cross
 
       - name: Build binary
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
+          # Stamped into the binary (see CLI_VERSION in crates/ai-hist/src/lib.rs)
+          # so `--version` reports the release version and can compare itself
+          # against the latest GitHub release. Cross.toml passes it through to
+          # the cross container.
+          AI_HIST_RELEASE_VERSION="${RELEASE_TAG#sdk-ts-v}"
+          export AI_HIST_RELEASE_VERSION
           if [ "${{ matrix.target }}" = "aarch64-unknown-linux-musl" ]; then
             RUSTFLAGS="-C target-feature=+crt-static" cross build --release --target "${{ matrix.target }}" -p ai-hist-cli
           else
@@ -78,7 +86,13 @@ jobs:
 
       - name: Verify binary
         if: matrix.run_binary
-        run: "./${{ matrix.asset }} --version"
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          OUT="$(./${{ matrix.asset }} --version --no-warning)"
+          echo "$OUT"
+          test "$OUT" = "ai-hist ${RELEASE_TAG#sdk-ts-v}"
 
       - name: Inspect binary
         if: ${{ !matrix.run_binary }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,12 @@ Notable changes to the native `ai-hist` CLI are documented here.
   so on stderr, with the install one-liner to update. The check is
   interactive-only (stderr must be a terminal), bounded by a 3-second timeout,
   and silent on any failure; suppress it with `--no-warning` or
-  `AI_HIST_NO_UPDATE_CHECK=1`. Release workflows now stamp the release version
-  into the binaries (`AI_HIST_RELEASE_VERSION`), so `--version` reports the
-  `sdk-ts-v*` release version instead of the internal crate version.
+  `AI_HIST_NO_UPDATE_CHECK=1`. To make `--version` report the `sdk-ts-v*`
+  release version instead of a stale internal crate version (released binaries
+  used to report `0.2.0` regardless of release), the crate version is bumped to
+  the current release and kept in lockstep by the publish workflow, and release
+  workflows additionally stamp the release version into the binaries they build
+  (`AI_HIST_RELEASE_VERSION`).
 
 ### Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Notable changes to the native `ai-hist` CLI are documented here.
   so on stderr, with the install one-liner to update. The check is
   interactive-only (stderr must be a terminal), bounded by a 3-second timeout,
   and silent on any failure; suppress it with `--no-warning` or
-  `AI_HIST_NO_UPDATE_CHECK=1`. To make `--version` report the `sdk-ts-v*`
+  `RELAYHISTORY_NO_UPDATE_CHECK=1`. To make `--version` report the `sdk-ts-v*`
   release version instead of a stale internal crate version (released binaries
   used to report `0.2.0` regardless of release), the crate version is bumped to
   the current release and kept in lockstep by the publish workflow, and release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ Notable changes to the native `ai-hist` CLI are documented here.
   databases migrate in place on the next open.
 - Expose `listSessions` and `discoverSessions` from the napi binding, so a Node
   host can drive the catalog in-process instead of shelling out.
+- `ai-hist --version` now notices when a newer GitHub release exists and says
+  so on stderr, with the install one-liner to update. The check is
+  interactive-only (stderr must be a terminal), bounded by a 3-second timeout,
+  and silent on any failure; suppress it with `--no-warning` or
+  `AI_HIST_NO_UPDATE_CHECK=1`. Release workflows now stamp the release version
+  into the binaries (`AI_HIST_RELEASE_VERSION`), so `--version` reports the
+  `sdk-ts-v*` release version instead of the internal crate version.
 
 ### Breaking
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "ai-hist-cli"
-version = "0.2.0"
+version = "0.6.0"
 dependencies = [
  "ai-hist-core",
  "anyhow",

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+# cross-rs container builds only forward allowlisted host env vars. The
+# release workflows stamp the GitHub release version into the binary via
+# this variable (see crates/ai-hist/src/lib.rs `CLI_VERSION`).
+[build.env]
+passthrough = ["AI_HIST_RELEASE_VERSION"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Release, and the prebuilt Rust assets consumed by the installer.
 release exists, a short update notice on stderr. The check only runs
 interactively (stderr must be a terminal), times out quickly, and stays silent
 when offline. To print just the version, pass `--no-warning` or set
-`AI_HIST_NO_UPDATE_CHECK=1`:
+`RELAYHISTORY_NO_UPDATE_CHECK=1`:
 
 ```bash
 ai-hist --version               # version + update notice when one is available

--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ AI_HIST_SOURCE_REF=my-branch sh install.sh    # override source fallback ref
 The publish workflow creates the npm packages, the `sdk-ts-v<version>` GitHub
 Release, and the prebuilt Rust assets consumed by the installer.
 
+### Checking your version
+
+`ai-hist --version` prints the installed version and, when a newer GitHub
+release exists, a short update notice on stderr. The check only runs
+interactively (stderr must be a terminal), times out quickly, and stays silent
+when offline. To print just the version, pass `--no-warning` or set
+`AI_HIST_NO_UPDATE_CHECK=1`:
+
+```bash
+ai-hist --version               # version + update notice when one is available
+ai-hist --version --no-warning  # version only
+```
+
 ## Usage
 
 ```bash

--- a/crates/ai-hist/Cargo.toml
+++ b/crates/ai-hist/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "ai-hist-cli"
-version = "0.2.0"
+# Kept in lockstep with the release version (sdk-ts/package.json) by the
+# publish workflow's "Sync CLI crate version" step, so `ai-hist --version`
+# reports the release version even for source builds.
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -26,6 +26,16 @@ mod cloud;
 /// listing that backs it.
 pub mod discover;
 mod learn;
+mod update;
+
+/// Version this build identifies as: the release version CI stamps in when
+/// building the binaries attached to a GitHub release (release tags follow
+/// `sdk-ts/package.json`, not the crate version), falling back to the crate
+/// version for local builds.
+pub const CLI_VERSION: &str = match option_env!("AI_HIST_RELEASE_VERSION") {
+    Some(version) => version,
+    None => env!("CARGO_PKG_VERSION"),
+};
 
 pub use discover::{
     discover_sessions, discover_sessions_collect, discover_sessions_with_env, list_session_catalog,
@@ -101,7 +111,7 @@ pub fn sync_and_push() -> Result<SyncPushOutcome> {
         id: cloud::machine_id()?,
         hostname: cloud::machine_hostname(),
         os: Some(std::env::consts::OS.to_string()),
-        cli_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        cli_version: Some(CLI_VERSION.to_string()),
         ..Default::default()
     };
     let cursor = cloud::load_cursor(&auth.base_url)?;
@@ -157,12 +167,19 @@ pub fn discover_sessions_local(
 #[command(
     name = "ai-hist",
     bin_name = "ai-hist",
-    version,
+    version = CLI_VERSION,
     about = "Sync, search, tag, and relay AI coding agent history"
 )]
 struct Cli {
     #[arg(long)]
     db: Option<PathBuf>,
+    /// Suppress the new-version notice `--version` may print.
+    // Never read from the parsed struct: `--version` short-circuits parsing
+    // (`ErrorKind::DisplayVersion`), so the version path re-scans raw args
+    // instead. The field exists so clap accepts and documents the flag.
+    #[allow(dead_code)]
+    #[arg(long = "no-warning", global = true)]
+    no_warning: bool,
     #[command(subcommand)]
     command: Command,
 }
@@ -700,7 +717,18 @@ fn read_only_connection(command: &Command, db_path: &Path) -> Option<Connection>
 /// CLI entry point. `src/main.rs` is a thin wrapper that calls this so the same
 /// code is available as a library (for the napi binding).
 pub fn run() -> Result<()> {
-    let cli = Cli::parse();
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        // `--version`: print the version like clap would, then (unless
+        // suppressed) check GitHub for a newer release and note it on stderr.
+        Err(err) if err.kind() == clap::error::ErrorKind::DisplayVersion => {
+            err.print()?;
+            update::maybe_print_update_notice();
+            return Ok(());
+        }
+        // Help, usage errors, …: keep clap's exact output and exit codes.
+        Err(err) => err.exit(),
+    };
     let db_path = cli.db.unwrap_or_else(default_db_path);
     // Sync commands must acquire their advisory lock before opening a writable connection.
     // Pre-dispatch them so the common connection setup below cannot initialize the schema or
@@ -1113,7 +1141,7 @@ pub fn run() -> Result<()> {
                 id: cloud::machine_id()?,
                 hostname: cloud::machine_hostname(),
                 os: Some(std::env::consts::OS.to_string()),
-                cli_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+                cli_version: Some(CLI_VERSION.to_string()),
                 ..Default::default()
             };
             let cursor = cloud::load_cursor(&auth.base_url)?;

--- a/crates/ai-hist/src/update.rs
+++ b/crates/ai-hist/src/update.rs
@@ -1,0 +1,203 @@
+//! The "new version available" notice printed by `ai-hist --version`.
+//!
+//! Release binaries are attached to GitHub releases tagged `sdk-ts-v<semver>`
+//! (see `.github/workflows/publish.yml`). The latest release is discovered
+//! without the GitHub API: `GET /releases/latest` answers with a redirect
+//! whose `Location` header names the release tag, which avoids API rate
+//! limits and JSON parsing entirely.
+//!
+//! The check is best-effort by design: it only runs when stderr is a
+//! terminal, it is bounded by a short timeout, and any failure — offline,
+//! proxy, unexpected redirect target — silently skips the notice. `--version`
+//! must always print the version and exit 0.
+
+use std::io::IsTerminal;
+use std::time::Duration;
+
+/// Repository whose GitHub releases carry the CLI binaries.
+const REPO_SLUG: &str = "AgentWorkforce/relayhistory";
+/// Prefix of release tags, e.g. `sdk-ts-v0.6.0`.
+const TAG_PREFIX: &str = "sdk-ts-v";
+/// Whole-request budget for the release lookup; `--version` must never hang.
+const CHECK_TIMEOUT: Duration = Duration::from_secs(3);
+/// Environment opt-out honored in addition to the `--no-warning` flag, for
+/// scripts that cannot change the invocation.
+const OPT_OUT_ENV: &str = "AI_HIST_NO_UPDATE_CHECK";
+
+/// A release `major.minor.patch` triple, ordered numerically so `0.10.0`
+/// beats `0.9.1`.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+struct ReleaseTriple(u64, u64, u64);
+
+impl std::fmt::Display for ReleaseTriple {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.0, self.1, self.2)
+    }
+}
+
+/// Parse `major.minor.patch` from the front of a version string, tolerating a
+/// `-prerelease` or `+build` suffix on the running version (`0.7.0-next.1`
+/// compares as `0.7.0`).
+fn parse_triple(version: &str) -> Option<ReleaseTriple> {
+    let core = version
+        .split_once(['-', '+'])
+        .map_or(version, |(core, _)| core);
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(ReleaseTriple(major, minor, patch))
+}
+
+/// Extract the release triple from a `Location` redirect target such as
+/// `https://github.com/…/releases/tag/sdk-ts-v0.6.0`, or from a bare tag.
+/// Only stable `sdk-ts-vX.Y.Z` tags parse; anything else (a prerelease tag,
+/// the no-releases redirect back to `/releases`) yields `None`.
+fn parse_release_tag(location: &str) -> Option<ReleaseTriple> {
+    let tag = location.rsplit('/').next()?;
+    let version = tag.strip_prefix(TAG_PREFIX)?;
+    // Reject prerelease/build suffixes outright rather than rounding them
+    // down: a `latest` release should always be a stable triple.
+    if version.contains(['-', '+']) {
+        return None;
+    }
+    parse_triple(version)
+}
+
+/// Whether the notice is suppressed by `--no-warning` or the opt-out
+/// environment variable. Argument scanning is deliberate: clap never yields
+/// parsed matches on the `--version` path, it short-circuits with
+/// `ErrorKind::DisplayVersion` instead.
+fn suppressed(mut args: impl Iterator<Item = String>, opt_out_env: Option<&str>) -> bool {
+    if args.any(|arg| arg == "--no-warning") {
+        return true;
+    }
+    matches!(opt_out_env, Some(value) if !value.is_empty() && value != "0")
+}
+
+/// Latest stable release version, from the `/releases/latest` redirect.
+fn latest_release_triple() -> Option<ReleaseTriple> {
+    let agent = ureq::builder()
+        .redirects(0)
+        .timeout(CHECK_TIMEOUT)
+        // Best-effort check: honor HTTPS_PROXY et al. so proxied machines
+        // still see the notice.
+        .try_proxy_from_env(true)
+        .build();
+    let url = format!("https://github.com/{REPO_SLUG}/releases/latest");
+    let response = agent.get(&url).call().ok()?;
+    parse_release_tag(response.header("location")?)
+}
+
+/// Print a stderr notice when a newer release exists. Never errors and never
+/// prints on failure: a `--version` that cannot reach GitHub stays silent.
+pub(crate) fn maybe_print_update_notice() {
+    if !std::io::stderr().is_terminal() {
+        return;
+    }
+    if suppressed(std::env::args(), std::env::var(OPT_OUT_ENV).ok().as_deref()) {
+        return;
+    }
+    let Some(current) = parse_triple(crate::CLI_VERSION) else {
+        return;
+    };
+    let Some(latest) = latest_release_triple() else {
+        return;
+    };
+    if latest > current {
+        eprintln!(
+            "\nA new version of ai-hist is available: {current} -> {latest}\n\
+             Update with:\n  \
+             curl -fsSL https://raw.githubusercontent.com/{REPO_SLUG}/main/install.sh | sh\n\
+             (pass --no-warning or set {OPT_OUT_ENV}=1 to hide this notice)"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn triples_parse_and_order_numerically() {
+        assert_eq!(parse_triple("0.6.0"), Some(ReleaseTriple(0, 6, 0)));
+        assert_eq!(parse_triple("1.2.30"), Some(ReleaseTriple(1, 2, 30)));
+        assert!(parse_triple("0.10.0") > parse_triple("0.9.9"));
+        assert!(parse_triple("1.0.0") > parse_triple("0.99.99"));
+    }
+
+    #[test]
+    fn a_prerelease_running_version_compares_by_its_core_triple() {
+        assert_eq!(parse_triple("0.7.0-next.1"), Some(ReleaseTriple(0, 7, 0)));
+        assert_eq!(parse_triple("0.7.0+abcdef"), Some(ReleaseTriple(0, 7, 0)));
+    }
+
+    #[test]
+    fn malformed_versions_do_not_parse() {
+        for bad in ["", "0.6", "0.6.0.1", "v0.6.0", "0.6.x", "six"] {
+            assert_eq!(parse_triple(bad), None, "{bad:?} should not parse");
+        }
+    }
+
+    #[test]
+    fn release_tags_parse_from_redirect_targets_and_bare_tags() {
+        assert_eq!(
+            parse_release_tag(
+                "https://github.com/AgentWorkforce/relayhistory/releases/tag/sdk-ts-v0.6.0"
+            ),
+            Some(ReleaseTriple(0, 6, 0))
+        );
+        assert_eq!(
+            parse_release_tag("sdk-ts-v1.2.3"),
+            Some(ReleaseTriple(1, 2, 3))
+        );
+    }
+
+    #[test]
+    fn non_release_redirects_do_not_parse() {
+        // No releases yet: GitHub redirects back to the releases index.
+        assert_eq!(
+            parse_release_tag("https://github.com/AgentWorkforce/relayhistory/releases"),
+            None
+        );
+        // Prerelease and foreign tags never trigger the notice.
+        assert_eq!(parse_release_tag("sdk-ts-v0.7.0-next.1"), None);
+        assert_eq!(parse_release_tag("v0.6.0"), None);
+    }
+
+    #[test]
+    fn no_warning_flag_and_env_opt_out_suppress() {
+        let args = |list: &[&str]| list.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert!(suppressed(
+            args(&["ai-hist", "--version", "--no-warning"]).into_iter(),
+            None
+        ));
+        assert!(suppressed(
+            args(&["ai-hist", "--no-warning", "--version"]).into_iter(),
+            None
+        ));
+        assert!(suppressed(
+            args(&["ai-hist", "--version"]).into_iter(),
+            Some("1")
+        ));
+        assert!(suppressed(
+            args(&["ai-hist", "--version"]).into_iter(),
+            Some("true")
+        ));
+        assert!(!suppressed(
+            args(&["ai-hist", "--version"]).into_iter(),
+            None
+        ));
+        assert!(!suppressed(
+            args(&["ai-hist", "--version"]).into_iter(),
+            Some("")
+        ));
+        assert!(!suppressed(
+            args(&["ai-hist", "--version"]).into_iter(),
+            Some("0")
+        ));
+    }
+}

--- a/crates/ai-hist/src/update.rs
+++ b/crates/ai-hist/src/update.rs
@@ -11,6 +11,7 @@
 //! proxy, unexpected redirect target — silently skips the notice. `--version`
 //! must always print the version and exit 0.
 
+use std::ffi::{OsStr, OsString};
 use std::io::IsTerminal;
 use std::time::Duration;
 
@@ -70,9 +71,11 @@ fn parse_release_tag(location: &str) -> Option<ReleaseTriple> {
 /// Whether the notice is suppressed by `--no-warning` or the opt-out
 /// environment variable. Argument scanning is deliberate: clap never yields
 /// parsed matches on the `--version` path, it short-circuits with
-/// `ErrorKind::DisplayVersion` instead.
-fn suppressed(mut args: impl Iterator<Item = String>, opt_out_env: Option<&str>) -> bool {
-    if args.any(|arg| arg == "--no-warning") {
+/// `ErrorKind::DisplayVersion` instead. Scans `OsString`s because
+/// `std::env::args()` panics on argv that is not valid Unicode, and
+/// `--version` must exit 0 whatever the argv looks like.
+fn suppressed(mut args: impl Iterator<Item = OsString>, opt_out_env: Option<&str>) -> bool {
+    if args.any(|arg| arg == *OsStr::new("--no-warning")) {
         return true;
     }
     matches!(opt_out_env, Some(value) if !value.is_empty() && value != "0")
@@ -98,7 +101,10 @@ pub(crate) fn maybe_print_update_notice() {
     if !std::io::stderr().is_terminal() {
         return;
     }
-    if suppressed(std::env::args(), std::env::var(OPT_OUT_ENV).ok().as_deref()) {
+    if suppressed(
+        std::env::args_os(),
+        std::env::var(OPT_OUT_ENV).ok().as_deref(),
+    ) {
         return;
     }
     let Some(current) = parse_triple(crate::CLI_VERSION) else {
@@ -168,9 +174,27 @@ mod tests {
         assert_eq!(parse_release_tag("v0.6.0"), None);
     }
 
+    /// argv containing bytes that are not valid UTF-8 must be scanned, not
+    /// panicked on: `--version` promises exit 0 for any argv.
+    #[cfg(unix)]
+    #[test]
+    fn non_utf8_arguments_are_scanned_without_panicking() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let invalid = OsString::from_vec(vec![0xff, 0xfe]);
+        assert!(suppressed(
+            [invalid.clone(), OsString::from("--no-warning")].into_iter(),
+            None
+        ));
+        assert!(!suppressed(
+            [invalid, OsString::from("--version")].into_iter(),
+            None
+        ));
+    }
+
     #[test]
     fn no_warning_flag_and_env_opt_out_suppress() {
-        let args = |list: &[&str]| list.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        let args = |list: &[&str]| list.iter().map(OsString::from).collect::<Vec<_>>();
         assert!(suppressed(
             args(&["ai-hist", "--version", "--no-warning"]).into_iter(),
             None

--- a/crates/ai-hist/src/update.rs
+++ b/crates/ai-hist/src/update.rs
@@ -22,7 +22,7 @@ const TAG_PREFIX: &str = "sdk-ts-v";
 const CHECK_TIMEOUT: Duration = Duration::from_secs(3);
 /// Environment opt-out honored in addition to the `--no-warning` flag, for
 /// scripts that cannot change the invocation.
-const OPT_OUT_ENV: &str = "AI_HIST_NO_UPDATE_CHECK";
+const OPT_OUT_ENV: &str = "RELAYHISTORY_NO_UPDATE_CHECK";
 
 /// A release `major.minor.patch` triple, ordered numerically so `0.10.0`
 /// beats `0.9.1`.

--- a/crates/ai-hist/tests/version_flag.rs
+++ b/crates/ai-hist/tests/version_flag.rs
@@ -1,0 +1,75 @@
+//! `--version` contract: the version line is stable, machine-readable stdout,
+//! and the update notice never leaks into it. With stderr not a terminal (as
+//! here), the update check is skipped entirely, so these tests are offline.
+
+use std::process::Command;
+
+fn version_output(args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_ai-hist"))
+        .args(args)
+        .output()
+        .expect("run ai-hist")
+}
+
+fn expected_version_line() -> String {
+    // Tests build without AI_HIST_RELEASE_VERSION, so the binary falls back
+    // to the crate version.
+    format!("ai-hist {}", env!("CARGO_PKG_VERSION"))
+}
+
+#[test]
+fn version_prints_only_the_version_line() {
+    let out = version_output(&["--version"]);
+    assert!(out.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        expected_version_line()
+    );
+    assert!(
+        out.stderr.is_empty(),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn no_warning_is_accepted_on_either_side_of_version() {
+    for args in [
+        &["--version", "--no-warning"][..],
+        &["--no-warning", "--version"][..],
+    ] {
+        let out = version_output(args);
+        assert!(out.status.success(), "{args:?} failed");
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout).trim(),
+            expected_version_line(),
+            "{args:?}"
+        );
+        assert!(out.stderr.is_empty(), "{args:?} wrote to stderr");
+    }
+}
+
+#[test]
+fn short_version_flag_still_works() {
+    let out = version_output(&["-V"]);
+    assert!(out.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        expected_version_line()
+    );
+}
+
+#[test]
+fn help_still_renders_and_documents_no_warning() {
+    let out = version_output(&["--help"]);
+    assert!(out.status.success());
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(help.contains("--no-warning"));
+}
+
+#[test]
+fn parse_errors_still_fail_with_usage() {
+    let out = version_output(&["--definitely-not-a-flag"]);
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("Usage"));
+}

--- a/crates/ai-hist/tests/version_flag.rs
+++ b/crates/ai-hist/tests/version_flag.rs
@@ -12,9 +12,11 @@ fn version_output(args: &[&str]) -> std::process::Output {
 }
 
 fn expected_version_line() -> String {
-    // Tests build without AI_HIST_RELEASE_VERSION, so the binary falls back
-    // to the crate version.
-    format!("ai-hist {}", env!("CARGO_PKG_VERSION"))
+    // Mirror CLI_VERSION: the release workflows stamp AI_HIST_RELEASE_VERSION
+    // into every build, and this test crate compiles in the same environment
+    // as the binary, so fall back to the crate version the same way it does.
+    let version = option_env!("AI_HIST_RELEASE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
+    format!("ai-hist {version}")
 }
 
 #[test]


### PR DESCRIPTION
## What

`ai-hist --version` now tells you when a newer release exists, and the version it prints is finally the release version.

- **Update notice**: `--version` resolves the latest GitHub release via the `/releases/latest` redirect (no API calls, no rate limits, no JSON — just the `Location` header's `sdk-ts-vX.Y.Z` tag) and, when the running binary is older, prints an update notice with the install one-liner on **stderr**. The stdout version line is untouched, so scripts parsing it are unaffected.
- **Silence options**: `--no-warning` (global flag, works on either side of `--version`) or `AI_HIST_NO_UPDATE_CHECK=1` print just the version. The check also only runs when stderr is a terminal, is bounded by a 3-second timeout, honors `HTTPS_PROXY`, and silently skips on any failure — `--version` always exits 0 fast.
- **Correct version identity**: released binaries have always reported the crate version, stuck at `0.2.0` while releases moved to `0.6.0`. Fixed two ways:
  - the crate version is bumped to `0.6.0` and the publish workflow now keeps it in lockstep with the release version (synced into `Cargo.toml`/`Cargo.lock` in the release commit), covering install.sh's build-from-source fallback;
  - both release workflows stamp `AI_HIST_RELEASE_VERSION` into the binaries they build (passed into the arm64 cross container via a new `Cross.toml`) and their verify steps now assert the stamped output. The cloud machine metadata (`cli_version`) reports the same identity.

## How

Clap's `--version` short-circuit (`ErrorKind::DisplayVersion`) is intercepted in `run()`: the version prints exactly as clap would, then the check in the new `crates/ai-hist/src/update.rs` runs. Suppression re-scans raw args because clap yields no parsed matches on that path.

## Notes

- Binaries already attached to `sdk-ts-v0.6.0` were built from old source and keep saying `0.2.0`; the next published release fixes that, and those old binaries will then show the update notice (0.2.0 < next release).
- Prerelease tags never trigger the notice; a prerelease running version compares by its core triple.

## Testing

- New `tests/version_flag.rs`: stdout stability, both `--no-warning` orders, `-V`, help, and parse-error paths (offline by construction — no TTY, no network).
- Unit tests for tag/triple parsing, ordering, and suppression logic.
- Full `ai-hist-cli` suite, CI's exact `clippy -D warnings` invocation, and `cargo fmt --check` all pass; verified `AI_HIST_RELEASE_VERSION=9.9.9` stamping, the crate-version fallback, and the workflow's sed against the real `Cargo.toml`.
- Live-verified the `/releases/latest` redirect shape against GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mW6qwP6WBzWejzFhxw6Lk

---
_Generated by [Claude Code](https://claude.ai/code/session_017mW6qwP6WBzWejzFhxw6Lk)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

