### PR TITLE
Unify release versions and create GitHub tags

### DIFF
--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -31,6 +31,11 @@ on:
 permissions:
   contents: read
 
+# A release publishes several packages that must share one exact version.
+concurrency:
+  group: publish-relayhistory
+  cancel-in-progress: false
+
 defaults:
   run:
     working-directory: crates/ai-hist-napi
@@ -137,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only the publish job mints OIDC tokens (npm provenance).
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
@@ -157,13 +162,68 @@ jobs:
         run: |
           set -euo pipefail
           if [ -n "$CUSTOM_VERSION" ]; then
-            npm version "$CUSTOM_VERSION" --no-git-tag-version --allow-same-version
+            VERSION="$CUSTOM_VERSION"
           else
-            npm version "$VERSION_TYPE" --no-git-tag-version
+            # The registry is the durable source of truth between manual runs;
+            # package.json is kept at the latest checked-in release baseline.
+            CURRENT_VERSION=$(npm view ai-hist version)
+            VERSION=$(node -e '
+              const [current, bump] = process.argv.slice(1);
+              const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(current);
+              if (!match) throw new Error("Expected a stable semver, received " + current);
+              let [, major, minor, patch] = match.map(Number);
+              if (bump === "major") [major, minor, patch] = [major + 1, 0, 0];
+              else if (bump === "minor") [minor, patch] = [minor + 1, 0];
+              else if (bump === "patch") patch += 1;
+              else throw new Error("Unsupported version bump: " + bump);
+              process.stdout.write([major, minor, patch].join("."));
+            ' "$CURRENT_VERSION" "$VERSION_TYPE")
           fi
-          VERSION=$(node -p "require('./package.json').version")
+          node -e '
+            const version = process.argv[1];
+            if (!/^\d+\.\d+\.\d+$/.test(version)) {
+              throw new Error("Version must be a stable semver: " + version);
+            }
+          ' "$VERSION"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+          (
+            cd ../../sdk-ts
+            npm version "$VERSION" --no-git-tag-version --allow-same-version
+            npm pkg set dependencies.ai-hist-native="$VERSION"
+          )
+          (
+            cd ../../mcp-package
+            npm version "$VERSION" --no-git-tag-version --allow-same-version
+            npm pkg set dependencies.ai-hist="$VERSION"
+          )
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing version $VERSION"
+
+      - name: Verify package versions are aligned
+        working-directory: .
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const manifests = [
+              "crates/ai-hist-napi/package.json",
+              "sdk-ts/package.json",
+              "mcp-package/package.json",
+            ].map((path) => [path, JSON.parse(fs.readFileSync(path, "utf8"))]);
+            for (const [path, manifest] of manifests) {
+              if (manifest.version !== process.env.VERSION) {
+                throw new Error(path + " has version " + manifest.version);
+              }
+            }
+            if (manifests[1][1].dependencies["ai-hist-native"] !== process.env.VERSION) {
+              throw new Error("ai-hist must pin ai-hist-native at the release version");
+            }
+            if (manifests[2][1].dependencies["ai-hist"] !== process.env.VERSION) {
+              throw new Error("ai-hist-mcp must pin ai-hist at the release version");
+            }
+            console.log("All packages aligned at " + process.env.VERSION);
+          '
       - uses: actions/download-artifact@v4
         with:
           path: crates/ai-hist-napi/artifacts
@@ -186,8 +246,8 @@ jobs:
           NPM_CONFIG_PROVENANCE: 'true'
         run: |
           set -euo pipefail
-          # --skip-gh-release: we ship npm packages only (a GitHub release needs
-          # contents:write + a token this job doesn't have).
+          # GitHub release creation is handled after all registry smoke tests,
+          # so napi must not create one while packages are still publishing.
           if [ "$DRY_RUN" = "true" ]; then
             echo "Dry run — skipping publish. Prepared packages:"
             npx napi prepublish -t npm --dry-run --skip-gh-release || true
