### PR TITLE
Fix Codex Desktop user message ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,5 +46,9 @@ Notable changes to the native `ai-hist` CLI are documented here.
 
 ### Changed
 
+- Recognize current Codex Desktop `response_item/message` user turns in both
+  bounded session discovery and full ingestion. Existing Codex rollout indexes
+  are repaired automatically, while adjacent legacy/current mirror records are
+  collapsed without removing intentionally repeated prompts.
 - Replace Python-based installer and end-to-end verification with shell,
   SQLite, Node.js, and the public Rust CLI interfaces.

--- a/crates/ai-hist/src/codex.rs
+++ b/crates/ai-hist/src/codex.rs
@@ -1,0 +1,192 @@
+//! Shared parsing for human-authored Codex rollout messages.
+//!
+//! Codex has emitted the same user turn through two record shapes over time.
+//! Keeping their interpretation here prevents shallow discovery and full
+//! ingestion from drifting when the rollout schema changes again.
+
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HumanMessageFormat {
+    EventMessage,
+    ResponseItem,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HumanMessage {
+    pub text: String,
+    pub format: HumanMessageFormat,
+    pub message_id: Option<String>,
+}
+
+/// Extract one substantive human turn from either supported Codex shape.
+///
+/// Multiple `input_text` parts are kept in provider order and separated by a
+/// newline, matching the way other multipart Codex text is materialized.
+/// Application-injected control wrappers are rejected here so every caller
+/// applies the same human-message classification.
+pub(crate) fn human_message(value: &Value) -> Option<HumanMessage> {
+    let payload = value.get("payload")?.as_object()?;
+    let (text, format) = match (
+        value.get("type").and_then(Value::as_str),
+        payload.get("type").and_then(Value::as_str),
+    ) {
+        (Some("event_msg"), Some("user_message")) => (
+            payload.get("message")?.as_str()?.to_string(),
+            HumanMessageFormat::EventMessage,
+        ),
+        (Some("response_item"), Some("message"))
+            if payload.get("role").and_then(Value::as_str) == Some("user") =>
+        {
+            let parts = payload
+                .get("content")?
+                .as_array()?
+                .iter()
+                .filter(|part| part.get("type").and_then(Value::as_str) == Some("input_text"))
+                .filter_map(|part| part.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>();
+            if parts.is_empty() {
+                return None;
+            }
+            (parts.join("\n"), HumanMessageFormat::ResponseItem)
+        }
+        _ => return None,
+    };
+    let text = text.trim();
+    if text.is_empty() || is_control_context(text) {
+        return None;
+    }
+    Some(HumanMessage {
+        text: text.to_string(),
+        format,
+        message_id: payload
+            .get("id")
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty())
+            .map(str::to_string),
+    })
+}
+
+pub(crate) fn is_control_context(prompt: &str) -> bool {
+    let value = prompt.trim_start();
+    [
+        "<environment_context",
+        "<permissions instructions",
+        "<app-context",
+        "<skills_instructions",
+        "<collaboration_mode",
+        "<INSTRUCTIONS>",
+        "<user_instructions",
+        "# AGENTS.md",
+    ]
+    .iter()
+    .any(|prefix| value.starts_with(prefix))
+}
+
+/// Suppress only adjacent mirrored encodings of one turn.
+///
+/// Text is deliberately not deduplicated globally: two equal messages in the
+/// same representation, or equal messages separated by any other record, are
+/// distinct human turns. Codex mirror pairs are adjacent, have equal text,
+/// and use opposite representations.
+#[derive(Default)]
+pub(crate) struct HumanMessageDeduper {
+    previous: Option<(HumanMessageFormat, String)>,
+}
+
+impl HumanMessageDeduper {
+    pub(crate) fn observe(&mut self, value: &Value) -> Option<HumanMessage> {
+        let current = human_message(value);
+        let Some(current) = current else {
+            self.previous = None;
+            return None;
+        };
+        let mirrored = self
+            .previous
+            .as_ref()
+            .is_some_and(|(format, text)| *format != current.format && text == &current.text);
+        if mirrored {
+            self.previous = None;
+            return None;
+        }
+        self.previous = Some((current.format, current.text.clone()));
+        Some(current)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_both_user_shapes_and_joins_text_parts() {
+        let old = json!({
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "  fix it  "}
+        });
+        assert_eq!(human_message(&old).unwrap().text, "fix it");
+
+        let current = json!({
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "id": "msg_1",
+                "content": [
+                    {"type": "input_text", "text": "first"},
+                    {"type": "image", "url": "ignored"},
+                    {"type": "input_text", "text": "second"}
+                ]
+            }
+        });
+        assert_eq!(human_message(&current).unwrap().text, "first\nsecond");
+        assert_eq!(
+            human_message(&current).unwrap().message_id.as_deref(),
+            Some("msg_1")
+        );
+    }
+
+    #[test]
+    fn rejects_assistant_and_control_messages() {
+        let assistant = json!({
+            "type": "response_item",
+            "payload": {"type": "message", "role": "assistant", "content": [
+                {"type": "output_text", "text": "done"}
+            ]}
+        });
+        assert!(human_message(&assistant).is_none());
+
+        let context = json!({
+            "type": "response_item",
+            "payload": {"type": "message", "role": "user", "content": [
+                {"type": "input_text", "text": "<environment_context>injected</environment_context>"}
+            ]}
+        });
+        assert!(human_message(&context).is_none());
+    }
+
+    #[test]
+    fn deduplicates_only_adjacent_opposite_representations() {
+        let response = json!({
+            "type": "response_item",
+            "payload": {"type": "message", "role": "user", "content": [
+                {"type": "input_text", "text": "retry"}
+            ]}
+        });
+        let event = json!({
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "retry"}
+        });
+        let assistant = json!({
+            "type": "event_msg",
+            "payload": {"type": "agent_message", "message": "working"}
+        });
+        let mut deduper = HumanMessageDeduper::default();
+        assert!(deduper.observe(&response).is_some());
+        assert!(deduper.observe(&event).is_none());
+        assert!(deduper.observe(&event).is_some());
+        assert!(deduper.observe(&assistant).is_none());
+        assert!(deduper.observe(&event).is_some());
+    }
+}

