### PR TITLE
Restore release version bump selector

### DIFF
--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -9,7 +9,16 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g. 0.4.1). Blank = use package.json.'
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      custom_version:
+        description: 'Custom version (optional, overrides version bump type)'
         required: false
         type: string
       dry_run:
@@ -135,14 +144,21 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Install deps
         run: npm ci
-      - name: Set version
+      - name: Resolve release version
+        id: version
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION_TYPE: ${{ inputs.version }}
+          CUSTOM_VERSION: ${{ inputs.custom_version }}
         run: |
           set -euo pipefail
-          if [ -n "$VERSION" ]; then
-            npm version "$VERSION" --no-git-tag-version --allow-same-version
+          if [ -n "$CUSTOM_VERSION" ]; then
+            npm version "$CUSTOM_VERSION" --no-git-tag-version --allow-same-version
+          else
+            npm version "$VERSION_TYPE" --no-git-tag-version
           fi
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing version $VERSION"
       - uses: actions/download-artifact@v4
         with:
           path: crates/ai-hist-napi/artifacts
@@ -183,10 +199,9 @@ jobs:
       - name: Build SDK and CLI against the release contract
         working-directory: sdk-ts
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          VERSION="${VERSION:-$(node -p "require('../crates/ai-hist-napi/package.json').version")}"
           npm install --ignore-scripts
           npm run build
           node dist/cli.js sessions list --db /tmp/relayhistory-empty.db --json
@@ -201,21 +216,19 @@ jobs:
       - name: Build and publish MCP wrapper
         working-directory: mcp-package
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          VERSION="${VERSION:-$(node -p "require('../crates/ai-hist-napi/package.json').version")}"
           npm pkg set version="$VERSION" dependencies.ai-hist="$VERSION"
           if [ "$DRY_RUN" != "true" ]; then npm publish --access public; fi
 
       - name: Registry clean-install smoke test
         if: ${{ !inputs.dry_run }}
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
-          VERSION="${VERSION:-$(node -p "require('./package.json').version")}"
           SMOKE=$(mktemp -d)
           cd "$SMOKE"
           npm init -y

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -18,6 +18,13 @@ The `Publish RelayHistory npm packages` workflow:
 The SDK root is never published before required platform artifacts. This is
 important because npm multi-package publication is not atomic.
 
+When manually dispatching the workflow, choose `patch`, `minor`, or `major`.
+The workflow computes the next version from `crates/ai-hist-napi/package.json`
+and applies that exact version to the native root, every platform package, the
+SDK/CLI, and the MCP wrapper. `custom_version` is available for an explicit
+version and overrides the selected bump type. Leave `dry_run` enabled to build
+and validate the release without publishing it.
+
 ## Supported matrix
 
 - Node.js: minimum 20; tested 20 and 22.


### PR DESCRIPTION
## Summary

- replace the exact-version dispatch field with a patch/minor/major choice
- retain an optional custom version override
- compute the release version once and propagate it to native, platform, SDK/CLI, and MCP packages
- document manual release behavior and dry runs

## Validation

- `actionlint .github/workflows/publish-napi.yml`
- simulated patch, minor, and major bumps from 1.2.3

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

