### PR TITLE
feat: benchmark opencode shallow discovery

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -75,32 +75,32 @@ event queries against it.
 ## 2026-08-31 baseline
 
 Measured on macOS arm64 (Apple M2 Max) with Node.js 22.22.2 against a real
-3,127,177,216 byte RelayHistory database with an active WAL:
+3,131,932,672 byte RelayHistory database with an active WAL:
 
 | Operation | Time | Rows/work |
 |---|---:|---:|
-| cold shallow discovery | 20.80 ms | 20 rows |
-| cold shallow discovery | 22.22 ms | 100 rows |
-| cold shallow discovery | 87.88 ms | 1,000 rows |
-| unchanged shallow discovery | 5.15 ms | 20 rows; zero files opened |
-| unchanged shallow discovery | 6.03 ms | 100 rows; zero files opened |
-| unchanged shallow discovery | 19.24 ms | 1,000 rows; zero files opened |
-| cold->changed shallow discovery | 6.97 ms | 20 changed rows |
-| cold->changed shallow discovery | 13.74 ms | 100 changed rows |
-| cold->changed shallow discovery | 82.77 ms | 1,000 changed rows |
-| opencode cold shallow discovery | 16.21 ms | 20 rows |
-| opencode cold shallow discovery | 41.23 ms | 100 rows |
-| opencode cold shallow discovery | 306.21 ms | 1,000 rows |
-| opencode unchanged shallow discovery | 2.94 ms | 20 rows; zero shallow reads |
-| opencode unchanged shallow discovery | 3.52 ms | 100 rows; zero shallow reads |
-| opencode unchanged shallow discovery | 16.53 ms | 1,000 rows; zero shallow reads |
-| opencode cold->changed shallow discovery | 9.47 ms | 20 changed rows |
-| opencode cold->changed shallow discovery | 34.41 ms | 100 changed rows |
-| opencode cold->changed shallow discovery | 376.92 ms | 1,000 changed rows |
-| warm session events | 0.58 ms | 20 rows |
-| warm session events | 1.69 ms | 200 rows |
-| CLI startup + cold shallow discovery | 50.40 ms | 20 rows |
-| MCP cold shallow discovery | 19.71 ms | 20 rows |
+| cold shallow discovery | 13.94 ms | 20 rows |
+| cold shallow discovery | 18.26 ms | 100 rows |
+| cold shallow discovery | 79.66 ms | 1,000 rows |
+| unchanged shallow discovery | 4.36 ms | 20 rows; zero files opened |
+| unchanged shallow discovery | 5.11 ms | 100 rows; zero files opened |
+| unchanged shallow discovery | 17.26 ms | 1,000 rows; zero files opened |
+| cold->changed shallow discovery | 6.29 ms | 20 changed rows |
+| cold->changed shallow discovery | 12.58 ms | 100 changed rows |
+| cold->changed shallow discovery | 77.61 ms | 1,000 changed rows |
+| opencode cold shallow discovery | 13.61 ms | 20 rows |
+| opencode cold shallow discovery | 36.77 ms | 100 rows |
+| opencode cold shallow discovery | 284.92 ms | 1,000 rows |
+| opencode unchanged shallow discovery | 2.15 ms | 20 rows; zero shallow reads |
+| opencode unchanged shallow discovery | 6.61 ms | 100 rows; zero shallow reads |
+| opencode unchanged shallow discovery | 12.44 ms | 1,000 rows; zero shallow reads |
+| opencode cold->changed shallow discovery | 7.60 ms | 20 changed rows |
+| opencode cold->changed shallow discovery | 32.84 ms | 100 changed rows |
+| opencode cold->changed shallow discovery | 372.95 ms | 1,000 changed rows |
+| warm session events | 0.66 ms | 20 rows |
+| warm session events | 1.32 ms | 200 rows |
+| CLI startup + cold shallow discovery | 48.62 ms | 20 rows |
+| MCP cold shallow discovery | 20.02 ms | 20 rows |
 
 The event queries did not load or copy the 2.9 GiB database: Rust opened it
 directly and returned a bounded indexed page. Every opencode run, including

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -39,18 +39,26 @@ AI_HIST_DB=/path/to/ai-history.db npm run benchmark -- --output=foo.md
 ## Benchmark definitions
 
 Discovery benchmarks use a generated home directory containing 1,000 valid,