@@ -203,14 +263,11 @@ jobs:
 
       - name: Build SDK and CLI against the release contract
         working-directory: sdk-ts
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
           npm install --ignore-scripts
           npm run build
           node dist/cli.js sessions list --db /tmp/relayhistory-empty.db --json
-          npm pkg set version="$VERSION" dependencies.ai-hist-native="$VERSION"
           if [ "${{ inputs.dry_run }}" = "true" ]; then npm pack --dry-run; fi
 
       - name: Publish SDK and CLI
@@ -221,11 +278,9 @@ jobs:
       - name: Build and publish MCP wrapper
         working-directory: mcp-package
         env:
-          VERSION: ${{ steps.version.outputs.version }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          npm pkg set version="$VERSION" dependencies.ai-hist="$VERSION"
           if [ "$DRY_RUN" != "true" ]; then npm publish --access public; fi
 
       - name: Registry clean-install smoke test
@@ -257,3 +312,15 @@ jobs:
               },
             );
           '
+
+      - name: Create GitHub Release and tag
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release create "sdk-ts-v$VERSION" \
+            --target "$GITHUB_SHA" \
+            --title "ai-hist@$VERSION" \
+            --generate-notes

--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -189,7 +189,6 @@ jobs:
           (
             cd ../../sdk-ts
             npm version "$VERSION" --no-git-tag-version --allow-same-version
-            npm pkg set dependencies.ai-hist-native="$VERSION"
           )
           (
             cd ../../mcp-package
@@ -216,8 +215,8 @@ jobs:
                 throw new Error(path + " has version " + manifest.version);
               }
             }
