### PR TITLE
Add unified local and remote session scopes

### DIFF
--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -123,12 +123,12 @@ jobs:
       - name: Execute native contract smoke test
         if: matrix.test_native
         shell: bash
-        run: node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==2) process.exit(1)"
+        run: node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==3) process.exit(1)"
 
       - name: Execute musl native contract smoke test
         if: matrix.test_musl
         shell: bash
-        run: docker run --rm -v "$PWD:/work" -w /work node:22-alpine node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==2) process.exit(1)"
+        run: docker run --rm -v "$PWD:/work" -w /work node:22-alpine node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==3) process.exit(1)"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,24 @@ Notable changes to the native `ai-hist` CLI are documented here.
 
 ### Added
 
+- Add a consistent session location scope to collection operations: `--local`,
+  `--remote`, and `--all` are mutually exclusive, with local as the default.
+  Listing, search, recent history, statistics, packs, and resume selection
+  filter one cached session ledger; `all`
+  deduplicates sessions that have both local and remote presences. Direct
+  session/event lookup remains scope-independent. Remote discovery and sync
+  are reserved and report unsupported until provider connectors ship; `all`
+  acquisition runs all configured adapters, which currently means local.
 - Add native search, recent, session, paged events, statistics, discovery,
-  catalog listing, and explicit sync operations with contract version 2.
+  catalog listing, and explicit sync operations. The native-addon contract is
+  now version 3.
 - Add deterministic bounded event pagination using `(ts_ms, id)`.
 
 - Add `ai-hist sessions list` and `ai-hist sessions discover`: a shallow session
   catalog over every provider. `discover` enumerates candidates cheaply, orders
   them globally by recency, and reads only bounded head/tail slices of the
   winners; `list` serves the cached catalog with one indexed query and no
-  provider I/O. Both emit a versioned contract (`contract_version: 1`) —
+  provider I/O. Both emit a versioned contract (`contract_version: 2`) —
   `list --json` as one object, `discover --json` as JSONL rows, diagnostics, and
   a closing summary with per-provider counts and operation counters. See
   `docs/session-catalog.md`.
@@ -29,6 +38,9 @@ Notable changes to the native `ai-hist` CLI are documented here.
   `workspace_roots_json`, `source_stamp`, and `discovery_state`, plus the
   `idx_sessions_source_last` and `idx_sessions_raw_path` indexes. Existing
   databases migrate in place on the next open.
+- Add `session_presences(source, session_id, location, raw_locator,
+  source_stamp, discovery_state)`, backfill existing local evidence, and expose
+  each catalog row's aggregated `locations` in catalog contract version 2.
 - Expose `listSessions` and `discoverSessions` from the napi binding, so a Node
   host can drive the catalog in-process instead of shelling out.
 - The npm-installed `ai-hist --version` reports the SDK package version and can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Notable changes to the native `ai-hist` CLI are documented here.
 - Retire standalone Rust CLI release assets and the curl/source installer.
   npm now distributes the public TypeScript SDK, Node CLI, MCP server, and
   mandatory Node-API engine.
+- Rust engine consumers must recompile for the scoped session API. Public
+  catalog/discovery option, page, summary, and row structs now carry scope or
+  location data, and the native/catalog contract versions are now 3 and 2.
+  The legacy-named `list_sessions_local*` and `discover_sessions_local*`
+  wrappers reject non-local options instead of silently rewriting them; use
+  their `*_scoped*` counterparts for `remote` or `all`.
+- Human-readable history and catalog rows now include observed locations, statistics print
+  the selected scope, and discovery summaries distinguish the requested scope
+  from the connector locations that ran. A remote-only resume match no longer
+  prints a local command; JSON reports it as unavailable and readable mode
+  exits with an explanation.
 
 ### Added
 
@@ -20,6 +31,9 @@ Notable changes to the native `ai-hist` CLI are documented here.
   session/event lookup remains scope-independent. Remote discovery and sync
   are reserved and report unsupported until provider connectors ship; `all`
   acquisition runs all configured adapters, which currently means local.
+  Discovery summary `scope` is the requested acquisition scope, while each
+  history/catalog row's `locations` contains observed presences; it is not a claim that a
+  connector ran at every requested location.
 - Add native search, recent, session, paged events, statistics, discovery,
   catalog listing, and explicit sync operations. The native-addon contract is
   now version 3.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ search, recent history, statistics, and sync. Local and remote are presences of 
 not separate catalogs: every result comes from the same session ledger. Reads
 only filter that cached ledger. Remote discovery and remote sync are reserved
 for provider connectors and currently return an unsupported-operation error;
-they never silently fall back to local work.
+they never silently fall back to local work. An acquisition summary's `scope`
+echoes the requested scope; it does not claim that connectors exist at every
+location in that scope. In particular, `--all` currently runs local connectors
+only. Each catalog row's `locations` array reports where that session was
+actually observed.
 
 No Rust toolchain, C/C++ compiler, standalone CLI, curl installer, or runtime
 binary download is used.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ ai-hist sessions discover --limit 100
 ai-hist sessions list --limit 100
 ```
 
+Session-set commands share one mutually exclusive location scope:
+
+```bash
+ai-hist sessions list --local   # default; identical to omitting a scope flag
+ai-hist sessions list --remote  # cached sessions with a remote presence
+ai-hist sessions list --all     # union of both, with each session returned once
+```
+
+The same `--local` / `--remote` / `--all` contract applies to discovery,
+search, recent history, statistics, and sync. Local and remote are presences of a session,
+not separate catalogs: every result comes from the same session ledger. Reads
+only filter that cached ledger. Remote discovery and remote sync are reserved
+for provider connectors and currently return an unsupported-operation error;
+they never silently fall back to local work.
+
 No Rust toolchain, C/C++ compiler, standalone CLI, curl installer, or runtime
 binary download is used.
 
@@ -56,21 +71,22 @@ import {
   sync,
 } from 'ai-hist';
 
-await discoverSessions({ limit: 100 });
-const sessions = await listSessionCatalog({ limit: 100 });
+await discoverSessions({ limit: 100, scope: 'local' });
+const sessions = await listSessionCatalog({ limit: 100, scope: 'all' });
 const firstEvents = sessions[0]
   ? await getSessionEventsPage(sessions[0].sessionId, {
       source: sessions[0].source,
       limit: 200,
     })
   : null;
-const matches = await search('migration', { limit: 20 });
-await sync(); // explicit full ingestion
+const matches = await search('migration', { limit: 20, scope: 'all' });
+await sync({ scope: 'local' }); // explicit full ingestion; local is the default
 ```
 
 `listSessionCatalog` is cache-only. `discoverSessions` performs bounded shallow
-provider discovery and updates the catalog. `sync` performs full ingestion.
-Reads never silently turn into either discovery or sync.
+provider discovery and updates the shared ledger. `sync` performs full
+ingestion. Reads never silently turn into either discovery or sync. Direct
+session and event lookup is identity-based and therefore has no location scope.
 
 ## MCP
 

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -542,8 +542,6 @@ pub fn open_db_readonly(path: &Path) -> Result<Connection> {
 pub fn init_db(conn: &Connection) -> Result<()> {
     conn.pragma_update(None, "journal_mode", "WAL")?;
     conn.execute_batch(SCHEMA)?;
-    let _ = conn.execute("ALTER TABLE history ADD COLUMN prompt_hash TEXT", []);
-    let _ = conn.execute("ALTER TABLE history ADD COLUMN git_branch TEXT", []);
     conn.execute_batch(
         r#"
 CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -603,32 +601,9 @@ END;
     // three declarations of the same nine names (CREATE TABLE, this loop, the
     // read-only guard) is two chances to drift, and every catalog column is
     // TEXT, so the guard list is the migration list.
-    for column in REQUIRED_SESSIONS_COLUMNS {
-        // "Already there" is the expected outcome on every run after the
-        // first, and the only error worth swallowing. Anything else -- a
-        // read-only file, a corrupt page, a locked database -- means the
-        // migration did not happen, and hiding it here turns one clear failure
-        // at init into `no such column` on the user's first listing.
-        if let Err(error) = conn.execute(
-            &format!("ALTER TABLE sessions ADD COLUMN {column} TEXT"),
-            [],
-        ) {
-            if !error.to_string().contains("duplicate column name") {
-                return Err(error).with_context(|| format!("adding column sessions.{column}"));
-            }
-        }
-    }
-    for column in REQUIRED_SESSION_PRESENCE_COLUMNS {
-        if let Err(error) = conn.execute(
-            &format!("ALTER TABLE session_presences ADD COLUMN {column} TEXT"),
-            [],
-        ) {
-            if !error.to_string().contains("duplicate column name") {
-                return Err(error)
-                    .with_context(|| format!("adding column session_presences.{column}"));
-            }
-        }
-    }
+    ensure_text_columns(conn, "history", REQUIRED_HISTORY_COLUMNS)?;
+    ensure_text_columns(conn, "sessions", REQUIRED_SESSIONS_COLUMNS)?;
+    ensure_text_columns(conn, "session_presences", REQUIRED_SESSION_PRESENCE_COLUMNS)?;
     // Before the presence model every identity in the local evidence ledger
     // was local. Check the marker before attempting a write so an
     // already-current database remains readable while another process writes.
@@ -782,6 +757,49 @@ COMMIT;
         "CREATE INDEX IF NOT EXISTS idx_session_commit_links_repo ON session_commit_links(repo, branch)",
         [],
     )?;
+    Ok(())
+}
+
+/// Add only columns that are actually absent.
+///
+/// A read-before-write keeps an already-current open lock-free. The second
+/// check runs after `BEGIN IMMEDIATE`, so concurrent first opens cannot both
+/// attempt the same `ALTER TABLE`; this avoids both guaranteed failing ALTERs
+/// and locale/version-sensitive matching on SQLite error strings.
+fn ensure_text_columns(conn: &Connection, table: &str, required: &[&str]) -> Result<()> {
+    let missing = |conn: &Connection| -> Result<Vec<&str>> {
+        let existing: HashSet<String> = conn
+            .prepare("SELECT name FROM pragma_table_info(?)")?
+            .query_map([table], |row| row.get::<_, String>(0))?
+            .collect::<rusqlite::Result<_>>()?;
+        Ok(required
+            .iter()
+            .copied()
+            .filter(|column| !existing.contains(*column))
+            .collect())
+    };
+
+    if missing(conn)?.is_empty() {
+        return Ok(());
+    }
+
+    conn.execute_batch("BEGIN IMMEDIATE")?;
+    let migration = (|| -> Result<()> {
+        for column in missing(conn)? {
+            // `table` and `column` come exclusively from internal constant
+            // lists, never from user input.
+            conn.execute(&format!("ALTER TABLE {table} ADD COLUMN {column} TEXT"), [])
+                .with_context(|| format!("adding column {table}.{column}"))?;
+        }
+        Ok(())
+    })();
+    match migration {
+        Ok(()) => conn.execute_batch("COMMIT")?,
+        Err(error) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            return Err(error);
+        }
+    }
     Ok(())
 }
 