--- a/crates/ai-hist/src/discover.rs
+++ b/crates/ai-hist/src/discover.rs
@@ -78,7 +78,7 @@ pub const SESSION_CATALOG_CONTRACT_VERSION: u32 = 1;
 /// invalidates every stored stamp, so a scanner that learns to extract a new
 /// field re-reads sources whose bytes never changed. `parser_version` keeps its
 /// existing meaning (full-ingest parser generation) and is untouched.
-pub const SHALLOW_SCANNER_VERSION: u32 = 1;
+pub const SHALLOW_SCANNER_VERSION: u32 = 2;
 
 /// Most bytes a shallow head read may consume from one transcript.
 pub const HEAD_SCAN_MAX_BYTES: u64 = 256 * 1024;
@@ -892,19 +892,7 @@ impl ShallowSessionProvider for CodexProvider {
 }
 
 fn codex_substantive_prompt(value: &Value) -> Option<String> {
-    if value.get("type").and_then(Value::as_str) != Some("event_msg") {
-        return None;
-    }
-    let payload = value.get("payload")?;
-    if payload.get("type").and_then(Value::as_str) != Some("user_message") {
-        return None;
-    }
-    let message = payload.get("message").and_then(Value::as_str)?;
-    let trimmed = message.trim();
-    if trimmed.is_empty() || crate::is_codex_control_context(trimmed) {
-        return None;
-    }
-    Some(excerpt(trimmed))
+    crate::codex::human_message(value).map(|message| excerpt(&message.text))
 }
 
 fn string_list(value: Option<&Value>) -> Vec<String> {

--- a/crates/ai-hist/src/discover/tests.rs
+++ b/crates/ai-hist/src/discover/tests.rs
@@ -573,6 +573,34 @@ fn codex_session_meta_supplies_originator_version_and_git_provenance() {
 }
 
 #[test]
+fn codex_desktop_response_items_supply_the_first_substantive_prompt() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    codex_rollout(
+        home.path(),
+        "codex-desktop",
+        concat!(
+            r#"{"timestamp":"2026-08-31T11:00:00.000Z","type":"session_meta","payload":{"id":"codex-desktop","cwd":"/work/api","thread_source":"user","source":"vscode","originator":"Codex Desktop"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-08-31T11:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>injected</environment_context>"}]}}"#,
+            "\n",
+            r#"{"timestamp":"2026-08-31T11:00:02.000Z","type":"response_item","payload":{"type":"message","role":"user","id":"msg-human","content":[{"type":"input_text","text":"repair"},{"type":"input_text","text":"the parser"}]}}"#,
+            "\n",
+            r#"{"timestamp":"2026-08-31T11:00:02.100Z","type":"event_msg","payload":{"type":"item_completed","item":{"type":"message"}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-08-31T11:00:03.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"working"}]}}"#,
+            "\n",
+        ),
+        1_788_200_000_000,
+    );
+
+    let found = discover(&conn, home.path(), &only(&["codex"]));
+    let row = found.row("codex-desktop");
+    assert_eq!(row.first_prompt.as_deref(), Some("repair\nthe parser"));
+    assert_eq!(row.originator.as_deref(), Some("Codex Desktop"));
+}
+
+#[test]
 fn codex_subagent_threads_are_not_sessions() {
     let conn = catalog();
     let home = tempfile::tempdir().unwrap();

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -23,6 +23,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 mod cloud;
+mod codex;
 /// Fast, shallow coding-agent session discovery and the cache-only catalog
 /// listing that backs it.
 pub mod discover;
@@ -4929,9 +4930,10 @@ fn sync_codex(conn: &Connection, state: &mut Map<String, Value>, home: &Path) ->
 /// conversation into `session_events` / `tool_calls` / `file_edits`.
 ///
 /// Replaces the earlier split walks (state keys `codex_rollouts` and
-/// `codex_rollout_user_messages_v2`) with one stamp map, `codex_rollouts_v3`,
-/// whose per-file record also carries the session id so a wiped database
-/// forces re-ingestion even when the file stamp is unchanged.
+/// `codex_rollout_user_messages_v2`) with one stamp map. The current
+/// `codex_rollouts_v4` generation repairs the user-message parser change by
+/// re-reading unchanged files once. Its per-file record carries the session id
+/// so a wiped database forces re-ingestion even when the file stamp is unchanged.
 /// (session cwds, session branches, prompts inserted).
 type CodexRolloutWalk = (HashMap<String, String>, HashMap<String, String>, usize);
 
@@ -4942,8 +4944,9 @@ fn sync_codex_rollouts(
 ) -> Result<CodexRolloutWalk> {
     let mut cwds = load_state_string_map(state, "codex_session_cwds");
     let mut branches = load_state_string_map(state, "codex_session_branches");
+    let repair_user_messages = !state.contains_key("codex_rollouts_v4");
     let mut seen = state
-        .get("codex_rollouts_v3")
+        .get("codex_rollouts_v4")
         .and_then(Value::as_object)
         .cloned()
         .unwrap_or_default();
@@ -5008,7 +5011,11 @@ fn sync_codex_rollouts(
                     branches.insert(meta.session_id.clone(), branch.clone());
                 }
             }
-            let outcome = ingest_codex_rollout(conn, &rollout, &meta)?;
+            let outcome = if repair_user_messages {
+                repair_codex_rollout_user_messages(conn, &rollout, &meta)?
+            } else {
+                ingest_codex_rollout(conn, &rollout, &meta)?
+            };
             inserted += outcome.prompts;
             events += outcome.events;
             // Subagent threads (guardian/reviewer spawns) keep their events
@@ -5026,6 +5033,13 @@ fn sync_codex_rollouts(
                         outcome.last_assistant_text.as_deref(),
                         Some(&rollout.to_string_lossy()),
                     )?;
+                    if let Some(first_prompt) = outcome.first_prompt.as_deref() {
+                        conn.execute(
+                            "UPDATE sessions SET first_prompt = ? \
+                             WHERE source = 'codex' AND session_id = ?",
+                            params![first_prompt, meta.session_id],
+                        )?;
+                    }
                 }
             }
             seen.insert(
@@ -5051,7 +5065,8 @@ fn sync_codex_rollouts(
                 .collect::<Map<_, _>>(),
         ),
     );
