### PR TITLE
docs: fix comments and documentation that no longer match the code

### DIFF
--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -7,7 +7,7 @@ name: Publish ai-hist-native (napi)
 # in-process. See docs/reflex-zero-setup.md.
 #
 # Linux is built for BOTH glibc (gnu) and musl so the loader resolves on Ubuntu
-# etc. (gnu) and Alpine (musl). Cross targets use zig via napi --cross-compile.
+# etc. (gnu) and Alpine (musl). Cross targets use zig via `napi build --zig`.
 # NOTE: napi cross-compilation can need tuning per runner image; validate a dry
 # run before the first real publish.
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -513,8 +513,8 @@ jobs:
         run: |
           set -euo pipefail
           VERSION='${{ needs.publish.outputs.version }}'
-          # Fall back to reading sdk-ts/package.json on the just-pushed HEAD
-          # if the publish job's output is empty (e.g. version=none re-runs).
+          # Fail loudly if the publish job reported no version: every later
+          # step derives the tag from it, so an empty value would tag garbage.
           if [ -z "$VERSION" ]; then
             echo "::error::publish job did not report a version"
             exit 1

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ ai-hist supports these sources:
 | Codex CLI | Local JSONL (`~/.codex/history.jsonl`) | `text`, `ts`, `session_id` | first `session_meta` line of `rollout-*.jsonl` (richest metadata) |
 | Cursor | Per-session JSONL (`~/.cursor/projects/<encoded-path>/agent-transcripts/<uuid>/<uuid>.jsonl`) | `role`, `message.content[].text` (user prompts wrapped in `<user_query>...`) | same files; no provider timestamps, so recency is file mtime |
 | Grok | Per-session JSONL (`~/.grok/sessions/<encoded-path>/<session-id>/chat_history.jsonl`) plus `summary.json` | `type`, `content[].text`, `info.cwd`, `head_branch` | `summary.json` + head of `chat_history.jsonl` |
