### PR TITLE
Default release workflow to publish

### DIFF
--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -24,7 +24,7 @@ on:
       dry_run:
         description: 'Dry run (build only, no publish)'
         required: true
-        default: true
+        default: false
         type: boolean
 
 # Least privilege: the build matrix needs neither repo writes nor OIDC.


### PR DESCRIPTION
## Summary
- default the manual npm release workflow to a real publish
- retain dry-run validation as an explicit opt-in checkbox

## Validation
- git diff --check
- actionlint .github/workflows/publish-napi.yml