-minimal Claude session transcripts. Setup, fixture creation, and source-file
-changes happen outside the timed regions. The fixture makes each run repeatable
-and lets the changed-source case avoid modifying real provider history.
+minimal Claude session transcripts and an opencode SQLite store
+(`.local/share/opencode/opencode.db`) holding 1,000 minimal sessions with one
+message and one part each. Setup, fixture creation, and source-file changes
+happen outside the timed regions. The fixture makes each run repeatable and
+lets the changed-source case avoid modifying real provider history. The
+opencode store is written with `node:sqlite`, so benchmarks need Node 22.13+.
 
-The number at the end of a benchmark name is the requested session or event
-limit, not a cache size.
+Unprefixed discovery benchmarks read the Claude fixture; the
+`opencode`-prefixed ones read the opencode fixture through the same
+SDK -> N-API -> Rust path. The number at the end of a benchmark name is the
+requested session or event limit, not a cache size.
 
 | Benchmark | Setup outside timing | Timed work |
 |---|---|---|
 | `cold shallow discovery N` | Fresh fixture; database does not exist | Create/migrate the database, enumerate the 1,000 candidates, shallow-read the newest N files, and upsert N catalog rows through SDK -> N-API -> Rust |
 | `unchanged shallow discovery N` | Run one cold discovery of N into a fresh database | Enumerate candidates, match source stamps, and return N cached rows without opening unchanged transcripts |
 | `cold->changed shallow discovery N` | Run one cold discovery of N, then append a valid assistant record to those N fixture transcripts | Enumerate candidates, detect changed stamps, shallow-read the N changed files, and update their catalog rows |
+| `opencode cold shallow discovery N` | Fresh fixture; database does not exist | Create/migrate the database, snapshot the opencode store, enumerate the 1,000 sessions, shallow-read the newest N from the snapshot, and upsert N catalog rows |
+| `opencode unchanged shallow discovery N` | Run one cold discovery of N into a fresh database | Snapshot the store, enumerate sessions, match `time_created`/`time_updated` stamps, and return N cached rows |
+| `opencode cold->changed shallow discovery N` | Run one cold discovery of N, then insert an assistant message and bump `time_updated` for those N sessions | Snapshot the store, detect the N changed stamps, re-read those sessions, and update their catalog rows |
 | `warm session events N` | Select a full session from the configured real database and make one untimed 200-event request | Open the database and return up to N cached events through SDK -> N-API -> Rust; provider transcripts are not read |
 | `CLI startup + cold shallow discovery 20` | Fresh database and the generated fixture | Start a new Node process, load the CLI and native addon, then perform cold discovery of 20 sessions and serialize JSON |
 | `MCP cold shallow discovery 20` | Start and initialize the MCP server with a fresh database and the generated fixture | Perform one MCP `tools/call` round trip that cold-discovers 20 sessions; MCP process startup and initialization are excluded |
@@ -64,26 +72,37 @@ file sparsely on a filesystem that supports sparse files. Do not run this test
 in ordinary CI; use the opt-in `AI_HIST_LARGE_DB` path and verify catalog and
 event queries against it.
 
-## 2026-08-30 baseline
+## 2026-08-31 baseline
 
-Measured on macOS 26.5 arm64 with Node.js 22.22.2 against a real 3,030,155,264
-byte RelayHistory database with an active WAL:
+Measured on macOS arm64 (Apple M2 Max) with Node.js 22.22.2 against a real
+3,127,177,216 byte RelayHistory database with an active WAL:
 
 | Operation | Time | Rows/work |
 |---|---:|---:|