-| [Agent Relay](https://github.com/AgentWorkforce/relay) | API (`https://api.relaycast.dev/v1`) | `sender`, `content`, `channel`, `timestamp` | already-synced local rows only — never the network |
+| [Agent Relay](https://github.com/AgentWorkforce/relay) | API (`https://api.relaycast.dev/v1`) | `from_name`, `text`, `thread_id`, `created_at` | already-synced local rows only — never the network |
 | Trajectories | Compacted per-run JSON (`$TRAJECTORY_ROOT/**/compacted/*.json`) | `personaId`, `projectId`, `task`, `decisions`, `retrospective` | exempt — derived records, not agent sessions |
 | OpenCode | Local SQLite (`$OPENCODE_DB` or `~/.local/share/opencode/opencode.db`) | user text parts joined to sessions | `session` table on a WAL-safe snapshot |
 

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -549,8 +549,9 @@ CREATE TABLE IF NOT EXISTS sessions (
         "CREATE INDEX IF NOT EXISTS idx_sessions_last ON sessions(last_activity_ms DESC)",
         [],
     )?;
-    // Source-filtered catalog listing (`sessions list --source codex`) orders by
-    // recency inside one source; without this the planner sorts the whole table.
+    // Recency inside one source. Superseded for the source-filtered catalog
+    // listing (`sessions list --source codex`) by `idx_sessions_source_recency`
+    // below, which carries that listing's whole ORDER BY.
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_sessions_source_last ON sessions(source, last_activity_ms DESC)",
         [],

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -1780,7 +1780,7 @@ mod tests {
 
             // Four rows from each source emit eight records. Halving the emitted count would
             // leave the per-source limit at four and retry those same eight forever; the retry
-            // must lower it to three and make progress.
+            // must lower it to two and make progress.
             assert_eq!(*client.attempted_record_counts.borrow(), vec![8, 4]);
             assert_eq!(report.batch_limit, 2);
             assert_eq!(report.attempts, 2);

--- a/crates/ai-hist/src/discover/tests.rs
+++ b/crates/ai-hist/src/discover/tests.rs
@@ -848,7 +848,7 @@ fn the_limit_is_global_not_per_provider() {
     let conn = catalog();
     let home = tempfile::tempdir().unwrap();
     // Two providers, three sessions each, interleaved in time. The three
-    // newest overall are two claude sessions and one codex session.
+    // newest overall are two codex sessions and one claude session.
     for (index, id) in ["claude-a", "claude-b", "claude-c"].iter().enumerate() {
         let body = CLAUDE_BODY.replace("claude-1", id);
         claude_session(

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -626,7 +626,7 @@ enum SetupAction {
 
 #[derive(Subcommand)]
 enum LinkAction {
-    /// Link the most recent matching session to a git commit and optional git note.
+    /// Link the best matching session to a git commit and optional git note.
     Commit {
         #[arg(long, default_value = ".")]
         repo: PathBuf,
@@ -3019,12 +3019,6 @@ fn shell_single_quote(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
-/// Translate a desired interval (seconds) into a cron schedule expression plus a
-/// human cadence. cron's finest granularity is one minute. When an interval
-/// isn't exactly expressible we round toward a *less* frequent cadence, never
-/// more — a scheduled cloud push should never fire more often than the user
-/// asked. Intervals of a day or longer collapse to a daily run (the coarsest
-/// simple cron cadence).
 /// Smallest divisor of `base` that is `>= n`. Using a divisor keeps a `*/step`
 /// cron field uniform — a non-divisor step (e.g. `*/45`) fires a short interval
 /// at the field's rollover (`:00, :45, :00` → a 15-minute gap).

--- a/crates/ai-hist/tests/discovery_bench.rs
+++ b/crates/ai-hist/tests/discovery_bench.rs
@@ -28,7 +28,7 @@
 //! 1. **Cached listing scales with the rows you ask for, not with the archive.**
 //!    Timings across catalog sizes and event volumes, at three limits. The
 //!    structural half of this claim — the query is served by
-//!    `idx_sessions_last` / `idx_sessions_source_last` and never sorts the
+//!    `idx_sessions_recency` / `idx_sessions_source_recency` and never sorts the
 //!    table — is asserted with `EXPLAIN QUERY PLAN` by the unit test
 //!    `discover::tests::the_catalog_listing_is_served_by_an_index_not_a_table_scan`.
 //! 2. **A cached listing reads zero provider files.** Structurally true

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -434,8 +434,8 @@ export interface OpenSourceInfo {
  * runtime lazily and the DB file is read asynchronously so the host
  * process's event loop isn't blocked.
  *
- * Each call snapshots the data; to pick up later writes, call `reload()`
- * (or open a fresh instance).
+ * Each call snapshots the data; to pick up later writes, open a fresh
+ * instance.
  */
 export async function openAiHist(opts: OpenOptions = {}): Promise<AiHist> {
   const dbPath = opts.dbPath ?? defaultDbPath();

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -161,9 +161,9 @@ Grok, OpenCode, Agent Relay, and trajectories — all searchable in a single ind
 
 ## Available tools
 
-- **search_history** — Full-text search across all prompts. Start here when looking
-  for past work on a specific topic, bug, feature, or keyword. Supports boolean
-  operators (AND, OR, NOT) and prefix wildcards (*).
+- **search_history** — Literal substring search across all prompts. Start here when
+  looking for past work on a specific topic, bug, feature, or keyword. Boolean
+  operators and prefix wildcards are not supported.
 
 - **get_session** — Read the full conversation thread for a session_id. Use after
   search_history or recent_history to see the complete context of a session, and
@@ -262,19 +262,19 @@ server.tool(
 
 server.tool(
   "search_history",
-  "Search your AI coding agent history using full-text search across all prompts " +
+  "Search your AI coding agent history using literal substring search across all prompts " +
     "from Claude Code, Codex, Cursor, Grok, OpenCode, Agent Relay, and trajectories. Returns matching entries with " +
     "source, project path, session ID, and timestamp ordered by most recent first. " +
-    "Supports FTS5 boolean operators (AND, OR, NOT), leading - to exclude a term, and " +
-    "trailing * for prefix matching. Use get_session with a returned session_id to read " +
+    "The query is matched as a case-insensitive literal substring; boolean operators, " +
+    "exclusions, and wildcards are not supported. Use get_session with a returned session_id to read " +
     "the full conversation.",
   {
     query: z
       .string()
       .describe(
-        "Search query. Plain terms are matched literally. Use AND/OR/NOT (uppercase) for " +
-          'boolean, leading - to exclude, trailing * for prefix. ' +
-          'Examples: "authentication", "auth AND login", "deploy*", "refactor -test"',
+        "Search query. The whole query is matched literally as a case-insensitive " +
+          'substring of the prompt or project path; boolean operators and wildcards are not supported. ' +
+          'Examples: "authentication", "auth login", "deploy", "refactor test"',
       ),
     source: SOURCE_SCHEMA
       .optional()
@@ -283,7 +283,7 @@ server.tool(
       .string()
       .optional()
       .describe(
-        'Filter by project directory path. Substring match — use a partial path like "/myproject" or "src/api".',
+        'Filter by project directory path. Exact match in the SDK — pass the full recorded path like "/work/myproject".',
       ),
     tag: z.string().optional().describe("Filter to sessions tagged with this tag."),
     limit: z
@@ -666,7 +666,7 @@ server.tool(
     project: z
       .string()
       .optional()
-      .describe('Filter by project directory path (substring match). Example: "/my-app" or "work/api".'),
+      .describe('Filter by project directory path (exact match in the SDK). Example: "/work/my-app".'),
     tag: z.string().optional().describe("Filter to sessions tagged with this tag."),
   },
   READ_ONLY,


### PR DESCRIPTION
A repo-wide audit of comments and documentation against the current code, fixing every claim that describes behavior that has changed or never existed. No executable behavior is changed — every edit is comment, doc-comment, help-string, or tool-description text.

## What was wrong and is now fixed

**sdk-ts MCP server advertised search features that don't exist** (`sdk-ts/src/mcp-server.ts`)
- `search_history`'s description, guide prompt, and `query` parameter promised FTS5 boolean operators (`AND`/`OR`/`NOT`), leading `-` exclusion, and trailing `*` prefix wildcards — with examples like `"auth AND login"` and `"deploy*"`. The implementation escapes the whole query and does a case-insensitive literal `LIKE` substring match (sql.js's WASM build has no FTS5), so those example queries would be matched verbatim and return nothing. Descriptions now state literal substring semantics with examples that work.
- `project` filters on `search_history` and `recent_history` claimed substring matching; the SDK emits `project = ?` — an exact match.
- `openAiHist`'s JSDoc pointed callers at a `reload()` method that doesn't exist (`sdk-ts/src/index.ts`).

**Rust crate comments drifted from the code** (`crates/ai-hist`, `crates/ai-hist-core`)
- `lib.rs`: `round_up_to_divisor` carried a doc paragraph describing a different function (`cron_schedule`); removed the misattributed paragraph. The `link commit` help said "most recent matching session" — selection is by highest confidence score, not recency.
- `cloud.rs`: a capacity-retry test comment said the per-source limit drops to three; the formula and the test's own assertion say two.
- `discover/tests.rs`: a fixture comment inverted which sessions are newest (it's two codex + one claude, as the assertion says).
- `discovery_bench.rs` and `ai-hist-core/src/lib.rs`: comments still credited the retired `idx_sessions_last`/`idx_sessions_source_last` indexes for the catalog listing; it is served by `idx_sessions_recency`/`idx_sessions_source_recency`.

**Workflows** (`.github/workflows`)
- `publish-napi.yml` header said cross targets build via `napi --cross-compile`; the step uses `napi build --zig`.
- `publish.yml` described a fallback to reading `sdk-ts/package.json` when the publish job reports no version; the step actually fails loudly (`::error` + `exit 1`).

**README**
- The sources table listed Agent Relay's key fields as `sender`/`content`/`channel`/`timestamp`; the sync actually reads `from_name`, `text`, `thread_id`, and `created_at`.

## Also audited, found accurate

`mcp-package/` (README + all bin scripts), `crates/ai-hist-napi/` (lib.rs docs, index.d.ts, index.js), `docs/` (cloud-sync, session-catalog, getting-started, agent-integration, pair-hooks, reflex-zero-setup), `install.sh`, `scripts/verify-e2e.sh`, `scripts/verify-install.sh`, `examples/hooks/`, `ci.yml`, `release-binaries.yml` — every checked claim (CLI flags and defaults, tool names, env vars, paths, schema, numeric constants, index names) matched the code, so those files are untouched.

## Out-of-scope code bug noticed during the audit (not fixed here)

`sdk-ts/src/pair-client.ts:57-64` passes `--repo-path`, `--cwd`, `--git-remote`, and `--action` to `ai-hist pair check`, but the CLI's `PairAction::Check` accepts none of those flags (it derives cwd/repo/remote itself), so any `pair_check` call supplying those fields gets a clap argument error. The docs describe the intended contract; the shell-out layer drifted. Left alone since this PR deliberately changes no behavior.

## Validation

- `cargo check --workspace` passes.
- `sdk-ts`: 37/38 tests pass; the one failure (`SDK fallback ingests OpenCode rows committed in WAL files`) is environmental — it spawns the `sqlite3` CLI, which isn't installed in the audit container — and is unrelated to these text-only edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CjtD5TjmvPPQrDww9iset

---
_Generated by [Claude Code](https://claude.ai/code/session_013CjtD5TjmvPPQrDww9iset)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