@@ -992,12 +1010,14 @@ fn append_filters(sql: &mut String, params: &mut Vec<String>, filter: &QueryFilt
 fn append_scope_filter(sql: &mut String, scope: SessionScope, alias: &str) {
     match scope {
         SessionScope::Local => {
-            // Rows written before presences existed are local by construction.
-            // Keep that compatibility fallback only while a session has no
-            // explicit presence: a remote-only session must not leak into the
-            // default local view.
+            // A row without a session identity cannot be remote-addressed and
+            // remains part of the historical local surface. Identified rows
+            // written before the presence model (or by an older binary) also
+            // remain visible while they have no classification. Current remote
+            // writers record presence before evidence, so a remote-only row
+            // never relies on this compatibility fallback.
             sql.push_str(&format!(
-                " AND (EXISTS (SELECT 1 FROM session_presences sp_local WHERE sp_local.source = {alias}.source AND sp_local.session_id = {alias}.session_id AND sp_local.location = 'local') OR NOT EXISTS (SELECT 1 FROM session_presences sp_any WHERE sp_any.source = {alias}.source AND sp_any.session_id = {alias}.session_id))"
+                " AND ({alias}.session_id IS NULL OR EXISTS (SELECT 1 FROM session_presences sp_local WHERE sp_local.source = {alias}.source AND sp_local.session_id = {alias}.session_id AND sp_local.location = 'local') OR NOT EXISTS (SELECT 1 FROM session_presences sp_any WHERE sp_any.source = {alias}.source AND sp_any.session_id = {alias}.session_id))"
             ));
         }
         SessionScope::Remote => {
@@ -1025,6 +1045,22 @@ pub fn mark_session_presence(
         params![source, session_id, location.as_str()],
     )?;
     Ok(())
+}
+
+/// Return the observed locations for one canonical session identity.
+///
+/// An empty result is intentionally distinct from `local`: it means no
+/// provenance row was recorded (for example, by an older writer).
+pub fn session_locations(conn: &Connection, source: &str, session_id: &str) -> Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT location FROM session_presences \
+         WHERE source = ? AND session_id = ? \
+         ORDER BY CASE location WHEN 'local' THEN 0 ELSE 1 END",
+    )?;
+    let locations = stmt
+        .query_map(params![source, session_id], |row| row.get(0))?
+        .collect::<rusqlite::Result<_>>()?;
+    Ok(locations)
 }
 
 /// Record a presence together with connector-specific cache metadata.
@@ -1078,21 +1114,19 @@ pub fn insert_history_at_location(
     entry: &HistoryEntry,
     location: SessionLocation,
 ) -> Result<usize> {
-    if conn.is_autocommit() {
-        let transaction = conn.unchecked_transaction()?;
-        let inserted = insert_history_with_presence(&transaction, entry, location)?;
-        transaction.commit()?;
-        return Ok(inserted);
+    if location == SessionLocation::Remote {
+        anyhow::ensure!(
+            entry
+                .session_id
+                .as_deref()
+                .is_some_and(|session_id| !session_id.is_empty()),
+            "remote history requires a non-empty session id"
+        );
     }
-    // An existing caller transaction makes the evidence and presence atomic.
-    insert_history_with_presence(conn, entry, location)
-}
-
-fn insert_history_with_presence(
-    conn: &Connection,
-    entry: &HistoryEntry,
-    location: SessionLocation,
-) -> Result<usize> {
+    // Presence first preserves the important failure invariant without adding
+    // a transaction per imported prompt: evidence can never commit before its
+    // classification. A lone presence after a later insert failure is harmless
+    // and a duplicate evidence insert still repairs a missing presence.
     if let Some(session_id) = entry.session_id.as_deref().filter(|id| !id.is_empty()) {
         mark_session_presence(conn, &entry.source, session_id, location)?;
     }
@@ -1826,7 +1860,7 @@ mod tests {
     }
 
     #[test]
-    fn search_and_recent_apply_presence_scope_with_a_local_legacy_fallback() {
+    fn search_and_recent_preserve_unclassified_rows_as_local() {
         let conn = Connection::open_in_memory().unwrap();
         init_db(&conn).unwrap();
         for (session_id, timestamp_ms) in [("legacy", 1), ("local", 2), ("remote", 3), ("both", 4)]
@@ -1856,10 +1890,20 @@ mod tests {
         mark_session_presence(&conn, "claude", "both", SessionLocation::Remote).unwrap();
         // Presence writes are idempotent.
         mark_session_presence(&conn, "claude", "both", SessionLocation::Remote).unwrap();
+        conn.execute(
+            "INSERT INTO history (source, session_id, prompt, timestamp_ms) VALUES ('claude', 'unclassified', 'scopeprobe', 5)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO history (source, session_id, prompt, timestamp_ms) VALUES ('claude', NULL, 'scopeprobe', 6)",
+            [],
+        )
+        .unwrap();
 
         let ids = |rows: Vec<HistoryEntry>| {
             rows.into_iter()
-                .map(|row| row.session_id.unwrap())
+                .map(|row| row.session_id.unwrap_or_else(|| "<none>".into()))
                 .collect::<Vec<_>>()
         };
         for query in [false, true] {
@@ -1875,18 +1919,28 @@ mod tests {
                     recent(&conn, &filter).unwrap()
                 }
             };
-            assert_eq!(ids(run(SessionScope::Local)), ["both", "local", "legacy"]);
+            assert_eq!(
+                ids(run(SessionScope::Local)),
+                ["<none>", "unclassified", "both", "local", "legacy"]
+            );
             assert_eq!(ids(run(SessionScope::Remote)), ["both", "remote"]);
             assert_eq!(
                 ids(run(SessionScope::All)),
-                ["both", "remote", "local", "legacy"]
+                [
+                    "<none>",
+                    "unclassified",
+                    "both",
+                    "remote",
+                    "local",
+                    "legacy"
+                ]
             );
         }
         assert_eq!(
             stats_scoped(&conn, None, SessionScope::Local)
                 .unwrap()
                 .total,
-            3
+            5
         );
         assert_eq!(
             stats_scoped(&conn, None, SessionScope::Remote)
@@ -1896,7 +1950,7 @@ mod tests {
         );
         assert_eq!(
             stats_scoped(&conn, None, SessionScope::All).unwrap().total,
-            4
+            6
         );
         // Direct lookup is identity-based rather than acquisition-scoped.
         assert_eq!(
@@ -1917,7 +1971,7 @@ mod tests {
     }
 
     #[test]
-    fn history_and_presence_insert_roll_back_together() {
+    fn history_insert_failure_cannot_leave_remote_evidence_unclassified() {
         let conn = Connection::open_in_memory().unwrap();
         init_db(&conn).unwrap();
         conn.execute_batch(
@@ -1943,6 +1997,84 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
+        assert_eq!(presence_count, 1);
+        let history_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM history WHERE source = 'codex' AND session_id = 'reject-me'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(history_count, 0);
+    }
+
+    #[test]
+    fn duplicate_history_insert_repairs_a_missing_presence() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let entry = HistoryEntry {
+            id: 0,
+            source: "codex".into(),
+            session_id: Some("repair-me".into()),
+            project: None,
+            prompt: "already stored".into(),
+            prompt_hash: None,
+            timestamp_ms: 1,
+        };
+        assert_eq!(
+            insert_history_at_location(&conn, &entry, SessionLocation::Remote).unwrap(),
+            1
+        );
+        conn.execute(
+            "DELETE FROM session_presences WHERE source = 'codex' AND session_id = 'repair-me'",
+            [],
+        )
+        .unwrap();
+        assert_eq!(
+            insert_history_at_location(&conn, &entry, SessionLocation::Remote).unwrap(),
+            0
+        );
+        let locations: Vec<String> = conn
+            .prepare(
+                "SELECT location FROM session_presences WHERE source = 'codex' AND session_id = 'repair-me'",
+            )
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(locations, ["remote"]);
+    }
+
+    #[test]
+    fn remote_history_rejects_missing_or_empty_session_identity() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        for session_id in [None, Some(String::new())] {
+            let entry = HistoryEntry {
+                id: 0,
+                source: "codex".into(),
+                session_id,
+                project: None,
+                prompt: "must have remote identity".into(),
+                prompt_hash: None,
+                timestamp_ms: 1,
+            };
+            let error = insert_history_at_location(&conn, &entry, SessionLocation::Remote)
+                .expect_err("identity-less remote history must fail closed");
+            assert!(error
+                .to_string()
+                .contains("remote history requires a non-empty session id"));
+        }
+        let history_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM history", [], |row| row.get(0))
+            .unwrap();
+        let presence_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM session_presences", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(history_count, 0);
         assert_eq!(presence_count, 0);
     }
 

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -282,6 +282,8 @@ const BUSY_RETRY_ATTEMPTS: i32 = 65;
 const BUSY_RETRY_BASE_MS: u64 = 10;
 const BUSY_RETRY_CAP_MS: u64 = 500;
 const BUSY_RETRY_JITTER_DIVISOR: u64 = 10;
+const JOURNAL_MODE_RETRY_ATTEMPTS: i32 = 20;
+const JOURNAL_MODE_RETRY_MS: u64 = 10;
 
 fn busy_retry_backoff_ms(prior_attempts: i32) -> Option<u64> {
     if !(0..BUSY_RETRY_ATTEMPTS).contains(&prior_attempts) {
@@ -313,6 +315,34 @@ fn busy_retry_handler(prior_attempts: i32) -> bool {
 fn configure_busy_retry(conn: &Connection) -> Result<()> {
     conn.busy_handler(Some(busy_retry_handler))?;
     Ok(())
+}
+
+fn sqlite_lock_error(error: &rusqlite::Error) -> bool {
+    matches!(
+        error,
+        rusqlite::Error::SqliteFailure(failure, _)
+            if matches!(
+                failure.code,
+                rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+            )
+    )
+}
+
+fn enable_wal_for_migration(conn: &Connection) -> Result<()> {
+    for attempt in 0..=JOURNAL_MODE_RETRY_ATTEMPTS {
+        match conn.pragma_update(None, "journal_mode", "WAL") {
+            Ok(()) => return Ok(()),
+            Err(error) if attempt < JOURNAL_MODE_RETRY_ATTEMPTS && sqlite_lock_error(&error) => {
+                // Changing journal mode can return SQLITE_BUSY without invoking
+                // the connection busy handler. This short retry only bridges
+                // simultaneous first opens; the migration write lock below has
+                // the normal bounded contention policy.
+                std::thread::sleep(Duration::from_millis(JOURNAL_MODE_RETRY_MS));
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    unreachable!("the bounded journal-mode retry loop always returns")
 }
 
 pub fn open_db(path: &Path) -> Result<Connection> {
@@ -438,6 +468,7 @@ const REQUIRED_EVENT_READ_INDEXES: &[&str] =
     &["idx_session_events_source_page", "idx_session_events_page"];
 const REQUIRED_SCOPE_READ_INDEXES: &[&str] = &["idx_session_presences_location"];
 const REQUIRED_TRIGGERS: &[&str] = &["delete_session_presences"];
+const REQUIRED_SCHEMA_MIGRATIONS: &[&str] = &["session_presences_local_backfill_v1"];
 
 /// Whether this database already has everything [`init_db`] would add.
 ///
@@ -474,6 +505,12 @@ fn schema_has_required_indexes(conn: &Connection, required_indexes: &[&str]) -> 
     }
     for name in REQUIRED_TRIGGERS {
         if !table.exists([name])? {
+            return Ok(false);
+        }
+    }
+    let mut migration = conn.prepare("SELECT 1 FROM schema_migrations WHERE name = ? LIMIT 1")?;
+    for name in REQUIRED_SCHEMA_MIGRATIONS {
+        if !migration.exists([name])? {
             return Ok(false);
         }
     }
@@ -540,39 +577,27 @@ pub fn open_db_readonly(path: &Path) -> Result<Connection> {
 }
 
 pub fn init_db(conn: &Connection) -> Result<()> {
-    let mut attempts = 0;
-    loop {
-        match init_db_once(conn) {
-            Ok(()) => return Ok(()),
-            Err(error) if migration_lock_error(&error) && busy_retry_handler(attempts) => {
-                attempts += 1;
-            }
-            Err(error) => return Err(error),
-        }
-    }
-}
-
-fn migration_lock_error(error: &anyhow::Error) -> bool {
-    error.chain().any(|cause| {
-        let Some(rusqlite::Error::SqliteFailure(failure, _)) =
-            cause.downcast_ref::<rusqlite::Error>()
-        else {
-            return false;
-        };
-        matches!(
-            failure.code,
-            rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
-        )
-    })
+    init_db_once(conn)
 }
 
 fn init_db_once(conn: &Connection) -> Result<()> {
-    conn.pragma_update(None, "journal_mode", "WAL")?;
-    // Serialize the complete DDL/backfill pass. SQLite busy handlers do not
-    // cover every SQLITE_LOCKED schema race, so `init_db` also retries the
-    // whole rollback-safe attempt above.
+    // A current database needs no write lock. Besides keeping ordinary opens
+    // cheap, this lets sync reach its per-source contention handling when a
+    // different writer already owns the ledger lock.
+    if schema_is_current(conn)? {
+        return Ok(());
+    }
+    enable_wal_for_migration(conn)?;
+    // Serialize the complete DDL/backfill pass. Acquiring the write lock before
+    // inspecting columns prevents concurrent first-open migrations from both
+    // deciding to add the same column. The connection's bounded busy handler
+    // covers ordinary writer overlap while preserving prompt lock diagnostics.
     let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-    init_db_locked(&transaction)?;
+    // Another first opener may have completed the migration while this
+    // connection waited for the lock.
+    if !schema_is_current(&transaction)? {
+        init_db_locked(&transaction)?;
+    }
     transaction.commit()?;
     Ok(())
 }

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use rusqlite::{params, Connection, DatabaseName, OpenFlags};
+use rusqlite::{params, Connection, DatabaseName, OpenFlags, Transaction, TransactionBehavior};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashSet;
@@ -540,7 +540,44 @@ pub fn open_db_readonly(path: &Path) -> Result<Connection> {
 }
 
 pub fn init_db(conn: &Connection) -> Result<()> {
+    let mut attempts = 0;
+    loop {
+        match init_db_once(conn) {
+            Ok(()) => return Ok(()),
+            Err(error) if migration_lock_error(&error) && busy_retry_handler(attempts) => {
+                attempts += 1;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn migration_lock_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        let Some(rusqlite::Error::SqliteFailure(failure, _)) =
+            cause.downcast_ref::<rusqlite::Error>()
+        else {
+            return false;
+        };
+        matches!(
+            failure.code,
+            rusqlite::ErrorCode::DatabaseBusy | rusqlite::ErrorCode::DatabaseLocked
+        )
+    })
+}
+
+fn init_db_once(conn: &Connection) -> Result<()> {
     conn.pragma_update(None, "journal_mode", "WAL")?;
+    // Serialize the complete DDL/backfill pass. SQLite busy handlers do not
+    // cover every SQLITE_LOCKED schema race, so `init_db` also retries the
+    // whole rollback-safe attempt above.
+    let transaction = Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    init_db_locked(&transaction)?;
+    transaction.commit()?;
+    Ok(())
+}
+
+fn init_db_locked(conn: &Connection) -> Result<()> {
     conn.execute_batch(SCHEMA)?;
     conn.execute_batch(
         r#"
@@ -606,9 +643,8 @@ END;
     ensure_text_columns(conn, "session_presences", REQUIRED_SESSION_PRESENCE_COLUMNS)?;
     // Before the presence model every identity in the local evidence ledger
     // was local. Check the marker before attempting a write so an
-    // already-current database remains readable while another process writes.
-    // The transaction rechecks after acquiring the write lock, making two
-    // concurrent first opens both safe and crash-atomic.
+    // already-current database remains cheap to check. The outer immediate
+    // transaction makes concurrent first opens safe and crash-atomic.
     let presence_backfilled = conn.query_row(
         "SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE name = 'session_presences_local_backfill_v1')",
         [],
@@ -617,7 +653,6 @@ END;
     if !presence_backfilled {
         conn.execute_batch(
             r#"
-BEGIN IMMEDIATE;
 INSERT OR IGNORE INTO session_presences
     (source, session_id, location, raw_locator, source_stamp, discovery_state)
 SELECT source, session_id, 'local', raw_path, source_stamp, discovery_state
@@ -642,7 +677,6 @@ WHERE NOT EXISTS (
 );
 INSERT OR IGNORE INTO schema_migrations (name)
 VALUES ('session_presences_local_backfill_v1');
-COMMIT;
 "#,
         )?;
     }
@@ -762,10 +796,10 @@ COMMIT;
 
 /// Add only columns that are actually absent.
 ///
-/// A read-before-write keeps an already-current open lock-free. The second
-/// check runs after `BEGIN IMMEDIATE`, so concurrent first opens cannot both
-/// attempt the same `ALTER TABLE`; this avoids both guaranteed failing ALTERs
-/// and locale/version-sensitive matching on SQLite error strings.
+/// The caller holds the migration write lock, so only genuinely missing
+/// columns are altered and concurrent opens cannot race the same statement.
+/// This avoids both guaranteed failing ALTERs and locale/version-sensitive
+/// matching on SQLite error strings.
 fn ensure_text_columns(conn: &Connection, table: &str, required: &[&str]) -> Result<()> {
     let missing = |conn: &Connection| -> Result<Vec<&str>> {
         let existing: HashSet<String> = conn
@@ -779,26 +813,11 @@ fn ensure_text_columns(conn: &Connection, table: &str, required: &[&str]) -> Res
             .collect())
     };
 
-    if missing(conn)?.is_empty() {
-        return Ok(());
-    }
-
-    conn.execute_batch("BEGIN IMMEDIATE")?;
-    let migration = (|| -> Result<()> {
-        for column in missing(conn)? {
-            // `table` and `column` come exclusively from internal constant
-            // lists, never from user input.
-            conn.execute(&format!("ALTER TABLE {table} ADD COLUMN {column} TEXT"), [])
-                .with_context(|| format!("adding column {table}.{column}"))?;
-        }
-        Ok(())
-    })();
-    match migration {
-        Ok(()) => conn.execute_batch("COMMIT")?,
-        Err(error) => {
-            let _ = conn.execute_batch("ROLLBACK");
-            return Err(error);
-        }
+    for column in missing(conn)? {
+        // `table` and `column` come exclusively from internal constant lists,
+        // never from user input.
+        conn.execute(&format!("ALTER TABLE {table} ADD COLUMN {column} TEXT"), [])
+            .with_context(|| format!("adding column {table}.{column}"))?;
     }
     Ok(())
 }

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -63,6 +63,38 @@ pub struct QueryFilter {
     pub tag: Option<String>,
     pub before_ms: Option<i64>,
     pub limit: i64,
+    pub scope: SessionScope,
+}
+
+/// Which acquisition surface a query should include.
+///
+/// Local remains the default so upgrading does not turn an offline read into a
+/// network-backed workflow or expose remotely discovered catalog entries in
+/// existing commands. `All` is the union of both locations, not a third place.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionScope {
+    #[default]
+    Local,
+    Remote,
+    All,
+}
+
+/// A place where one logical provider session has been observed.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionLocation {
+    Local,
+    Remote,
+}
+
+impl SessionLocation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Remote => "remote",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -350,6 +382,8 @@ const REQUIRED_TABLES: &[&str] = &[
     "tags",
     "session_tags",
     "sessions",
+    "session_presences",
+    "schema_migrations",
     "discovery_skips",
 ];
 const REQUIRED_HISTORY_COLUMNS: &[&str] = &["prompt_hash", "git_branch"];
@@ -368,6 +402,8 @@ const REQUIRED_SESSIONS_COLUMNS: &[&str] = &[
     "source_stamp",
     "discovery_state",
 ];
+const REQUIRED_SESSION_PRESENCE_COLUMNS: &[&str] =
+    &["raw_locator", "source_stamp", "discovery_state"];
 
 /// Indexes the session catalog's fast paths depend on.
 ///
@@ -389,12 +425,19 @@ const REQUIRED_SESSIONS_INDEXES: &[&str] = &[
     "idx_sessions_raw_path",
     "idx_session_events_source_page",
     "idx_session_events_page",
+    "idx_session_presences_location",
+    "idx_session_presences_locator",
 ];
 
-const REQUIRED_CATALOG_READ_INDEXES: &[&str] =
-    &["idx_sessions_recency", "idx_sessions_source_recency"];
+const REQUIRED_CATALOG_READ_INDEXES: &[&str] = &[
+    "idx_sessions_recency",
+    "idx_sessions_source_recency",
+    "idx_session_presences_location",
+];
 const REQUIRED_EVENT_READ_INDEXES: &[&str] =
     &["idx_session_events_source_page", "idx_session_events_page"];
+const REQUIRED_SCOPE_READ_INDEXES: &[&str] = &["idx_session_presences_location"];
+const REQUIRED_TRIGGERS: &[&str] = &["delete_session_presences"];
 
 /// Whether this database already has everything [`init_db`] would add.
 ///
@@ -409,7 +452,7 @@ pub fn schema_is_current(conn: &Connection) -> Result<bool> {
 
 /// Whether read-only APIs can safely and efficiently query this database.
 pub fn schema_is_read_current(conn: &Connection) -> Result<bool> {
-    schema_has_required_indexes(conn, &[])
+    schema_has_required_indexes(conn, REQUIRED_SCOPE_READ_INDEXES)
 }
 
 /// Whether the cache-only catalog can use its sort-free query plans.
@@ -425,6 +468,11 @@ pub fn schema_is_event_read_current(conn: &Connection) -> Result<bool> {
 fn schema_has_required_indexes(conn: &Connection, required_indexes: &[&str]) -> Result<bool> {
     let mut table = conn.prepare("SELECT 1 FROM sqlite_master WHERE name = ? LIMIT 1")?;
     for name in REQUIRED_TABLES {
+        if !table.exists([name])? {
+            return Ok(false);
+        }
+    }
+    for name in REQUIRED_TRIGGERS {
         if !table.exists([name])? {
             return Ok(false);
         }
@@ -446,6 +494,16 @@ fn schema_has_required_indexes(conn: &Connection, required_indexes: &[&str]) -> 
     if !REQUIRED_SESSIONS_COLUMNS
         .iter()
         .all(|needed| session_columns.contains(*needed))
+    {
+        return Ok(false);
+    }
+    let presence_columns: HashSet<String> = conn
+        .prepare("SELECT name FROM pragma_table_info('session_presences')")?
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<_>>()?;
+    if !REQUIRED_SESSION_PRESENCE_COLUMNS
+        .iter()
+        .all(|needed| presence_columns.contains(*needed))
     {
         return Ok(false);
     }
@@ -488,6 +546,9 @@ pub fn init_db(conn: &Connection) -> Result<()> {
     let _ = conn.execute("ALTER TABLE history ADD COLUMN git_branch TEXT", []);
     conn.execute_batch(
         r#"
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    name TEXT PRIMARY KEY
+);
 CREATE TABLE IF NOT EXISTS discovery_skips (
     source TEXT NOT NULL,
     locator TEXT NOT NULL,
@@ -517,6 +578,21 @@ CREATE TABLE IF NOT EXISTS sessions (
     discovery_state TEXT,
     PRIMARY KEY (session_id, source)
 );
+CREATE TABLE IF NOT EXISTS session_presences (
+    source TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    location TEXT NOT NULL CHECK(location IN ('local', 'remote')),
+    raw_locator TEXT,
+    source_stamp TEXT,
+    discovery_state TEXT,
+    PRIMARY KEY (source, session_id, location)
+);
+CREATE TRIGGER IF NOT EXISTS delete_session_presences
+AFTER DELETE ON sessions
+BEGIN
+    DELETE FROM session_presences
+    WHERE source = OLD.source AND session_id = OLD.session_id;
+END;
 "#,
     )?;
     // `sessions` predates the shallow catalog. Databases created by an older
@@ -541,6 +617,59 @@ CREATE TABLE IF NOT EXISTS sessions (
                 return Err(error).with_context(|| format!("adding column sessions.{column}"));
             }
         }
+    }
+    for column in REQUIRED_SESSION_PRESENCE_COLUMNS {
+        if let Err(error) = conn.execute(
+            &format!("ALTER TABLE session_presences ADD COLUMN {column} TEXT"),
+            [],
+        ) {
+            if !error.to_string().contains("duplicate column name") {
+                return Err(error)
+                    .with_context(|| format!("adding column session_presences.{column}"));
+            }
+        }
+    }
+    // Before the presence model every identity in the local evidence ledger
+    // was local. Check the marker before attempting a write so an
+    // already-current database remains readable while another process writes.
+    // The transaction rechecks after acquiring the write lock, making two
+    // concurrent first opens both safe and crash-atomic.
+    let presence_backfilled = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE name = 'session_presences_local_backfill_v1')",
+        [],
+        |row| row.get::<_, bool>(0),
+    )?;
+    if !presence_backfilled {
+        conn.execute_batch(
+            r#"
+BEGIN IMMEDIATE;
+INSERT OR IGNORE INTO session_presences
+    (source, session_id, location, raw_locator, source_stamp, discovery_state)
+SELECT source, session_id, 'local', raw_path, source_stamp, discovery_state
+FROM sessions
+WHERE session_id <> ''
+  AND NOT EXISTS (
+      SELECT 1 FROM schema_migrations
+      WHERE name = 'session_presences_local_backfill_v1'
+  );
+INSERT OR IGNORE INTO session_presences (source, session_id, location)
+SELECT source, session_id, 'local'
+FROM (
+    SELECT source, session_id FROM history WHERE session_id IS NOT NULL AND session_id <> ''
+    UNION SELECT source, session_id FROM session_events WHERE session_id <> ''
+    UNION SELECT source, session_id FROM tool_calls WHERE session_id <> ''
+    UNION SELECT source, session_id FROM file_edits WHERE session_id <> ''
+    UNION SELECT source, session_id FROM session_commit_links WHERE session_id <> ''
+)
+WHERE NOT EXISTS (
+    SELECT 1 FROM schema_migrations
+    WHERE name = 'session_presences_local_backfill_v1'
+);
+INSERT OR IGNORE INTO schema_migrations (name)
+VALUES ('session_presences_local_backfill_v1');
+COMMIT;
+"#,
+        )?;
     }
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_history_hash ON history(prompt_hash)",
@@ -599,6 +728,14 @@ CREATE TABLE IF NOT EXISTS sessions (
     // path, because a transcript's session id is not known until it is read.
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_sessions_raw_path ON sessions(source, raw_path)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_session_presences_location ON session_presences(location, source, session_id)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_session_presences_locator ON session_presences(location, source, raw_locator)",
         [],
     )?;
     conn.execute(
@@ -852,11 +989,118 @@ fn append_filters(sql: &mut String, params: &mut Vec<String>, filter: &QueryFilt
     }
 }
 
+fn append_scope_filter(sql: &mut String, scope: SessionScope, alias: &str) {
+    match scope {
+        SessionScope::Local => {
+            // Rows written before presences existed are local by construction.
+            // Keep that compatibility fallback only while a session has no
+            // explicit presence: a remote-only session must not leak into the
+            // default local view.
+            sql.push_str(&format!(
+                " AND (EXISTS (SELECT 1 FROM session_presences sp_local WHERE sp_local.source = {alias}.source AND sp_local.session_id = {alias}.session_id AND sp_local.location = 'local') OR NOT EXISTS (SELECT 1 FROM session_presences sp_any WHERE sp_any.source = {alias}.source AND sp_any.session_id = {alias}.session_id))"
+            ));
+        }
+        SessionScope::Remote => {
+            sql.push_str(&format!(
+                " AND EXISTS (SELECT 1 FROM session_presences sp_remote WHERE sp_remote.source = {alias}.source AND sp_remote.session_id = {alias}.session_id AND sp_remote.location = 'remote')"
+            ));
+        }
+        SessionScope::All => {}
+    }
+}
+
+/// Record that a provider session exists at one acquisition location.
+///
+/// The operation is idempotent and intentionally does not infer the opposite
+/// location. A teleported session can therefore have both rows, while a cloud
+/// catalog entry stays remote-only until local materialization is observed.
+pub fn mark_session_presence(
+    conn: &Connection,
+    source: &str,
+    session_id: &str,
+    location: SessionLocation,
+) -> Result<()> {
+    conn.execute(
+        "INSERT OR IGNORE INTO session_presences (source, session_id, location) VALUES (?, ?, ?)",
+        params![source, session_id, location.as_str()],
+    )?;
+    Ok(())
+}
+
+/// Record a presence together with connector-specific cache metadata.
+///
+/// Locator and stamp live on the presence so a dual local/remote session can
+/// retain independent change detection state. Canonical merged metadata stays
+/// on `sessions` for the unified user-facing row.
+#[allow(clippy::too_many_arguments)]
+pub fn upsert_session_presence(
+    conn: &Connection,
+    source: &str,
+    session_id: &str,
+    location: SessionLocation,
+    raw_locator: Option<&str>,
+    source_stamp: Option<&str>,
+    discovery_state: Option<&str>,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO session_presences \
+         (source, session_id, location, raw_locator, source_stamp, discovery_state) \
+         VALUES (?, ?, ?, ?, ?, ?) \
+         ON CONFLICT(source, session_id, location) DO UPDATE SET \
+         raw_locator = COALESCE(excluded.raw_locator, session_presences.raw_locator), \
+         source_stamp = COALESCE(excluded.source_stamp, session_presences.source_stamp), \
+         discovery_state = CASE \
+             WHEN session_presences.discovery_state = 'full' THEN 'full' \
+             ELSE COALESCE(excluded.discovery_state, session_presences.discovery_state) \
+         END",
+        params![
+            source,
+            session_id,
+            location.as_str(),
+            raw_locator,
+            source_stamp,
+            discovery_state
+        ],
+    )?;
+    Ok(())
+}
+
 pub fn insert_history(conn: &Connection, entry: &HistoryEntry) -> Result<usize> {
-    Ok(conn.execute(
+    insert_history_at_location(conn, entry, SessionLocation::Local)
+}
+
+/// Insert one history row and record the acquisition location of its session.
+/// Existing callers use [`insert_history`] for the local default; remote
+/// connectors use this entry point so ingestion never manufactures a local
+/// presence.
+pub fn insert_history_at_location(
+    conn: &Connection,
+    entry: &HistoryEntry,
+    location: SessionLocation,
+) -> Result<usize> {
+    if conn.is_autocommit() {
+        let transaction = conn.unchecked_transaction()?;
+        let inserted = insert_history_with_presence(&transaction, entry, location)?;
+        transaction.commit()?;
+        return Ok(inserted);
+    }
+    // An existing caller transaction makes the evidence and presence atomic.
+    insert_history_with_presence(conn, entry, location)
+}
+
+fn insert_history_with_presence(
+    conn: &Connection,
+    entry: &HistoryEntry,
+    location: SessionLocation,
+) -> Result<usize> {
+    if let Some(session_id) = entry.session_id.as_deref().filter(|id| !id.is_empty()) {
+        mark_session_presence(conn, &entry.source, session_id, location)?;
+    }
+    let inserted = conn.execute(
         "INSERT OR IGNORE INTO history (source, session_id, project, prompt, prompt_hash, timestamp_ms) VALUES (?, ?, ?, ?, ?, ?)",
         params![entry.source, entry.session_id, entry.project, entry.prompt, entry.prompt_hash, entry.timestamp_ms],
-    )?)
+    )?;
+    Ok(inserted)
 }
 
 pub fn search(
@@ -872,6 +1116,7 @@ pub fn search(
     let mut sql = "SELECT h.id, h.source, h.session_id, h.project, h.prompt, h.timestamp_ms FROM history_fts f JOIN history h ON f.rowid = h.id WHERE history_fts MATCH ?".to_string();
     let mut params_vec = vec![query];
     append_filters(&mut sql, &mut params_vec, filter, "h");
+    append_scope_filter(&mut sql, filter.scope, "h");
     sql.push_str(" ORDER BY h.timestamp_ms DESC LIMIT ?");
     params_vec.push(filter.limit.max(1).to_string());
     let mut stmt = conn.prepare(&sql)?;
@@ -886,6 +1131,7 @@ pub fn recent(conn: &Connection, filter: &QueryFilter) -> Result<Vec<HistoryEntr
     let mut sql = "SELECT h.id, h.source, h.session_id, h.project, h.prompt, h.timestamp_ms FROM history h WHERE 1=1".to_string();
     let mut params_vec = Vec::new();
     append_filters(&mut sql, &mut params_vec, filter, "h");
+    append_scope_filter(&mut sql, filter.scope, "h");
     sql.push_str(" ORDER BY h.timestamp_ms DESC LIMIT ?");
     params_vec.push(filter.limit.max(1).to_string());
     let mut stmt = conn.prepare(&sql)?;
@@ -1147,10 +1393,15 @@ pub fn session_file_edits(
 }
 
 pub fn stats(conn: &Connection, tag: Option<&str>) -> Result<Stats> {
-    let mut where_sql = String::new();
+    stats_scoped(conn, tag, SessionScope::Local)
+}
+
+pub fn stats_scoped(conn: &Connection, tag: Option<&str>, scope: SessionScope) -> Result<Stats> {
+    let mut where_sql = " WHERE 1=1".to_string();
     let mut params_vec = Vec::new();
+    append_scope_filter(&mut where_sql, scope, "h");
     if let Some(tag) = tag {
-        where_sql = " WHERE EXISTS (SELECT 1 FROM session_tags st JOIN tags t ON t.id = st.tag_id WHERE st.source = h.source AND st.session_id = h.session_id AND t.name = ?)".into();
+        where_sql.push_str(" AND EXISTS (SELECT 1 FROM session_tags st JOIN tags t ON t.id = st.tag_id WHERE st.source = h.source AND st.session_id = h.session_id AND t.name = ?)");
         params_vec.push(normalize_tag_name(tag));
     }
     let total = conn.query_row(
@@ -1170,11 +1421,7 @@ pub fn stats(conn: &Connection, tag: Option<&str>) -> Result<Stats> {
         rows
     };
     let by_project = {
-        let extra = if where_sql.is_empty() {
-            "WHERE project IS NOT NULL".to_string()
-        } else {
-            format!("{where_sql} AND project IS NOT NULL")
-        };
+        let extra = format!("{where_sql} AND project IS NOT NULL");
         let mut stmt = conn.prepare(&format!("SELECT project, COUNT(*) FROM history h {extra} GROUP BY project ORDER BY COUNT(*) DESC LIMIT 10"))?;
         let rows = stmt
             .query_map(rusqlite::params_from_iter(params_vec.clone()), |r| {
@@ -1563,6 +1810,140 @@ mod tests {
             "\"parity-check\""
         );
         assert_eq!(build_fts_query(&["foo*".into()], false), "foo*");
+    }
+
+    #[test]
+    fn session_scope_defaults_to_local_and_uses_lowercase_wire_names() {
+        assert_eq!(SessionScope::default(), SessionScope::Local);
+        assert_eq!(
+            serde_json::to_string(&SessionScope::Remote).unwrap(),
+            "\"remote\""
+        );
+        assert_eq!(
+            serde_json::from_str::<SessionScope>("\"all\"").unwrap(),
+            SessionScope::All
+        );
+    }
+
+    #[test]
+    fn search_and_recent_apply_presence_scope_with_a_local_legacy_fallback() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        for (session_id, timestamp_ms) in [("legacy", 1), ("local", 2), ("remote", 3), ("both", 4)]
+        {
+            insert_history(
+                &conn,
+                &HistoryEntry {
+                    id: 0,
+                    source: "claude".into(),
+                    session_id: Some(session_id.into()),
+                    project: None,
+                    prompt: "scopeprobe".into(),
+                    prompt_hash: None,
+                    timestamp_ms,
+                },
+            )
+            .unwrap();
+        }
+        mark_session_presence(&conn, "claude", "local", SessionLocation::Local).unwrap();
+        conn.execute(
+            "DELETE FROM session_presences WHERE source = 'claude' AND session_id = 'remote'",
+            [],
+        )
+        .unwrap();
+        mark_session_presence(&conn, "claude", "remote", SessionLocation::Remote).unwrap();
+        mark_session_presence(&conn, "claude", "both", SessionLocation::Local).unwrap();
+        mark_session_presence(&conn, "claude", "both", SessionLocation::Remote).unwrap();
+        // Presence writes are idempotent.
+        mark_session_presence(&conn, "claude", "both", SessionLocation::Remote).unwrap();
+
+        let ids = |rows: Vec<HistoryEntry>| {
+            rows.into_iter()
+                .map(|row| row.session_id.unwrap())
+                .collect::<Vec<_>>()
+        };
+        for query in [false, true] {
+            let run = |scope| {
+                let filter = QueryFilter {
+                    limit: 20,
+                    scope,
+                    ..Default::default()
+                };
+                if query {
+                    search(&conn, &["scopeprobe".into()], false, &filter).unwrap()
+                } else {
+                    recent(&conn, &filter).unwrap()
+                }
+            };
+            assert_eq!(ids(run(SessionScope::Local)), ["both", "local", "legacy"]);
+            assert_eq!(ids(run(SessionScope::Remote)), ["both", "remote"]);
+            assert_eq!(
+                ids(run(SessionScope::All)),
+                ["both", "remote", "local", "legacy"]
+            );
+        }
+        assert_eq!(
+            stats_scoped(&conn, None, SessionScope::Local)
+                .unwrap()
+                .total,
+            3
+        );
+        assert_eq!(
+            stats_scoped(&conn, None, SessionScope::Remote)
+                .unwrap()
+                .total,
+            2
+        );
+        assert_eq!(
+            stats_scoped(&conn, None, SessionScope::All).unwrap().total,
+            4
+        );
+        // Direct lookup is identity-based rather than acquisition-scoped.
+        assert_eq!(
+            session(&conn, "remote", Some("claude"), None)
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let presence_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_presences WHERE source = 'claude' AND session_id = 'both' AND location = 'remote'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(presence_count, 1);
+    }
+
+    #[test]
+    fn history_and_presence_insert_roll_back_together() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER reject_history_insert BEFORE INSERT ON history
+             WHEN NEW.session_id = 'reject-me'
+             BEGIN SELECT RAISE(ABORT, 'injected failure'); END;",
+        )
+        .unwrap();
+        let entry = HistoryEntry {
+            id: 0,
+            source: "codex".into(),
+            session_id: Some("reject-me".into()),
+            project: None,
+            prompt: "must roll back".into(),
+            prompt_hash: None,
+            timestamp_ms: 1,
+        };
+        assert!(insert_history_at_location(&conn, &entry, SessionLocation::Remote).is_err());
+        let presence_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_presences WHERE source = 'codex' AND session_id = 'reject-me'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(presence_count, 0);
     }
 
     #[test]
@@ -1991,7 +2372,9 @@ mod tests {
                          PRIMARY KEY (session_id, source)
                      );
                      INSERT INTO sessions (session_id, source, last_activity_ms)
-                     VALUES ('legacy-1', 'claude', 42);",
+                     VALUES ('legacy-1', 'claude', 42);
+                     INSERT INTO history (source, session_id, prompt, timestamp_ms)
+                     VALUES ('codex', 'history-only', 'legacy prompt', 41);",
                 )
                 .unwrap();
             assert!(
@@ -2022,6 +2405,118 @@ mod tests {
             .unwrap();
         assert_eq!(id, "legacy-1");
         assert_eq!(state, None);
+        let location: String = conn
+            .query_row(
+                "SELECT location FROM session_presences WHERE source = 'claude' AND session_id = 'legacy-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(location, "local");
+        let history_location: String = conn
+            .query_row(
+                "SELECT location FROM session_presences WHERE source = 'codex' AND session_id = 'history-only'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(history_location, "local");
+
+        // The legacy backfill is permanently guarded. A session discovered
+        // remotely after migration remains remote-only on every later init.
+        conn.execute(
+            "INSERT INTO sessions (session_id, source) VALUES ('cloud-1', 'codex')",
+            [],
+        )
+        .unwrap();
+        mark_session_presence(&conn, "codex", "cloud-1", SessionLocation::Remote).unwrap();
+        init_db(&conn).unwrap();
+        let locations = conn
+            .prepare(
+                "SELECT location FROM session_presences WHERE source = 'codex' AND session_id = 'cloud-1' ORDER BY location",
+            )
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(locations, ["remote"]);
+
+        conn.execute(
+            "DELETE FROM sessions WHERE source = 'codex' AND session_id = 'cloud-1'",
+            [],
+        )
+        .unwrap();
+        let stale: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_presences WHERE source = 'codex' AND session_id = 'cloud-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stale, 0, "canonical deletion cleans presence state");
+    }
+
+    #[test]
+    fn concurrent_first_presence_migrations_are_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("concurrent-legacy.db");
+        {
+            let legacy = Connection::open(&db_path).unwrap();
+            legacy.execute_batch(SCHEMA).unwrap();
+            legacy
+                .execute_batch(
+                    "ALTER TABLE history ADD COLUMN git_branch TEXT;
+                     CREATE TABLE sessions (
+                         session_id TEXT NOT NULL,
+                         source TEXT NOT NULL,
+                         cwd TEXT,
+                         git_branch TEXT,
+                         first_activity_ms INTEGER,
+                         last_activity_ms INTEGER,
+                         last_assistant_text TEXT,
+                         raw_path TEXT,
+                         parser_version INTEGER NOT NULL DEFAULT 1,
+                         PRIMARY KEY (session_id, source)
+                     );
+                     INSERT INTO sessions (session_id, source)
+                     VALUES ('legacy-race', 'claude');",
+                )
+                .unwrap();
+        }
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(4));
+        let handles = (0..4)
+            .map(|_| {
+                let barrier = barrier.clone();
+                let path = db_path.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    open_db(&path).map(drop)
+                })
+            })
+            .collect::<Vec<_>>();
+        for handle in handles {
+            handle.join().unwrap().unwrap();
+        }
+
+        let conn = open_db(&db_path).unwrap();
+        let marker_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM schema_migrations WHERE name = 'session_presences_local_backfill_v1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(marker_count, 1);
+        let presence_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_presences WHERE source = 'claude' AND session_id = 'legacy-race' AND location = 'local'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(presence_count, 1);
     }
 
     /// The catalog listing's promise is an indexed, sort-free read. A database
@@ -2075,6 +2570,15 @@ mod tests {
             .unwrap();
         assert!(schema_is_read_current(&conn).unwrap());
         assert!(!schema_is_event_read_current(&conn).unwrap());
+
+        init_db(&conn).unwrap();
+        conn.execute_batch("DROP INDEX idx_session_presences_location")
+            .unwrap();
+        assert!(!schema_is_current(&conn).unwrap());
+        assert!(!schema_is_read_current(&conn).unwrap());
+        assert!(!schema_is_catalog_read_current(&conn).unwrap());
+        // Direct event pagination does not use session location.
+        assert!(schema_is_event_read_current(&conn).unwrap());
     }
 
     /// A fresh database and a migrated one must end up with the same `sessions`

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -41,6 +41,7 @@ export interface NativeHistoryEntry {
   project?: string
   prompt: string
   timestampMs: number
+  locations: Array<string>
 }
 export interface NativeSessionEvent {
   id: number

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -11,6 +11,7 @@ export declare function nativeContractVersion(): number
  */
 export declare function nativeBuildProfile(): string
 export interface HistoryQueryOptions {
+  scope?: string
   dbPath?: string
   source?: string
   project?: string
@@ -19,6 +20,7 @@ export interface HistoryQueryOptions {
   limit?: number
 }
 export interface SearchOptions {
+  scope?: string
   dbPath?: string
   source?: string
   project?: string
@@ -80,6 +82,7 @@ export interface ProjectCount {
   count: number
 }
 export interface NativeStats {
+  scope: string
   total: number
   bySource: Array<SourceCount>
   byProject: Array<ProjectCount>
@@ -87,6 +90,7 @@ export interface NativeStats {
   lastTimestampMs?: number
 }
 export interface StatsOptions {
+  scope?: string
   dbPath?: string
   tag?: string
 }
@@ -118,6 +122,7 @@ export interface CatalogSession {
   rawPath?: string
   sourceStamp?: string
   discoveryState: string
+  locations: Array<string>
   fromCache: boolean
 }
 export interface CatalogCursor {
@@ -126,6 +131,7 @@ export interface CatalogCursor {
   sessionId: string
 }
 export interface ListCatalogOptions {
+  scope?: string
   dbPath?: string
   sources?: Array<string>
   limit?: number
@@ -134,6 +140,7 @@ export interface ListCatalogOptions {
 }
 export interface SessionCatalogPage {
   contractVersion: number
+  scope: string
   sessions: Array<CatalogSession>
   nextCursor?: CatalogCursor
 }
@@ -142,6 +149,7 @@ export declare function listSessionCatalogPage(options?: ListCatalogOptions | un
 /** Convenience first-page catalog listing with identical cache-only semantics. */
 export declare function listSessionCatalog(options?: ListCatalogOptions | undefined | null): Promise<Array<CatalogSession>>
 export interface DiscoverOptions {
+  scope?: string
   dbPath?: string
   sources?: Array<string>
   limit?: number
@@ -171,6 +179,7 @@ export interface SourceExemption {
 }
 export interface DiscoverResult {
   contractVersion: number
+  scope: string
   sessions: Array<CatalogSession>
   discovered: number
   skippedUnchanged: number
@@ -183,10 +192,12 @@ export interface DiscoverResult {
 export declare function discoverSessions(options?: DiscoverOptions | undefined | null): Promise<DiscoverResult>
 export interface SyncOptions {
   dbPath?: string
+  scope?: string
 }
 export interface SyncResult {
   databasePath: string
   completed: boolean
+  scope: string
 }
 /** Explicit full ingestion. A read operation never calls this implicitly. */
 export declare function sync(options?: SyncOptions | undefined | null): Promise<SyncResult>

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -10,8 +10,8 @@ use ai_hist_core::{
     default_db_path, open_db, open_db_readonly, recent as core_recent,
     schema_is_catalog_read_current, schema_is_event_read_current, schema_is_read_current,
     search as core_search, session as core_session,
-    session_events_page as core_session_events_page, stats_scoped as core_stats_scoped,
-    HistoryEntry, QueryFilter, SessionEvent as CoreSessionEvent,
+    session_events_page as core_session_events_page, session_locations,
+    stats_scoped as core_stats_scoped, HistoryEntry, QueryFilter, SessionEvent as CoreSessionEvent,
     SessionEventCursor as CoreEventCursor, SessionScope,
 };
 use napi_derive::napi;
@@ -70,6 +70,18 @@ fn scope_name(scope: SessionScope) -> String {
         SessionScope::All => "all",
     }
     .to_string()
+}
+
+fn ensure_acquisition_scope_supported(scope: SessionScope, operation: &str) -> napi::Result<()> {
+    if scope == SessionScope::Remote {
+        return Err(native_error(
+            "UNSUPPORTED_OPERATION",
+            format!(
+                "remote session {operation} is not available: no remote provider connectors are configured"
+            ),
+        ));
+    }
+    Ok(())
 }
 
 /// Contract version implemented by this native addon.
@@ -140,18 +152,24 @@ pub struct NativeHistoryEntry {
     pub project: Option<String>,
     pub prompt: String,
     pub timestamp_ms: i64,
+    pub locations: Vec<String>,
 }
 
-impl From<HistoryEntry> for NativeHistoryEntry {
-    fn from(entry: HistoryEntry) -> Self {
-        Self {
+impl NativeHistoryEntry {
+    fn from_entry(conn: &rusqlite::Connection, entry: HistoryEntry) -> anyhow::Result<Self> {
+        let locations = match entry.session_id.as_deref() {
+            Some(session_id) => session_locations(conn, &entry.source, session_id)?,
+            None => Vec::new(),
+        };
+        Ok(Self {
             id: entry.id,
             source: entry.source,
             session_id: entry.session_id,
             project: entry.project,
             prompt: entry.prompt,
             timestamp_ms: entry.timestamp_ms,
-        }
+            locations,
+        })
     }
 }
 
@@ -310,10 +328,10 @@ pub async fn search(
         .collect::<Vec<_>>();
     let raw_fts = options.raw_fts.unwrap_or(false);
     read_database(path, Vec::new(), move |conn| {
-        Ok(core_search(conn, &terms, raw_fts, &filter)?
+        core_search(conn, &terms, raw_fts, &filter)?
             .into_iter()
-            .map(NativeHistoryEntry::from)
-            .collect())
+            .map(|entry| NativeHistoryEntry::from_entry(conn, entry))
+            .collect()
     })
     .await
 }
@@ -334,10 +352,10 @@ pub async fn recent(options: Option<HistoryQueryOptions>) -> napi::Result<Vec<Na
     let path = db_path(options.db_path.clone());
     let filter = options.filter(limit)?;
     read_database(path, Vec::new(), move |conn| {
-        Ok(core_recent(conn, &filter)?
+        core_recent(conn, &filter)?
             .into_iter()
-            .map(NativeHistoryEntry::from)
-            .collect())
+            .map(|entry| NativeHistoryEntry::from_entry(conn, entry))
+            .collect()
     })
     .await
 }
@@ -355,15 +373,15 @@ pub async fn get_session(
     });
     let path = db_path(options.db_path);
     read_database(path, Vec::new(), move |conn| {
-        Ok(core_session(
+        core_session(
             conn,
             &session_id,
             options.source.as_deref(),
             options.tag.as_deref(),
         )?
         .into_iter()
-        .map(NativeHistoryEntry::from)
-        .collect())
+        .map(|entry| NativeHistoryEntry::from_entry(conn, entry))
+        .collect()
     })
     .await
 }
@@ -657,6 +675,7 @@ pub async fn discover_sessions(options: Option<DiscoverOptions>) -> napi::Result
         limit: None,
     });
     let scope = parse_scope(options.scope)?;
+    ensure_acquisition_scope_supported(scope, "discovery")?;
     let path = db_path(options.db_path);
     let request = ai_hist_engine::DiscoverOptions {
         scope,
@@ -734,6 +753,7 @@ pub async fn sync(options: Option<SyncOptions>) -> napi::Result<SyncResult> {
         scope: None,
     });
     let scope = parse_scope(options.scope)?;
+    ensure_acquisition_scope_supported(scope, "sync")?;
     let path = db_path(options.db_path);
     let result_path = path.display().to_string();
     let completed =

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -10,13 +10,14 @@ use ai_hist_core::{
     default_db_path, open_db, open_db_readonly, recent as core_recent,
     schema_is_catalog_read_current, schema_is_event_read_current, schema_is_read_current,
     search as core_search, session as core_session,
-    session_events_page as core_session_events_page, stats as core_stats, HistoryEntry,
-    QueryFilter, SessionEvent as CoreSessionEvent, SessionEventCursor as CoreEventCursor,
+    session_events_page as core_session_events_page, stats_scoped as core_stats_scoped,
+    HistoryEntry, QueryFilter, SessionEvent as CoreSessionEvent,
+    SessionEventCursor as CoreEventCursor, SessionScope,
 };
 use napi_derive::napi;
 
 /// Bump whenever native object shapes or semantics require an SDK change.
-pub const NATIVE_CONTRACT_VERSION: u32 = 2;
+pub const NATIVE_CONTRACT_VERSION: u32 = 3;
 const DEFAULT_LIMIT: i64 = 50;
 const DEFAULT_EVENT_LIMIT: i64 = 200;
 
@@ -50,6 +51,27 @@ fn validate_limit(limit: Option<i64>, default: i64, max: i64) -> napi::Result<i6
     Ok(limit)
 }
 
+fn parse_scope(scope: Option<String>) -> napi::Result<SessionScope> {
+    match scope.as_deref().unwrap_or("local") {
+        "local" => Ok(SessionScope::Local),
+        "remote" => Ok(SessionScope::Remote),
+        "all" => Ok(SessionScope::All),
+        value => Err(native_error(
+            "INVALID_ARGUMENT",
+            format!("scope must be local, remote, or all (got '{value}')"),
+        )),
+    }
+}
+
+fn scope_name(scope: SessionScope) -> String {
+    match scope {
+        SessionScope::Local => "local",
+        SessionScope::Remote => "remote",
+        SessionScope::All => "all",
+    }
+    .to_string()
+}
+
 /// Contract version implemented by this native addon.
 #[napi]
 pub fn native_contract_version() -> u32 {
@@ -69,6 +91,7 @@ pub fn native_build_profile() -> String {
 
 #[napi(object)]
 pub struct HistoryQueryOptions {
+    pub scope: Option<String>,
     pub db_path: Option<String>,
     pub source: Option<String>,
     pub project: Option<String>,
@@ -78,19 +101,21 @@ pub struct HistoryQueryOptions {
 }
 
 impl HistoryQueryOptions {
-    fn filter(&self, limit: i64) -> QueryFilter {
-        QueryFilter {
+    fn filter(&self, limit: i64) -> napi::Result<QueryFilter> {
+        Ok(QueryFilter {
+            scope: parse_scope(self.scope.clone())?,
             source: self.source.clone(),
             project: self.project.clone(),
             tag: self.tag.clone(),
             before_ms: self.before_ms,
             limit,
-        }
+        })
     }
 }
 
 #[napi(object)]
 pub struct SearchOptions {
+    pub scope: Option<String>,
     pub db_path: Option<String>,
     pub source: Option<String>,
     pub project: Option<String>,
@@ -205,6 +230,7 @@ pub struct ProjectCount {
 
 #[napi(object)]
 pub struct NativeStats {
+    pub scope: String,
     pub total: i64,
     pub by_source: Vec<SourceCount>,
     pub by_project: Vec<ProjectCount>,
@@ -214,6 +240,7 @@ pub struct NativeStats {
 
 #[napi(object)]
 pub struct StatsOptions {
+    pub scope: Option<String>,
     pub db_path: Option<String>,
     pub tag: Option<String>,
 }
@@ -258,6 +285,7 @@ pub async fn search(
     options: Option<SearchOptions>,
 ) -> napi::Result<Vec<NativeHistoryEntry>> {
     let options = options.unwrap_or(SearchOptions {
+        scope: None,
         db_path: None,
         source: None,
         project: None,
@@ -269,6 +297,7 @@ pub async fn search(
     let limit = validate_limit(options.limit, 20, 1_000)?;
     let path = db_path(options.db_path.clone());
     let filter = QueryFilter {
+        scope: parse_scope(options.scope)?,
         source: options.source,
         project: options.project,
         tag: options.tag,
@@ -293,6 +322,7 @@ pub async fn search(
 #[napi]
 pub async fn recent(options: Option<HistoryQueryOptions>) -> napi::Result<Vec<NativeHistoryEntry>> {
     let options = options.unwrap_or(HistoryQueryOptions {
+        scope: None,
         db_path: None,
         source: None,
         project: None,
@@ -302,7 +332,7 @@ pub async fn recent(options: Option<HistoryQueryOptions>) -> napi::Result<Vec<Na
     });
     let limit = validate_limit(options.limit, 20, 1_000)?;
     let path = db_path(options.db_path.clone());
-    let filter = options.filter(limit);
+    let filter = options.filter(limit)?;
     read_database(path, Vec::new(), move |conn| {
         Ok(core_recent(conn, &filter)?
             .into_iter()
@@ -391,13 +421,16 @@ pub async fn get_session_events_page(
 #[napi]
 pub async fn stats(options: Option<StatsOptions>) -> napi::Result<NativeStats> {
     let options = options.unwrap_or(StatsOptions {
+        scope: None,
         db_path: None,
         tag: None,
     });
+    let scope = parse_scope(options.scope)?;
     let path = db_path(options.db_path);
     read_database(
         path,
         NativeStats {
+            scope: scope_name(scope),
             total: 0,
             by_source: Vec::new(),
             by_project: Vec::new(),
@@ -405,8 +438,9 @@ pub async fn stats(options: Option<StatsOptions>) -> napi::Result<NativeStats> {
             last_timestamp_ms: None,
         },
         move |conn| {
-            let result = core_stats(conn, options.tag.as_deref())?;
+            let result = core_stats_scoped(conn, options.tag.as_deref(), scope)?;
             Ok(NativeStats {
+                scope: scope_name(scope),
                 total: result.total,
                 by_source: result
                     .by_source
@@ -445,6 +479,7 @@ pub struct CatalogSession {
     pub raw_path: Option<String>,
     pub source_stamp: Option<String>,
     pub discovery_state: String,
+    pub locations: Vec<String>,
     pub from_cache: bool,
 }
 
@@ -468,6 +503,7 @@ impl From<ai_hist_engine::ShallowSession> for CatalogSession {
             raw_path: session.raw_path,
             source_stamp: session.source_stamp,
             discovery_state: session.discovery_state,
+            locations: session.locations,
             from_cache: session.from_cache,
         }
     }
@@ -482,6 +518,7 @@ pub struct CatalogCursor {
 
 #[napi(object)]
 pub struct ListCatalogOptions {
+    pub scope: Option<String>,
     pub db_path: Option<String>,
     pub sources: Option<Vec<String>>,
     pub limit: Option<i64>,
@@ -492,6 +529,7 @@ pub struct ListCatalogOptions {
 #[napi(object)]
 pub struct SessionCatalogPage {
     pub contract_version: u32,
+    pub scope: String,
     pub sessions: Vec<CatalogSession>,
     pub next_cursor: Option<CatalogCursor>,
 }
@@ -502,6 +540,7 @@ pub async fn list_session_catalog_page(
     options: Option<ListCatalogOptions>,
 ) -> napi::Result<SessionCatalogPage> {
     let options = options.unwrap_or(ListCatalogOptions {
+        scope: None,
         db_path: None,
         sources: None,
         limit: None,
@@ -509,8 +548,10 @@ pub async fn list_session_catalog_page(
         after: None,
     });
     validate_limit(options.limit, DEFAULT_LIMIT, 1_000)?;
+    let scope = parse_scope(options.scope)?;
     let path = db_path(options.db_path);
     let request = ai_hist_engine::CatalogListOptions {
+        scope,
         sources: options.sources.unwrap_or_default(),
         limit: options.limit,
         before_ms: options.before_ms,
@@ -522,13 +563,17 @@ pub async fn list_session_catalog_page(
     };
     read_database_with_schema(
         path,
-        ai_hist_engine::SessionCatalogPage::default(),
+        ai_hist_engine::SessionCatalogPage {
+            scope,
+            ..Default::default()
+        },
         schema_is_catalog_read_current,
         move |conn| ai_hist_engine::list_session_catalog_page(conn, &request),
     )
     .await
     .map(|page| SessionCatalogPage {
         contract_version: ai_hist_engine::SESSION_CATALOG_CONTRACT_VERSION,
+        scope: scope_name(page.scope),
         sessions: page
             .sessions
             .into_iter()
@@ -552,6 +597,7 @@ pub async fn list_session_catalog(
 
 #[napi(object)]
 pub struct DiscoverOptions {
+    pub scope: Option<String>,
     pub db_path: Option<String>,
     pub sources: Option<Vec<String>>,
     pub limit: Option<u32>,
@@ -591,6 +637,7 @@ pub struct SourceExemption {
 #[napi(object)]
 pub struct DiscoverResult {
     pub contract_version: u32,
+    pub scope: String,
     pub sessions: Vec<CatalogSession>,
     pub discovered: u32,
     pub skipped_unchanged: u32,
@@ -604,23 +651,27 @@ pub struct DiscoverResult {
 #[napi]
 pub async fn discover_sessions(options: Option<DiscoverOptions>) -> napi::Result<DiscoverResult> {
     let options = options.unwrap_or(DiscoverOptions {
+        scope: None,
         db_path: None,
         sources: None,
         limit: None,
     });
+    let scope = parse_scope(options.scope)?;
     let path = db_path(options.db_path);
     let request = ai_hist_engine::DiscoverOptions {
+        scope,
         sources: options.sources.unwrap_or_default(),
         limit: options.limit.map(|limit| limit as usize),
     };
     let (sessions, summary) = napi::tokio::task::spawn_blocking(move || {
-        ai_hist_engine::discover_sessions_local_at(&path, &request)
+        ai_hist_engine::discover_sessions_scoped_at(&path, &request)
     })
     .await
     .map_err(worker_error)?
     .map_err(|error| native_error("DISCOVERY_FAILED", format!("{error:#}")))?;
     Ok(DiscoverResult {
         contract_version: summary.contract_version,
+        scope: scope_name(scope),
         sessions: sessions.into_iter().map(CatalogSession::from).collect(),
         discovered: summary.discovered as u32,
         skipped_unchanged: summary.skipped_unchanged as u32,
@@ -665,26 +716,35 @@ pub async fn discover_sessions(options: Option<DiscoverOptions>) -> napi::Result
 #[napi(object)]
 pub struct SyncOptions {
     pub db_path: Option<String>,
+    pub scope: Option<String>,
 }
 
 #[napi(object)]
 pub struct SyncResult {
     pub database_path: String,
     pub completed: bool,
+    pub scope: String,
 }
 
 /// Explicit full ingestion. A read operation never calls this implicitly.
 #[napi]
 pub async fn sync(options: Option<SyncOptions>) -> napi::Result<SyncResult> {
-    let path = db_path(options.and_then(|options| options.db_path));
+    let options = options.unwrap_or(SyncOptions {
+        db_path: None,
+        scope: None,
+    });
+    let scope = parse_scope(options.scope)?;
+    let path = db_path(options.db_path);
     let result_path = path.display().to_string();
-    let completed = napi::tokio::task::spawn_blocking(move || ai_hist_engine::sync_local_at(&path))
-        .await
-        .map_err(worker_error)?
-        .map_err(|error| native_error("SYNC_FAILED", format!("{error:#}")))?;
+    let completed =
+        napi::tokio::task::spawn_blocking(move || ai_hist_engine::sync_scoped_at(&path, scope))
+            .await
+            .map_err(worker_error)?
+            .map_err(|error| native_error("SYNC_FAILED", format!("{error:#}")))?;
     Ok(SyncResult {
         database_path: result_path,
         completed,
+        scope: scope_name(scope),
     })
 }
 

--- a/crates/ai-hist/src/discover.rs
+++ b/crates/ai-hist/src/discover.rs
@@ -60,9 +60,9 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
 
-use ai_hist_core::SOURCE_CHOICES;
+use ai_hist_core::{upsert_session_presence, SessionLocation, SessionScope, SOURCE_CHOICES};
 use anyhow::{Context, Result};
-use rusqlite::{params, Connection, DatabaseName, OpenFlags};
+use rusqlite::{params, Connection, DatabaseName, OpenFlags, OptionalExtension};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -70,7 +70,7 @@ use serde_json::Value;
 ///
 /// Bumped when the shape or meaning of [`ShallowSession`] / the CLI JSON
 /// payloads changes in a way a consumer must notice.
-pub const SESSION_CATALOG_CONTRACT_VERSION: u32 = 1;
+pub const SESSION_CATALOG_CONTRACT_VERSION: u32 = 2;
 
 /// Version of the shallow scanners themselves.
 ///
@@ -144,6 +144,10 @@ pub struct ShallowSession {
     pub source_stamp: Option<String>,
     /// `"shallow"` (catalog row only) or `"full"` (full evidence ingested).
     pub discovery_state: String,
+    /// Places where this logical provider session is known to exist.
+    /// A session may be present both locally and remotely while remaining one
+    /// catalog row.
+    pub locations: Vec<String>,
     /// `true` when this row was served from the catalog without re-reading the
     /// provider source — either a cache-only list, or a rescan whose stamp
     /// matched.
@@ -1425,7 +1429,15 @@ fn file_candidates(
 const SESSION_COLUMNS: &str = "source, session_id, cwd, git_branch, first_activity_ms, \
      last_activity_ms, first_prompt, last_assistant_text, models_json, originator, \
      agent_version, repo_url, initial_commit, workspace_roots_json, raw_path, source_stamp, \
-     discovery_state";
+     discovery_state, \
+     CASE \
+       WHEN EXISTS (SELECT 1 FROM session_presences p WHERE p.source = sessions.source AND p.session_id = sessions.session_id AND p.location = 'local') \
+        AND EXISTS (SELECT 1 FROM session_presences p WHERE p.source = sessions.source AND p.session_id = sessions.session_id AND p.location = 'remote') \
+       THEN '[\"local\",\"remote\"]' \
+       WHEN EXISTS (SELECT 1 FROM session_presences p WHERE p.source = sessions.source AND p.session_id = sessions.session_id AND p.location = 'remote') \
+       THEN '[\"remote\"]' \
+       ELSE '[\"local\"]' \
+     END";
 
 fn json_string_list(raw: Option<String>) -> Vec<String> {
     raw.and_then(|raw| serde_json::from_str::<Vec<String>>(&raw).ok())
@@ -1453,6 +1465,7 @@ fn row_to_session(row: &rusqlite::Row<'_>) -> rusqlite::Result<ShallowSession> {
         discovery_state: row
             .get::<_, Option<String>>(16)?
             .unwrap_or_else(|| "full".to_string()),
+        locations: json_string_list(row.get(17)?),
         from_cache: true,
     })
 }
@@ -1478,6 +1491,8 @@ pub struct CatalogCursor {
 /// Options for the cache-only catalog listing.
 #[derive(Debug, Clone, Default)]
 pub struct CatalogListOptions {
+    /// Which presences to include. Defaults to local for compatibility.
+    pub scope: SessionScope,
     /// Restrict to these sources. Empty means every discoverable source.
     pub sources: Vec<String>,
     /// Row cap; defaults to [`DEFAULT_CATALOG_LIMIT`].
@@ -1494,6 +1509,8 @@ pub struct CatalogListOptions {
 /// One page of the catalog plus the cursor that continues it.
 #[derive(Debug, Clone, Default)]
 pub struct SessionCatalogPage {
+    /// Scope applied to this cache-only page.
+    pub scope: SessionScope,
     /// The rows, newest first.
     pub sessions: Vec<ShallowSession>,
     /// Pass as [`CatalogListOptions::after`] for the next page. `None` when
@@ -1508,6 +1525,16 @@ pub struct SessionCatalogPage {
 fn catalog_list_query(options: &CatalogListOptions) -> (String, Vec<Box<dyn rusqlite::ToSql>>) {
     let mut sql = format!("SELECT {SESSION_COLUMNS} FROM sessions WHERE source <> 'trajectory'");
     let mut args: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    match options.scope {
+        SessionScope::Local => sql.push_str(
+            " AND (EXISTS (SELECT 1 FROM session_presences p WHERE p.source = sessions.source AND p.session_id = sessions.session_id AND p.location = 'local') \
+               OR NOT EXISTS (SELECT 1 FROM session_presences p WHERE p.source = sessions.source AND p.session_id = sessions.session_id))",
+        ),
+        SessionScope::Remote => sql.push_str(
+            " AND EXISTS (SELECT 1 FROM session_presences p WHERE p.source = sessions.source AND p.session_id = sessions.session_id AND p.location = 'remote')",
+        ),
+        SessionScope::All => {}
+    }
     if !options.sources.is_empty() {
         let placeholders = vec!["?"; options.sources.len()].join(", ");
         sql.push_str(&format!(" AND source IN ({placeholders})"));
@@ -1597,6 +1624,7 @@ pub fn list_session_catalog_page(
             session_id: row.session_id.clone(),
         });
     Ok(SessionCatalogPage {
+        scope: options.scope,
         sessions,
         next_cursor,
     })
@@ -1613,16 +1641,59 @@ fn fetch_catalog_row(
         .ok())
 }
 
+fn fetch_catalog_row_at_location(
+    conn: &Connection,
+    source: &str,
+    session_id: &str,
+    location: SessionLocation,
+) -> Result<Option<ShallowSession>> {
+    let Some(mut row) = fetch_catalog_row(conn, source, session_id)? else {
+        return Ok(None);
+    };
+    let location = match location {
+        SessionLocation::Local => "local",
+        SessionLocation::Remote => "remote",
+    };
+    let presence = conn
+        .query_row(
+            "SELECT raw_locator, source_stamp FROM session_presences \
+             WHERE source = ? AND session_id = ? AND location = ?",
+            params![source, session_id, location],
+            |result| {
+                Ok((
+                    result.get::<_, Option<String>>(0)?,
+                    result.get::<_, Option<String>>(1)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((raw_locator, source_stamp)) = presence else {
+        return Ok(None);
+    };
+    row.raw_path = raw_locator;
+    row.source_stamp = source_stamp;
+    Ok(Some(row))
+}
+
 fn fetch_catalog_row_by_path(
     conn: &Connection,
     source: &str,
     raw_path: &str,
 ) -> Result<Option<ShallowSession>> {
-    let sql =
-        format!("SELECT {SESSION_COLUMNS} FROM sessions WHERE source = ? AND raw_path = ? LIMIT 1");
-    Ok(conn
-        .query_row(&sql, params![source, raw_path], row_to_session)
-        .ok())
+    let session_id = conn
+        .query_row(
+            "SELECT session_id FROM session_presences \
+             WHERE location = 'local' AND source = ? AND raw_locator = ? LIMIT 1",
+            params![source, raw_path],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    match session_id {
+        Some(session_id) => {
+            fetch_catalog_row_at_location(conn, source, &session_id, SessionLocation::Local)
+        }
+        None => Ok(None),
+    }
 }
 
 /// Whether this source was already examined at this exact stamp and found not
@@ -1684,6 +1755,15 @@ fn now_ms() -> i64 {
 /// `'full'`. A shallow rescan of such a row still refreshes its metadata and
 /// stamp.
 pub fn upsert_shallow_session(conn: &Connection, session: &ShallowSession) -> Result<()> {
+    upsert_shallow_session_at_location(conn, session, SessionLocation::Local)
+}
+
+/// Upsert shallow canonical metadata and connector-specific presence state.
+pub fn upsert_shallow_session_at_location(
+    conn: &Connection,
+    session: &ShallowSession,
+    location: SessionLocation,
+) -> Result<()> {
     conn.execute(
         "INSERT INTO sessions \
          (session_id, source, cwd, git_branch, first_activity_ms, last_activity_ms, \
@@ -1734,6 +1814,15 @@ pub fn upsert_shallow_session(conn: &Connection, session: &ShallowSession) -> Re
             session.source_stamp,
         ],
     )?;
+    upsert_session_presence(
+        conn,
+        &session.source,
+        &session.session_id,
+        location,
+        session.raw_path.as_deref(),
+        session.source_stamp.as_deref(),
+        Some(&session.discovery_state),
+    )?;
     Ok(())
 }
 
@@ -1744,6 +1833,8 @@ pub fn upsert_shallow_session(conn: &Connection, session: &ShallowSession) -> Re
 /// Options for one discovery run.
 #[derive(Debug, Clone, Default)]
 pub struct DiscoverOptions {
+    /// Provider-presence scope. Defaults to local for compatibility.
+    pub scope: SessionScope,
     /// Restrict to these sources. Empty means every adapter.
     pub sources: Vec<String>,
     /// Global cap on emitted rows, applied across providers by recency.
@@ -1780,6 +1871,8 @@ pub struct ProviderSummary {
 pub struct DiscoverySummary {
     /// [`SESSION_CATALOG_CONTRACT_VERSION`].
     pub contract_version: u32,
+    /// Scope selected for this discovery run.
+    pub scope: SessionScope,
     /// Rows freshly read and upserted.
     pub discovered: usize,
     /// Rows served from the catalog on an unchanged stamp.
@@ -1824,7 +1917,21 @@ fn stored_stamp(raw: &str) -> String {
     format!("v{SHALLOW_SCANNER_VERSION}:{raw}")
 }
 
+/// Reject an acquisition scope for which no connector is configured.
+///
+/// Call this before opening the ledger so an unsupported remote-only request
+/// has no database side effects.
+pub fn validate_discovery_scope(scope: SessionScope) -> Result<()> {
+    if scope == SessionScope::Remote {
+        anyhow::bail!(
+            "remote session discovery is not available: no remote provider connectors are configured"
+        );
+    }
+    Ok(())
+}
+
 fn select_providers(options: &DiscoverOptions) -> Result<Vec<Box<dyn ShallowSessionProvider>>> {
+    validate_discovery_scope(options.scope)?;
     for source in &options.sources {
         if let Some(exempt) = DISCOVERY_EXEMPTIONS
             .iter()
@@ -1880,6 +1987,7 @@ pub fn discover_sessions_with_env(
     let providers = select_providers(options)?;
     let mut summary = DiscoverySummary {
         contract_version: SESSION_CATALOG_CONTRACT_VERSION,
+        scope: options.scope,
         exempt_sources: DISCOVERY_EXEMPTIONS.to_vec(),
         ..Default::default()
     };
@@ -1961,7 +2069,12 @@ pub fn discover_sessions_with_env(
             };
             let expected = stored_stamp(&candidate.stamp);
             let cached = match candidate.session_id.as_deref() {
-                Some(session_id) => fetch_catalog_row(conn, candidate.source, session_id)?,
+                Some(session_id) => fetch_catalog_row_at_location(
+                    conn,
+                    candidate.source,
+                    session_id,
+                    SessionLocation::Local,
+                )?,
                 None => fetch_catalog_row_by_path(conn, candidate.source, &candidate.locator)?,
             };
             if let Some(cached) =

--- a/crates/ai-hist/src/discover.rs
+++ b/crates/ai-hist/src/discover.rs
@@ -1436,7 +1436,9 @@ const SESSION_COLUMNS: &str = "source, session_id, cwd, git_branch, first_activi
        THEN '[\"local\",\"remote\"]' \
        WHEN EXISTS (SELECT 1 FROM session_presences p WHERE p.source = sessions.source AND p.session_id = sessions.session_id AND p.location = 'remote') \
        THEN '[\"remote\"]' \
-       ELSE '[\"local\"]' \
+       WHEN EXISTS (SELECT 1 FROM session_presences p WHERE p.source = sessions.source AND p.session_id = sessions.session_id AND p.location = 'local') \
+       THEN '[\"local\"]' \
+       ELSE '[]' \
      END";
 
 fn json_string_list(raw: Option<String>) -> Vec<String> {
@@ -1760,6 +1762,20 @@ pub fn upsert_shallow_session(conn: &Connection, session: &ShallowSession) -> Re
 
 /// Upsert shallow canonical metadata and connector-specific presence state.
 pub fn upsert_shallow_session_at_location(
+    conn: &Connection,
+    session: &ShallowSession,
+    location: SessionLocation,
+) -> Result<()> {
+    if conn.is_autocommit() {
+        let transaction = conn.unchecked_transaction()?;
+        upsert_shallow_session_in_transaction(&transaction, session, location)?;
+        transaction.commit()?;
+        return Ok(());
+    }
+    upsert_shallow_session_in_transaction(conn, session, location)
+}
+
+fn upsert_shallow_session_in_transaction(
     conn: &Connection,
     session: &ShallowSession,
     location: SessionLocation,

--- a/crates/ai-hist/src/discover/tests.rs
+++ b/crates/ai-hist/src/discover/tests.rs
@@ -1102,6 +1102,11 @@ fn catalog_scope_filters_presences_without_duplicating_dual_sessions() {
     ] {
         seed_row(&conn, "codex", id, Some(recency));
     }
+    conn.execute(
+        "DELETE FROM session_presences WHERE source = 'codex' AND session_id IN ('legacy-local', 'remote-only')",
+        [],
+    )
+    .unwrap();
     mark_session_presence(&conn, "codex", "local-only", SessionLocation::Local).unwrap();
     mark_session_presence(&conn, "codex", "remote-only", SessionLocation::Remote).unwrap();
     upsert_session_presence(
@@ -1134,7 +1139,7 @@ fn catalog_scope_filters_presences_without_duplicating_dual_sessions() {
     assert_eq!(
         ids(SessionScope::Local),
         vec![
-            ("legacy-local".into(), vec!["local".into()]),
+            ("legacy-local".into(), vec![]),
             ("local-only".into(), vec!["local".into()]),
             ("dual".into(), vec!["local".into(), "remote".into()]),
         ]
@@ -1146,7 +1151,15 @@ fn catalog_scope_filters_presences_without_duplicating_dual_sessions() {
             ("dual".into(), vec!["local".into(), "remote".into()]),
         ]
     );
-    assert_eq!(ids(SessionScope::All).len(), 4);
+    assert_eq!(
+        ids(SessionScope::All),
+        vec![
+            ("legacy-local".into(), vec![]),
+            ("local-only".into(), vec!["local".into()]),
+            ("remote-only".into(), vec!["remote".into()]),
+            ("dual".into(), vec!["local".into(), "remote".into()]),
+        ]
+    );
 
     assert!(
         fetch_catalog_row_at_location(&conn, "codex", "remote-only", SessionLocation::Local,)
@@ -1165,6 +1178,48 @@ fn catalog_scope_filters_presences_without_duplicating_dual_sessions() {
         remote_cache.source_stamp.as_deref(),
         Some("v1:remote-stamp")
     );
+}
+
+#[test]
+fn remote_shallow_upsert_rolls_back_canonical_row_when_presence_write_fails() {
+    let conn = catalog();
+    conn.execute_batch(
+        "CREATE TRIGGER reject_remote_presence BEFORE INSERT ON session_presences
+         WHEN NEW.location = 'remote'
+         BEGIN SELECT RAISE(ABORT, 'injected remote presence failure'); END;",
+    )
+    .unwrap();
+    let session = ShallowSession {
+        source: "codex".into(),
+        session_id: "remote-atomic".into(),
+        first_prompt: Some("remote prompt".into()),
+        raw_path: Some("cloud://remote-atomic".into()),
+        source_stamp: Some("v1:remote".into()),
+        discovery_state: "shallow".into(),
+        ..Default::default()
+    };
+
+    let error = upsert_shallow_session_at_location(&conn, &session, SessionLocation::Remote)
+        .expect_err("presence failure must abort the canonical upsert");
+    assert!(error
+        .to_string()
+        .contains("injected remote presence failure"));
+    let session_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sessions WHERE source = 'codex' AND session_id = 'remote-atomic'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let presence_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM session_presences WHERE source = 'codex' AND session_id = 'remote-atomic'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(session_count, 0);
+    assert_eq!(presence_count, 0);
 }
 
 #[test]
@@ -1194,6 +1249,7 @@ fn trajectory_rows_never_appear_in_a_session_listing() {
         [],
     )
     .unwrap();
+    mark_session_presence(&conn, "claude", "claude-1", SessionLocation::Local).unwrap();
     let rows = list_session_catalog(&conn, &CatalogListOptions::default()).unwrap();
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].source, "claude");
@@ -1207,12 +1263,7 @@ fn the_catalog_listing_filters_by_source_and_paginates_by_recency() {
         ("claude", "c2", 200),
         ("codex", "x1", 250),
     ] {
-        conn.execute(
-            "INSERT INTO sessions (session_id, source, last_activity_ms, discovery_state) \
-             VALUES (?, ?, ?, 'shallow')",
-            params![id, source, ts],
-        )
-        .unwrap();
+        seed_row(&conn, source, id, Some(ts));
     }
     let claude_only = list_session_catalog(
         &conn,
@@ -1258,6 +1309,7 @@ fn seed_row(conn: &Connection, source: &str, session_id: &str, last: Option<i64>
         params![session_id, source, last],
     )
     .unwrap();
+    mark_session_presence(conn, source, session_id, SessionLocation::Local).unwrap();
 }
 
 /// Walk the whole catalog one page at a time and assert the walk is a

--- a/crates/ai-hist/src/discover/tests.rs
+++ b/crates/ai-hist/src/discover/tests.rs
@@ -11,7 +11,7 @@
 //! listing performs no file I/O at all.
 
 use super::*;
-use ai_hist_core::init_db;
+use ai_hist_core::{init_db, mark_session_presence, upsert_session_presence};
 use std::fs;
 use std::time::{Duration, SystemTime};
 
@@ -150,6 +150,7 @@ fn only(sources: &[&str]) -> DiscoverOptions {
     DiscoverOptions {
         sources: sources.iter().map(|s| s.to_string()).collect(),
         limit: None,
+        ..Default::default()
     }
 }
 
@@ -896,6 +897,7 @@ fn the_limit_is_global_not_per_provider() {
         &DiscoverOptions {
             sources: Vec::new(),
             limit: Some(3),
+            ..Default::default()
         },
     );
     assert_eq!(
@@ -983,6 +985,7 @@ fn bounded_reads_do_not_grow_with_the_size_of_the_archive() {
     let limited = DiscoverOptions {
         sources: Vec::new(),
         limit: Some(2),
+        ..Default::default()
     };
     let baseline = discover(&conn, small.path(), &limited);
 
@@ -1086,6 +1089,82 @@ fn the_cache_only_listing_survives_the_provider_files_disappearing() {
     let mut sorted = recency.clone();
     sorted.sort_by(|a, b| b.cmp(a));
     assert_eq!(recency, sorted, "the catalog lists newest first");
+}
+
+#[test]
+fn catalog_scope_filters_presences_without_duplicating_dual_sessions() {
+    let conn = catalog();
+    for (id, recency) in [
+        ("legacy-local", 400),
+        ("local-only", 300),
+        ("remote-only", 200),
+        ("dual", 100),
+    ] {
+        seed_row(&conn, "codex", id, Some(recency));
+    }
+    mark_session_presence(&conn, "codex", "local-only", SessionLocation::Local).unwrap();
+    mark_session_presence(&conn, "codex", "remote-only", SessionLocation::Remote).unwrap();
+    upsert_session_presence(
+        &conn,
+        "codex",
+        "remote-only",
+        SessionLocation::Remote,
+        Some("cloud://remote-only"),
+        Some("v1:remote-stamp"),
+        Some("shallow"),
+    )
+    .unwrap();
+    mark_session_presence(&conn, "codex", "dual", SessionLocation::Local).unwrap();
+    mark_session_presence(&conn, "codex", "dual", SessionLocation::Remote).unwrap();
+
+    let ids = |scope| {
+        list_session_catalog(
+            &conn,
+            &CatalogListOptions {
+                scope,
+                ..Default::default()
+            },
+        )
+        .unwrap()
+        .into_iter()
+        .map(|row| (row.session_id, row.locations))
+        .collect::<Vec<_>>()
+    };
+
+    assert_eq!(
+        ids(SessionScope::Local),
+        vec![
+            ("legacy-local".into(), vec!["local".into()]),
+            ("local-only".into(), vec!["local".into()]),
+            ("dual".into(), vec!["local".into(), "remote".into()]),
+        ]
+    );
+    assert_eq!(
+        ids(SessionScope::Remote),
+        vec![
+            ("remote-only".into(), vec!["remote".into()]),
+            ("dual".into(), vec!["local".into(), "remote".into()]),
+        ]
+    );
+    assert_eq!(ids(SessionScope::All).len(), 4);
+
+    assert!(
+        fetch_catalog_row_at_location(&conn, "codex", "remote-only", SessionLocation::Local,)
+            .unwrap()
+            .is_none()
+    );
+    let remote_cache =
+        fetch_catalog_row_at_location(&conn, "codex", "remote-only", SessionLocation::Remote)
+            .unwrap()
+            .unwrap();
+    assert_eq!(
+        remote_cache.raw_path.as_deref(),
+        Some("cloud://remote-only")
+    );
+    assert_eq!(
+        remote_cache.source_stamp.as_deref(),
+        Some("v1:remote-stamp")
+    );
 }
 
 #[test]
@@ -1387,6 +1466,7 @@ fn the_catalog_listing_is_served_by_an_index_not_a_table_scan() {
         limit: Some(10),
         before_ms: Some(1),
         after: None,
+        ..Default::default()
     });
     assert!(
         filtered.contains("idx_sessions_source_recency") && !filtered.contains("TEMP B-TREE"),
@@ -1530,6 +1610,7 @@ fn non_session_candidates_do_not_consume_limit_slots() {
         &DiscoverOptions {
             sources: vec!["codex".into()],
             limit: Some(2),
+            ..Default::default()
         },
     );
     assert_eq!(
@@ -1550,7 +1631,8 @@ fn bumping_the_scanner_version_invalidates_stored_stamps() {
     discover(&conn, home.path(), &only(&["claude"]));
     // Simulate a database stamped by an older scanner generation.
     conn.execute(
-        "UPDATE sessions SET source_stamp = 'v0:stale' WHERE session_id = 'claude-1'",
+        "UPDATE session_presences SET source_stamp = 'v0:stale' \
+         WHERE location = 'local' AND session_id = 'claude-1'",
         [],
     )
     .unwrap();

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -6,9 +6,10 @@ use ai_hist_core::{
     session_file_edits, session_tool_calls, sync_opencode_db, untag_session, HistoryEntry,
     QueryFilter, SourceDatabaseError, SOURCE_CHOICES,
 };
+pub use ai_hist_core::{SessionLocation, SessionScope};
 use anyhow::{Context, Result};
 use chrono::{Local, TimeZone};
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -30,11 +31,12 @@ mod learn;
 
 pub use discover::{
     discover_sessions, discover_sessions_collect, discover_sessions_with_env, list_session_catalog,
-    list_session_catalog_page, shallow_providers, AllProvidersFailed, Candidate, CatalogCursor,
-    CatalogListOptions, DiscoverOptions, DiscoveryCounters, DiscoveryDiagnostic, DiscoveryEnv,
-    DiscoverySummary, ProviderSummary, ScanEnv, SessionCatalogPage, ShallowReadAccess,
-    ShallowSession, ShallowSessionProvider, SourceExemption, DEFAULT_CATALOG_LIMIT,
-    DISCOVERY_EXEMPTIONS, SESSION_CATALOG_CONTRACT_VERSION, SHALLOW_SCANNER_VERSION,
+    list_session_catalog_page, shallow_providers, validate_discovery_scope, AllProvidersFailed,
+    Candidate, CatalogCursor, CatalogListOptions, DiscoverOptions, DiscoveryCounters,
+    DiscoveryDiagnostic, DiscoveryEnv, DiscoverySummary, ProviderSummary, ScanEnv,
+    SessionCatalogPage, ShallowReadAccess, ShallowSession, ShallowSessionProvider, SourceExemption,
+    DEFAULT_CATALOG_LIMIT, DISCOVERY_EXEMPTIONS, SESSION_CATALOG_CONTRACT_VERSION,
+    SHALLOW_SCANNER_VERSION,
 };
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering as AtomicOrdering};
@@ -79,6 +81,29 @@ pub fn sync_local() -> Result<()> {
 pub fn sync_local_at(db_path: &Path) -> Result<bool> {
     SYNC_QUIET.store(true, AtomicOrdering::Relaxed);
     sync_exclusive(db_path)
+}
+
+/// Full ingestion for a selected session-presence scope.
+///
+/// Remote provider connectors are intentionally a capability boundary. Until
+/// one is configured, remote-only ingestion fails loudly; `all` runs every
+/// available connector, which currently means the local registry.
+pub fn sync_scoped_at(db_path: &Path, scope: SessionScope) -> Result<bool> {
+    SYNC_QUIET.store(true, AtomicOrdering::Relaxed);
+    sync_scope_exclusive(db_path, scope)
+}
+
+fn sync_scope_exclusive(db_path: &Path, scope: SessionScope) -> Result<bool> {
+    validate_sync_scope(scope)?;
+    sync_exclusive(db_path)
+}
+
+fn validate_sync_scope(scope: SessionScope) -> Result<()> {
+    anyhow::ensure!(
+        scope != SessionScope::Remote,
+        "remote session sync is not available: no remote provider connectors are configured"
+    );
+    Ok(())
 }
 
 /// Sync local agent history into the DB, then push new records to
@@ -145,8 +170,26 @@ pub fn list_sessions_local_at(
     db_path: &Path,
     options: &CatalogListOptions,
 ) -> Result<SessionCatalogPage> {
+    let mut options = options.clone();
+    options.scope = SessionScope::Local;
+    list_sessions_scoped_at(db_path, &options)
+}
+
+/// Cache-only catalog listing for an explicit session-presence scope.
+pub fn list_sessions_scoped(options: &CatalogListOptions) -> Result<SessionCatalogPage> {
+    list_sessions_scoped_at(&default_db_path(), options)
+}
+
+/// Scoped cache-only catalog listing against an explicitly selected database.
+pub fn list_sessions_scoped_at(
+    db_path: &Path,
+    options: &CatalogListOptions,
+) -> Result<SessionCatalogPage> {
     if !db_path.exists() {
-        return Ok(SessionCatalogPage::default());
+        return Ok(SessionCatalogPage {
+            scope: options.scope,
+            ..Default::default()
+        });
     }
     let conn = match open_db_readonly(db_path) {
         Ok(conn) if schema_is_catalog_read_current(&conn).unwrap_or(false) => conn,
@@ -174,7 +217,54 @@ pub fn discover_sessions_local_at(
     options: &DiscoverOptions,
 ) -> Result<(Vec<ShallowSession>, DiscoverySummary)> {
     let conn = open_db(db_path)?;
+    let mut local = options.clone();
+    local.scope = SessionScope::Local;
+    discover_sessions_collect(&conn, &local)
+}
+
+/// Scoped discovery into an explicitly selected database.
+pub fn discover_sessions_scoped_at(
+    db_path: &Path,
+    options: &DiscoverOptions,
+) -> Result<(Vec<ShallowSession>, DiscoverySummary)> {
+    validate_discovery_scope(options.scope)?;
+    let conn = open_db(db_path)?;
     discover_sessions_collect(&conn, options)
+}
+
+#[derive(Args, Debug, Clone, Copy, Default)]
+#[group(id = "session_scope", multiple = false)]
+struct SessionScopeArgs {
+    /// Select sessions with a local presence (default).
+    #[arg(long, group = "session_scope")]
+    local: bool,
+    /// Select sessions with a provider-cloud presence.
+    #[arg(long, group = "session_scope")]
+    remote: bool,
+    /// Select the union of local and remote presences.
+    #[arg(long, group = "session_scope")]
+    all: bool,
+}
+
+impl SessionScopeArgs {
+    fn resolve(self) -> SessionScope {
+        if self.remote {
+            SessionScope::Remote
+        } else if self.all {
+            SessionScope::All
+        } else {
+            SessionScope::Local
+        }
+    }
+
+    fn service_args(self) -> Vec<String> {
+        match self.resolve() {
+            SessionScope::Local if self.local => vec!["--local".to_string()],
+            SessionScope::Local => Vec::new(),
+            SessionScope::Remote => vec!["--remote".to_string()],
+            SessionScope::All => vec!["--all".to_string()],
+        }
+    }
 }
 
 #[derive(Parser)]
@@ -195,6 +285,8 @@ struct Cli {
 enum Command {
     /// Search prompts and sessions.
     Search {
+        #[command(flatten)]
+        scope: SessionScopeArgs,
         query: Vec<String>,
         #[arg(long)]
         source: Option<String>,
@@ -219,6 +311,8 @@ enum Command {
     },
     /// Show recent history entries.
     Recent {
+        #[command(flatten)]
+        scope: SessionScopeArgs,
         #[arg(default_value_t = 20)]
         n: i64,
         #[arg(long)]
@@ -266,8 +360,10 @@ enum Command {
         #[arg(long, default_value_t = 5)]
         window: i64,
     },
-    /// Show local history statistics.
+    /// Show history statistics.
     Stats {
+        #[command(flatten)]
+        scope: SessionScopeArgs,
         #[arg(long)]
         tag: Option<String>,
         #[arg(long)]
@@ -304,6 +400,8 @@ enum Command {
     },
     /// Print a resume command for the best matching session.
     Resume {
+        #[command(flatten)]
+        scope: SessionScopeArgs,
         #[arg(required = true)]
         query: Vec<String>,
         /// Pass the query through as a raw FTS5 MATCH expression. Operators such as
@@ -320,6 +418,8 @@ enum Command {
     },
     /// Sync local agent history into the relayhistory database.
     Sync {
+        #[command(flatten)]
+        scope: SessionScopeArgs,
         /// Install a background service (launchd on macOS, cron on Linux) that
         /// runs `sync` on an interval so the database stays fresh automatically.
         #[arg(long)]
@@ -334,6 +434,8 @@ enum Command {
     },
     /// Repeatedly sync local agent history.
     Watch {
+        #[command(flatten)]
+        scope: SessionScopeArgs,
         #[arg(long, default_value_t = 60)]
         interval: u64,
     },
@@ -344,6 +446,8 @@ enum Command {
     },
     /// Build a compact context pack from matching history.
     Pack {
+        #[command(flatten)]
+        scope: SessionScopeArgs,
         #[arg(required = true)]
         query: Vec<String>,
         #[arg(long)]
@@ -514,6 +618,8 @@ enum SessionsAction {
     /// tool calls: one indexed query over `sessions`. Run `sessions discover`
     /// first to populate a fresh database.
     List {
+        #[command(flatten)]
+        scope: SessionScopeArgs,
         /// Restrict to a source (repeatable). Defaults to every discoverable source.
         #[arg(long)]
         source: Vec<String>,
@@ -553,6 +659,8 @@ enum SessionsAction {
     /// only what the catalog needs, and upserts rows as it goes. Sources whose
     /// bytes have not changed since the last run are served from the catalog.
     Discover {
+        #[command(flatten)]
+        scope: SessionScopeArgs,
         /// Restrict to a source (repeatable). Defaults to every discoverable source.
         #[arg(long)]
         source: Vec<String>,
@@ -731,19 +839,27 @@ pub fn run() -> Result<()> {
     // wait on SQLite before contention is detected.
     match &cli.command {
         Command::Sync {
+            scope,
             install_service,
             uninstall_service,
             interval,
         } => {
             if *install_service {
-                return install_managed_service(&SYNC_SERVICE, *interval, &[]);
+                validate_sync_scope(scope.resolve())?;
+                return install_managed_service(&SYNC_SERVICE, *interval, &scope.service_args());
             }
             if *uninstall_service {
                 return uninstall_managed_service(&SYNC_SERVICE);
             }
-            return sync_exclusive(&db_path).map(|_| ());
+            return sync_scope_exclusive(&db_path, scope.resolve()).map(|_| ());
         }
-        Command::Watch { interval } => return watch_loop(&db_path, *interval),
+        Command::Watch { scope, interval } => {
+            validate_sync_scope(scope.resolve())?;
+            return watch_loop(&db_path, *interval, scope.resolve());
+        }
+        Command::Sessions {
+            action: SessionsAction::Discover { scope, .. },
+        } => validate_discovery_scope(scope.resolve())?,
         Command::SyncOpencode { opencode_db } => {
             let source = opencode_db.clone().unwrap_or_else(default_opencode_db_path);
             return sync_opencode_exclusive(&db_path, &source).map(|_| ());
@@ -762,6 +878,7 @@ pub fn run() -> Result<()> {
 
     match cli.command {
         Command::Search {
+            scope,
             query,
             source,
             project,
@@ -780,6 +897,7 @@ pub fn run() -> Result<()> {
                 &query,
                 fts,
                 &QueryFilter {
+                    scope: scope.resolve(),
                     source,
                     project,
                     tag,
@@ -799,6 +917,7 @@ pub fn run() -> Result<()> {
             print_search_rows(rows, json)
         }
         Command::Recent {
+            scope,
             n,
             source,
             project,
@@ -809,6 +928,7 @@ pub fn run() -> Result<()> {
             let rows = recent(
                 &conn,
                 &QueryFilter {
+                    scope: scope.resolve(),
                     source,
                     project,
                     tag,
@@ -861,6 +981,7 @@ pub fn run() -> Result<()> {
         Command::Context { id, window } => show_context(&conn, id, window),
         Command::Doctor { json } => doctor(&db_path, json),
         Command::Pack {
+            scope,
             query,
             source,
             project,
@@ -875,6 +996,7 @@ pub fn run() -> Result<()> {
                 &conn,
                 query,
                 QueryFilter {
+                    scope: scope.resolve(),
                     source,
                     project,
                     tag,
@@ -886,7 +1008,9 @@ pub fn run() -> Result<()> {
                 json,
             )
         }
-        Command::Stats { tag, json } => print_stats(&conn, tag.as_deref(), json),
+        Command::Stats { scope, tag, json } => {
+            print_stats(&conn, scope.resolve(), tag.as_deref(), json)
+        }
         Command::Tag {
             session_id,
             tag_name,
@@ -949,12 +1073,18 @@ pub fn run() -> Result<()> {
             sessions,
             json,
         } => print_tags(&conn, tag.as_deref(), sessions, json),
-        Command::Resume { query, fts, json } => {
+        Command::Resume {
+            scope,
+            query,
+            fts,
+            json,
+        } => {
             let rows = search(
                 &conn,
                 &query,
                 fts,
                 &QueryFilter {
+                    scope: scope.resolve(),
                     limit: 1,
                     ..Default::default()
                 },
@@ -1025,7 +1155,7 @@ pub fn run() -> Result<()> {
                     !dry_run,
                     "`ai-hist import --watch` cannot be combined with --dry-run"
                 );
-                watch_loop(&db_path, interval)
+                watch_loop(&db_path, interval, SessionScope::Local)
             } else {
                 let file = file.context("`ai-hist import` requires FILE unless --watch is set")?;
                 import_history(&conn, &file, dry_run)
@@ -1315,6 +1445,7 @@ pub fn run() -> Result<()> {
         },
         Command::Sessions { action } => match action {
             SessionsAction::List {
+                scope,
                 source,
                 limit,
                 before_ms,
@@ -1345,6 +1476,7 @@ pub fn run() -> Result<()> {
                 let page = list_session_catalog_page(
                     &conn,
                     &CatalogListOptions {
+                        scope: scope.resolve(),
                         sources: source,
                         limit,
                         before_ms,
@@ -1354,10 +1486,11 @@ pub fn run() -> Result<()> {
                 print_session_catalog(&page, json)
             }
             SessionsAction::Discover {
+                scope,
                 source,
                 limit,
                 json,
-            } => run_session_discovery(&conn, source, limit, json),
+            } => run_session_discovery(&conn, scope.resolve(), source, limit, json),
         },
     }
 }
@@ -1366,7 +1499,7 @@ pub fn run() -> Result<()> {
 ///
 /// The JSON form is one object, not a bare array, so the contract version and
 /// the pagination cursor travel with the payload:
-/// `{"contract_version":1,"sessions":[…],"next_cursor":{…}|null}`. Feed
+/// `{"contract_version":2,"scope":"local","sessions":[…],"next_cursor":{…}|null}`. Feed
 /// `next_cursor` back as `--after-ms/--after-source/--after-session-id` to get
 /// the next page; it is null once the catalog is exhausted.
 fn print_session_catalog(page: &SessionCatalogPage, as_json: bool) -> Result<()> {
@@ -1376,6 +1509,7 @@ fn print_session_catalog(page: &SessionCatalogPage, as_json: bool) -> Result<()>
             "{}",
             json!({
                 "contract_version": SESSION_CATALOG_CONTRACT_VERSION,
+                "scope": page.scope,
                 "sessions": rows,
                 "next_cursor": page.next_cursor,
             })
@@ -1423,9 +1557,10 @@ fn fmt_session_row(row: &ShallowSession) -> String {
             }
         })
         .unwrap_or_default();
+    let locations = row.locations.join(",");
     format!(
-        "  {when}  {:<8} {:<8} {:<38} {cwd}  {prompt}",
-        row.source, row.discovery_state, row.session_id
+        "  {when}  {:<8} {:<12} {:<8} {:<38} {cwd}  {prompt}",
+        row.source, locations, row.discovery_state, row.session_id
     )
 }
 
@@ -1437,11 +1572,16 @@ fn fmt_session_row(row: &ShallowSession) -> String {
 /// not change the exit code; only an every-provider failure does.
 fn run_session_discovery(
     conn: &Connection,
+    scope: SessionScope,
     sources: Vec<String>,
     limit: Option<usize>,
     as_json: bool,
 ) -> Result<()> {
-    let options = DiscoverOptions { sources, limit };
+    let options = DiscoverOptions {
+        scope,
+        sources,
+        limit,
+    };
     let mut count = 0usize;
     let outcome = discover_sessions(conn, &options, |session| {
         count += 1;
@@ -1926,13 +2066,18 @@ fn show_context(conn: &Connection, id: i64, window_minutes: i64) -> Result<()> {
     Ok(())
 }
 
-fn print_stats(conn: &Connection, tag: Option<&str>, as_json: bool) -> Result<()> {
+fn print_stats(
+    conn: &Connection,
+    scope: SessionScope,
+    tag: Option<&str>,
+    as_json: bool,
+) -> Result<()> {
     let tag_norm = tag.map(normalize_tag_name);
-    let where_sql = if tag_norm.is_some() {
-        format!(" WHERE {}", tag_filter_clause("h"))
-    } else {
-        String::new()
-    };
+    let mut where_sql = " WHERE 1=1".to_string();
+    append_session_scope_filter(&mut where_sql, scope, "h");
+    if tag_norm.is_some() {
+        where_sql.push_str(&format!(" AND {}", tag_filter_clause("h")));
+    }
     let params_vec = tag_norm.iter().map(String::as_str).collect::<Vec<_>>();
     let total: i64 = conn.query_row(
         &format!("SELECT COUNT(*) FROM history h{where_sql}"),
@@ -1950,11 +2095,7 @@ fn print_stats(conn: &Connection, tag: Option<&str>, as_json: bool) -> Result<()
         .iter()
         .cloned()
         .collect::<serde_json::Map<_, _>>();
-    let project_where = if tag_norm.is_some() {
-        format!("WHERE project IS NOT NULL AND {}", tag_filter_clause("h"))
-    } else {
-        "WHERE project IS NOT NULL".to_string()
-    };
+    let project_where = format!("{where_sql} AND project IS NOT NULL");
     let top_projects = query_pairs(
         conn,
         &format!("SELECT project, COUNT(*) FROM history h {project_where} GROUP BY project ORDER BY COUNT(*) DESC LIMIT 10"),
@@ -1978,11 +2119,20 @@ fn print_stats(conn: &Connection, tag: Option<&str>, as_json: bool) -> Result<()
                 "first_timestamp_ms": first,
                 "last_timestamp_ms": last,
                 "tag": tag_norm,
+                "scope": scope,
             })
         );
         return Ok(());
     }
     println!("\nTotal entries: {total}");
+    println!(
+        "Scope: {}",
+        match scope {
+            SessionScope::Local => "local",
+            SessionScope::Remote => "remote",
+            SessionScope::All => "all",
+        }
+    );
     if let Some(tag) = tag_norm {
         println!("Tag filter: {tag}");
     }
@@ -2953,10 +3103,10 @@ fn prepare_sync_and_push_db(db_path: &Path) -> Result<(Connection, bool)> {
     Ok((conn, false))
 }
 
-fn watch_loop(db_path: &Path, interval: u64) -> Result<()> {
+fn watch_loop(db_path: &Path, interval: u64, scope: SessionScope) -> Result<()> {
     println!("Watching every {interval}s (Ctrl-C to stop)...");
     loop {
-        match sync_exclusive(db_path) {
+        match sync_scope_exclusive(db_path, scope) {
             Ok(_) => {}
             Err(err) => eprintln!("Error: {err:#}"),
         }
@@ -3911,6 +4061,7 @@ fn append_history_search_filters(
     filter: &QueryFilter,
     alias: &str,
 ) {
+    append_session_scope_filter(sql, filter.scope, alias);
     if let Some(source) = &filter.source {
         sql.push_str(&format!(" AND {alias}.source = ?"));
         params.push(source.clone());
@@ -3932,6 +4083,7 @@ fn append_event_search_filters(
     alias: &str,
     role: SearchRole,
 ) {
+    append_session_scope_filter(sql, filter.scope, alias);
     if let Some(source) = &filter.source {
         sql.push_str(&format!(" AND {alias}.source = ?"));
         params.push(source.clone());
@@ -3948,6 +4100,26 @@ fn append_event_search_filters(
         SearchRole::All => {}
         SearchRole::User => sql.push_str(&format!(" AND {alias}.role = 'user'")),
         SearchRole::Assistant => sql.push_str(&format!(" AND {alias}.role = 'assistant'")),
+    }
+}
+
+/// Restrict a history/event query by where its canonical session is present.
+///
+/// Legacy rows with no session id or no classification are local so upgrading
+/// cannot make existing history disappear. Remote requires an explicit remote
+/// presence. `all` adds no predicate and therefore cannot multiply rows.
+fn append_session_scope_filter(sql: &mut String, scope: SessionScope, alias: &str) {
+    match scope {
+        SessionScope::Local => sql.push_str(&format!(
+            " AND ({alias}.session_id IS NULL \
+               OR EXISTS (SELECT 1 FROM session_presences p WHERE p.source = {alias}.source AND p.session_id = {alias}.session_id AND p.location = 'local') \
+               OR NOT EXISTS (SELECT 1 FROM session_presences p WHERE p.source = {alias}.source AND p.session_id = {alias}.session_id))"
+        )),
+        SessionScope::Remote => sql.push_str(&format!(
+            " AND {alias}.session_id IS NOT NULL \
+               AND EXISTS (SELECT 1 FROM session_presences p WHERE p.source = {alias}.source AND p.session_id = {alias}.session_id AND p.location = 'remote')"
+        )),
+        SessionScope::All => {}
     }
 }
 
@@ -4996,6 +5168,10 @@ fn sync_codex_rollouts(
                 branches.remove(&meta.session_id);
                 conn.execute(
                     "DELETE FROM history WHERE source = 'codex' AND session_id = ?",
+                    [meta.session_id.as_str()],
+                )?;
+                conn.execute(
+                    "DELETE FROM session_presences WHERE source = 'codex' AND session_id = ?",
                     [meta.session_id.as_str()],
                 )?;
                 conn.execute(
@@ -6523,6 +6699,15 @@ fn upsert_session(
             raw_path,
         ],
     )?;
+    ai_hist_core::upsert_session_presence(
+        conn,
+        source,
+        session_id,
+        SessionLocation::Local,
+        raw_path,
+        None,
+        Some("full"),
+    )?;
     Ok(())
 }
 
@@ -8036,6 +8221,7 @@ mod tests {
     fn only_non_mutating_commands_get_a_read_only_handle() {
         // Reads must not take the write lock...
         assert!(super::is_read_only(&super::Command::Stats {
+            scope: super::SessionScopeArgs::default(),
             tag: None,
             json: false
         }));
@@ -8058,6 +8244,7 @@ mod tests {
         // ...and anything that writes must not get a read-only handle, or it
         // fails at runtime with "attempt to write a readonly database".
         assert!(!super::is_read_only(&super::Command::Sync {
+            scope: super::SessionScopeArgs::default(),
             install_service: false,
             uninstall_service: false,
             interval: 60,

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -83,6 +83,11 @@ pub fn sync_local_at(db_path: &Path) -> Result<bool> {
     sync_exclusive(db_path)
 }
 
+/// Full ingestion for a selected scope into the default database.
+pub fn sync_scoped(scope: SessionScope) -> Result<bool> {
+    sync_scoped_at(&default_db_path(), scope)
+}
+
 /// Full ingestion for a selected session-presence scope.
 ///
 /// Remote provider connectors are intentionally a capability boundary. Until
@@ -170,9 +175,11 @@ pub fn list_sessions_local_at(
     db_path: &Path,
     options: &CatalogListOptions,
 ) -> Result<SessionCatalogPage> {
-    let mut options = options.clone();
-    options.scope = SessionScope::Local;
-    list_sessions_scoped_at(db_path, &options)
+    anyhow::ensure!(
+        options.scope == SessionScope::Local,
+        "list_sessions_local_at only accepts local scope; use list_sessions_scoped_at for remote or all"
+    );
+    list_sessions_scoped_at(db_path, options)
 }
 
 /// Cache-only catalog listing for an explicit session-presence scope.
@@ -216,10 +223,19 @@ pub fn discover_sessions_local_at(
     db_path: &Path,
     options: &DiscoverOptions,
 ) -> Result<(Vec<ShallowSession>, DiscoverySummary)> {
+    anyhow::ensure!(
+        options.scope == SessionScope::Local,
+        "discover_sessions_local_at only accepts local scope; use discover_sessions_scoped_at for remote or all"
+    );
     let conn = open_db(db_path)?;
-    let mut local = options.clone();
-    local.scope = SessionScope::Local;
-    discover_sessions_collect(&conn, &local)
+    discover_sessions_collect(&conn, options)
+}
+
+/// Scoped discovery into the default database.
+pub fn discover_sessions_scoped(
+    options: &DiscoverOptions,
+) -> Result<(Vec<ShallowSession>, DiscoverySummary)> {
+    discover_sessions_scoped_at(&default_db_path(), options)
 }
 
 /// Scoped discovery into an explicitly selected database.
@@ -235,13 +251,13 @@ pub fn discover_sessions_scoped_at(
 #[derive(Args, Debug, Clone, Copy, Default)]
 #[group(id = "session_scope", multiple = false)]
 struct SessionScopeArgs {
-    /// Select sessions with a local presence (default).
+    /// Request/select sessions with a local presence (default).
     #[arg(long, group = "session_scope")]
     local: bool,
-    /// Select sessions with a provider-cloud presence.
+    /// Request/select sessions with a remote provider presence.
     #[arg(long, group = "session_scope")]
     remote: bool,
-    /// Select the union of local and remote presences.
+    /// Request/select the deduplicated union of local and remote presences.
     #[arg(long, group = "session_scope")]
     all: bool,
 }
@@ -416,7 +432,7 @@ enum Command {
         #[arg(long)]
         opencode_db: Option<PathBuf>,
     },
-    /// Sync local agent history into the relayhistory database.
+    /// Sync agent history using the requested configured connectors.
     Sync {
         #[command(flatten)]
         scope: SessionScopeArgs,
@@ -432,7 +448,7 @@ enum Command {
         #[arg(long, default_value_t = 60)]
         interval: u64,
     },
-    /// Repeatedly sync local agent history.
+    /// Repeatedly sync agent history using the requested configured connectors.
     Watch {
         #[command(flatten)]
         scope: SessionScopeArgs,
@@ -653,11 +669,14 @@ enum SessionsAction {
         #[arg(long)]
         json: bool,
     },
-    /// Discover sessions from provider locations with bounded reads.
+    /// Discover sessions from the requested provider locations with bounded reads.
     ///
     /// Enumerates every provider, orders candidates globally by recency, reads
     /// only what the catalog needs, and upserts rows as it goes. Sources whose
     /// bytes have not changed since the last run are served from the catalog.
+    /// The summary `scope` echoes the request; it is not a list of connector
+    /// locations that ran. Remote connectors are not configured yet, so
+    /// `--remote` is unsupported and `--all` currently runs local adapters.
     Discover {
         #[command(flatten)]
         scope: SessionScopeArgs,
@@ -1079,12 +1098,13 @@ pub fn run() -> Result<()> {
             fts,
             json,
         } => {
+            let requested_scope = scope.resolve();
             let rows = search(
                 &conn,
                 &query,
                 fts,
                 &QueryFilter {
-                    scope: scope.resolve(),
+                    scope: requested_scope,
                     limit: 1,
                     ..Default::default()
                 },
@@ -1093,13 +1113,26 @@ pub fn run() -> Result<()> {
                 .into_iter()
                 .find(|e| e.session_id.as_ref().is_some_and(|s| !s.is_empty()));
             if let Some(entry) = entry {
-                let cmd = resume_command(&entry);
+                let (locations, cmd) = local_resume_details(&conn, &entry)?;
+                let locally_available =
+                    locations.is_empty() || locations.iter().any(|location| location == "local");
                 if json {
                     let mut out = entry_output(&entry);
                     out["resume_cmd"] = json!(cmd);
+                    out["scope"] = json!(requested_scope);
+                    out["locations"] = json!(locations);
+                    if !locally_available {
+                        out["resume_unavailable_reason"] =
+                            json!("session is remote-only; materialize it locally before resuming");
+                    }
                     println!("{}", out);
                 } else if let Some(cmd) = cmd {
                     println!("{cmd}");
+                } else if !locally_available {
+                    anyhow::bail!(
+                        "Session {} is remote-only and cannot be resumed locally; materialize it locally first.",
+                        entry.session_id.as_deref().unwrap_or("(unknown)")
+                    );
                 } else {
                     anyhow::bail!("No resume command available for source '{}'", entry.source);
                 }
@@ -1642,17 +1675,26 @@ fn run_session_discovery(
         println!("{payload}");
     } else {
         println!(
-            "  {count} session(s): {} discovered, {} unchanged ({} file(s) opened, {} shallow read(s))",
+            "  {count} session(s): {} discovered, {} unchanged ({} file(s) opened, {} shallow read(s)); requested scope: {}, connector locations run: local",
             summary.discovered,
             summary.skipped_unchanged,
             summary.counters.files_opened,
-            summary.counters.shallow_reads
+            summary.counters.shallow_reads,
+            session_scope_label(summary.scope),
         );
     }
     if let Some(failure) = failure {
         return Err(failure);
     }
     Ok(())
+}
+
+fn session_scope_label(scope: SessionScope) -> &'static str {
+    match scope {
+        SessionScope::Local => "local",
+        SessionScope::Remote => "remote",
+        SessionScope::All => "all",
+    }
 }
 
 /// Best-effort `git remote get-url origin` for project scoping (None if not a repo).
@@ -1909,6 +1951,39 @@ fn entry_output(row: &HistoryEntry) -> serde_json::Value {
     })
 }
 
+/// Locations recorded for an indexed history entry.
+///
+/// A missing presence remains an empty list. Callers that select local rows
+/// apply the legacy local fallback separately; output should report observed
+/// presences, not invent one.
+fn entry_locations(conn: &Connection, entry: &HistoryEntry) -> Result<Vec<String>> {
+    let Some(session_id) = entry.session_id.as_deref() else {
+        return Ok(Vec::new());
+    };
+    let mut stmt = conn.prepare(
+        "SELECT location FROM session_presences \
+         WHERE source = ? AND session_id = ? \
+         ORDER BY CASE location WHEN 'local' THEN 0 ELSE 1 END",
+    )?;
+    let locations = stmt
+        .query_map(params![entry.source, session_id], |row| row.get(0))?
+        .collect::<rusqlite::Result<Vec<String>>>()?;
+    Ok(locations)
+}
+
+fn local_resume_details(
+    conn: &Connection,
+    entry: &HistoryEntry,
+) -> Result<(Vec<String>, Option<String>)> {
+    let locations = entry_locations(conn, entry)?;
+    // A zero-presence row is legacy local evidence. Keep that compatibility
+    // fallback for behavior without claiming an observed location in output.
+    let locally_available =
+        locations.is_empty() || locations.iter().any(|location| location == "local");
+    let command = locally_available.then(|| resume_command(entry)).flatten();
+    Ok((locations, command))
+}
+
 fn fmt_row(row: &HistoryEntry, verbose: bool) -> String {
     let dt = Local
         .timestamp_millis_opt(row.timestamp_ms)
@@ -1959,7 +2034,7 @@ fn validate_source(source: Option<&str>) -> Result<()> {
 
 fn show_entry(conn: &Connection, id: i64, as_json: bool) -> Result<()> {
     let entry = get_entry(conn, id)?;
-    let resume = resume_command(&entry);
+    let (locations, resume) = local_resume_details(conn, &entry)?;
     let session_count: Option<i64> = if let Some(session_id) = &entry.session_id {
         Some(conn.query_row(
             "SELECT COUNT(*) FROM history WHERE source = ? AND session_id = ?",
@@ -1977,6 +2052,7 @@ fn show_entry(conn: &Connection, id: i64, as_json: bool) -> Result<()> {
     if as_json {
         let mut out = entry_output(&entry);
         out["resume_cmd"] = json!(resume);
+        out["locations"] = json!(locations);
         out["session_count"] = json!(session_count);
         out["tags"] = json!(tags);
         println!("{out}");
@@ -3567,6 +3643,12 @@ fn link_git_commit(
             Err(_) => {}
         }
     }
+    ai_hist_core::mark_session_presence(
+        conn,
+        &candidate.source,
+        &candidate.session_id,
+        SessionLocation::Local,
+    )?;
     conn.execute(
         "INSERT INTO session_commit_links \
          (source, session_id, repo, branch, commit_sha, note_ref, match_method, confidence, files_json, numstat_json, evidence_json, created_at_ms) \
@@ -5107,6 +5189,58 @@ fn sync_codex(conn: &Connection, state: &mut Map<String, Value>, home: &Path) ->
 /// (session cwds, session branches, prompts inserted).
 type CodexRolloutWalk = (HashMap<String, String>, HashMap<String, String>, usize);
 
+/// Reconcile the catalog registration for a locally observed Codex subagent.
+///
+/// A local-only subagent stays out of the catalog. If the same canonical
+/// session was separately discovered remotely, its retained local events are
+/// also local evidence, so both presences and the canonical row must survive.
+fn cleanup_codex_subagent_registration(conn: &Connection, session_id: &str) -> Result<()> {
+    conn.execute(
+        "DELETE FROM session_presences \
+         WHERE source = 'codex' AND session_id = ? AND location = 'local' \
+           AND NOT EXISTS (\
+             SELECT 1 FROM session_presences \
+             WHERE source = 'codex' AND session_id = ? AND location = 'remote'\
+           )",
+        params![session_id, session_id],
+    )?;
+    conn.execute(
+        "DELETE FROM sessions \
+         WHERE source = 'codex' AND session_id = ? \
+           AND NOT EXISTS (\
+             SELECT 1 FROM session_presences \
+             WHERE source = 'codex' AND session_id = ?\
+           )",
+        params![session_id, session_id],
+    )?;
+    Ok(())
+}
+
+fn codex_session_has_remote_presence(conn: &Connection, session_id: &str) -> Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(\
+           SELECT 1 FROM session_presences \
+           WHERE source = 'codex' AND session_id = ? AND location = 'remote'\
+         )",
+        [session_id],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
+}
+
+/// Remove prompt history that an older local sync incorrectly attributed to a
+/// subagent. A remote presence makes the history canonical shared evidence, so
+/// it must not be destroyed by a later local scan.
+fn cleanup_codex_subagent_history(conn: &Connection, session_id: &str) -> Result<()> {
+    if !codex_session_has_remote_presence(conn, session_id)? {
+        conn.execute(
+            "DELETE FROM history WHERE source = 'codex' AND session_id = ?",
+            [session_id],
+        )?;
+    }
+    Ok(())
+}
+
 fn sync_codex_rollouts(
     conn: &Connection,
     state: &mut Map<String, Value>,
@@ -5141,10 +5275,26 @@ fn sync_codex_rollouts(
                 .map(|r| r.get("stamp").and_then(Value::as_str) == Some(stamp.as_str()))
                 .unwrap_or(false);
             if stamp_unchanged {
-                match record
+                let recorded_session = record
                     .and_then(|r| r.get("session"))
-                    .and_then(Value::as_str)
+                    .and_then(Value::as_str);
+                if record
+                    .and_then(|r| r.get("subagent"))
+                    .and_then(Value::as_bool)
+                    == Some(true)
                 {
+                    if let Some(session_id) = recorded_session {
+                        // The fast path must still repair state from an older
+                        // sync/migration. In particular, presence backfill can
+                        // recreate a local catalog registration from retained
+                        // subagent events without changing the rollout stamp.
+                        cwds.remove(session_id);
+                        branches.remove(session_id);
+                        cleanup_codex_subagent_history(conn, session_id)?;
+                        cleanup_codex_subagent_registration(conn, session_id)?;
+                    }
+                }
+                match recorded_session {
                     // No session id was recorded because the file had no
                     // usable session_meta; there is nothing to re-ingest.
                     None => continue,
@@ -5166,25 +5316,32 @@ fn sync_codex_rollouts(
                 // would resurrect the session row this walk refuses to create.
                 cwds.remove(&meta.session_id);
                 branches.remove(&meta.session_id);
-                conn.execute(
-                    "DELETE FROM history WHERE source = 'codex' AND session_id = ?",
-                    [meta.session_id.as_str()],
-                )?;
-                conn.execute(
-                    "DELETE FROM session_presences WHERE source = 'codex' AND session_id = ?",
-                    [meta.session_id.as_str()],
-                )?;
-                conn.execute(
-                    "DELETE FROM sessions WHERE source = 'codex' AND session_id = ?",
-                    [meta.session_id.as_str()],
-                )?;
+                cleanup_codex_subagent_history(conn, &meta.session_id)?;
             } else {
                 cwds.insert(meta.session_id.clone(), meta.cwd.clone());
                 if let Some(branch) = &meta.git_branch {
                     branches.insert(meta.session_id.clone(), branch.clone());
                 }
             }
-            let outcome = ingest_codex_rollout(conn, &rollout, &meta)?;
+            let outcome = ingest_codex_rollout(conn, &rollout, &meta);
+            let cleanup = meta
+                .is_subagent
+                .then(|| cleanup_codex_subagent_registration(conn, &meta.session_id));
+            let outcome = match outcome {
+                Ok(outcome) => {
+                    if let Some(cleanup) = cleanup {
+                        cleanup?;
+                    }
+                    outcome
+                }
+                Err(error) => {
+                    // Cleanup was attempted above. Preserve the ingestion
+                    // failure as the primary diagnostic if both operations
+                    // fail, since it explains why this rollout made no
+                    // progress and is what a retry must address.
+                    return Err(error);
+                }
+            };
             inserted += outcome.prompts;
             events += outcome.events;
             // Subagent threads (guardian/reviewer spawns) keep their events
@@ -6412,6 +6569,7 @@ fn insert_session_event(
     token_json: Option<&str>,
     event_uid: &str,
 ) -> Result<()> {
+    ai_hist_core::mark_session_presence(conn, source, session_id, SessionLocation::Local)?;
     conn.execute(
         "INSERT INTO session_events \
          (source, session_id, project, cwd, git_branch, message_id, parent_id, ts_ms, role, kind, text, model, token_json, event_uid) \
@@ -6453,6 +6611,7 @@ fn insert_tool_call(
     is_error: Option<bool>,
     ts_ms: i64,
 ) -> Result<()> {
+    ai_hist_core::mark_session_presence(conn, source, session_id, SessionLocation::Local)?;
     conn.execute(
         "INSERT INTO tool_calls \
          (source, session_id, message_id, tool_use_id, name, target, args_json, is_error, ts_ms) \
@@ -6502,6 +6661,7 @@ fn upsert_file_edit_from_call(
     git_branch: Option<&str>,
     cwd: Option<&str>,
 ) -> Result<()> {
+    ai_hist_core::mark_session_presence(conn, source, session_id, SessionLocation::Local)?;
     conn.execute(
         "INSERT INTO file_edits \
          (source, session_id, message_id, tool_use_id, file_path, tool_name, ts_ms, git_branch, cwd) \
@@ -8259,6 +8419,203 @@ mod tests {
     }
 
     #[test]
+    fn local_named_catalog_wrappers_reject_nonlocal_scope_without_touching_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("must-not-be-created.db");
+
+        let list_error = super::list_sessions_local_at(
+            &db,
+            &super::CatalogListOptions {
+                scope: super::SessionScope::Remote,
+                ..Default::default()
+            },
+        )
+        .expect_err("the local wrapper must not coerce a remote request");
+        assert!(list_error
+            .to_string()
+            .contains("use list_sessions_scoped_at"));
+        assert!(!db.exists());
+
+        let discover_error = super::discover_sessions_local_at(
+            &db,
+            &super::DiscoverOptions {
+                scope: super::SessionScope::All,
+                ..Default::default()
+            },
+        )
+        .expect_err("the local wrapper must not coerce an all-scope request");
+        assert!(discover_error
+            .to_string()
+            .contains("use discover_sessions_scoped_at"));
+        assert!(!db.exists());
+    }
+
+    #[test]
+    fn resume_requires_local_or_legacy_local_evidence() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let entry = HistoryEntry {
+            id: 1,
+            source: "codex".into(),
+            session_id: Some("cloud-session".into()),
+            project: None,
+            prompt: "continue".into(),
+            prompt_hash: None,
+            timestamp_ms: 1,
+        };
+
+        // Legacy rows without a presence retain the old local resume behavior,
+        // while output truthfully reports no observed location.
+        let (locations, command) = super::local_resume_details(&conn, &entry).unwrap();
+        assert!(locations.is_empty());
+        assert!(command.is_some());
+
+        ai_hist_core::mark_session_presence(
+            &conn,
+            "codex",
+            "cloud-session",
+            super::SessionLocation::Remote,
+        )
+        .unwrap();
+        let (locations, command) = super::local_resume_details(&conn, &entry).unwrap();
+        assert_eq!(locations, vec!["remote"]);
+        assert!(command.is_none());
+
+        ai_hist_core::mark_session_presence(
+            &conn,
+            "codex",
+            "cloud-session",
+            super::SessionLocation::Local,
+        )
+        .unwrap();
+        let (locations, command) = super::local_resume_details(&conn, &entry).unwrap();
+        assert_eq!(locations, vec!["local", "remote"]);
+        assert!(command.is_some());
+    }
+
+    #[test]
+    fn normalized_local_evidence_records_local_presence() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+
+        super::insert_session_event(
+            &conn,
+            "claude",
+            "event-session",
+            None,
+            None,
+            None,
+            "message-1",
+            None,
+            1,
+            "user",
+            "text",
+            Some("hello"),
+            None,
+            None,
+            "event-1",
+        )
+        .unwrap();
+        super::insert_tool_call(
+            &conn,
+            "claude",
+            "tool-session",
+            "message-2",
+            "tool-1",
+            "Read",
+            Some("README.md"),
+            "{}",
+            None,
+            2,
+        )
+        .unwrap();
+        super::upsert_file_edit_from_call(
+            &conn,
+            "claude",
+            "edit-session",
+            "message-3",
+            "tool-2",
+            "src/lib.rs",
+            "Edit",
+            3,
+            None,
+            None,
+        )
+        .unwrap();
+
+        for session_id in ["event-session", "tool-session", "edit-session"] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM session_presences \
+                     WHERE source = 'claude' AND session_id = ? AND location = 'local'",
+                    [session_id],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 1, "missing local presence for {session_id}");
+        }
+    }
+
+    #[test]
+    fn codex_subagent_cleanup_preserves_remote_session_and_local_evidence() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO sessions (source, session_id) VALUES ('codex', 'subagent')",
+            [],
+        )
+        .unwrap();
+        ai_hist_core::mark_session_presence(
+            &conn,
+            "codex",
+            "subagent",
+            super::SessionLocation::Local,
+        )
+        .unwrap();
+        ai_hist_core::mark_session_presence(
+            &conn,
+            "codex",
+            "subagent",
+            super::SessionLocation::Remote,
+        )
+        .unwrap();
+
+        super::cleanup_codex_subagent_registration(&conn, "subagent").unwrap();
+
+        let locations: Vec<String> = conn
+            .prepare(
+                "SELECT location FROM session_presences \
+                 WHERE source = 'codex' AND session_id = 'subagent' ORDER BY location",
+            )
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(locations, vec!["local", "remote"]);
+        let session_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions \
+                 WHERE source = 'codex' AND session_id = 'subagent'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(session_count, 1);
+
+        let local_page = super::list_session_catalog_page(
+            &conn,
+            &super::CatalogListOptions {
+                scope: super::SessionScope::Local,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(local_page.sessions.len(), 1);
+        assert_eq!(local_page.sessions[0].session_id, "subagent");
+    }
+
+    #[test]
     fn a_stopped_or_zombie_holder_is_reported_as_wedged() {
         let wedged = |state: &str| {
             super::DbHolder {
@@ -9161,6 +9518,15 @@ mod tests {
         let evidence: Value = serde_json::from_str(&evidence).unwrap();
         assert_eq!(evidence["candidate"]["branch_match"], true);
         assert_eq!(evidence["candidate"]["file_overlap"], 1);
+        let local_presence: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_presences \
+                 WHERE source = 'claude' AND session_id = 's-link' AND location = 'local'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(local_presence, 1);
     }
 
     #[test]
@@ -9441,6 +9807,211 @@ mod tests {
             .query_row("SELECT text FROM session_events", [], |r| r.get(0))
             .unwrap();
         assert_eq!(text, "first");
+    }
+
+    fn write_codex_subagent_rollout(path: &std::path::Path, session_id: &str) {
+        fs::write(
+            path,
+            format!(
+                concat!(
+                    r#"{{"timestamp":"2026-08-01T10:01:00.000Z","type":"session_meta","payload":{{"id":"{}","session_id":"parent","parent_thread_id":"parent","thread_source":"subagent","source":{{"subagent":{{"other":"guardian"}}}},"cwd":"/tmp/proj"}}}}"#,
+                    "\n",
+                    r#"{{"timestamp":"2026-08-01T10:01:01.000Z","type":"event_msg","payload":{{"type":"agent_message","message":"Reviewing."}}}}"#,
+                    "\n",
+                ),
+                session_id
+            ),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn unchanged_subagent_state_still_repairs_migrated_local_catalog_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        let day = home.join(".codex/sessions/2026/08/01");
+        fs::create_dir_all(&day).unwrap();
+        let rollout = day.join("rollout-unchanged-sub.jsonl");
+        write_codex_subagent_rollout(&rollout, "sess-unchanged-sub");
+
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO sessions (session_id, source, cwd) \
+             VALUES ('sess-unchanged-sub', 'codex', '/tmp/proj')",
+            [],
+        )
+        .unwrap();
+        ai_hist_core::mark_session_presence(
+            &conn,
+            "codex",
+            "sess-unchanged-sub",
+            super::SessionLocation::Local,
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO history (source, session_id, prompt, timestamp_ms) \
+             VALUES ('codex', 'sess-unchanged-sub', 'stale task', 1)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_events \
+             (source, session_id, ts_ms, role, kind, text, event_uid) \
+             VALUES ('codex', 'sess-unchanged-sub', 2, 'assistant', 'text', 'kept event', 'event-1')",
+            [],
+        )
+        .unwrap();
+
+        let key = rollout.to_string_lossy().to_string();
+        let mut state = Map::new();
+        state.insert(
+            "codex_rollouts_v3".into(),
+            json!({
+                (key): {
+                    "stamp": file_stamp(&rollout).unwrap(),
+                    "session": "sess-unchanged-sub",
+                    "subagent": true
+                }
+            }),
+        );
+        state.insert(
+            "codex_session_cwds".into(),
+            json!({"sess-unchanged-sub": "/tmp/proj"}),
+        );
+        state.insert(
+            "codex_session_branches".into(),
+            json!({"sess-unchanged-sub": "main"}),
+        );
+
+        let (cwds, branches, inserted) =
+            super::sync_codex_rollouts(&conn, &mut state, home).unwrap();
+        assert_eq!(inserted, 0);
+        assert!(!cwds.contains_key("sess-unchanged-sub"));
+        assert!(!branches.contains_key("sess-unchanged-sub"));
+        let stale_rows: i64 = conn
+            .query_row(
+                "SELECT \
+                   (SELECT COUNT(*) FROM sessions WHERE source='codex' AND session_id='sess-unchanged-sub') + \
+                   (SELECT COUNT(*) FROM session_presences WHERE source='codex' AND session_id='sess-unchanged-sub') + \
+                   (SELECT COUNT(*) FROM history WHERE source='codex' AND session_id='sess-unchanged-sub')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stale_rows, 0);
+        let events: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_events \
+                 WHERE source='codex' AND session_id='sess-unchanged-sub'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(events, 1);
+    }
+
+    #[test]
+    fn local_subagent_sync_preserves_history_for_a_remote_canonical_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        let day = home.join(".codex/sessions/2026/08/01");
+        fs::create_dir_all(&day).unwrap();
+        let rollout = day.join("rollout-remote-sub.jsonl");
+        write_codex_subagent_rollout(&rollout, "sess-remote-sub");
+
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO sessions (session_id, source, cwd) \
+             VALUES ('sess-remote-sub', 'codex', '/remote/project')",
+            [],
+        )
+        .unwrap();
+        ai_hist_core::insert_history_at_location(
+            &conn,
+            &HistoryEntry {
+                id: 0,
+                source: "codex".into(),
+                session_id: Some("sess-remote-sub".into()),
+                project: Some("/remote/project".into()),
+                prompt: "remote canonical prompt".into(),
+                prompt_hash: None,
+                timestamp_ms: 1,
+            },
+            super::SessionLocation::Remote,
+        )
+        .unwrap();
+
+        super::sync_codex_rollouts(&conn, &mut Map::new(), home).unwrap();
+
+        let prompts: Vec<String> = conn
+            .prepare(
+                "SELECT prompt FROM history \
+                 WHERE source='codex' AND session_id='sess-remote-sub'",
+            )
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(prompts, vec!["remote canonical prompt"]);
+        let locations: Vec<String> = conn
+            .prepare(
+                "SELECT location FROM session_presences \
+                 WHERE source='codex' AND session_id='sess-remote-sub' ORDER BY location",
+            )
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(locations, vec!["local", "remote"]);
+    }
+
+    #[test]
+    fn failed_subagent_ingest_still_cleans_local_catalog_registration() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        let day = home.join(".codex/sessions/2026/08/01");
+        fs::create_dir_all(&day).unwrap();
+        let rollout = day.join("rollout-failing-sub.jsonl");
+        write_codex_subagent_rollout(&rollout, "sess-failing-sub");
+
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO sessions (session_id, source) VALUES ('sess-failing-sub', 'codex')",
+            [],
+        )
+        .unwrap();
+        ai_hist_core::mark_session_presence(
+            &conn,
+            "codex",
+            "sess-failing-sub",
+            super::SessionLocation::Local,
+        )
+        .unwrap();
+        conn.execute_batch(
+            "CREATE TRIGGER reject_subagent_event \
+             BEFORE INSERT ON session_events \
+             BEGIN SELECT RAISE(FAIL, 'forced subagent ingest failure'); END;",
+        )
+        .unwrap();
+
+        let error = super::sync_codex_rollouts(&conn, &mut Map::new(), home)
+            .expect_err("the trigger must fail ingestion");
+        assert!(error.to_string().contains("forced subagent ingest failure"));
+        let stale_rows: i64 = conn
+            .query_row(
+                "SELECT \
+                   (SELECT COUNT(*) FROM sessions WHERE source='codex' AND session_id='sess-failing-sub') + \
+                   (SELECT COUNT(*) FROM session_presences WHERE source='codex' AND session_id='sess-failing-sub')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stale_rows, 0);
     }
 
     #[test]

--- a/crates/ai-hist/tests/session_discovery.rs
+++ b/crates/ai-hist/tests/session_discovery.rs
@@ -104,7 +104,8 @@ fn discover_streams_jsonl_rows_then_a_summary() {
 
     let summary = lines.last().expect("a summary line");
     assert_eq!(summary["type"], "summary");
-    assert_eq!(summary["contract_version"], 1);
+    assert_eq!(summary["contract_version"], 2);
+    assert_eq!(summary["scope"], "local");
     assert_eq!(summary["discovered"], 2);
     assert_eq!(summary["skipped_unchanged"], 0);
     assert_eq!(summary["providers"]["claude"]["discovered"], 1);
@@ -159,11 +160,15 @@ fn list_serves_the_catalog_after_the_provider_files_are_gone() {
         String::from_utf8_lossy(&output.stderr)
     );
     let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(payload["contract_version"], 1);
+    assert_eq!(payload["contract_version"], 2);
+    assert_eq!(payload["scope"], "local");
     let sessions = payload["sessions"].as_array().unwrap();
     assert_eq!(sessions.len(), 2);
     assert_eq!(sessions[0]["session_id"], "codex-cli");
     assert_eq!(sessions[1]["session_id"], "claude-cli");
+    assert!(sessions
+        .iter()
+        .all(|row| row["locations"] == serde_json::json!(["local"])));
     assert!(sessions.iter().all(|row| row["from_cache"] == true));
 
     // A page that did not fill its limit ends the walk.
@@ -179,6 +184,75 @@ fn list_serves_the_catalog_after_the_provider_files_are_gone() {
     let payload: Value = serde_json::from_slice(&filtered.stdout).unwrap();
     assert_eq!(payload["sessions"].as_array().unwrap().len(), 1);
     assert_eq!(payload["sessions"][0]["source"], "claude");
+}
+
+#[test]
+fn scope_flags_default_to_local_and_all_is_a_deduplicated_union() {
+    let temp = fake_home();
+    let db_path = temp.path().join("history.db");
+    assert!(isolated(&temp, &db_path, &["sessions", "discover"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    let list = |scope: Option<&str>| {
+        let mut args = vec!["sessions", "list", "--json"];
+        if let Some(scope) = scope {
+            args.push(scope);
+        }
+        let output = isolated(&temp, &db_path, &args).output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::from_slice::<Value>(&output.stdout).unwrap()
+    };
+
+    let implicit = list(None);
+    let explicit = list(Some("--local"));
+    assert_eq!(implicit, explicit);
+    assert_eq!(implicit["scope"], "local");
+    assert_eq!(implicit["sessions"].as_array().unwrap().len(), 2);
+
+    let remote = list(Some("--remote"));
+    assert_eq!(remote["scope"], "remote");
+    assert!(remote["sessions"].as_array().unwrap().is_empty());
+
+    let all = list(Some("--all"));
+    assert_eq!(all["scope"], "all");
+    assert_eq!(all["sessions"].as_array().unwrap().len(), 2);
+
+    let conflict = isolated(
+        &temp,
+        &db_path,
+        &["sessions", "list", "--local", "--remote"],
+    )
+    .output()
+    .unwrap();
+    assert!(!conflict.status.success());
+    assert!(String::from_utf8_lossy(&conflict.stderr).contains("cannot be used with"));
+}
+
+#[test]
+fn explicit_remote_discovery_fails_instead_of_falling_back_to_local() {
+    let temp = fake_home();
+    let db_path = temp.path().join("history.db");
+    let output = isolated(
+        &temp,
+        &db_path,
+        &["sessions", "discover", "--remote", "--json"],
+    )
+    .output()
+    .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("no remote provider connectors are configured"));
+    assert!(
+        !db_path.exists(),
+        "unsupported discovery must not create a ledger"
+    );
 }
 
 #[test]

--- a/crates/ai-hist/tests/sync_resilience.rs
+++ b/crates/ai-hist/tests/sync_resilience.rs
@@ -77,7 +77,11 @@ fn a_busy_source_failure_prints_a_fresh_write_capability_probe() {
     let output = isolated_sync(&temp, &db_path).output().unwrap();
     // Other absent/up-to-date sources still complete, so #48 deliberately
     // keeps the aggregate run successful while reporting this source failure.
-    assert!(output.status.success());
+    assert!(
+        output.status.success(),
+        "sync failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("ai-hist contention diagnostic")
@@ -86,4 +90,35 @@ fn a_busy_source_failure_prints_a_fresh_write_capability_probe() {
     );
 
     holder.execute_batch("ROLLBACK").unwrap();
+}
+
+#[test]
+fn unsupported_remote_sync_fails_before_watch_or_service_setup() {
+    let temp = tempfile::tempdir().unwrap();
+    let db_path = temp.path().join("history.db");
+    for args in [vec!["--remote"], vec!["--remote", "--install-service"]] {
+        let mut command = isolated_sync(&temp, &db_path);
+        command.args(args);
+        let output = command.output().unwrap();
+        assert!(!output.status.success());
+        assert!(String::from_utf8_lossy(&output.stderr)
+            .contains("no remote provider connectors are configured"));
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_ai-hist"))
+        .arg("--db")
+        .arg(&db_path)
+        .args(["watch", "--remote", "--interval", "1"])
+        .env("HOME", temp.path())
+        .env("USERPROFILE", temp.path())
+        .env("XDG_DATA_HOME", temp.path().join("xdg"))
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "watch must fail rather than loop");
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("no remote provider connectors are configured"));
+    assert!(
+        !db_path.exists(),
+        "unsupported sync must not create a ledger"
+    );
 }

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -30,6 +30,9 @@ Remote discovery and remote sync are reserved but unsupported until provider
 connectors ship. Integrations must surface that error for explicit `remote`
 acquisition rather than retrying locally. `all` runs every configured adapter,
 which means local adapters only until remote connectors are available.
+Acquisition result `scope` echoes the request; use session `locations` for
+observed presences rather than treating that summary field as proof that a
+connector executed at each requested location.
 
 The CLI equivalents are `sessions list`, `sessions discover`, `search`,
 `recent`, `session`, `events`, `stats`, and `sync`. See

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -5,6 +5,11 @@ server call the mandatory Rust Node-API engine. Reads are cache-only; provider
 I/O happens only when an integration explicitly requests shallow discovery or
 full sync.
 
+All collection operations use the same session ledger and a shared scope enum:
+`local`, `remote`, or `all`. `local` is the default. Local and remote are
+presences of one logical session; `all` is a deduplicated union, not a second
+query followed by concatenation.
+
 Use these public operations:
 
 - `listSessionCatalogPage()` / MCP `list_sessions` for bounded cache-only
@@ -14,6 +19,17 @@ Use these public operations:
 - `search()`, `recent()`, `getSession()`, and `getSessionEventsPage()` for
   indexed history reads.
 - `sync()` / MCP `sync` for explicit full local ingestion.
+
+Pass `scope` to collection operations when the default local view is not
+enough. The CLI spelling is the mutually exclusive `--local`, `--remote`, and
+`--all` flags. `sessions list`, `search`, `recent`, and `stats` always query the
+cached ledger and never contact a provider. Direct `getSession()` and event-page
+lookups are identity-based and scope-independent.
+
+Remote discovery and remote sync are reserved but unsupported until provider
+connectors ship. Integrations must surface that error for explicit `remote`
+acquisition rather than retrying locally. `all` runs every configured adapter,
+which means local adapters only until remote connectors are available.
 
 The CLI equivalents are `sessions list`, `sessions discover`, `search`,
 `recent`, `session`, `events`, `stats`, and `sync`. See

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,6 +47,10 @@ Explicit remote discovery/sync returns an unsupported operation until provider
 connectors ship; the engine must not silently fall back to local work. `all`
 acquisition runs all configured adapters, which currently means the local
 adapters and will include remote adapters when they become available.
+An acquisition result's `scope` records the request, not the set of connector
+locations that executed. Observed locations belong to each session row's
+`locations`; `all` therefore remains the result scope even while only local
+adapters are configured.
 
 ## Operation semantics
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,27 +21,54 @@ Rust owns provider discovery/parsing, schema creation and migration, direct
 SQLite connections, catalog queries, history/event queries, search,
 statistics, and sync. Blocking filesystem and SQLite work is dispatched away
 from Node's event loop. TypeScript validates inputs, validates native contract
-version 2 and catalog contract version 1, normalizes nullable fields, maps
+version 3 and catalog contract version 2, normalizes nullable fields, maps
 native errors, and supplies pagination helpers.
 
 The CLI and MCP server import only the SDK's public functions. They do not
 open SQLite, import `ai-hist-native`, scan providers, or invoke another CLI.
 
+## Session ledger and location scope
+
+There is one session ledger. `local` and `remote` are presences recording where
+a logical session was observed, not independent session stores. Collection
+operations accept one scope: `local` (the default), `remote`, or `all`. The
+`all` view is the union of both presences, deduplicated by canonical session
+identity, so materializing a remote session locally does not create a second
+user-visible session. Connector-specific locator, change stamp, and discovery
+state live on each presence, preventing a local scan and a cloud scan from
+overwriting one another's acquisition state.
+
+Scope changes selection, not I/O. Cached collection reads (`sessions list`,
+`search`, and `recent`) stay database-only for every scope. Direct session and
+event lookup already names one session and remains scope-independent.
+
+Acquisition is still explicit. Local discovery and sync are implemented.
+Explicit remote discovery/sync returns an unsupported operation until provider
+connectors ship; the engine must not silently fall back to local work. `all`
+acquisition runs all configured adapters, which currently means the local
+adapters and will include remote adapters when they become available.
+
 ## Operation semantics
 
 | Operation | Provider I/O | Database work | Missing database |
 |---|---:|---|---|
-| `listSessionCatalog*` | none | one indexed cache query | empty page |
-| `discoverSessions` | bounded shallow reads | catalog upserts | creates catalog DB |
-| `search`, `recent`, `getSession`, `stats` | none | indexed reads | empty result |
+| `listSessionCatalog*` (`local` / `remote` / `all`) | none | one indexed cache query | empty page |
+| `discoverSessions` (`local`, default) | bounded shallow reads | catalog upserts | creates catalog DB |
+| `discoverSessions` (`remote`) | unsupported until connectors ship | none | unsupported operation |
+| `discoverSessions` (`all`) | all configured adapters (currently local) | catalog upserts | creates catalog DB |
+| `search`, `recent` (`local` / `remote` / `all`) | none | indexed reads | empty result |
+| `stats` (`local` / `remote` / `all`) | none | indexed aggregate reads | empty result |
+| `getSession` | none | indexed identity read | empty result |
 | `getSessionEventsPage` | none | bounded keyset page | empty page |
-| `sync` | full explicit scan | migrations + ingestion | creates DB |
+| `sync` (`local`, default) | full explicit scan | migrations + ingestion | creates DB |
+| `sync` (`remote`) | unsupported until connectors ship | none | unsupported operation |
+| `sync` (`all`) | all configured adapters (currently local) | migrations + ingestion | creates DB |
 
 No read operation invokes discovery or sync. A common cold start is:
 
 ```ts
-await discoverSessions({ limit: 100 });
-const sessions = await listSessionCatalog({ limit: 100 });
+await discoverSessions({ limit: 100, scope: 'local' });
+const sessions = await listSessionCatalog({ limit: 100, scope: 'all' });
 ```
 
 Events use `(ts_ms, id)` keyset pagination. Catalog ordering is

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,16 +24,39 @@ These are intentionally different:
   metadata.
 - `sync` performs full ingestion for search and event history.
 
+They use one session ledger. Local and remote describe where a session was
+observed (its presence), not separate kinds of session or separate databases.
+Commands that select a set of sessions accept exactly one of:
+
+- `--local` — sessions with a local presence; this is the default.
+- `--remote` — sessions with a remote provider presence.
+- `--all` — the union, deduplicated so a session with both presences appears
+  once.
+
+Omitting the flag is exactly equivalent to `--local`. Combining scope flags is
+an error.
+
 ```bash
-ai-hist sessions discover --limit 100
-ai-hist sessions list --limit 20
-ai-hist sync
-ai-hist search "authentication" --limit 20
+ai-hist sessions discover --local --limit 100
+ai-hist sessions list --all --limit 20
+ai-hist sync --local
+ai-hist search "authentication" --all --limit 20
+ai-hist recent --remote --limit 20
 ai-hist events SESSION_ID --limit 200
 ```
 
-A missing database produces an empty list/search result. Reads do not trigger
-hidden provider work.
+`sessions list`, `search`, and `recent` only query cached rows in the unified
+ledger, regardless of scope. A missing database produces an empty result.
+Reads do not trigger hidden provider work. `session` and `events` address an
+already-known session directly, so they are scope-independent and do not
+accept a location flag.
+
+Remote provider connectors are not shipped yet. Until they are, remote
+discovery and ingestion are explicit unsupported operations: `sessions
+discover --remote` and `sync --remote` fail instead of falling back to local
+work. `--all` runs all configured adapters, so today it performs local
+acquisition; it will include remote adapters once they ship. Cached remote/all
+queries are already part of the stable contract.
 
 ## SDK
 
@@ -44,9 +67,9 @@ npm install ai-hist
 ```ts
 import { discoverSessions, listSessionCatalog, search } from 'ai-hist';
 
-await discoverSessions({ limit: 100 });
-const sessions = await listSessionCatalog({ limit: 100 });
-const matches = await search('authentication');
+await discoverSessions({ limit: 100, scope: 'local' });
+const sessions = await listSessionCatalog({ limit: 100, scope: 'all' });
+const matches = await search('authentication', { scope: 'all' });
 ```
 
 ## MCP

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,6 +58,11 @@ work. `--all` runs all configured adapters, so today it performs local
 acquisition; it will include remote adapters once they ship. Cached remote/all
 queries are already part of the stable contract.
 
+Discovery results keep those two facts separate: the summary `scope` is the
+scope requested by the caller, while row `locations` are the presences actually
+observed. Thus a current `--all` discovery summary says `all` even though its
+connector-location work is local-only.
+
 ## SDK
 
 ```bash

--- a/docs/native-sdk-migration.md
+++ b/docs/native-sdk-migration.md
@@ -34,6 +34,14 @@ Every database API is now async. Remove `fallback`, `sourceKind`, `close`, and
 binary-path options. If the database is missing, read APIs return empty data;
 call `discoverSessions()` or `sync()` explicitly.
 
+Collection APIs, including statistics, now use a shared `scope` option: `'local'`, `'remote'`, or
+`'all'`; omitting it means `'local'`. The CLI equivalents are mutually
+exclusive `--local`, `--remote`, and `--all` flags. Local and remote rows live
+in one ledger and represent presences of the same session, so `all` is
+deduplicated. Direct session and event lookup does not take a scope. Remote
+discovery and sync remain unsupported until provider connectors ship; `all`
+acquisition runs all currently configured adapters.
+
 Replace unbounded event reads with a page or async iterator:
 
 ```ts

--- a/docs/native-sdk-migration.md
+++ b/docs/native-sdk-migration.md
@@ -42,6 +42,20 @@ deduplicated. Direct session and event lookup does not take a scope. Remote
 discovery and sync remain unsupported until provider connectors ship; `all`
 acquisition runs all currently configured adapters.
 
+The acquisition result's `scope` echoes what was requested. It is not an
+"executed connector locations" list: `all` currently executes local adapters
+only. Use each returned session's `locations` for observed presences. Search,
+recent, and direct-session history rows also carry `locations`;
+`resumeCommand()` returns `null` when those locations are remote-only.
+
+Rust embedders must also update and recompile. Catalog/discovery option, page,
+summary, and row structs gained scope/location fields. The local-named wrapper
+functions now reject a non-local option instead of silently coercing it; call
+the corresponding `*_scoped*` API for `remote` or `all`. Human CLI parsers must
+account for a locations column in catalog rows, a scope line in statistics,
+and requested/executed wording in discovery summaries. Remote-only matches do
+not produce a local resume command.
+
 Replace unbounded event reads with a page or async iterator:
 
 ```ts

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,7 @@
 # Release and platform validation
 
 All public packages use one version: `ai-hist`, `ai-hist-native`, each native
-platform package, and `ai-hist-mcp`. The SDK checks native contract version 2
+platform package, and `ai-hist-mcp`. The SDK checks native contract version 3
 at initialization.
 
 The `Publish RelayHistory npm packages` workflow:

--- a/docs/session-catalog.md
+++ b/docs/session-catalog.md
@@ -114,6 +114,11 @@ Keys are `snake_case`. `models`, `workspace_roots`, and `locations` are always
 arrays (possibly empty); every other absent value is `null`, never an invented
 placeholder or an empty string.
 
+For this cache-only operation, top-level `scope` is the filter applied to the
+ledger. `locations` contains observed presences only; legacy rows that predate
+presence tracking may therefore have an empty array while still appearing in
+the compatibility-preserving default local view.
+
 `next_cursor` is the continuation for the next page, or `null` once the catalog
 is exhausted (the page came back short of its limit). See
 [Pagination](#pagination).
@@ -162,15 +167,19 @@ types, in this order:
 `counters` is the run's bill of work, and it is the honest way to check that
 discovery stayed cheap — `bytes_read` and `files_opened` are what a bounded
 request bounds, and `shallow_reads` is `0` on a rescan where nothing changed.
+Summary `scope` echoes the requested acquisition scope. It does not enumerate
+connector locations that executed, and `providers` groups source adapters
+rather than local/remote locations. Today an `all` summary accompanies
+local-only connector work; row `locations` still report observed presences.
 
 Diagnostics are their own lines and never appear inside the `summary` object,
 so a consumer that only wants the tally can read the last line and stop. In
 human (non-`--json`) mode they go to stderr instead, leaving stdout clean:
 
 ```text
-  2026-06-21 11:00  codex    shallow  0198c2ad-codex   /Users/you/Projects/api  make the backoff configurable
-  2026-06-20 10:05  claude   shallow  3f6c1b7a-claude  /Users/you/Projects/api  add a retry to the http client
-  2 session(s): 0 discovered, 2 unchanged (0 file(s) opened, 0 shallow read(s))
+  2026-06-21 11:00  codex    local        shallow  0198c2ad-codex   /Users/you/Projects/api  make the backoff configurable
+  2026-06-20 10:05  claude   local        shallow  3f6c1b7a-claude  /Users/you/Projects/api  add a retry to the http client
+  2 session(s): 0 discovered, 2 unchanged (0 file(s) opened, 0 shallow read(s)); requested scope: local, connector locations run: local
 ```
 
 A provider that fails contributes a `diagnostic` and nothing else; the run
@@ -242,6 +251,13 @@ today. Explicit remote acquisition is reserved but unsupported until provider
 connectors ship, and returns an error rather than silently doing local work.
 `--all` means every configured adapter; today that is the local adapters, and
 remote adapters will join the same operation when implemented.
+
+The discovery summary preserves the requested scope, so `--all` reports
+`scope: "all"` even while connector-location execution is local-only. That is
+different from each row's observed `locations`. A remote-only session can be
+selected by resume search, but it cannot yield a usable local resume command;
+materialize it locally first. Sessions with both presences remain locally
+resumable.
 
 Direct `session` and `events` lookups already name a `(source, session_id)` and
 therefore remain scope-independent.
@@ -364,7 +380,8 @@ read with no sort.
 
 ## Rescans and source stamps
 
-Each row stores a `source_stamp` — `v{scanner version}:{provider change marker}`:
+Each connector presence stores a `source_stamp` —
+`v{scanner version}:{provider change marker}`:
 
 | Source | Change marker |
 |---|---|
@@ -373,10 +390,13 @@ Each row stores a `source_stamp` — `v{scanner version}:{provider change marker
 | opencode | `{time_created}:{time_updated}` |
 | relay | `{newest synced timestamp}:{synced row count}` |
 
-On a rescan, a candidate whose stamp matches the stored one is served straight
-from the catalog: no read, no parse, `skipped_unchanged` incremented,
-`from_cache: true` on the emitted row. In the benchmark below, a rescan of 450
-unchanged sessions performs **zero** shallow reads.
+On a rescan, a candidate whose stamp matches the stamp for that same location
+in `session_presences` is served straight from the catalog: no read, no parse,
+`skipped_unchanged` incremented, `from_cache: true` on the emitted row. The
+top-level catalog row retains a canonical `source_stamp` summary for backward
+compatibility, but connector change detection never relies on that merged
+copy. In the benchmark below, a rescan of 450 unchanged sessions performs
+**zero** shallow reads.
 
 The `v{N}` prefix is the *scanner* version (`SHALLOW_SCANNER_VERSION`), separate
 from `parser_version` (the full-ingest parser generation). Bumping it
@@ -419,8 +439,8 @@ plus the `idx_sessions_source_last`, `idx_sessions_raw_path`,
 sessions (a codex subagent thread, a Claude subagent sidecar), keyed by
 `(source, locator)` with the stamp, so a rescan costs a primary-key lookup
 instead of re-reading them every run.
-Databases created by an older release are migrated in place by ignore-error
-`ALTER TABLE`s in `init_db`, and `schema_is_current` knows about the new
+Databases created by an older release are migrated in place by a serialized
+missing-column check in `init_db`, and `schema_is_current` knows about the new
 columns, so a read-only handle over an old database is upgraded instead of
 failing with `no such column`.
 

--- a/docs/session-catalog.md
+++ b/docs/session-catalog.md
@@ -1,6 +1,7 @@
 # Session Catalog — shallow coding-agent session discovery
 
-**Answer "which coding-agent sessions exist on this machine, newest first?" in milliseconds, without indexing a single transcript.**
+**Answer "which coding-agent sessions have been found, newest first?" in
+milliseconds, without indexing a single transcript.**
 
 `ai-hist sync` builds the deep index: every message, tool call, file edit and
 full-text row. That is the right thing for search, and the wrong thing for a
@@ -12,13 +13,22 @@ table so the next listing touches no provider file at all.
 The two layers coexist. Discovery never blocks or downgrades a full sync, and a
 fully indexed session keeps its richer state when discovery re-reads it.
 
+The catalog is one ledger, not separate local and remote catalogs. A session
+may have a `local` presence, a `remote` presence, or both. Its presences are
+stored in `session_presences`, while callers still receive one session row.
+Collection commands select a location with exactly one of `--local`,
+`--remote`, or `--all`; omitting a scope flag means `--local`. `--all` is the
+deduplicated union, so the same `(source, session_id)` is never returned twice
+just because it has both presences. Combining scope flags is an invalid
+argument; provider `--source` filters remain orthogonal to location scope.
+
 ---
 
 ## The two operations
 
 | | `ai-hist sessions list` | `ai-hist sessions discover` |
 |---|---|---|
-| Reads | the `sessions` table only | provider locations, with bounded reads |
+| Reads | the cached ledger only | configured provider locations, with bounded reads |
 | Provider I/O | none | head/tail of the newest candidates |
 | Writes | nothing (read-only handle when the schema is current) | upserts `sessions` rows |
 | Output | one JSON object | JSONL session, diagnostic, and summary records |
@@ -32,15 +42,17 @@ Use **`discover`** when the catalog may be stale — on app launch, on a manual
 refresh, or on a timer. It is safe to run beside `ai-hist sync`.
 
 ```bash
-# Refresh the catalog from every provider, newest first.
+# Refresh from local provider locations (the default).
 ai-hist sessions discover
+ai-hist sessions discover --local
 
-# Just the 20 most recent sessions across all providers (bounded work).
-ai-hist sessions discover --limit 20
+# Run every configured discovery adapter (currently local adapters).
+ai-hist sessions discover --all --limit 20
 
 # Read back what the catalog holds — no provider file is opened.
 ai-hist sessions list
-ai-hist sessions list --limit 100 --source codex --source claude
+ai-hist sessions list --remote --limit 100 --source codex --source claude
+ai-hist sessions list --all --limit 100
 
 # Page backwards by recency (keyset, not OFFSET).
 ai-hist sessions list --limit 50 --before-ms 1781949900000
@@ -54,7 +66,7 @@ ai-hist sessions discover --json      # JSONL: sessions, diagnostics, summary
 
 ## The output contract
 
-Both operations carry `contract_version` — currently **1**
+Both operations carry `contract_version` — currently **2**
 (`SESSION_CATALOG_CONTRACT_VERSION`). It is bumped whenever the shape or the
 meaning of a row changes in a way a consumer must notice, so parse it and fail
 loudly on a version you do not know rather than guessing.
@@ -65,7 +77,8 @@ One object, never a bare array, so the version travels with the payload:
 
 ```jsonc
 {
-  "contract_version": 1,
+  "contract_version": 2,
+  "scope": "local",
   "sessions": [
     {
       "source": "codex",
@@ -85,6 +98,7 @@ One object, never a bare array, so the version travels with the payload:
       "raw_path": "/Users/you/.codex/sessions/2026/06/21/rollout-codex.jsonl",
       "source_stamp": "v1:1788042670103317900:569",
       "discovery_state": "shallow",
+      "locations": ["local"],
       "from_cache": true
     }
   ],
@@ -96,8 +110,8 @@ One object, never a bare array, so the version travels with the payload:
 }
 ```
 
-Keys are `snake_case`. `models` and `workspace_roots` are always arrays
-(possibly empty); every other absent value is `null`, never an invented
+Keys are `snake_case`. `models`, `workspace_roots`, and `locations` are always
+arrays (possibly empty); every other absent value is `null`, never an invented
 placeholder or an empty string.
 
 `next_cursor` is the continuation for the next page, or `null` once the catalog
@@ -120,7 +134,8 @@ types, in this order:
 // so a consumer always sees the reason before the non-zero exit
 {
   "type": "summary",
-  "contract_version": 1,
+  "contract_version": 2,
+  "scope": "local",
   "discovered": 2,
   "skipped_unchanged": 0,
   "providers": {
@@ -188,13 +203,14 @@ contract:
 | `raw_path` | observed | provider file this row came from; `null` for database- and network-backed sources |
 | `source_stamp` | internal | change marker; see [rescan behaviour](#rescans-and-source-stamps) |
 | `discovery_state` | internal | `"shallow"` or `"full"` |
+| `locations` | derived | sorted presences from `session_presences`: `"local"`, `"remote"`, or both |
 | `from_cache` | per-response | `true` when the row was served without re-reading the source |
 
 Absent metadata stays `null`. Nothing is ever invented to fill a column.
 
 ### What the catalog deliberately does not have
 
-These require `ai-hist sync`, for every provider, without exception:
+These require a full `ai-hist sync` through an available provider connector:
 
 - per-message events (`session_events`), tool calls, file edits
 - token usage and cost
@@ -205,13 +221,30 @@ These require `ai-hist sync`, for every provider, without exception:
 `discovery_state` tells you which you have: `"full"` means a full ingest has
 run for that session, `"shallow"` means catalog metadata only. Full ingest
 always wins — a shallow rescan refreshes a `full` row's metadata and stamp but
-never downgrades its state.
+never downgrades its state. Local connectors provide full sync today; remote
+rows remain shallow until remote connectors ship.
 
 ### Product boundary
 
 Discovery reports *which sessions exist* and identifying metadata. It does not
 infer project membership, work status, health, risk or success, and it does not
 summarize outcomes.
+
+### Scope and connector availability
+
+Scope filtering is consistent across catalog listing, search, recent history,
+statistics, packs, and resume selection: `local` selects sessions with a local presence, `remote` selects those
+with a remote presence, and `all` returns their deduplicated union. These are
+cache-only queries over the same ledger.
+
+Discovery and sync are acquisition operations. Local adapters are available
+today. Explicit remote acquisition is reserved but unsupported until provider
+connectors ship, and returns an error rather than silently doing local work.
+`--all` means every configured adapter; today that is the local adapters, and
+remote adapters will join the same operation when implemented.
+
+Direct `session` and `events` lookups already name a `(source, session_id)` and
+therefore remain scope-independent.
 
 ---
 
@@ -274,8 +307,9 @@ How each adapter works:
 
 The ordering and the limit are **global**, not per provider:
 
-1. Every selected provider enumerates its candidates **cheaply** — a directory
-   walk plus `stat`, or one indexed query. No file content is read.
+1. Every selected provider adapter in the requested scope enumerates its
+   candidates **cheaply** — a directory walk plus `stat`, or one indexed query.
+   No file content is read.
 2. Candidates from all providers are merged and sorted by recency hint,
    descending. Candidates with no recency signal sort last; ties break on
    `(source, locator)` so a run is reproducible.
@@ -390,6 +424,16 @@ Databases created by an older release are migrated in place by ignore-error
 columns, so a read-only handle over an old database is upgraded instead of
 failing with `no such column`.
 
+`session_presences` is the location child table. It is keyed by
+`(source, session_id, location)`, where `location` is `local` or `remote`, and
+is joined to the corresponding `sessions` row by `(source, session_id)`.
+Each presence also keeps its connector-specific `raw_locator`, `source_stamp`,
+and `discovery_state`, so local and cloud change detection cannot overwrite
+one another. Existing identities found in local catalog and evidence tables
+are backfilled with a local presence during migration. Scope queries use this
+table to select sessions and aggregate their `locations`; they do not duplicate
+the session or its events.
+
 ---
 
 ## Adding a provider
@@ -417,11 +461,12 @@ discoverable".
 
 ## Programmatic access
 
-- **Native (napi)** — `listSessions(options?)` returns
-  `{contractVersion, sessions, nextCursor}`; `discoverSessions(options?)` runs a shallow
-  scan and returns the rows plus the summary. The CLI renders the same collected
+- **Native (napi)** — `listSessionCatalogPage(options?)` returns
+  `{contractVersion, scope, sessions, nextCursor}`;
+  `discoverSessions(options?)` runs a shallow scan and returns the rows plus
+  the summary. The CLI renders the same collected
   result as JSONL when line-oriented records are more convenient. Both run on
-  a blocking worker thread and accept `sources` / `limit`, with `beforeMs` and
+  a blocking worker thread and accept `scope` / `sources` / `limit`, with `beforeMs` and
   `after` (the previous page's `nextCursor`) on the listing.
 - **TypeScript SDK** — `listSessionCatalog()` / `discoverSessions()` wrap the
   same contract for Node consumers; see the SDK's own documentation for the

--- a/mcp-package/README.md
+++ b/mcp-package/README.md
@@ -13,3 +13,9 @@ Tools: `search_history`, `recent_history`, `list_sessions`,
 `discover_sessions`, `get_session`, `get_session_events`, `history_stats`, and
 `sync`. Search, recent history, session listing, discovery, statistics, and sync accept a
 `scope` of `local`, `remote`, or `all`; scope defaults to `local`.
+
+Cached reads support all three scopes. Remote discovery and sync connectors are
+not available yet: explicit `remote` acquisition returns
+`UNSUPPORTED_OPERATION`, while `all` runs the configured local connectors.
+Consequently, the current discovery and sync tools are annotated as local,
+closed-world writes; their annotations will change when remote connectors ship.

--- a/mcp-package/README.md
+++ b/mcp-package/README.md
@@ -11,4 +11,5 @@ loads the native addon directly, scans provider files, or invokes a CLI.
 
 Tools: `search_history`, `recent_history`, `list_sessions`,
 `discover_sessions`, `get_session`, `get_session_events`, `history_stats`, and
-`sync`.
+`sync`. Search, recent history, session listing, discovery, statistics, and sync accept a
+`scope` of `local`, `remote`, or `all`; scope defaults to `local`.

--- a/scripts/verify-e2e.sh
+++ b/scripts/verify-e2e.sh
@@ -169,7 +169,7 @@ assert_eq "discovered sources" "$discovered_sources" "claude,codex,cursor,grok,o
 
 discover_contract=$(printf '%s\n' "$discover_json" | jsonl_field \
   'd.find((l) => l.type === "summary").contract_version')
-assert_eq "discover contract version" "$discover_contract" "1"
+assert_eq "discover contract version" "$discover_contract" "2"
 
 discover_trailer=$(printf '%s\n' "$discover_json" | jsonl_field 'd[d.length - 1].type')
 assert_eq "discover trailer" "$discover_trailer" "summary"
@@ -215,7 +215,7 @@ assert_eq "global discover limit" "$limited" "2"
 
 list_json=$("$ROOT/ai-hist" sessions list --json)
 list_contract=$(printf '%s\n' "$list_json" | json_field 'd.contract_version')
-assert_eq "sessions list contract version" "$list_contract" "1"
+assert_eq "sessions list contract version" "$list_contract" "2"
 
 list_sessions=$(printf '%s\n' "$list_json" | json_field \
   'd.sessions.map((s) => `${s.source}:${s.session_id}`).sort().join(",")')

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add the shared `SessionScope` (`local`, `remote`, or `all`) to session
+  discovery, listing, search, recent history, statistics, and sync. The SDK and CLI default
+  to local scope; the CLI exposes mutually exclusive `--local`, `--remote`, and
+  `--all` flags, and MCP tools expose the equivalent `scope` argument.
+- Catalog pages, discovery results, statistics, and sync results echo their applied scope, while each
+  `CatalogSession` reports its `local` and/or `remote` locations. This advances
+  the session-catalog contract to 2 and the native-addon contract to 3.
 - Mandatory `ai-hist-native` contract validation and stable errors for
   unsupported/missing platforms, load/version failures, and database errors.
 - Native-backed discovery, catalog pages, session history, event pages,

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -21,8 +21,8 @@ import {
   sync,
 } from 'ai-hist';
 
-await discoverSessions({ limit: 100 });
-const page = await listSessionCatalogPage({ limit: 20 });
+await discoverSessions({ scope: 'all', limit: 100 });
+const page = await listSessionCatalogPage({ scope: 'all', limit: 20 });
 const first = page.sessions[0];
 if (first) {
   const prompts = await getSession(first.sessionId);
@@ -34,6 +34,17 @@ if (first) {
 All APIs are async. `listSessionCatalog` and `listSessionCatalogPage` are
 cache-only. `discoverSessions` is shallow discovery. `sync` is full ingestion.
 Missing databases return empty read results; they do not trigger provider I/O.
+
+Session discovery, listing, search, recent history, statistics, and sync accept
+`scope: 'local' | 'remote' | 'all'`. Scope defaults to `local`, preserving
+offline behavior and making provider-cloud access explicit. The CLI exposes the
+same mutually exclusive `--local`, `--remote`, and `--all` flags; omitting them
+is equivalent to `--local`.
+
+Catalog pages, discovery results, statistics, and sync results echo the applied `scope`. Each catalog
+session also has `locations`, containing `local`, `remote`, or both, so an
+`all` query still returns one logical session while preserving where it was
+found.
 
 The event primitive is page-based and uses `{ tsMs, id }` as a deterministic
 cursor. The `sessionEvents` async iterator walks pages without accumulating a

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -41,10 +41,19 @@ offline behavior and making provider-cloud access explicit. The CLI exposes the
 same mutually exclusive `--local`, `--remote`, and `--all` flags; omitting them
 is equivalent to `--local`.
 
-Catalog pages, discovery results, statistics, and sync results echo the applied `scope`. Each catalog
-session also has `locations`, containing `local`, `remote`, or both, so an
+Cached reads already support every scope. Remote acquisition connectors are not
+shipped yet, so `discoverSessions({ scope: 'remote' })` and
+`sync({ scope: 'remote' })` fail with `UnsupportedOperationError` and the stable
+code `UNSUPPORTED_OPERATION`; they never fall back to local acquisition.
+`scope: 'all'` runs every configured connector, which currently means local
+connectors only.
+
+Catalog pages, discovery results, statistics, and sync results echo the requested `scope`.
+History and catalog rows have `locations`, containing `local`, `remote`, or both, so an
 `all` query still returns one logical session while preserving where it was
-found.
+found. `resumeCommand()` returns `null` for a remote-only history row rather
+than emitting a local CLI command; an empty `locations` array retains legacy
+local behavior for rows written before provenance tracking.
 
 The event primitive is page-based and uses `{ tsMs, id }` as a deterministic
 cursor. The `sessionEvents` async iterator walks pages without accumulating a
@@ -52,7 +61,8 @@ large transcript. `getSessionEvents` is an explicit collecting convenience.
 
 Native loading failures distinguish unsupported platforms, missing optional
 platform packages, addon load failures, SDK/native contract mismatches, and
-database open failures through stable `RelayHistoryError` subclasses.
+database open failures through stable `RelayHistoryError` subclasses. Provider
+capability failures use `UnsupportedOperationError`.
 
 The old synchronous `AiHist` class and `openAiHist()` API were removed in 1.0.
 See [the migration guide](https://github.com/AgentWorkforce/relayhistory/blob/main/docs/native-sdk-migration.md).

--- a/sdk-ts/src/architecture.test.ts
+++ b/sdk-ts/src/architecture.test.ts
@@ -27,3 +27,21 @@ test('CLI and MCP import only the public SDK for history operations', async () =
   assert.match(mcp, /from '\.\/index\.js'/);
   assert.doesNotMatch(cli + mcp, /ai-hist-native|node:sqlite|sql\.js|child_process/);
 });
+
+test('MCP session operations expose scope and remote-capable writes are open-world', async () => {
+  const mcp = await readFile(join(sourceDir, 'mcp-server.ts'), 'utf8');
+  assert.match(mcp, /const SESSION_SCOPE = z\.enum\(\['local', 'remote', 'all'\]\)/);
+  assert.match(mcp, /const OPEN_WORLD_WRITE = \{ readOnlyHint: false, idempotentHint: true, openWorldHint: true \}/);
+  for (const tool of ['search_history', 'recent_history', 'list_sessions', 'discover_sessions', 'history_stats', 'sync']) {
+    const start = mcp.indexOf(`server.tool('${tool}'`);
+    assert.notEqual(start, -1, `${tool} is registered`);
+    const end = mcp.indexOf("server.tool('", start + 13);
+    const registration = mcp.slice(start, end === -1 ? undefined : end);
+    assert.match(registration, /scope: SESSION_SCOPE\.optional\(\)\.default\('local'\)/, `${tool} defaults scope to local`);
+  }
+  for (const tool of ['discover_sessions', 'sync']) {
+    const start = mcp.indexOf(`server.tool('${tool}'`);
+    const end = mcp.indexOf("server.tool('", start + 13);
+    assert.match(mcp.slice(start, end === -1 ? undefined : end), /OPEN_WORLD_WRITE/, `${tool} is open-world`);
+  }
+});

--- a/sdk-ts/src/architecture.test.ts
+++ b/sdk-ts/src/architecture.test.ts
@@ -28,10 +28,10 @@ test('CLI and MCP import only the public SDK for history operations', async () =
   assert.doesNotMatch(cli + mcp, /ai-hist-native|node:sqlite|sql\.js|child_process/);
 });
 
-test('MCP session operations expose scope and remote-capable writes are open-world', async () => {
+test('MCP session operations expose scope and current local writes are closed-world', async () => {
   const mcp = await readFile(join(sourceDir, 'mcp-server.ts'), 'utf8');
   assert.match(mcp, /const SESSION_SCOPE = z\.enum\(\['local', 'remote', 'all'\]\)/);
-  assert.match(mcp, /const OPEN_WORLD_WRITE = \{ readOnlyHint: false, idempotentHint: true, openWorldHint: true \}/);
+  assert.match(mcp, /const LOCAL_WRITE = \{ readOnlyHint: false, idempotentHint: true, openWorldHint: false \}/);
   for (const tool of ['search_history', 'recent_history', 'list_sessions', 'discover_sessions', 'history_stats', 'sync']) {
     const start = mcp.indexOf(`server.tool('${tool}'`);
     assert.notEqual(start, -1, `${tool} is registered`);
@@ -42,6 +42,6 @@ test('MCP session operations expose scope and remote-capable writes are open-wor
   for (const tool of ['discover_sessions', 'sync']) {
     const start = mcp.indexOf(`server.tool('${tool}'`);
     const end = mcp.indexOf("server.tool('", start + 13);
-    assert.match(mcp.slice(start, end === -1 ? undefined : end), /OPEN_WORLD_WRITE/, `${tool} is open-world`);
+    assert.match(mcp.slice(start, end === -1 ? undefined : end), /LOCAL_WRITE/, `${tool} is currently local-only`);
   }
 });

--- a/sdk-ts/src/cli-output.test.ts
+++ b/sdk-ts/src/cli-output.test.ts
@@ -35,9 +35,12 @@ test('sessions discover preserves repeated sources and emits JSONL', async () =>
       '--db', join(root, 'history.db'), '--json', '--no-warning',
     ], { env: { ...process.env, HOME: home, USERPROFILE: home } });
     const lines = stdout.trim().split('\n').map((line) => JSON.parse(line) as Record<string, unknown>);
-    assert.deepEqual(lines.filter((line) => line.type === 'session').map((line) => line.source).sort(), ['claude', 'codex']);
+    const sessions = lines.filter((line) => line.type === 'session');
+    assert.deepEqual(sessions.map((line) => line.source).sort(), ['claude', 'codex']);
+    assert.ok(sessions.every((line) => JSON.stringify(line.locations) === '["local"]'));
     assert.equal(lines.at(-1)?.type, 'summary');
-    assert.equal(lines.at(-1)?.contract_version, 1);
+    assert.equal(lines.at(-1)?.contract_version, 2);
+    assert.equal(lines.at(-1)?.scope, 'local');
     assert.equal('sessions' in (lines.at(-1) ?? {}), false);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -51,8 +54,46 @@ test('sessions list keeps human and JSON output contracts distinct', async () =>
     const human = await run(process.execPath, [cli, 'sessions', 'list', '--db', db, '--no-warning']);
     assert.match(human.stdout, /No sessions in the catalog/);
     const json = await run(process.execPath, [cli, 'sessions', 'list', '--db', db, '--json', '--no-warning']);
-    assert.deepEqual(JSON.parse(json.stdout), { contract_version: 1, sessions: [], next_cursor: null });
+    assert.deepEqual(JSON.parse(json.stdout), { contract_version: 2, scope: 'local', sessions: [], next_cursor: null });
   } finally {
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('scope flags are boolean, default to local, and are mutually exclusive', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'relayhistory-cli-scope-'));
+  const db = join(root, 'missing.db');
+  try {
+    const implicit = await run(process.execPath, [cli, 'sessions', 'list', '--db', db, '--json', '--no-warning']);
+    const explicit = await run(process.execPath, [cli, '--json', 'sessions', 'list', '--local', '--db', db, '--no-warning']);
+    assert.deepEqual(JSON.parse(explicit.stdout), JSON.parse(implicit.stdout));
+    const remote = await run(process.execPath, [cli, 'sessions', 'list', '--remote', '--db', db, '--json', '--no-warning']);
+    assert.equal(JSON.parse(remote.stdout).scope, 'remote');
+
+    await assert.rejects(
+      run(process.execPath, [cli, 'sessions', 'list', '--local', '--remote', '--db', db, '--no-warning']),
+      (error: unknown) => typeof error === 'object' && error !== null
+        && 'stderr' in error
+        && String(error.stderr).includes('--local, --remote, and --all are mutually exclusive'),
+    );
+    await assert.rejects(
+      run(process.execPath, [cli, 'sessions', 'list', '--remote=false', '--db', db, '--no-warning']),
+      (error: unknown) => typeof error === 'object' && error !== null
+        && 'stderr' in error
+        && String(error.stderr).includes('--remote does not take a value'),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('identity commands reject location scope instead of silently ignoring it', async () => {
+  for (const command of ['session', 'events']) {
+    await assert.rejects(
+      run(process.execPath, [cli, command, 'session-id', '--remote', '--no-warning']),
+      (error: unknown) => typeof error === 'object' && error !== null
+        && 'stderr' in error
+        && String(error.stderr).includes('does not accept --local, --remote, or --all'),
+    );
   }
 });

--- a/sdk-ts/src/cli-output.test.ts
+++ b/sdk-ts/src/cli-output.test.ts
@@ -10,6 +10,13 @@ import test from 'node:test';
 const run = promisify(execFile);
 const cli = join(dirname(fileURLToPath(import.meta.url)), 'cli.js');
 
+function isUsageFailure(error: unknown, message: string): boolean {
+  return typeof error === 'object' && error !== null
+    && 'code' in error && error.code === 2
+    && 'stderr' in error && String(error.stderr).includes(message)
+    && String(error.stderr).includes('Usage:');
+}
+
 test('sessions discover preserves repeated sources and emits JSONL', async () => {
   const root = await mkdtemp(join(tmpdir(), 'relayhistory-cli-'));
   const home = join(root, 'home');
@@ -17,6 +24,9 @@ test('sessions discover preserves repeated sources and emits JSONL', async () =>
   const codex = join(home, '.codex', 'sessions', '2026', '08', '30');
   await mkdir(claude, { recursive: true });
   await mkdir(codex, { recursive: true });
+  await writeFile(join(home, '.claude', 'history.jsonl'), `${JSON.stringify({
+    display: 'indexed prompt', sessionId: 'claude-1', project: '/work/claude', timestamp: 1,
+  })}\n`);
   await writeFile(join(claude, 'claude-1.jsonl'), `${JSON.stringify({
     sessionId: 'claude-1', cwd: '/work/claude', type: 'user',
     message: { role: 'user', content: 'claude prompt' }, timestamp: '2026-08-30T10:00:00.000Z',
@@ -42,6 +52,20 @@ test('sessions discover preserves repeated sources and emits JSONL', async () =>
     assert.equal(lines.at(-1)?.contract_version, 2);
     assert.equal(lines.at(-1)?.scope, 'local');
     assert.equal('sessions' in (lines.at(-1) ?? {}), false);
+
+    const human = await run(process.execPath, [
+      cli, 'sessions', 'discover', '--all', '--source', 'codex',
+      '--db', join(root, 'history.db'), '--no-warning',
+    ], { env: { ...process.env, HOME: home, USERPROFILE: home } });
+    assert.match(human.stdout, /requested scope: all, connector locations run: local/);
+
+    await run(process.execPath, [
+      cli, 'sync', '--db', join(root, 'history.db'), '--json', '--no-warning',
+    ], { env: { ...process.env, HOME: home, USERPROFILE: home } });
+    const searched = await run(process.execPath, [
+      cli, 'search', 'indexed prompt', '--db', join(root, 'history.db'), '--json', '--no-warning',
+    ], { env: { ...process.env, HOME: home, USERPROFILE: home } });
+    assert.deepEqual((JSON.parse(searched.stdout) as Array<Record<string, unknown>>)[0]?.locations, ['local']);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -78,12 +102,32 @@ test('scope flags are boolean, default to local, and are mutually exclusive', as
     );
     await assert.rejects(
       run(process.execPath, [cli, 'sessions', 'list', '--remote=false', '--db', db, '--no-warning']),
-      (error: unknown) => typeof error === 'object' && error !== null
-        && 'stderr' in error
-        && String(error.stderr).includes('--remote does not take a value'),
+      (error: unknown) => isUsageFailure(error, '--remote does not take a value'),
+    );
+    await assert.rejects(
+      run(process.execPath, [cli, 'sessions', 'list', '--remote', 'false', '--db', db, '--no-warning']),
+      (error: unknown) => isUsageFailure(error, '--remote does not take a value'),
     );
   } finally {
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('commands reject surplus positional arguments with usage exit 2', async () => {
+  for (const args of [
+    ['sessions', 'list', 'extra'],
+    ['sessions', 'discover', 'extra'],
+    ['recent', '1', 'extra'],
+    ['session', 'session-id', 'extra'],
+    ['events', 'session-id', 'extra'],
+    ['stats', 'extra'],
+    ['sync', 'extra'],
+  ]) {
+    await assert.rejects(
+      run(process.execPath, [cli, ...args, '--no-warning']),
+      (error: unknown) => isUsageFailure(error, 'does not accept positional argument'),
+      args.join(' '),
+    );
   }
 });
 
@@ -95,5 +139,35 @@ test('identity commands reject location scope instead of silently ignoring it', 
         && 'stderr' in error
         && String(error.stderr).includes('does not accept --local, --remote, or --all'),
     );
+  }
+});
+
+test('unknown, missing-value, and command-inapplicable flags fail with usage exit 2', async () => {
+  for (const { args, message } of [
+    { args: ['sessions', 'list', '--remtoe'], message: "unknown option '--remtoe'" },
+    { args: ['sessions', 'list', '--db'], message: '--db requires a value' },
+    { args: ['sessions', 'list', '--source'], message: '--source requires a value' },
+    { args: ['sessions', 'list', '--project', '/work'], message: 'sessions list does not accept --project' },
+    { args: ['sessions', 'list', '--version'], message: 'sessions list does not accept --version' },
+    { args: ['sessions', 'list', '-V'], message: 'sessions list does not accept --version' },
+    { args: ['stats', '--source', 'codex'], message: 'stats does not accept --source' },
+  ]) {
+    await assert.rejects(
+      run(process.execPath, [cli, ...args, '--no-warning']),
+      (error: unknown) => isUsageFailure(error, message),
+      args.join(' '),
+    );
+  }
+});
+
+test('search preserves a multi-word positional query', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'relayhistory-cli-search-'));
+  try {
+    const result = await run(process.execPath, [
+      cli, 'search', 'two', 'word query', '--db', join(root, 'missing.db'), '--json', '--no-warning',
+    ]);
+    assert.deepEqual(JSON.parse(result.stdout), []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
   }
 });

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -12,6 +12,11 @@ type Parsed = { positional: string[]; flags: Map<string, Array<string | true>> }
 type PackageMetadata = { version?: string };
 
 const BOOLEAN_FLAGS = new Set(['all', 'fts', 'json', 'local', 'no-warning', 'remote', 'version']);
+const VALUE_FLAGS = new Set([
+  'after', 'after-ms', 'after-session-id', 'after-source', 'before-ms', 'db', 'limit',
+  'project', 'source', 'tag',
+]);
+const KNOWN_FLAGS = new Set([...BOOLEAN_FLAGS, ...VALUE_FLAGS]);
 
 function versionTriple(value: string): [number, number, number] | null {
   const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(value);
@@ -59,15 +64,37 @@ function parse(argv: string[]): Parsed {
   const flags = new Map<string, Array<string | true>>();
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
+    if (arg === '-V') {
+      flags.set('version', [...(flags.get('version') ?? []), true]);
+      continue;
+    }
     if (!arg.startsWith('--')) { positional.push(arg); continue; }
     const [name, inline] = arg.slice(2).split('=', 2);
-    if (inline !== undefined) { flags.set(name, [...(flags.get(name) ?? []), inline]); continue; }
-    if (BOOLEAN_FLAGS.has(name)) { flags.set(name, [...(flags.get(name) ?? []), true]); continue; }
+    if (!KNOWN_FLAGS.has(name)) usage(`unknown option '--${name}'`);
+    if (inline !== undefined && BOOLEAN_FLAGS.has(name)) usage(`--${name} does not take a value`);
+    if (inline !== undefined) {
+      if (inline === '') usage(`--${name} requires a value`);
+      flags.set(name, [...(flags.get(name) ?? []), inline]);
+      continue;
+    }
+    if (BOOLEAN_FLAGS.has(name)) {
+      const next = argv[i + 1];
+      if (next === 'true' || next === 'false') usage(`--${name} does not take a value`);
+      flags.set(name, [...(flags.get(name) ?? []), true]);
+      continue;
+    }
     const next = argv[i + 1];
     if (next && !next.startsWith('-')) { flags.set(name, [...(flags.get(name) ?? []), next]); i++; }
-    else flags.set(name, [...(flags.get(name) ?? []), true]);
+    else usage(`--${name} requires a value`);
   }
   return { positional, flags };
+}
+
+function validateFlags(args: Parsed, command: string, allowed: readonly string[]): void {
+  const permitted = new Set([...allowed, 'no-warning']);
+  for (const name of args.flags.keys()) {
+    if (!permitted.has(name)) usage(`${command} does not accept --${name}`);
+  }
 }
 
 function textFlag(args: Parsed, name: string): string | undefined {
@@ -91,17 +118,21 @@ function scopeFlag(args: Parsed): SessionScope {
   const selected = (['local', 'remote', 'all'] as const).filter((scope) => args.flags.has(scope));
   for (const scope of selected) {
     if (args.flags.get(scope)?.some((value) => value !== true)) {
-      throw new Error(`--${scope} does not take a value`);
+      usage(`--${scope} does not take a value`);
     }
   }
-  if (selected.length > 1) throw new Error('--local, --remote, and --all are mutually exclusive');
+  if (selected.length > 1) usage('--local, --remote, and --all are mutually exclusive');
   return selected[0] ?? 'local';
 }
 
 function rejectScopeFlag(args: Parsed, command: string): void {
   if (['local', 'remote', 'all'].some((scope) => args.flags.has(scope))) {
-    throw new Error(`${command} addresses a session by identity and does not accept --local, --remote, or --all`);
+    usage(`${command} addresses a session by identity and does not accept --local, --remote, or --all`);
   }
+}
+
+function rejectSurplusPositionals(values: string[], command: string): void {
+  if (values.length > 0) usage(`${command} does not accept positional argument '${values[0]}'`);
 }
 
 function common(args: Parsed) {
@@ -153,7 +184,8 @@ function output(value: unknown, json: boolean): void {
   }
 }
 
-function usage(): never {
+function usage(message?: string): never {
+  if (message) process.stderr.write(`ai-hist: ${message}\n\n`);
   process.stderr.write(`Usage:
   ai-hist sessions list [--local | --remote | --all] [--source SOURCE]... [--limit N] [--before-ms MS] [--after JSON | --after-source SOURCE --after-session-id ID [--after-ms MS]] [--json]
   ai-hist sessions discover [--local | --remote | --all] [--source SOURCE] [--limit N] [--json]
@@ -185,7 +217,11 @@ function catalogCursorFlag(args: Parsed): CatalogCursor | undefined {
 function outputDiscovery(value: Awaited<ReturnType<typeof discoverSessions>>, json: boolean): void {
   if (!json) {
     for (const session of value.sessions) process.stdout.write(`${humanLine(session)}\n`);
-    process.stdout.write(`${value.sessions.length} session(s): ${value.discovered} discovered, ${value.skippedUnchanged} unchanged\n`);
+    process.stdout.write(
+      `${value.sessions.length} session(s): ${value.discovered} discovered, ${value.skippedUnchanged} unchanged ` +
+      `(${value.counters.filesOpened} file(s) opened, ${value.counters.shallowReads} shallow read(s)); ` +
+      `requested scope: ${value.scope}, connector locations run: local\n`,
+    );
     return;
   }
   for (const session of value.sessions) output({ type: 'session', ...session }, true);
@@ -197,7 +233,8 @@ function outputDiscovery(value: Awaited<ReturnType<typeof discoverSessions>>, js
 
 async function main(): Promise<void> {
   const rawArgs = process.argv.slice(2);
-  if (rawArgs.includes('--version') || rawArgs.includes('-V')) {
+  const versionArgs = rawArgs.filter((arg) => arg !== '--no-warning');
+  if (versionArgs.length === 1 && (versionArgs[0] === '--version' || versionArgs[0] === '-V')) {
     const version = await packageVersion();
     process.stdout.write(`ai-hist ${version}\n`);
     await maybePrintUpdateNotice(version, rawArgs);
@@ -208,6 +245,11 @@ async function main(): Promise<void> {
   const json = args.flags.has('json');
 
   if (command === 'sessions' && subcommand === 'list') {
+    validateFlags(args, 'sessions list', [
+      'after', 'after-ms', 'after-session-id', 'after-source', 'all', 'before-ms', 'db',
+      'json', 'limit', 'local', 'remote', 'source',
+    ]);
+    rejectSurplusPositionals(rest, 'sessions list');
     const sources = textFlags(args, 'source');
     output(await listSessionCatalogPage({
       dbPath: textFlag(args, 'db'), scope: scopeFlag(args), sources: sources.length ? sources as never : undefined,
@@ -217,6 +259,8 @@ async function main(): Promise<void> {
     return;
   }
   if (command === 'sessions' && subcommand === 'discover') {
+    validateFlags(args, 'sessions discover', ['all', 'db', 'json', 'limit', 'local', 'remote', 'source']);
+    rejectSurplusPositionals(rest, 'sessions discover');
     const sources = textFlags(args, 'source');
     outputDiscovery(await discoverSessions({
       dbPath: textFlag(args, 'db'), scope: scopeFlag(args), sources: sources.length ? sources as never : undefined,
@@ -225,23 +269,35 @@ async function main(): Promise<void> {
     return;
   }
   if (command === 'search') {
+    validateFlags(args, 'search', [
+      'all', 'before-ms', 'db', 'fts', 'json', 'limit', 'local', 'project', 'remote', 'source', 'tag',
+    ]);
     if (!subcommand) usage();
     output(await search([subcommand, ...rest].join(' '), { ...common(args), rawFts: args.flags.has('fts') }), json);
     return;
   }
   if (command === 'recent') {
+    validateFlags(args, 'recent', [
+      'all', 'before-ms', 'db', 'json', 'limit', 'local', 'project', 'remote', 'source', 'tag',
+    ]);
+    rejectSurplusPositionals(rest, 'recent');
     const fallback = subcommand ? Number(subcommand) : undefined;
+    if (fallback !== undefined && !Number.isFinite(fallback)) usage(`recent count must be a number (got '${subcommand}')`);
     output(await recent({ ...common(args), limit: numberFlag(args, 'limit') ?? fallback }), json);
     return;
   }
   if (command === 'session') {
+    validateFlags(args, 'session', ['all', 'db', 'json', 'local', 'remote', 'source', 'tag']);
     if (!subcommand) usage();
+    rejectSurplusPositionals(rest, 'session');
     rejectScopeFlag(args, 'session');
     output(await getSession(subcommand, { dbPath: textFlag(args, 'db'), source: textFlag(args, 'source') as never, tag: textFlag(args, 'tag') }), json);
     return;
   }
   if (command === 'events') {
+    validateFlags(args, 'events', ['after', 'all', 'db', 'json', 'limit', 'local', 'remote', 'source']);
     if (!subcommand) usage();
+    rejectSurplusPositionals(rest, 'events');
     rejectScopeFlag(args, 'events');
     output(await getSessionEventsPage(subcommand, {
       dbPath: textFlag(args, 'db'), source: textFlag(args, 'source') as never,
@@ -249,8 +305,18 @@ async function main(): Promise<void> {
     }), json);
     return;
   }
-  if (command === 'stats') { output(await stats({ dbPath: textFlag(args, 'db'), scope: scopeFlag(args), tag: textFlag(args, 'tag') }), json); return; }
-  if (command === 'sync') { output(await sync({ dbPath: textFlag(args, 'db'), scope: scopeFlag(args) }), json); return; }
+  if (command === 'stats') {
+    validateFlags(args, 'stats', ['all', 'db', 'json', 'local', 'remote', 'tag']);
+    rejectSurplusPositionals([subcommand, ...rest].filter((value): value is string => value !== undefined), 'stats');
+    output(await stats({ dbPath: textFlag(args, 'db'), scope: scopeFlag(args), tag: textFlag(args, 'tag') }), json);
+    return;
+  }
+  if (command === 'sync') {
+    validateFlags(args, 'sync', ['all', 'db', 'json', 'local', 'remote']);
+    rejectSurplusPositionals([subcommand, ...rest].filter((value): value is string => value !== undefined), 'sync');
+    output(await sync({ dbPath: textFlag(args, 'db'), scope: scopeFlag(args) }), json);
+    return;
+  }
   usage();
 }
 

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -4,12 +4,14 @@ import { readFile } from 'node:fs/promises';
 
 import {
   discoverSessions, getSession, getSessionEventsPage, listSessionCatalogPage,
-  recent, search, stats, sync, type CatalogCursor,
+  recent, search, stats, sync, type CatalogCursor, type SessionScope,
 } from './index.js';
 
 type Parsed = { positional: string[]; flags: Map<string, Array<string | true>> };
 
 type PackageMetadata = { version?: string };
+
+const BOOLEAN_FLAGS = new Set(['all', 'fts', 'json', 'local', 'no-warning', 'remote', 'version']);
 
 function versionTriple(value: string): [number, number, number] | null {
   const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(value);
@@ -60,6 +62,7 @@ function parse(argv: string[]): Parsed {
     if (!arg.startsWith('--')) { positional.push(arg); continue; }
     const [name, inline] = arg.slice(2).split('=', 2);
     if (inline !== undefined) { flags.set(name, [...(flags.get(name) ?? []), inline]); continue; }
+    if (BOOLEAN_FLAGS.has(name)) { flags.set(name, [...(flags.get(name) ?? []), true]); continue; }
     const next = argv[i + 1];
     if (next && !next.startsWith('-')) { flags.set(name, [...(flags.get(name) ?? []), next]); i++; }
     else flags.set(name, [...(flags.get(name) ?? []), true]);
@@ -84,9 +87,27 @@ function numberFlag(args: Parsed, name: string): number | undefined {
   return parsed;
 }
 
+function scopeFlag(args: Parsed): SessionScope {
+  const selected = (['local', 'remote', 'all'] as const).filter((scope) => args.flags.has(scope));
+  for (const scope of selected) {
+    if (args.flags.get(scope)?.some((value) => value !== true)) {
+      throw new Error(`--${scope} does not take a value`);
+    }
+  }
+  if (selected.length > 1) throw new Error('--local, --remote, and --all are mutually exclusive');
+  return selected[0] ?? 'local';
+}
+
+function rejectScopeFlag(args: Parsed, command: string): void {
+  if (['local', 'remote', 'all'].some((scope) => args.flags.has(scope))) {
+    throw new Error(`${command} addresses a session by identity and does not accept --local, --remote, or --all`);
+  }
+}
+
 function common(args: Parsed) {
   return {
     dbPath: textFlag(args, 'db'),
+    scope: scopeFlag(args),
     source: textFlag(args, 'source') as never,
     project: textFlag(args, 'project'),
     tag: textFlag(args, 'tag'),
@@ -108,7 +129,8 @@ function wireValue(value: unknown): unknown {
 function humanLine(value: unknown): string {
   if (!value || typeof value !== 'object') return String(value);
   const row = value as Record<string, unknown>;
-  return [row.timestampMs ?? row.lastActivityMs ?? '', row.source ?? '', row.sessionId ?? '', row.project ?? row.cwd ?? '', row.prompt ?? row.firstPrompt ?? '']
+  const locations = Array.isArray(row.locations) ? `[${row.locations.join(',')}]` : '';
+  return [row.timestampMs ?? row.lastActivityMs ?? '', row.source ?? '', locations, row.sessionId ?? '', row.project ?? row.cwd ?? '', row.prompt ?? row.firstPrompt ?? '']
     .filter((item) => item !== '' && item != null)
     .join('  ');
 }
@@ -133,14 +155,14 @@ function output(value: unknown, json: boolean): void {
 
 function usage(): never {
   process.stderr.write(`Usage:
-  ai-hist sessions list [--source SOURCE]... [--limit N] [--before-ms MS] [--after JSON | --after-source SOURCE --after-session-id ID [--after-ms MS]] [--json]
-  ai-hist sessions discover [--source SOURCE] [--limit N] [--json]
-  ai-hist search QUERY... [--source SOURCE] [--project PATH] [--limit N] [--json]
-  ai-hist recent [N] [--source SOURCE] [--project PATH] [--json]
+  ai-hist sessions list [--local | --remote | --all] [--source SOURCE]... [--limit N] [--before-ms MS] [--after JSON | --after-source SOURCE --after-session-id ID [--after-ms MS]] [--json]
+  ai-hist sessions discover [--local | --remote | --all] [--source SOURCE] [--limit N] [--json]
+  ai-hist search QUERY... [--local | --remote | --all] [--source SOURCE] [--project PATH] [--limit N] [--json]
+  ai-hist recent [N] [--local | --remote | --all] [--source SOURCE] [--project PATH] [--json]
   ai-hist session SESSION_ID [--source SOURCE] [--json]
   ai-hist events SESSION_ID [--source SOURCE] [--limit N] [--after JSON] [--json]
-  ai-hist stats [--json]
-  ai-hist sync [--db PATH] [--json]
+  ai-hist stats [--local | --remote | --all] [--json]
+  ai-hist sync [--local | --remote | --all] [--db PATH] [--json]
 `);
   process.exit(2);
 }
@@ -188,7 +210,7 @@ async function main(): Promise<void> {
   if (command === 'sessions' && subcommand === 'list') {
     const sources = textFlags(args, 'source');
     output(await listSessionCatalogPage({
-      dbPath: textFlag(args, 'db'), sources: sources.length ? sources as never : undefined,
+      dbPath: textFlag(args, 'db'), scope: scopeFlag(args), sources: sources.length ? sources as never : undefined,
       limit: numberFlag(args, 'limit'), beforeMs: numberFlag(args, 'before-ms'),
       after: catalogCursorFlag(args),
     }), json);
@@ -197,7 +219,7 @@ async function main(): Promise<void> {
   if (command === 'sessions' && subcommand === 'discover') {
     const sources = textFlags(args, 'source');
     outputDiscovery(await discoverSessions({
-      dbPath: textFlag(args, 'db'), sources: sources.length ? sources as never : undefined,
+      dbPath: textFlag(args, 'db'), scope: scopeFlag(args), sources: sources.length ? sources as never : undefined,
       limit: numberFlag(args, 'limit'),
     }), json);
     return;
@@ -214,19 +236,21 @@ async function main(): Promise<void> {
   }
   if (command === 'session') {
     if (!subcommand) usage();
+    rejectScopeFlag(args, 'session');
     output(await getSession(subcommand, { dbPath: textFlag(args, 'db'), source: textFlag(args, 'source') as never, tag: textFlag(args, 'tag') }), json);
     return;
   }
   if (command === 'events') {
     if (!subcommand) usage();
+    rejectScopeFlag(args, 'events');
     output(await getSessionEventsPage(subcommand, {
       dbPath: textFlag(args, 'db'), source: textFlag(args, 'source') as never,
       limit: numberFlag(args, 'limit'), after: cursorFlag(args),
     }), json);
     return;
   }
-  if (command === 'stats') { output(await stats({ dbPath: textFlag(args, 'db'), tag: textFlag(args, 'tag') }), json); return; }
-  if (command === 'sync') { output(await sync({ dbPath: textFlag(args, 'db') }), json); return; }
+  if (command === 'stats') { output(await stats({ dbPath: textFlag(args, 'db'), scope: scopeFlag(args), tag: textFlag(args, 'tag') }), json); return; }
+  if (command === 'sync') { output(await sync({ dbPath: textFlag(args, 'db'), scope: scopeFlag(args) }), json); return; }
   usage();
 }
 

--- a/sdk-ts/src/helpers.test.ts
+++ b/sdk-ts/src/helpers.test.ts
@@ -22,9 +22,9 @@ test('defaultDbPath follows native environment precedence', () => {
 });
 
 test('resumeCommand preserves source and project-aware commands', () => {
-  assert.equal(resumeCommand({ source: 'claude', sessionId: 's1', project: '/work/app' }), 'cd /work/app && claude --resume s1');
-  assert.equal(resumeCommand({ source: 'codex', sessionId: 's2', project: null }), 'codex resume s2');
-  assert.equal(resumeCommand({ source: 'cursor', sessionId: 's3', project: '/work/app' }), 'cd /work/app && cursor-agent --resume=s3');
-  assert.equal(resumeCommand({ source: 'grok', sessionId: 's4', project: null }), 'grok resume s4');
-  assert.equal(resumeCommand({ source: 'relay', sessionId: 's5', project: null }), null);
+  assert.equal(resumeCommand({ source: 'claude', sessionId: 's1', project: '/work/app', locations: [] }), 'cd /work/app && claude --resume s1');
+  assert.equal(resumeCommand({ source: 'codex', sessionId: 's2', project: null, locations: ['local'] }), 'codex resume s2');
+  assert.equal(resumeCommand({ source: 'cursor', sessionId: 's3', project: '/work/app', locations: ['local', 'remote'] }), 'cd /work/app && cursor-agent --resume=s3');
+  assert.equal(resumeCommand({ source: 'grok', sessionId: 's4', project: null, locations: ['remote'] }), null);
+  assert.equal(resumeCommand({ source: 'relay', sessionId: 's5', project: null, locations: ['local'] }), null);
 });

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -30,6 +30,7 @@ export class NativeLoadError extends RelayHistoryError {}
 export class NativeContractMismatchError extends RelayHistoryError {}
 export class DatabaseOpenError extends RelayHistoryError {}
 export class InvalidArgumentError extends RelayHistoryError {}
+export class UnsupportedOperationError extends RelayHistoryError {}
 
 export interface HistoryEntry {
   id: number;
@@ -38,6 +39,7 @@ export interface HistoryEntry {
   project: string | null;
   prompt: string;
   timestampMs: number;
+  locations: SessionLocation[];
 }
 
 export interface ListOptions {
@@ -303,6 +305,9 @@ async function nativeCall<T>(call: (binding: NativeBinding) => Promise<T>): Prom
     if (native.code === 'INVALID_ARGUMENT') {
       throw new InvalidArgumentError(native.message, native.code, { cause: error });
     }
+    if (native.code === 'UNSUPPORTED_OPERATION') {
+      throw new UnsupportedOperationError(native.message, native.code, { cause: error });
+    }
     throw new RelayHistoryError(native.message, native.code, { cause: error });
   }
 }
@@ -319,6 +324,9 @@ function historyEntry(value: UnknownRecord): HistoryEntry {
     project: nullableString(value.project),
     prompt: String(value.prompt),
     timestampMs: Number(value.timestampMs),
+    locations: Array.isArray(value.locations)
+      ? value.locations.filter((location): location is SessionLocation => location === 'local' || location === 'remote')
+      : [],
   };
 }
 
@@ -358,8 +366,12 @@ function catalogSession(value: UnknownRecord): CatalogSession {
   };
 }
 
-function sessionScope(value: unknown): SessionScope {
-  return value === 'remote' || value === 'all' ? value : 'local';
+export function validateNativeScope(value: unknown): SessionScope {
+  if (value === 'local' || value === 'remote' || value === 'all') return value;
+  throw new NativeContractMismatchError(
+    `ai-hist-native returned an invalid session scope: ${JSON.stringify(value)}. Reinstall matching ai-hist packages.`,
+    'NATIVE_CONTRACT_MISMATCH',
+  );
 }
 
 function assertCatalogContract(value: number): void {
@@ -435,7 +447,7 @@ export async function listSessionCatalogPage(options: ListCatalogOptions = {}): 
     assertCatalogContract(contractVersion);
     return {
       contractVersion,
-      scope: sessionScope(page.scope),
+      scope: validateNativeScope(page.scope),
       sessions: Array.isArray(page.sessions) ? (page.sessions as UnknownRecord[]).map(catalogSession) : [],
       nextCursor: catalogCursor(page.nextCursor),
     };
@@ -449,7 +461,7 @@ export async function discoverSessions(options: DiscoverSessionsOptions = {}): P
     assertCatalogContract(contractVersion);
     return {
       contractVersion,
-      scope: sessionScope(result.scope),
+      scope: validateNativeScope(result.scope),
       sessions: Array.isArray(result.sessions) ? (result.sessions as UnknownRecord[]).map(catalogSession) : [],
       discovered: Number(result.discovered),
       skippedUnchanged: Number(result.skippedUnchanged),
@@ -503,7 +515,7 @@ export async function stats(options: StatsOptions = {}): Promise<Stats> {
       bySource[String(item.source) as Source] = Number(item.count);
     }
     return {
-      scope: sessionScope(result.scope),
+      scope: validateNativeScope(result.scope),
       total: Number(result.total), bySource,
       byProject: ((result.byProject as UnknownRecord[] | undefined) ?? []).map((item) => ({ project: String(item.project), count: Number(item.count) })),
       firstTimestampMs: typeof result.firstTimestampMs === 'number' ? result.firstTimestampMs : null,
@@ -517,14 +529,15 @@ export async function sync(options: SyncOptions = {}): Promise<SyncResult> {
     const result = await native.sync({ ...options, scope: options.scope ?? 'local' });
     return {
       databasePath: String(result.databasePath),
-      scope: sessionScope(result.scope),
+      scope: validateNativeScope(result.scope),
       completed: result.completed === true,
     };
   });
 }
 
-export function resumeCommand(entry: Pick<HistoryEntry, 'source' | 'sessionId' | 'project'>): string | null {
+export function resumeCommand(entry: Pick<HistoryEntry, 'source' | 'sessionId' | 'project' | 'locations'>): string | null {
   if (!entry.sessionId) return null;
+  if (entry.locations.length > 0 && !entry.locations.includes('local')) return null;
   const resume = (() => {
     if (entry.source === 'claude') return `claude --resume ${shellQuote(entry.sessionId)}`;
     if (entry.source === 'codex') return `codex resume ${shellQuote(entry.sessionId)}`;

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -9,11 +9,13 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-export const NATIVE_CONTRACT_VERSION = 2;
-export const SESSION_CATALOG_CONTRACT_VERSION = 1;
+export const NATIVE_CONTRACT_VERSION = 3;
+export const SESSION_CATALOG_CONTRACT_VERSION = 2;
 
 export type Source = 'claude' | 'codex' | 'cursor' | 'grok' | 'relay' | 'trajectory' | 'opencode';
 export type CatalogSource = Exclude<Source, 'trajectory'>;
+export type SessionScope = 'local' | 'remote' | 'all';
+export type SessionLocation = Exclude<SessionScope, 'all'>;
 
 export class RelayHistoryError extends Error {
   constructor(message: string, readonly code: string, options?: ErrorOptions) {
@@ -40,6 +42,7 @@ export interface HistoryEntry {
 
 export interface ListOptions {
   dbPath?: string;
+  scope?: SessionScope;
   source?: Source;
   project?: string;
   tag?: string;
@@ -82,10 +85,12 @@ export interface CatalogSession {
   sourceStamp: string | null;
   discoveryState: 'shallow' | 'full';
   fromCache: boolean;
+  locations: SessionLocation[];
 }
 
 export interface ListCatalogOptions {
   dbPath?: string;
+  scope?: SessionScope;
   sources?: CatalogSource[];
   limit?: number;
   beforeMs?: number;
@@ -94,6 +99,7 @@ export interface ListCatalogOptions {
 
 export interface SessionCatalogPage {
   contractVersion: number;
+  scope: SessionScope;
   sessions: CatalogSession[];
   nextCursor: CatalogCursor | null;
 }
@@ -124,12 +130,14 @@ export interface SourceExemption { source: string; reason: string }
 
 export interface DiscoverSessionsOptions {
   dbPath?: string;
+  scope?: SessionScope;
   sources?: CatalogSource[];
   limit?: number;
 }
 
 export interface DiscoverResult {
   contractVersion: number;
+  scope: SessionScope;
   sessions: CatalogSession[];
   discovered: number;
   skippedUnchanged: number;
@@ -172,6 +180,7 @@ export interface SessionEventsPage {
 }
 
 export interface Stats {
+  scope: SessionScope;
   total: number;
   bySource: Partial<Record<Source, number>>;
   byProject: Array<{ project: string; count: number }>;
@@ -179,9 +188,9 @@ export interface Stats {
   lastTimestampMs: number | null;
 }
 
-export interface StatsOptions { dbPath?: string; tag?: string }
-export interface SyncOptions { dbPath?: string }
-export interface SyncResult { databasePath: string; completed: boolean }
+export interface StatsOptions { dbPath?: string; scope?: SessionScope; tag?: string }
+export interface SyncOptions { dbPath?: string; scope?: SessionScope }
+export interface SyncResult { databasePath: string; scope: SessionScope; completed: boolean }
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -343,7 +352,14 @@ function catalogSession(value: UnknownRecord): CatalogSession {
     sourceStamp: nullableString(value.sourceStamp),
     discoveryState: value.discoveryState === 'shallow' ? 'shallow' : 'full',
     fromCache: value.fromCache === true,
+    locations: Array.isArray(value.locations)
+      ? value.locations.filter((location): location is SessionLocation => location === 'local' || location === 'remote')
+      : [],
   };
+}
+
+function sessionScope(value: unknown): SessionScope {
+  return value === 'remote' || value === 'all' ? value : 'local';
 }
 
 function assertCatalogContract(value: number): void {
@@ -394,11 +410,11 @@ export async function nativeBuildProfile(): Promise<string> {
 }
 
 export async function search(query: string, options: SearchOptions = {}): Promise<HistoryEntry[]> {
-  return nativeCall(async (native) => (await native.search(query, options)).map(historyEntry));
+  return nativeCall(async (native) => (await native.search(query, { ...options, scope: options.scope ?? 'local' })).map(historyEntry));
 }
 
 export async function recent(options: ListOptions = {}): Promise<HistoryEntry[]> {
-  return nativeCall(async (native) => (await native.recent(options)).map(historyEntry));
+  return nativeCall(async (native) => (await native.recent({ ...options, scope: options.scope ?? 'local' })).map(historyEntry));
 }
 
 export async function getSession(sessionId: string, options: SessionOptions = {}): Promise<HistoryEntry[]> {
@@ -411,7 +427,7 @@ export async function listSessionCatalog(options: ListCatalogOptions = {}): Prom
 
 export async function listSessionCatalogPage(options: ListCatalogOptions = {}): Promise<SessionCatalogPage> {
   return nativeCall(async (native) => {
-    const page = await native.listSessionCatalogPage({ ...options, after: options.after ? {
+    const page = await native.listSessionCatalogPage({ ...options, scope: options.scope ?? 'local', after: options.after ? {
       ...options.after,
       lastActivityMs: options.after.lastActivityMs ?? undefined,
     } : undefined });
@@ -419,6 +435,7 @@ export async function listSessionCatalogPage(options: ListCatalogOptions = {}): 
     assertCatalogContract(contractVersion);
     return {
       contractVersion,
+      scope: sessionScope(page.scope),
       sessions: Array.isArray(page.sessions) ? (page.sessions as UnknownRecord[]).map(catalogSession) : [],
       nextCursor: catalogCursor(page.nextCursor),
     };
@@ -427,11 +444,12 @@ export async function listSessionCatalogPage(options: ListCatalogOptions = {}): 
 
 export async function discoverSessions(options: DiscoverSessionsOptions = {}): Promise<DiscoverResult> {
   return nativeCall(async (native) => {
-    const result = await native.discoverSessions(options);
+    const result = await native.discoverSessions({ ...options, scope: options.scope ?? 'local' });
     const contractVersion = Number(result.contractVersion);
     assertCatalogContract(contractVersion);
     return {
       contractVersion,
+      scope: sessionScope(result.scope),
       sessions: Array.isArray(result.sessions) ? (result.sessions as UnknownRecord[]).map(catalogSession) : [],
       discovered: Number(result.discovered),
       skippedUnchanged: Number(result.skippedUnchanged),
@@ -479,12 +497,13 @@ export async function getSessionEvents(sessionId: string, options: Omit<EventsPa
 
 export async function stats(options: StatsOptions = {}): Promise<Stats> {
   return nativeCall(async (native) => {
-    const result = await native.stats(options);
+    const result = await native.stats({ ...options, scope: options.scope ?? 'local' });
     const bySource: Partial<Record<Source, number>> = {};
     for (const item of (result.bySource as UnknownRecord[] | undefined) ?? []) {
       bySource[String(item.source) as Source] = Number(item.count);
     }
     return {
+      scope: sessionScope(result.scope),
       total: Number(result.total), bySource,
       byProject: ((result.byProject as UnknownRecord[] | undefined) ?? []).map((item) => ({ project: String(item.project), count: Number(item.count) })),
       firstTimestampMs: typeof result.firstTimestampMs === 'number' ? result.firstTimestampMs : null,
@@ -495,8 +514,12 @@ export async function stats(options: StatsOptions = {}): Promise<Stats> {
 
 export async function sync(options: SyncOptions = {}): Promise<SyncResult> {
   return nativeCall(async (native) => {
-    const result = await native.sync(options);
-    return { databasePath: String(result.databasePath), completed: result.completed === true };
+    const result = await native.sync({ ...options, scope: options.scope ?? 'local' });
+    return {
+      databasePath: String(result.databasePath),
+      scope: sessionScope(result.scope),
+      completed: result.completed === true,
+    };
   });
 }
 

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -11,9 +11,10 @@ import {
 } from './index.js';
 
 const READ = { readOnlyHint: true, idempotentHint: true, openWorldHint: false } as const;
-const WRITE = { readOnlyHint: false, idempotentHint: true, openWorldHint: false } as const;
+const OPEN_WORLD_WRITE = { readOnlyHint: false, idempotentHint: true, openWorldHint: true } as const;
 const SOURCE = z.enum(['claude', 'codex', 'cursor', 'grok', 'relay', 'trajectory', 'opencode']);
 const CATALOG_SOURCE = z.enum(['claude', 'codex', 'cursor', 'grok', 'relay', 'opencode']);
+const SESSION_SCOPE = z.enum(['local', 'remote', 'all']);
 const packageVersion = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
 ).version as string;
@@ -37,27 +38,31 @@ async function call(operation: () => Promise<unknown>) {
 
 server.tool('search_history', 'Search already-indexed RelayHistory prompts.', {
   query: z.string(), source: SOURCE.optional(), project: z.string().optional(), tag: z.string().optional(),
+  scope: SESSION_SCOPE.optional().default('local'),
   limit: z.number().int().min(1).max(1000).optional().default(20),
-}, READ, ({ query, source, project, tag, limit }) => call(() => search(query, { source, project, tag, limit })));
+}, READ, ({ query, source, project, tag, scope, limit }) => call(() => search(query, { source, project, tag, scope, limit })));
 
 server.tool('recent_history', 'List recent already-indexed history.', {
   source: SOURCE.optional(), project: z.string().optional(), tag: z.string().optional(),
+  scope: SESSION_SCOPE.optional().default('local'),
   n: z.number().int().min(1).max(1000).optional().default(20),
   before_ms: z.number().int().optional(),
-}, READ, ({ source, project, tag, n, before_ms }) => call(() => recent({ source, project, tag, limit: n, beforeMs: before_ms })));
+}, READ, ({ source, project, tag, scope, n, before_ms }) => call(() => recent({ source, project, tag, scope, limit: n, beforeMs: before_ms })));
 
 server.tool('list_sessions', 'Cache-only indexed session catalog listing. This never discovers or syncs.', {
   sources: z.array(CATALOG_SOURCE).optional(), limit: z.number().int().min(1).max(1000).optional().default(20),
+  scope: SESSION_SCOPE.optional().default('local'),
   before_ms: z.number().int().optional(),
   after: z.object({ lastActivityMs: z.number().int().nullable().optional(), source: z.string(), sessionId: z.string() }).optional(),
-}, READ, ({ sources, limit, before_ms, after }) => call(() => listSessionCatalogPage({
-  sources, limit, beforeMs: before_ms,
+}, READ, ({ sources, scope, limit, before_ms, after }) => call(() => listSessionCatalogPage({
+  sources, scope, limit, beforeMs: before_ms,
   after: after ? { ...after, lastActivityMs: after.lastActivityMs ?? null } : undefined,
 })));
 
 server.tool('discover_sessions', 'Explicit shallow provider discovery. Updates only the session catalog.', {
   sources: z.array(CATALOG_SOURCE).optional(), limit: z.number().int().min(1).max(10000).optional(),
-}, WRITE, (args) => call(() => discoverSessions(args)));
+  scope: SESSION_SCOPE.optional().default('local'),
+}, OPEN_WORLD_WRITE, (args) => call(() => discoverSessions(args)));
 
 server.tool('get_session', 'Get indexed prompts for one session.', {
   session_id: z.string(), source: SOURCE.optional(), tag: z.string().optional(),
@@ -69,9 +74,12 @@ server.tool('get_session_events', 'Get one bounded page of normalized events.', 
 }, READ, ({ session_id, source, limit, after }) => call(() => getSessionEventsPage(session_id, { source, limit, after })));
 
 server.tool('history_stats', 'Statistics for already-indexed RelayHistory data.', {
+  scope: SESSION_SCOPE.optional().default('local'),
   tag: z.string().optional(),
-}, READ, ({ tag }) => call(() => stats({ tag })));
+}, READ, ({ scope, tag }) => call(() => stats({ scope, tag })));
 
-server.tool('sync', 'Explicit full provider ingestion into RelayHistory.', {}, WRITE, () => call(() => sync()));
+server.tool('sync', 'Explicit full provider ingestion into RelayHistory.', {
+  scope: SESSION_SCOPE.optional().default('local'),
+}, OPEN_WORLD_WRITE, ({ scope }) => call(() => sync({ scope })));
 
 await server.connect(new StdioServerTransport());

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -11,7 +11,7 @@ import {
 } from './index.js';
 
 const READ = { readOnlyHint: true, idempotentHint: true, openWorldHint: false } as const;
-const OPEN_WORLD_WRITE = { readOnlyHint: false, idempotentHint: true, openWorldHint: true } as const;
+const LOCAL_WRITE = { readOnlyHint: false, idempotentHint: true, openWorldHint: false } as const;
 const SOURCE = z.enum(['claude', 'codex', 'cursor', 'grok', 'relay', 'trajectory', 'opencode']);
 const CATALOG_SOURCE = z.enum(['claude', 'codex', 'cursor', 'grok', 'relay', 'opencode']);
 const SESSION_SCOPE = z.enum(['local', 'remote', 'all']);
@@ -62,7 +62,7 @@ server.tool('list_sessions', 'Cache-only indexed session catalog listing. This n
 server.tool('discover_sessions', 'Explicit shallow provider discovery. Updates only the session catalog.', {
   sources: z.array(CATALOG_SOURCE).optional(), limit: z.number().int().min(1).max(10000).optional(),
   scope: SESSION_SCOPE.optional().default('local'),
-}, OPEN_WORLD_WRITE, (args) => call(() => discoverSessions(args)));
+}, LOCAL_WRITE, (args) => call(() => discoverSessions(args)));
 
 server.tool('get_session', 'Get indexed prompts for one session.', {
   session_id: z.string(), source: SOURCE.optional(), tag: z.string().optional(),
@@ -80,6 +80,6 @@ server.tool('history_stats', 'Statistics for already-indexed RelayHistory data.'
 
 server.tool('sync', 'Explicit full provider ingestion into RelayHistory.', {
   scope: SESSION_SCOPE.optional().default('local'),
-}, OPEN_WORLD_WRITE, ({ scope }) => call(() => sync({ scope })));
+}, LOCAL_WRITE, ({ scope }) => call(() => sync({ scope })));
 
 await server.connect(new StdioServerTransport());

--- a/sdk-ts/src/native-errors.test.ts
+++ b/sdk-ts/src/native-errors.test.ts
@@ -4,8 +4,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import {
-  DatabaseOpenError, NativeContractMismatchError, listSessionCatalogPage, recent, stats,
-  validateNativeContract,
+  DatabaseOpenError, NativeContractMismatchError, UnsupportedOperationError, discoverSessions,
+  listSessionCatalogPage, recent, stats, sync, validateNativeContract, validateNativeScope,
 } from './index.js';
 
 test('missing database reads are explicit empty cache operations', async () => {
@@ -31,6 +31,32 @@ test('SDK/native contract mismatch is actionable', () => {
       && error.code === 'NATIVE_CONTRACT_MISMATCH'
       && /requires native contract 3/.test(error.message),
   );
+  assert.throws(
+    () => validateNativeScope('cloud'),
+    (error: unknown) => error instanceof NativeContractMismatchError
+      && error.code === 'NATIVE_CONTRACT_MISMATCH'
+      && /invalid session scope/.test(error.message),
+  );
+});
+
+test('unsupported remote acquisition has one stable SDK error', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'relayhistory-unsupported-remote-'));
+  const dbPath = join(root, 'history.db');
+  try {
+    for (const operation of [
+      () => discoverSessions({ dbPath, scope: 'remote' }),
+      () => sync({ dbPath, scope: 'remote' }),
+    ]) {
+      await assert.rejects(
+        operation(),
+        (error: unknown) => error instanceof UnsupportedOperationError
+          && error.code === 'UNSUPPORTED_OPERATION'
+          && error.message.includes('no remote provider connectors are configured'),
+      );
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test('database open failures use the stable SDK error', async () => {

--- a/sdk-ts/src/native-errors.test.ts
+++ b/sdk-ts/src/native-errors.test.ts
@@ -13,11 +13,11 @@ test('missing database reads are explicit empty cache operations', async () => {
   const dbPath = join(root, 'missing', 'history.db');
   try {
     assert.deepEqual(await listSessionCatalogPage({ dbPath, limit: 20 }), {
-      contractVersion: 1, sessions: [], nextCursor: null,
+      contractVersion: 2, scope: 'local', sessions: [], nextCursor: null,
     });
     assert.deepEqual(await recent({ dbPath, limit: 20 }), []);
     assert.deepEqual(await stats({ dbPath }), {
-      total: 0, bySource: {}, byProject: [], firstTimestampMs: null, lastTimestampMs: null,
+      scope: 'local', total: 0, bySource: {}, byProject: [], firstTimestampMs: null, lastTimestampMs: null,
     });
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -29,7 +29,7 @@ test('SDK/native contract mismatch is actionable', () => {
     () => validateNativeContract(999),
     (error: unknown) => error instanceof NativeContractMismatchError
       && error.code === 'NATIVE_CONTRACT_MISMATCH'
-      && /requires native contract 2/.test(error.message),
+      && /requires native contract 3/.test(error.message),
   );
 });
 


### PR DESCRIPTION
## Summary

- add local, remote, and all session scopes across the Rust CLI/engine, native binding, TypeScript SDK/CLI, and MCP
- keep one canonical session ledger with deduplicated local/remote presence rows and per-presence acquisition metadata
- default every collection surface to local; direct session and event identity lookups remain scope-independent
- migrate legacy evidence to local presence with concurrent, crash-safe backfill and cleanup semantics
- reserve remote discovery and sync as explicit unsupported operations until cloud connectors are configured; all runs every configured connector, currently local
- bump native contract to 3 and catalog contract to 2, including release checks and documentation

## Verification

- cargo fmt --all -- --check
- cargo test --workspace: 218 passed, 1 benchmark ignored
- native release addon rebuilt with npm run build
- SDK npm run typecheck
- SDK npm test: 15 passed
- git diff --check

Three independent adversarial reviews covered schema/migration behavior, API-surface consistency, and compatibility/release paths. Follow-up findings were fixed and regression-tested, including concurrent migration, cross-location cache isolation, remote watch/service side effects, and atomic evidence/presence writes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

