### PR TITLE
Fix ARM64 musl release build on Rust 1.98

### DIFF
--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -66,6 +66,10 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             cross: true
+            # Rust 1.98 adds --fix-cortex-a53-843419, which Zig 0.13 rejects.
+            # Keep this target on the last compatible toolchain until Zig's
+            # linker accepts the flag.
+            rust: 1.97.0
             test_musl: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
@@ -82,6 +86,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: ${{ matrix.rust || 'stable' }}
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary
- pin only the ARM64 musl matrix entry to Rust 1.97
- keep every other release target on stable Rust
- avoid the Rust 1.98 / Zig 0.13 incompatibility where Zig rejects `--fix-cortex-a53-843419`

## Validation
- `actionlint .github/workflows/publish-napi.yml`
- `git diff --check`
- [full publish workflow dry run passed](https://github.com/AgentWorkforce/relayhistory/actions/runs/33338302456), including the ARM64-musl build and Alpine contract smoke test