-            if (manifests[1][1].dependencies["ai-hist-native"] !== process.env.VERSION) {
-              throw new Error("ai-hist must pin ai-hist-native at the release version");
+            if (manifests[1][1].dependencies["ai-hist-native"] !== "file:../crates/ai-hist-napi") {
+              throw new Error("ai-hist must keep its local native dependency while building");
             }
             if (manifests[2][1].dependencies["ai-hist"] !== process.env.VERSION) {
               throw new Error("ai-hist-mcp must pin ai-hist at the release version");
@@ -263,11 +262,25 @@ jobs:
 
       - name: Build SDK and CLI against the release contract
         working-directory: sdk-ts
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set -euo pipefail
           npm install --ignore-scripts
           npm run build
           node dist/cli.js sessions list --db /tmp/relayhistory-empty.db --json
+          # Keep the local native package available through validation, then
+          # rewrite only the manifest that will be packed and published.
+          npm pkg set dependencies.ai-hist-native="$VERSION"
+          node -e '
+            const manifest = require("./package.json");
+            if (manifest.version !== process.env.VERSION) {
+              throw new Error("ai-hist version is not aligned");
+            }
+            if (manifest.dependencies["ai-hist-native"] !== process.env.VERSION) {
+              throw new Error("ai-hist-native publish dependency is not aligned");
+            }
+          '
           if [ "${{ inputs.dry_run }}" = "true" ]; then npm pack --dry-run; fi
 
       - name: Publish SDK and CLI

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "ai-hist-napi"
-version = "1.0.0"
+version = "0.6.0"
 dependencies = [
  "ai-hist-core",
  "ai-hist-engine",

--- a/crates/ai-hist-napi/Cargo.toml
+++ b/crates/ai-hist-napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ai-hist-napi"
-version = "1.0.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/ai-hist-napi/package-lock.json
+++ b/crates/ai-hist-napi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-hist-native",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-hist-native",
-      "version": "1.0.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"

--- a/crates/ai-hist-napi/package.json
+++ b/crates/ai-hist-napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-hist-native",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "Mandatory Node-API engine for RelayHistory.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,17 +13,19 @@ The `Publish RelayHistory npm packages` workflow:
 5. publishes `ai-hist-native` with exact optional dependencies;
 6. builds and publishes `ai-hist` (SDK + CLI);
 7. publishes `ai-hist-mcp` last;
-8. performs a clean registry install and CLI/MCP smoke test.
+8. performs a clean registry install and CLI/MCP smoke test;
+9. creates the `sdk-ts-v<version>` tag and GitHub Release.
 
 The SDK root is never published before required platform artifacts. This is
 important because npm multi-package publication is not atomic.
 
 When manually dispatching the workflow, choose `patch`, `minor`, or `major`.
-The workflow computes the next version from `crates/ai-hist-napi/package.json`
-and applies that exact version to the native root, every platform package, the
-SDK/CLI, and the MCP wrapper. `custom_version` is available for an explicit
-version and overrides the selected bump type. Leave `dry_run` enabled to build
-and validate the release without publishing it.
+The workflow computes the next version from the currently published `ai-hist`
+version on npm and applies that exact version to the native root, every platform
+package, the SDK/CLI, and the MCP wrapper. For example, from `0.6.0`, `patch`
+produces `0.6.1` and `minor` produces `0.7.0`. `custom_version` is available for
+an explicit version and overrides the selected bump type. Leave `dry_run`
+enabled to build and validate without publishing packages or creating a tag.
 
 ## Supported matrix
 

--- a/mcp-package/package.json
+++ b/mcp-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-hist-mcp",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "Thin npx wrapper for the ai-hist stdio MCP server.",
   "license": "MIT",
   "private": false,
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "dependencies": {
-    "ai-hist": "1.0.0"
+    "ai-hist": "0.6.0"
   },
   "engines": {
     "node": ">=20"

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2026-08-30
-
 ### Breaking
 
 - Replace the synchronous `openAiHist()`/`AiHist` snapshot API with top-level

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-hist",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-hist",
-      "version": "1.0.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -27,7 +27,7 @@
     },
     "../crates/ai-hist-napi": {
       "name": "ai-hist-native",
-      "version": "1.0.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-hist",
-  "version": "1.0.0",
+  "version": "0.6.0",
   "description": "Native-backed TypeScript SDK, CLI, and MCP server for RelayHistory.",
   "license": "MIT",
   "private": false,

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 /** Thin MCP adapters over the public `ai-hist` TypeScript SDK. */
+import { readFileSync } from 'node:fs';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
@@ -13,7 +14,14 @@ const READ = { readOnlyHint: true, idempotentHint: true, openWorldHint: false } 
 const WRITE = { readOnlyHint: false, idempotentHint: true, openWorldHint: false } as const;
 const SOURCE = z.enum(['claude', 'codex', 'cursor', 'grok', 'relay', 'trajectory', 'opencode']);
 const CATALOG_SOURCE = z.enum(['claude', 'codex', 'cursor', 'grok', 'relay', 'opencode']);
-const server = new McpServer({ name: 'ai-hist', version: '1.0.0' }, { capabilities: { tools: {} } });
+const packageVersion = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+).version as string;
+
+const server = new McpServer(
+  { name: 'ai-hist', version: packageVersion },
+  { capabilities: { tools: {} } },
+);
 
 function result(value: unknown) {
   return { content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] };


### PR DESCRIPTION
## Summary
- compute patch/minor/major from the currently published `ai-hist` npm version
- align native, SDK/CLI, MCP, platform package, lockfile, and crate baselines at `0.6.0`
- keep the SDK native dependency local through install/build validation, then pin the publish manifest
- validate exact internal dependency/version alignment during publishing
- create `sdk-ts-v<version>` and a GitHub Release after registry smoke tests pass
- serialize publish runs to prevent overlapping releases
- make the MCP server advertise the installed package version

## Expected next versions
- patch: `0.6.1`
- minor: `0.7.0`

## Validation
- [corrected full publish workflow dry run passed](https://github.com/AgentWorkforce/relayhistory/actions/runs/33339915333)
- dry run installed/built against the local native package, then packed `ai-hist@0.6.1` with the exact published dependency
- `actionlint .github/workflows/publish-napi.yml`
- `npm test` in `sdk-ts`
- `cargo check -p ai-hist-napi`
- clean local release synchronization simulation at `0.6.1`