### PR TITLE
Persist release versions in source

### DIFF
--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -147,7 +147,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # A real release persists its version commit before publishing.
+          # A real release persists its version commit once publishing and
+          # the registry smoke tests succeed.
           persist-credentials: true
       - uses: actions/setup-node@v6
         with:
@@ -298,25 +299,6 @@ jobs:
           else
             git commit -m "chore: release $VERSION"
           fi
-      - name: Persist release version
-        id: persist-version
-        if: ${{ !inputs.dry_run }}
-        working-directory: .
-        run: |
-          set -euo pipefail
-          if [[ "$GITHUB_REF" != refs/heads/* ]]; then
-            echo "Release versions can only be persisted from a branch checkout" >&2
-            exit 1
-          fi
-          BRANCH="${GITHUB_REF#refs/heads/}"
-          git fetch origin "$BRANCH"
-          REMOTE_SHA=$(git rev-parse "origin/$BRANCH")
-          if [[ "$REMOTE_SHA" != "$GITHUB_SHA" ]]; then
-            echo "The release branch advanced from $GITHUB_SHA to $REMOTE_SHA; rerun from the new tip" >&2
-            exit 1
-          fi
-          git push origin "HEAD:$GITHUB_REF"
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: actions/download-artifact@v4
         with:
           path: crates/ai-hist-napi/artifacts
@@ -420,6 +402,29 @@ jobs:
             );
           '
 
+      # The branch only advances once every package is published and the
+      # registry smoke tests pass, so a failed release never persists its
+      # version bump. The commit itself was prepared before the publish-only
+      # sdk-ts/package.json rewrite, so it stays version-only.
+      - name: Persist release version
+        id: persist-version
+        if: ${{ !inputs.dry_run }}
+        working-directory: .
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != refs/heads/* ]]; then
+            echo "Release versions can only be persisted from a branch checkout" >&2
+            exit 1
+          fi
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          git fetch origin "$BRANCH"
+          REMOTE_SHA=$(git rev-parse "origin/$BRANCH")
+          if [[ "$REMOTE_SHA" != "$GITHUB_SHA" ]]; then
+            echo "The release branch advanced from $GITHUB_SHA to $REMOTE_SHA; rerun from the new tip" >&2
+            exit 1
+          fi
+          git push origin "HEAD:$GITHUB_REF"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Create GitHub Release and tag
         if: ${{ !inputs.dry_run }}
         env:

--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -82,7 +82,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          # A successful release pushes its version-only commit before tagging it.
+          persist-credentials: true
 
       - uses: actions/setup-node@v6
         with:
@@ -164,8 +165,8 @@ jobs:
           if [ -n "$CUSTOM_VERSION" ]; then
             VERSION="$CUSTOM_VERSION"
           else
-            # The registry is the durable source of truth between manual runs;
-            # package.json is kept at the latest checked-in release baseline.
+            # The registry determines the next version. A successful release
+            # persists that version back to the checked-in manifests below.
             CURRENT_VERSION=$(npm view ai-hist version)
             VERSION=$(node -e '
               const [current, bump] = process.argv.slice(1);
@@ -195,6 +196,33 @@ jobs:
             npm version "$VERSION" --no-git-tag-version --allow-same-version
             npm pkg set dependencies.ai-hist="$VERSION"
           )
+          node - "$VERSION" <<'NODE'
+          const fs = require("node:fs");
+          const version = process.argv[2];
+          const sdkLockPath = "../../sdk-ts/package-lock.json";
+          const sdkLock = JSON.parse(fs.readFileSync(sdkLockPath, "utf8"));
+          const nativeLink = sdkLock.packages["../crates/ai-hist-napi"];
+          if (!nativeLink) {
+            throw new Error("SDK lockfile is missing its local ai-hist-native package");
+          }
+          nativeLink.version = version;
+          fs.writeFileSync(sdkLockPath, JSON.stringify(sdkLock, null, 2) + "\n");
+
+          const files = [
+            ["../../crates/ai-hist-napi/Cargo.toml", /(\[package\]\nname = "ai-hist-napi"\nversion = ")[^"]+("\n)/],
+            ["../../Cargo.lock", /(\[\[package\]\]\nname = "ai-hist-napi"\nversion = ")[^"]+("\n)/],
+          ];
+          for (const [path, pattern] of files) {
+            const contents = fs.readFileSync(path, "utf8");
+            if (!pattern.test(contents)) {
+              throw new Error("Could not find ai-hist-napi version in " + path);
+            }
+            fs.writeFileSync(
+              path,
+              contents.replace(pattern, (_, prefix, suffix) => prefix + version + suffix),
+            );
+          }
+          NODE
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Publishing version $VERSION"
 
@@ -221,8 +249,55 @@ jobs:
             if (manifests[2][1].dependencies["ai-hist"] !== process.env.VERSION) {
               throw new Error("ai-hist-mcp must pin ai-hist at the release version");
             }
+            const lockVersions = [
+              ["crates/ai-hist-napi/package-lock.json", ["", null]],
+              ["sdk-ts/package-lock.json", ["", "../crates/ai-hist-napi"]],
+            ];
+            for (const [path, packageKeys] of lockVersions) {
+              const lock = JSON.parse(fs.readFileSync(path, "utf8"));
+              if (lock.version !== process.env.VERSION) {
+                throw new Error(path + " has root version " + lock.version);
+              }
+              for (const key of packageKeys) {
+                if (key !== null && lock.packages[key]?.version !== process.env.VERSION) {
+                  throw new Error(path + " package " + key + " is not aligned");
+                }
+              }
+            }
+            for (const path of ["crates/ai-hist-napi/Cargo.toml", "Cargo.lock"]) {
+              const contents = fs.readFileSync(path, "utf8");
+              const pattern = path.endsWith("Cargo.toml")
+                ? /\[package\]\nname = "ai-hist-napi"\nversion = "([^"]+)"/
+                : /\[\[package\]\]\nname = "ai-hist-napi"\nversion = "([^"]+)"/;
+              const version = pattern.exec(contents)?.[1];
+              if (version !== process.env.VERSION) {
+                throw new Error(path + " has ai-hist-napi version " + version);
+              }
+            }
             console.log("All packages aligned at " + process.env.VERSION);
           '
+      - name: Prepare release version commit
+        if: ${{ !inputs.dry_run }}
+        working-directory: .
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            Cargo.lock \
+            crates/ai-hist-napi/Cargo.toml \
+            crates/ai-hist-napi/package.json \
+            crates/ai-hist-napi/package-lock.json \
+            sdk-ts/package.json \
+            sdk-ts/package-lock.json \
+            mcp-package/package.json
+          if git diff --cached --quiet; then
+            echo "Version metadata is already committed at $VERSION"
+          else
+            git commit -m "chore: release $VERSION"
+          fi
       - uses: actions/download-artifact@v4
         with:
           path: crates/ai-hist-napi/artifacts
@@ -326,6 +401,19 @@ jobs:
             );
           '
 
+      - name: Persist release version
+        id: persist-version
+        if: ${{ !inputs.dry_run }}
+        working-directory: .
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != refs/heads/* ]]; then
+            echo "Release versions can only be persisted from a branch checkout" >&2
+            exit 1
+          fi
+          git push origin "HEAD:$GITHUB_REF"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release and tag
         if: ${{ !inputs.dry_run }}
         env:
@@ -334,6 +422,6 @@ jobs:
         run: |
           set -euo pipefail
           gh release create "sdk-ts-v$VERSION" \
-            --target "$GITHUB_SHA" \
+            --target "${{ steps.persist-version.outputs.sha }}" \
             --title "ai-hist@$VERSION" \
             --generate-notes

--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -82,8 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # A successful release pushes its version-only commit before tagging it.
-          persist-credentials: true
+          persist-credentials: false
 
       - uses: actions/setup-node@v6
         with:
@@ -148,7 +147,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          # A real release persists its version commit before publishing.
+          persist-credentials: true
       - uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
@@ -298,6 +298,25 @@ jobs:
           else
             git commit -m "chore: release $VERSION"
           fi
+      - name: Persist release version
+        id: persist-version
+        if: ${{ !inputs.dry_run }}
+        working-directory: .
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != refs/heads/* ]]; then
+            echo "Release versions can only be persisted from a branch checkout" >&2
+            exit 1
+          fi
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          git fetch origin "$BRANCH"
+          REMOTE_SHA=$(git rev-parse "origin/$BRANCH")
+          if [[ "$REMOTE_SHA" != "$GITHUB_SHA" ]]; then
+            echo "The release branch advanced from $GITHUB_SHA to $REMOTE_SHA; rerun from the new tip" >&2
+            exit 1
+          fi
+          git push origin "HEAD:$GITHUB_REF"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: actions/download-artifact@v4
         with:
           path: crates/ai-hist-napi/artifacts
@@ -400,19 +419,6 @@ jobs:
               },
             );
           '
-
-      - name: Persist release version
-        id: persist-version
-        if: ${{ !inputs.dry_run }}
-        working-directory: .
-        run: |
-          set -euo pipefail
-          if [[ "$GITHUB_REF" != refs/heads/* ]]; then
-            echo "Release versions can only be persisted from a branch checkout" >&2
-            exit 1
-          fi
-          git push origin "HEAD:$GITHUB_REF"
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release and tag
         if: ${{ !inputs.dry_run }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "ai-hist-napi"
-version = "0.6.0"
+version = "0.8.2"
 dependencies = [
  "ai-hist-core",
  "ai-hist-engine",

--- a/crates/ai-hist-napi/Cargo.toml
+++ b/crates/ai-hist-napi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ai-hist-napi"
-version = "0.6.0"
+version = "0.8.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/ai-hist-napi/package-lock.json
+++ b/crates/ai-hist-napi/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-hist-native",
-  "version": "0.6.0",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-hist-native",
-      "version": "0.6.0",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"

--- a/crates/ai-hist-napi/package.json
+++ b/crates/ai-hist-napi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-hist-native",
-  "version": "0.6.0",
+  "version": "0.8.2",
   "description": "Mandatory Node-API engine for RelayHistory.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -27,6 +27,11 @@ produces `0.6.1` and `minor` produces `0.7.0`. `custom_version` is available for
 an explicit version and overrides the selected bump type. Leave `dry_run`
 enabled to build and validate without publishing packages or creating a tag.
 
+After every successful non-dry release, the workflow pushes a version-only
+commit containing the updated package manifests and lockfiles, then creates the
+GitHub tag and Release from that commit. Failed releases and dry runs never
+change the checked-in version baseline.
+
 ## Supported matrix
 
 - Node.js: minimum 20; tested 20 and 22.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -27,10 +27,13 @@ produces `0.6.1` and `minor` produces `0.7.0`. `custom_version` is available for
 an explicit version and overrides the selected bump type. Leave `dry_run`
 enabled to build and validate without publishing packages or creating a tag.
 
-After every successful non-dry release, the workflow pushes a version-only
-commit containing the updated package manifests and lockfiles, then creates the
-GitHub tag and Release from that commit. Failed releases and dry runs never
-change the checked-in version baseline.
+Before a non-dry release publishes any package, the workflow verifies that the
+selected branch has not advanced and pushes a version-only commit containing
+the updated package manifests and lockfiles. This makes partial publication
+recovery deterministic and prevents a late non-fast-forward push from leaving
+published packages without source metadata. Dry runs never change the checked-in
+version baseline. After registry validation, the workflow creates the GitHub tag
+and Release from the persisted version commit.
 
 ## Supported matrix
 

--- a/mcp-package/package.json
+++ b/mcp-package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-hist-mcp",
-  "version": "0.6.0",
+  "version": "0.8.2",
   "description": "Thin npx wrapper for the ai-hist stdio MCP server.",
   "license": "MIT",
   "private": false,
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "dependencies": {
-    "ai-hist": "0.6.0"
+    "ai-hist": "0.8.2"
   },
   "engines": {
     "node": ">=20"

--- a/sdk-ts/package-lock.json
+++ b/sdk-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-hist",
-  "version": "0.6.0",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-hist",
-      "version": "0.6.0",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -27,7 +27,7 @@
     },
     "../crates/ai-hist-napi": {
       "name": "ai-hist-native",
-      "version": "0.6.0",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-hist",
-  "version": "0.6.0",
+  "version": "0.8.2",
   "description": "Native-backed TypeScript SDK, CLI, and MCP server for RelayHistory.",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
## Summary
- align the checked-in npm and native Cargo release metadata with the published 0.8.2 release
- prepare a version-only commit for each non-dry release and push it after registry smoke tests pass
- create the GitHub tag and Release from the persisted version commit
- verify npm manifests, npm lockfiles, Cargo.toml, and Cargo.lock all share the resolved release version

## Validation
- actionlint .github/workflows/publish-napi.yml
- git diff --check
- cargo check -p ai-hist-napi --locked
- npm ci --ignore-scripts in crates/ai-hist-napi
- npm ci --ignore-scripts and npm run build in sdk-ts

PR #83 remains independent and only changes the dry-run checkbox default.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