-    state.insert("codex_rollouts_v3".to_string(), Value::Object(seen));
+    state.remove("codex_rollouts_v3");
+    state.insert("codex_rollouts_v4".to_string(), Value::Object(seen));
     if scanned > 0 {
         sync_note!(
             "  [codex-rollouts] scanned {scanned} files; +{inserted} prompts, +{events} events"
@@ -5153,6 +5168,7 @@ struct CodexIngestOutcome {
     events: usize,
     first_ts: Option<i64>,
     last_ts: Option<i64>,
+    first_prompt: Option<String>,
     last_assistant_text: Option<String>,
 }
 
@@ -5246,14 +5262,37 @@ impl CodexTokenTotals {
 /// `tool_calls`, and `file_edits`, and its user prompts into `history`.
 ///
 /// Format notes (verified against rollouts spanning cli 0.36 to 0.148):
-/// message text is taken from the `event_msg` stream only — the
-/// `response_item/message` rows duplicate it, and `response_item/reasoning`
-/// carries encrypted content while the readable stream is
-/// `event_msg/agent_reasoning`. Tool calls are `response_item` rows
-/// correlated by `call_id`. Token usage arrives as cumulative
+/// user text can arrive as either `event_msg/user_message` or
+/// `response_item/message`; adjacent mirrored encodings of one turn are
+/// collapsed. `response_item/reasoning` carries encrypted content while the
+/// readable stream is `event_msg/agent_reasoning`. Tool calls are
+/// `response_item` rows correlated by `call_id`. Token usage arrives as cumulative
 /// `token_count` snapshots; consecutive strictly-advancing snapshots are
 /// diffed into per-request deltas and attached to the nearest assistant
 /// event, so summing `token_json` over a session equals the session total.
+fn repair_codex_rollout_user_messages(
+    conn: &Connection,
+    path: &Path,
+    meta: &CodexSessionMeta,
+) -> Result<CodexIngestOutcome> {
+    // One bounded transaction per rollout makes an interrupted parser upgrade
+    // leave either the old user rows or the fully rebuilt ones. Assistant,
+    // tool, and file-edit evidence is retained and idempotently upserted.
+    let tx = conn.unchecked_transaction()?;
+    tx.execute(
+        "DELETE FROM session_events \
+         WHERE source = 'codex' AND session_id = ? AND role = 'user'",
+        [meta.session_id.as_str()],
+    )?;
+    tx.execute(
+        "DELETE FROM history WHERE source = 'codex' AND session_id = ?",
+        [meta.session_id.as_str()],
+    )?;
+    let outcome = ingest_codex_rollout(&tx, path, meta)?;
+    tx.commit()?;
+    Ok(outcome)
+}
+
 fn ingest_codex_rollout(
     conn: &Connection,
     path: &Path,
@@ -5269,6 +5308,7 @@ fn ingest_codex_rollout(
     let mut pending_delta: Option<CodexTokenTotals> = None;
     let mut untokened_assistant_uid: Option<String> = None;
     let mut saw_model_output = false;
+    let mut human_messages = codex::HumanMessageDeduper::default();
     let mut reader = BufReader::new(file);
     let mut raw = Vec::new();
     let mut line_index = 0usize;
@@ -5305,6 +5345,49 @@ fn ingest_codex_rollout(
         }
         let payload_type = payload.get("type").and_then(Value::as_str).unwrap_or("");
         let payload_str = |key: &str| payload.get(key).and_then(Value::as_str);
+        if let Some(message) = human_messages.observe(&value) {
+            let suffix = match message.format {
+                codex::HumanMessageFormat::EventMessage => "user_message",
+                codex::HumanMessageFormat::ResponseItem => "response_item_user_message",
+            };
+            let uid = format!("{index}:{suffix}");
+            let message_id = message.message_id.as_deref().unwrap_or(uid.as_str());
+            insert_codex_event(
+                conn,
+                session_id,
+                cwd,
+                branch,
+                ts_ms,
+                "user",
+                "text",
+                &message.text,
+                &uid,
+                message_id,
+                None,
+                None,
+            )?;
+            outcome.events += 1;
+            // A subagent's "user" turns are the parent agent's task prompts;
+            // only human threads feed prompt history and session discovery.
+            if !meta.is_subagent {
+                outcome
+                    .first_prompt
+                    .get_or_insert_with(|| message.text.chars().take(4096).collect());
+                outcome.prompts += insert_history(
+                    conn,
+                    &HistoryEntry {
+                        id: 0,
+                        source: "codex".into(),
+                        session_id: Some(meta.session_id.clone()),
+                        project: Some(meta.cwd.clone()),
+                        prompt_hash: Some(prompt_hash(&message.text)),
+                        prompt: message.text,
+                        timestamp_ms: ts_ms,
+                    },
+                )?;
+            }
+            continue;
+        }
         match line_type {
             "turn_context" => {
                 if let Some(m) = payload_str("model") {
@@ -5312,37 +5395,7 @@ fn ingest_codex_rollout(
                 }
             }
             "event_msg" => match payload_type {
-                "user_message" => {
-                    for prompt in codex_rollout_user_prompts(&value) {
-                        if is_codex_control_context(&prompt) {
-                            continue;
-                        }
-                        let uid = format!("{index}:user_message");
-                        insert_codex_event(
-                            conn, session_id, cwd, branch, ts_ms, "user", "text", &prompt, &uid,
-                            &uid, None, None,
-                        )?;
-                        outcome.events += 1;
-                        // A subagent's "user" turns are the parent agent's
-                        // task prompts; only human threads feed the prompt
-                        // history that session discovery is built on.
-                        if meta.is_subagent {
-                            continue;
-                        }
-                        outcome.prompts += insert_history(
-                            conn,
-                            &HistoryEntry {
-                                id: 0,
-                                source: "codex".into(),
-                                session_id: Some(meta.session_id.clone()),
-                                project: Some(meta.cwd.clone()),
-                                prompt_hash: Some(prompt_hash(&prompt)),
-                                prompt,
-                                timestamp_ms: ts_ms,
-                            },
-                        )?;
-                    }
-                }
+                "user_message" => {}
                 "agent_message" => {
                     if let Some(message) = payload_str("message").filter(|m| !m.trim().is_empty()) {
                         let uid = format!("{index}:agent_message");
@@ -5637,9 +5690,9 @@ fn ingest_codex_rollout(
                 // Readable reasoning arrives as event_msg/agent_reasoning;
                 // this row is encrypted, but it still marks model output.
                 "reasoning" => saw_model_output = true,
-                // `response_item` messages duplicate the event_msg text
-                // stream; ingesting both would double every message. An
-                // assistant one still marks model output for token baselines.
+                // Assistant `response_item` messages still duplicate the
+                // readable event_msg stream, but mark model output for token
+                // baselines. User messages were handled canonically above.
                 "message" if payload_str("role") == Some("assistant") => saw_model_output = true,
                 _ => {}
             },
@@ -5736,40 +5789,6 @@ fn count_unified_diff_lines(diff: &str) -> (i64, i64) {
         }
     }
     (added, removed)
-}
-
-fn codex_rollout_user_prompts(value: &Value) -> Vec<String> {
-    let mut prompts = Vec::new();
-    let payload = value.get("payload").and_then(Value::as_object);
-    if value.get("type").and_then(Value::as_str) == Some("event_msg")
-        && payload.and_then(|p| p.get("type")).and_then(Value::as_str) == Some("user_message")
-    {
-        if let Some(message) = payload
-            .and_then(|p| p.get("message"))
-            .and_then(Value::as_str)
-        {
-            if !message.trim().is_empty() {
-                prompts.push(message.trim().to_string());
-            }
-        }
-    }
-    prompts
-}
-
-fn is_codex_control_context(prompt: &str) -> bool {
-    let value = prompt.trim_start();
-    [
-        "<environment_context",
-        "<permissions instructions",
-        "<app-context",
-        "<skills_instructions",
-        "<collaboration_mode",
-        "<INSTRUCTIONS>",
-        "<user_instructions",
-        "# AGENTS.md",
-    ]
-    .iter()
-    .any(|prefix| value.starts_with(prefix))
 }
 
 fn backfill_codex_metadata(
@@ -7559,10 +7578,10 @@ fn home_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::{
-        checkpoint_sync_state, cleanup_stale_sync_state_temps, codex_rollout_user_prompts,
-        cron_schedule, doctor_report, export_history, file_stamp, git_commit_time_ms, git_stdout,
-        import_history, ingest_claude_transcript, is_sqlite_contention, link_git_commit,
-        load_sync_state, parse_trajectory_file, paths_overlap, prepare_sync_and_push_db,
+        checkpoint_sync_state, cleanup_stale_sync_state_temps, cron_schedule, doctor_report,
+        export_history, file_stamp, git_commit_time_ms, git_stdout, import_history,
+        ingest_claude_transcript, is_sqlite_contention, link_git_commit, load_sync_state,
+        parse_trajectory_file, paths_overlap, prepare_sync_and_push_db,
         process_status_with_programs, save_sync_state, search_all, service_command_args,
         shell_single_quote, source_database_path, strip_url_credentials,
         sync_claude_session_metadata, sync_exclusive, sync_local_at, sync_opencode_exclusive,
@@ -7608,34 +7627,6 @@ mod tests {
             super::DecodedFileCursor::Typed(cursor) => cursor,
             super::DecodedFileCursor::Legacy(_) => panic!("expected typed cursor"),
         }
-    }
-
-    #[test]
-    fn codex_rollout_prompts_normalize_desktop_user_turns() {
-        let event = json!({
-            "type": "event_msg",
-            "payload": {"type": "user_message", "message": "  fix the importer  "}
-        });
-        assert_eq!(codex_rollout_user_prompts(&event), vec!["fix the importer"]);
-
-        let mirrored_response_item = json!({
-            "type": "response_item",
-            "payload": {
-                "type": "message",
-                "role": "user",
-                "content": [
-                    {"type": "input_text", "text": "summarize this task"},
-                    {"type": "image", "url": "ignored"}
-                ]
-            }
-        });
-        assert!(codex_rollout_user_prompts(&mirrored_response_item).is_empty());
-
-        let assistant = json!({
-            "type": "response_item",
-            "payload": {"type": "message", "role": "assistant", "content": "ignored"}
-        });
-        assert!(codex_rollout_user_prompts(&assistant).is_empty());
     }
 
     #[test]
@@ -9034,6 +9025,109 @@ mod tests {
         super::read_codex_session_meta(path).unwrap().unwrap()
     }
 
+    fn response_user(ts: &str, text: &str) -> String {
+        serde_json::json!({
+            "timestamp": ts,
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}]
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn ingests_current_codex_desktop_user_messages_and_filters_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout-current.jsonl");
+        fs::write(
+            &path,
+            format!(
+                "{}\n{}\n{}\n{}\n{}\n{}\n",
+                r#"{"timestamp":"2026-08-31T10:00:00.000Z","type":"session_meta","payload":{"id":"sess-current","cwd":"/tmp/proj","thread_source":"user","source":"vscode","originator":"Codex Desktop"}}"#,
+                response_user(
+                    "2026-08-31T10:00:01.000Z",
+                    "<environment_context>injected</environment_context>"
+                ),
+                serde_json::json!({
+                    "timestamp": "2026-08-31T10:00:02.000Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message", "role": "user", "id": "msg_user_1",
+                        "content": [
+                            {"type": "input_text", "text": "fix"},
+                            {"type": "input_text", "text": "the scanner"}
+                        ]
+                    }
+                }),
+                r#"{"timestamp":"2026-08-31T10:00:02.100Z","type":"event_msg","payload":{"type":"item_completed"}}"#,
+                r#"{"timestamp":"2026-08-31T10:00:03.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"duplicate assistant stream"}]}}"#,
+                r#"{"timestamp":"2026-08-31T10:00:03.100Z","type":"event_msg","payload":{"type":"agent_message","message":"Done."}}"#,
+            ),
+        )
+        .unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+
+        let outcome = super::ingest_codex_rollout(&conn, &path, &codex_meta(&path)).unwrap();
+        assert_eq!(outcome.prompts, 1);
+        assert_eq!(outcome.events, 2);
+        assert_eq!(outcome.first_prompt.as_deref(), Some("fix\nthe scanner"));
+        let rows: Vec<(String, String, String)> = conn
+            .prepare("SELECT role, text, message_id FROM session_events ORDER BY ts_ms")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                (
+                    "user".into(),
+                    "fix\nthe scanner".into(),
+                    "msg_user_1".into()
+                ),
+                ("assistant".into(), "Done.".into(), "5:agent_message".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn codex_user_mirrors_dedupe_but_repeated_turns_survive() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout-mirrors.jsonl");
+        fs::write(
+            &path,
+            format!(
+                "{}\n{}\n{}\n{}\n{}\n",
+                r#"{"timestamp":"2026-08-31T10:00:00.000Z","type":"session_meta","payload":{"id":"sess-mirror","cwd":"/tmp/proj"}}"#,
+                response_user("2026-08-31T10:00:01.000Z", "retry"),
+                r#"{"timestamp":"2026-08-31T10:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"retry"}}"#,
+                r#"{"timestamp":"2026-08-31T10:00:02.000Z","type":"event_msg","payload":{"type":"agent_message","message":"Try one."}}"#,
+                response_user("2026-08-31T10:00:03.000Z", "retry"),
+            ),
+        )
+        .unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+
+        let outcome = super::ingest_codex_rollout(&conn, &path, &codex_meta(&path)).unwrap();
+        assert_eq!(outcome.prompts, 2);
+        let user_rows: Vec<(i64, String)> = conn
+            .prepare("SELECT ts_ms, text FROM session_events WHERE role='user' ORDER BY ts_ms")
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(user_rows.len(), 2);
+        assert_eq!(user_rows[0].1, "retry");
+        assert_eq!(user_rows[1].1, "retry");
+    }
+
     #[test]
     fn ingests_codex_rollout_events_tools_edits_and_token_deltas() {
         let dir = tempfile::tempdir().unwrap();
@@ -9204,6 +9298,111 @@ mod tests {
     }
 
     #[test]
+    fn codex_v4_repair_restores_users_without_duplicating_existing_evidence() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        let day = home.join(".codex/sessions/2026/08/31");
+        fs::create_dir_all(&day).unwrap();
+        let path = day.join("rollout-2026-08-31T10-00-00-repair.jsonl");
+        fs::write(
+            &path,
+            format!(
+                "{}\n{}\n{}\n{}\n",
+                r#"{"timestamp":"2026-08-31T10:00:00.000Z","type":"session_meta","payload":{"id":"sess-repair","cwd":"/tmp/proj"}}"#,
+                response_user("2026-08-31T10:00:01.000Z", "restore my prompt"),
+                r#"{"timestamp":"2026-08-31T10:00:02.000Z","type":"response_item","payload":{"type":"function_call","id":"fc_1","name":"exec_command","arguments":"{\"cmd\":\"git status\"}","call_id":"call_1"}}"#,
+                r#"{"timestamp":"2026-08-31T10:00:03.000Z","type":"event_msg","payload":{"type":"agent_message","message":"Done."}}"#,
+            ),
+        )
+        .unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO sessions (session_id, source, cwd, first_activity_ms, last_activity_ms) \
+             VALUES ('sess-repair', 'codex', '/tmp/proj', 1, 2)",
+            [],
+        )
+        .unwrap();
+        super::insert_session_event(
+            &conn,
+            "codex",
+            "sess-repair",
+            Some("/tmp/proj"),
+            Some("/tmp/proj"),
+            None,
+            "3:agent_message",
+            None,
+            1_788_176_403_000,
+            "assistant",
+            "text",
+            Some("Done."),
+            None,
+            None,
+            "3:agent_message",
+        )
+        .unwrap();
+        super::insert_tool_call(
+            &conn,
+            "codex",
+            "sess-repair",
+            "fc_1",
+            "call_1",
+            "exec_command",
+            Some("git status"),
+            r#"{"cmd":"git status"}"#,
+            None,
+            1_788_176_402_000,
+        )
+        .unwrap();
+
+        let mut state = Map::new();
+        state.insert(
+            "codex_rollouts_v3".into(),
+            json!({path.to_string_lossy().to_string(): {
+                "stamp": super::file_stamp(&path).unwrap(),
+                "session": "sess-repair"
+            }}),
+        );
+        super::sync_codex_rollouts(&conn, &mut state, home).unwrap();
+        let counts: (i64, i64, i64, Option<String>) = conn
+            .query_row(
+                "SELECT \
+                 (SELECT COUNT(*) FROM history WHERE session_id='sess-repair'), \
+                 (SELECT COUNT(*) FROM session_events WHERE session_id='sess-repair' AND role='user'), \
+                 (SELECT COUNT(*) FROM session_events WHERE session_id='sess-repair' AND role='assistant'), \
+                 (SELECT first_prompt FROM sessions WHERE session_id='sess-repair')",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(counts, (1, 1, 2, Some("restore my prompt".into())));
+        let tool_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM tool_calls WHERE session_id='sess-repair'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(tool_count, 1);
+        assert!(state.get("codex_rollouts_v3").is_none());
+        assert!(state.get("codex_rollouts_v4").is_some());
+
+        super::sync_codex_rollouts(&conn, &mut state, home).unwrap();
+        let second_counts: (i64, i64, i64, i64) = conn
+            .query_row(
+                "SELECT \
+                 (SELECT COUNT(*) FROM history WHERE session_id='sess-repair'), \
+                 (SELECT COUNT(*) FROM session_events WHERE session_id='sess-repair' AND role='user'), \
+                 (SELECT COUNT(*) FROM session_events WHERE session_id='sess-repair' AND role='assistant'), \
+                 (SELECT COUNT(*) FROM tool_calls WHERE session_id='sess-repair')",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(second_counts, (1, 1, 2, 1));
+    }
+
+    #[test]
     fn resumed_codex_rollout_treats_first_snapshot_as_carried_baseline() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("rollout-resumed.jsonl");
@@ -9275,6 +9474,7 @@ mod tests {
             day.join("rollout-2026-08-01T10-01-00-sub.jsonl"),
             concat!(
                 r#"{"timestamp":"2026-08-01T10:01:00.000Z","type":"session_meta","payload":{"id":"sess-sub","session_id":"sess-top","parent_thread_id":"sess-top","thread_source":"subagent","source":{"subagent":{"other":"guardian"}},"cwd":"/tmp/proj"}}"#, "\n",
+                r#"{"timestamp":"2026-08-01T10:01:00.500Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Review the implementation."}]}}"#, "\n",
                 r#"{"timestamp":"2026-08-01T10:01:01.000Z","type":"event_msg","payload":{"type":"agent_message","message":"Reviewing."}}"#, "\n",
             ),
         )
@@ -9340,6 +9540,14 @@ mod tests {
             event_sessions,
             vec!["sess-sub".to_string(), "sess-top".to_string()]
         );
+        let sub_user_events: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_events WHERE session_id='sess-sub' AND role='user'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(sub_user_events, 1);
 
         // A second walk with unchanged stamps ingests nothing new.
         let before: i64 = conn


### PR DESCRIPTION
## Summary

- centralize Codex human-message extraction for legacy event_msg/user_message and current response_item/message records
- use the shared parser in bounded discovery and full history/event ingestion while preserving control-context and subagent behavior
- deduplicate only adjacent, equal-text records in opposite encodings so intentional repeated turns survive
- bump the shallow scanner and Codex rollout state to v4, transactionally rebuilding only user/history rows while preserving assistant, tool, and file-edit evidence

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -A clippy::too_many_arguments -D warnings
- cargo test --workspace
- native N-API debug build
- TypeScript lint and all 12 SDK tests
- focused Codex regression suite: 15 tests
- real local verification for the three reported session IDs: non-control firstPrompt restored, matching history present, matching normalized user event present exactly once

## Notes

The shallow read remains capped at the existing 256 KiB head budget. Multipart response input text is joined in provider order with newlines. Deduplication is intentionally adjacency-scoped rather than global text deduplication.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