-| cold shallow discovery | 13.83 ms | 20 rows |
-| cold shallow discovery | 16.17 ms | 100 rows |
-| cold shallow discovery | 82.99 ms | 1,000 rows |
-| unchanged shallow discovery | 4.17 ms | 20 rows; zero files opened |
-| unchanged shallow discovery | 5.39 ms | 100 rows; zero files opened |
-| unchanged shallow discovery | 17.72 ms | 1,000 rows; zero files opened |
-| cold->changed shallow discovery | 6.28 ms | 20 changed rows |
-| cold->changed shallow discovery | 11.40 ms | 100 changed rows |
-| cold->changed shallow discovery | 80.42 ms | 1,000 changed rows |
-| warm session events | 0.95 ms | 20 rows |
-| warm session events | 1.82 ms | 200 rows |
-| CLI startup + cold shallow discovery | 54.94 ms | 20 rows |
-| MCP cold shallow discovery | 20.54 ms | 20 rows |
+| cold shallow discovery | 20.80 ms | 20 rows |
+| cold shallow discovery | 22.22 ms | 100 rows |
+| cold shallow discovery | 87.88 ms | 1,000 rows |
+| unchanged shallow discovery | 5.15 ms | 20 rows; zero files opened |
+| unchanged shallow discovery | 6.03 ms | 100 rows; zero files opened |
+| unchanged shallow discovery | 19.24 ms | 1,000 rows; zero files opened |
+| cold->changed shallow discovery | 6.97 ms | 20 changed rows |
+| cold->changed shallow discovery | 13.74 ms | 100 changed rows |
+| cold->changed shallow discovery | 82.77 ms | 1,000 changed rows |
+| opencode cold shallow discovery | 16.21 ms | 20 rows |
+| opencode cold shallow discovery | 41.23 ms | 100 rows |
+| opencode cold shallow discovery | 306.21 ms | 1,000 rows |
+| opencode unchanged shallow discovery | 2.94 ms | 20 rows; zero shallow reads |
+| opencode unchanged shallow discovery | 3.52 ms | 100 rows; zero shallow reads |
+| opencode unchanged shallow discovery | 16.53 ms | 1,000 rows; zero shallow reads |
+| opencode cold->changed shallow discovery | 9.47 ms | 20 changed rows |
+| opencode cold->changed shallow discovery | 34.41 ms | 100 changed rows |
+| opencode cold->changed shallow discovery | 376.92 ms | 1,000 changed rows |
+| warm session events | 0.58 ms | 20 rows |
+| warm session events | 1.69 ms | 200 rows |
+| CLI startup + cold shallow discovery | 50.40 ms | 20 rows |
+| MCP cold shallow discovery | 19.71 ms | 20 rows |
 
-The event queries did not load or copy the 2.8 GiB database: Rust opened it
-directly and returned a bounded indexed page.
+The event queries did not load or copy the 2.9 GiB database: Rust opened it
+directly and returned a bounded indexed page. Every opencode run, including
+unchanged, snapshots the whole store once with SQLite backup, so its
+`filesOpened` is always 1 and its `bytesRead` is the store's size.

--- a/scripts/benchmark-native.mjs
+++ b/scripts/benchmark-native.mjs
@@ -2,6 +2,7 @@ import { execFile, spawn } from 'node:child_process';
 import { appendFile, mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises';
 import { arch, cpus, platform, release, tmpdir } from 'node:os';
 import { dirname, extname, join, resolve } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import { performance } from 'node:perf_hooks';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
@@ -124,24 +125,32 @@ async function createDiscoveryFixture(home, count) {
   }
 }
 
-async function withHome(home, operation) {
-  const previousHome = process.env.HOME;
-  const previousProfile = process.env.USERPROFILE;
-  process.env.HOME = home;
-  process.env.USERPROFILE = home;
+async function withEnvironment(overrides, operation) {
+  const saved = {};
+  for (const [key, value] of Object.entries(overrides)) {
+    saved[key] = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
   try {
     return await operation();
   } finally {
-    if (previousHome === undefined) delete process.env.HOME;
-    else process.env.HOME = previousHome;
-    if (previousProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = previousProfile;
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   }
 }
 
-async function discoverFixture(home, benchmarkDbPath, limit) {
+// OPENCODE_DB would point discovery past the fixture home at a real store.
+const withHome = (home, operation) => withEnvironment(
+  { HOME: home, USERPROFILE: home, OPENCODE_DB: undefined },
+  operation,
+);
+
+async function discoverFixture(home, benchmarkDbPath, source, limit) {
   return withHome(home, () => discoverSessions({
-    dbPath: benchmarkDbPath, sources: ['claude'], limit,
+    dbPath: benchmarkDbPath, sources: [source], limit,
   }));
 }
 
@@ -175,37 +184,140 @@ async function restoreFixtureSessions(originals) {
   }
 }
 
+// The minimal subset of opencode's store that discovery reads: sessions carry
+// the change stamp, and message/part rows feed the excerpt and model queries.
+async function createOpencodeFixture(home, count) {
+  const databasePath = join(home, '.local', 'share', 'opencode', 'opencode.db');
+  await mkdir(dirname(databasePath), { recursive: true });
+  const db = new DatabaseSync(databasePath);
+  try {
+    db.exec(
+      'CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, time_created INTEGER, time_updated INTEGER);'
+      + 'CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);'
+      + 'CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);',
+    );
+    const insertSession = db.prepare('INSERT INTO session VALUES (?, ?, ?, ?)');
+    const insertMessage = db.prepare('INSERT INTO message VALUES (?, ?, ?, ?)');
+    const insertPart = db.prepare('INSERT INTO part VALUES (?, ?, ?, ?, ?)');
+    const baseTimestamp = Date.UTC(2026, 0, 1);
+    db.exec('BEGIN');
+    for (let index = 0; index < count; index++) {
+      const sessionId = `benchmark-oc-${String(index).padStart(4, '0')}`;
+      const timestampMs = baseTimestamp + index * 1_000;
+      insertSession.run(sessionId, '/benchmark/project', timestampMs, timestampMs);
+      insertMessage.run(`m-${index}`, sessionId, timestampMs, '{"role":"user","modelID":"benchmark-model"}');
+      insertPart.run(`p-${index}`, `m-${index}`, sessionId, timestampMs, JSON.stringify({ type: 'text', text: `benchmark prompt ${index}` }));
+    }
+    db.exec('COMMIT');
+  } finally {
+    db.close();
+  }
+  return databasePath;
+}
+
+// A changed opencode session is a bumped `time_updated` stamp plus a new
+// assistant message, mirroring the appended record in the Claude fixture.
+function changeOpencodeSessions(databasePath, sessions) {
+  const timestampMs = Date.now();
+  const db = new DatabaseSync(databasePath);
+  try {
+    const readStamp = db.prepare('SELECT time_updated FROM session WHERE id = ?');
+    const bumpStamp = db.prepare('UPDATE session SET time_updated = ? WHERE id = ?');
+    const insertMessage = db.prepare('INSERT INTO message VALUES (?, ?, ?, ?)');
+    const insertPart = db.prepare('INSERT INTO part VALUES (?, ?, ?, ?, ?)');
+    const originals = [];
+    db.exec('BEGIN');
+    for (const session of sessions) {
+      originals.push({ sessionId: session.sessionId, timeUpdated: readStamp.get(session.sessionId).time_updated });
+      bumpStamp.run(timestampMs, session.sessionId);
+      insertMessage.run(`changed-m-${session.sessionId}`, session.sessionId, timestampMs, '{"role":"assistant","modelID":"benchmark-model"}');
+      insertPart.run(`changed-p-${session.sessionId}`, `changed-m-${session.sessionId}`, session.sessionId, timestampMs, '{"type":"text","text":"changed benchmark response"}');
+    }
+    db.exec('COMMIT');
+    return originals;
+  } finally {
+    db.close();
+  }
+}
+
+function restoreOpencodeSessions(databasePath, originals) {
+  const db = new DatabaseSync(databasePath);
+  try {
+    const restoreStamp = db.prepare('UPDATE session SET time_updated = ? WHERE id = ?');
+    const deleteMessage = db.prepare('DELETE FROM message WHERE id = ?');
+    const deletePart = db.prepare('DELETE FROM part WHERE id = ?');
+    db.exec('BEGIN');
+    for (const original of originals) {
+      restoreStamp.run(original.timeUpdated, original.sessionId);
+      deleteMessage.run(`changed-m-${original.sessionId}`);
+      deletePart.run(`changed-p-${original.sessionId}`);
+    }
+    db.exec('COMMIT');
+  } finally {
+    db.close();
+  }
+}
+
+function discoveryMeasurement(measurement) {
+  return {
+    name: measurement.name,
+    ms: measurement.ms,
+    rows: measurement.value.sessions.length,
+    counters: measurement.value.counters,
+  };
+}
+
+async function measureDiscoveryScaling({ prefix, source, home, temporary, change, restore }) {
+  const coldResults = [];
+  const unchangedResults = [];
+  const changedResults = [];
+  for (const limit of discoveryLimits) {
+    const coldDb = join(temporary, `${source}-cold-${limit}.db`);
+    coldResults.push(discoveryMeasurement(await timed(
+      `${prefix}cold shallow discovery ${limit}`,
+      () => discoverFixture(home, coldDb, source, limit),
+    )));
+
+    const unchangedDb = join(temporary, `${source}-unchanged-${limit}.db`);
+    await discoverFixture(home, unchangedDb, source, limit);
+    unchangedResults.push(discoveryMeasurement(await timed(
+      `${prefix}unchanged shallow discovery ${limit}`,
+      () => discoverFixture(home, unchangedDb, source, limit),
+    )));
+
+    const changedDb = join(temporary, `${source}-changed-${limit}.db`);
+    const seeded = await discoverFixture(home, changedDb, source, limit);
+    const originals = await change(seeded.sessions);
+    try {
+      changedResults.push(discoveryMeasurement(await timed(
+        `${prefix}cold->changed shallow discovery ${limit}`,
+        () => discoverFixture(home, changedDb, source, limit),
+      )));
+    } finally {
+      await restore(originals);
+    }
+  }
+  return [...coldResults, ...unchangedResults, ...changedResults];
+}
+
 const info = await stat(dbPath);
 const results = [];
 const temporary = await mkdtemp(join(tmpdir(), 'relayhistory-benchmark-'));
 try {
   const fixtureHome = join(temporary, 'home');
   await createDiscoveryFixture(fixtureHome, Math.max(...discoveryLimits));
+  const opencodeDb = await createOpencodeFixture(fixtureHome, Math.max(...discoveryLimits));
 
-  const coldResults = [];
-  const unchangedResults = [];
-  const changedResults = [];
-  for (const limit of discoveryLimits) {
-    const coldDb = join(temporary, `cold-${limit}.db`);
-    const cold = await timed(`cold shallow discovery ${limit}`, () => discoverFixture(fixtureHome, coldDb, limit));
-    coldResults.push({ name: cold.name, ms: cold.ms, rows: cold.value.sessions.length, counters: cold.value.counters });
-
-    const unchangedDb = join(temporary, `unchanged-${limit}.db`);
-    await discoverFixture(fixtureHome, unchangedDb, limit);
-    const unchanged = await timed(`unchanged shallow discovery ${limit}`, () => discoverFixture(fixtureHome, unchangedDb, limit));
-    unchangedResults.push({ name: unchanged.name, ms: unchanged.ms, rows: unchanged.value.sessions.length, counters: unchanged.value.counters });
-
-    const changedDb = join(temporary, `changed-${limit}.db`);
-    const seeded = await discoverFixture(fixtureHome, changedDb, limit);
-    const originals = await changeDiscoveredSessions(seeded.sessions);
-    try {
-      const changed = await timed(`cold->changed shallow discovery ${limit}`, () => discoverFixture(fixtureHome, changedDb, limit));
-      changedResults.push({ name: changed.name, ms: changed.ms, rows: changed.value.sessions.length, counters: changed.value.counters });
-    } finally {
-      await restoreFixtureSessions(originals);
-    }
-  }
-  results.push(...coldResults, ...unchangedResults, ...changedResults);
+  results.push(...await measureDiscoveryScaling({
+    prefix: '', source: 'claude', home: fixtureHome, temporary,
+    change: changeDiscoveredSessions,
+    restore: restoreFixtureSessions,
+  }));
+  results.push(...await measureDiscoveryScaling({
+    prefix: 'opencode ', source: 'opencode', home: fixtureHome, temporary,
+    change: (sessions) => changeOpencodeSessions(opencodeDb, sessions),
+    restore: (originals) => restoreOpencodeSessions(opencodeDb, originals),
+  }));
 
   const firstPage = await listSessionCatalogPage({ dbPath, limit: 20 });
   const candidate = firstPage.sessions.find((session) => session.discoveryState === 'full') ?? firstPage.sessions[0];

--- a/scripts/benchmark-native.mjs
+++ b/scripts/benchmark-native.mjs
@@ -1,5 +1,5 @@
 import { execFile, spawn } from 'node:child_process';
-import { appendFile, mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises';
+import { appendFile, copyFile, mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from 'node:fs/promises';
 import { arch, cpus, platform, release, tmpdir } from 'node:os';
 import { dirname, extname, join, resolve } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -217,40 +217,21 @@ async function createOpencodeFixture(home, count) {
 
 // A changed opencode session is a bumped `time_updated` stamp plus a new
 // assistant message, mirroring the appended record in the Claude fixture.
+// Restoration is a byte copy of the pristine store, not reversed rows: a
+// DELETE leaves the inserted pages on the freelist, so later cases would
+// snapshot a larger store than the one the first cold case measured.
 function changeOpencodeSessions(databasePath, sessions) {
   const timestampMs = Date.now();
   const db = new DatabaseSync(databasePath);
   try {
-    const readStamp = db.prepare('SELECT time_updated FROM session WHERE id = ?');
     const bumpStamp = db.prepare('UPDATE session SET time_updated = ? WHERE id = ?');
     const insertMessage = db.prepare('INSERT INTO message VALUES (?, ?, ?, ?)');
     const insertPart = db.prepare('INSERT INTO part VALUES (?, ?, ?, ?, ?)');
-    const originals = [];
     db.exec('BEGIN');
     for (const session of sessions) {
-      originals.push({ sessionId: session.sessionId, timeUpdated: readStamp.get(session.sessionId).time_updated });
       bumpStamp.run(timestampMs, session.sessionId);
       insertMessage.run(`changed-m-${session.sessionId}`, session.sessionId, timestampMs, '{"role":"assistant","modelID":"benchmark-model"}');
       insertPart.run(`changed-p-${session.sessionId}`, `changed-m-${session.sessionId}`, session.sessionId, timestampMs, '{"type":"text","text":"changed benchmark response"}');
-    }
-    db.exec('COMMIT');
-    return originals;
-  } finally {
-    db.close();
-  }
-}
-
-function restoreOpencodeSessions(databasePath, originals) {
-  const db = new DatabaseSync(databasePath);
-  try {
-    const restoreStamp = db.prepare('UPDATE session SET time_updated = ? WHERE id = ?');
-    const deleteMessage = db.prepare('DELETE FROM message WHERE id = ?');
-    const deletePart = db.prepare('DELETE FROM part WHERE id = ?');
-    db.exec('BEGIN');
-    for (const original of originals) {
-      restoreStamp.run(original.timeUpdated, original.sessionId);
-      deleteMessage.run(`changed-m-${original.sessionId}`);
-      deletePart.run(`changed-p-${original.sessionId}`);
     }
     db.exec('COMMIT');
   } finally {
@@ -307,6 +288,8 @@ try {
   const fixtureHome = join(temporary, 'home');
   await createDiscoveryFixture(fixtureHome, Math.max(...discoveryLimits));
   const opencodeDb = await createOpencodeFixture(fixtureHome, Math.max(...discoveryLimits));
+  const opencodePristine = join(temporary, 'opencode-pristine.db');
+  await copyFile(opencodeDb, opencodePristine);
 
   results.push(...await measureDiscoveryScaling({
     prefix: '', source: 'claude', home: fixtureHome, temporary,
@@ -316,7 +299,7 @@ try {
   results.push(...await measureDiscoveryScaling({
     prefix: 'opencode ', source: 'opencode', home: fixtureHome, temporary,
     change: (sessions) => changeOpencodeSessions(opencodeDb, sessions),
-    restore: (originals) => restoreOpencodeSessions(opencodeDb, originals),
+    restore: () => copyFile(opencodePristine, opencodeDb),
   }));
 
   const firstPage = await listSessionCatalogPage({ dbPath, limit: 20 });


### PR DESCRIPTION
## Summary

\`npm run benchmark\` measures shallow discovery for the opencode provider alongside Claude. The generated fixture home now carries an opencode SQLite store (\`.local/share/opencode/opencode.db\`, written with \`node:sqlite\`) holding 1,000 minimal sessions — the same three-table subset the discovery provider reads (\`session\` for change stamps, \`message\`/\`part\` for excerpt and model queries).

- \`opencode cold / unchanged / cold->changed shallow discovery N\` run the same scaling trio as the Claude fixture, at limits 20/100/1,000, through the same SDK -> N-API -> Rust path. The changed case bumps \`time_updated\` and inserts an assistant message — the provider's actual change stamp — and restores the store afterwards.
- The per-source scaling loop is one parameterized \`measureDiscoveryScaling\`; the Claude benchmark names and semantics are unchanged.
- Discovery runs clear \`OPENCODE_DB\` so a developer's real opencode store is never read.
- \`docs/benchmarks.md\` documents the new benchmarks and carries a fresh baseline including them (measured on this branch; counters verify the unchanged runs do zero shallow reads and the changed runs re-read exactly N sessions).

Requires Node 22.13+ for \`node:sqlite\` (the documented baseline already runs on 22.22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LY2sg154jqvU5E5CCZF5DJ

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

