### PR TITLE
Retry npm registry smoke installs after publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Rust formatting
         run: cargo fmt --all -- --check
 
+      - name: Release workflow tests
+        run: node --test scripts/*.test.mjs
+
       - name: Rust lint
         run: cargo clippy --workspace --all-targets -- -A clippy::too_many_arguments -D warnings
 

--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -381,14 +381,16 @@ jobs:
           SMOKE=$(mktemp -d)
           cd "$SMOKE"
           npm init -y
-          npm install "ai-hist@$VERSION" "ai-hist-mcp@$VERSION"
+          node "$GITHUB_WORKSPACE/scripts/npm-install-with-registry-retry.mjs" \
+            "ai-hist@$VERSION" "ai-hist-mcp@$VERSION"
           ./node_modules/.bin/ai-hist sessions list --db "$SMOKE/empty.db" --json
           timeout 2 ./node_modules/.bin/ai-hist-mcp </dev/null || test $? -eq 124
 
           NO_OPTIONAL=$(mktemp -d)
           cd "$NO_OPTIONAL"
           npm init -y
-          npm install --omit=optional "ai-hist@$VERSION"
+          node "$GITHUB_WORKSPACE/scripts/npm-install-with-registry-retry.mjs" \
+            --omit=optional "ai-hist@$VERSION"
           node --input-type=module -e '
             import("ai-hist").then((sdk) => sdk.recent()).then(
               () => process.exit(1),

--- a/scripts/npm-install-with-registry-retry.mjs
+++ b/scripts/npm-install-with-registry-retry.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const DEFAULT_ATTEMPTS = 18;
+const DEFAULT_DELAY_MS = 5_000;
+
+export function isRegistryVisibilityFailure(output) {
+  return /\b(?:ETARGET|E404)\b/.test(output);
+}
+
+function runNpmInstall(args) {
+  const cache = mkdtempSync(join(tmpdir(), 'ai-hist-npm-cache-'));
+  try {
+    const result = spawnSync('npm', ['install', '--prefer-online', ...args], {
+      encoding: 'utf8',
+      env: { ...process.env, npm_config_cache: cache },
+    });
+    if (result.error) throw result.error;
+    return {
+      status: result.status ?? 1,
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+    };
+  } finally {
+    rmSync(cache, { recursive: true, force: true });
+  }
+}
+
+function clearPartialInstall(cwd = process.cwd()) {
+  rmSync(join(cwd, 'node_modules'), { recursive: true, force: true });
+  rmSync(join(cwd, 'package-lock.json'), { force: true });
+}
+
+function delay(ms) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
+}
+
+function positiveInteger(value, fallback, name) {
+  if (value === undefined || value === '') return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+export async function installWithRegistryRetry(args, options = {}) {
+  if (args.length === 0) throw new Error('at least one npm install argument is required');
+
+  const attempts = options.attempts ?? DEFAULT_ATTEMPTS;
+  const delayMs = options.delayMs ?? DEFAULT_DELAY_MS;
+  const runInstall = options.runInstall ?? runNpmInstall;
+  const sleep = options.sleep ?? delay;
+  const reset = options.reset ?? clearPartialInstall;
+  const emit = options.emit ?? ((stream, output) => stream.write(output));
+  const log = options.log ?? ((message) => console.error(message));
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = runInstall(args);
+    emit(process.stdout, result.stdout);
+    emit(process.stderr, result.stderr);
+    if (result.status === 0) return;
+
+    const output = `${result.stdout}\n${result.stderr}`;
+    const retryable = isRegistryVisibilityFailure(output);
+    if (!retryable || attempt === attempts) {
+      const reason = retryable
+        ? `npm registry did not expose the requested packages after ${attempts} attempts`
+        : 'npm install failed with a non-registry-visibility error';
+      const error = new Error(reason);
+      error.exitCode = result.status || 1;
+      throw error;
+    }
+
+    log(
+      `npm registry has not exposed all requested packages `
+        + `(attempt ${attempt}/${attempts}); retrying in ${delayMs}ms`,
+    );
+    reset();
+    await sleep(delayMs);
+  }
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+const modulePath = fileURLToPath(import.meta.url);
+if (invokedPath === modulePath) {
+  const attempts = positiveInteger(
+    process.env.NPM_REGISTRY_RETRY_ATTEMPTS,
+    DEFAULT_ATTEMPTS,
+    'NPM_REGISTRY_RETRY_ATTEMPTS',
+  );
+  const delayMs = positiveInteger(
+    process.env.NPM_REGISTRY_RETRY_DELAY_MS,
+    DEFAULT_DELAY_MS,
+    'NPM_REGISTRY_RETRY_DELAY_MS',
+  );
+  installWithRegistryRetry(process.argv.slice(2), { attempts, delayMs }).catch((error) => {
+    console.error(error.message);
+    process.exitCode = error.exitCode ?? 1;
+  });
+}

--- a/scripts/npm-install-with-registry-retry.test.mjs
+++ b/scripts/npm-install-with-registry-retry.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  installWithRegistryRetry,
+  isRegistryVisibilityFailure,
+} from './npm-install-with-registry-retry.mjs';
+
+const quiet = {
+  emit: () => {},
+  log: () => {},
+  reset: () => {},
+};
+
+test('recognizes only npm registry visibility errors as retryable', () => {
+  assert.equal(isRegistryVisibilityFailure('npm error code ETARGET'), true);
+  assert.equal(isRegistryVisibilityFailure('npm error code E404'), true);
+  assert.equal(isRegistryVisibilityFailure('npm error code EACCES'), false);
+  assert.equal(isRegistryVisibilityFailure('network timeout'), false);
+});
+
+test('retries a registry miss until the exact release becomes installable', async () => {
+  const results = [
+    { status: 1, stdout: '', stderr: 'npm error code ETARGET' },
+    { status: 1, stdout: '', stderr: 'npm error code E404' },
+    { status: 0, stdout: 'installed', stderr: '' },
+  ];
+  const waits = [];
+  let resets = 0;
+
+  await installWithRegistryRetry(['ai-hist@0.9.0'], {
+    ...quiet,
+    attempts: 5,
+    delayMs: 7,
+    runInstall: () => results.shift(),
+    sleep: async (ms) => waits.push(ms),
+    reset: () => { resets += 1; },
+  });
+
+  assert.deepEqual(waits, [7, 7]);
+  assert.equal(resets, 2);
+  assert.equal(results.length, 0);
+});
+
+test('fails immediately for authentication and other non-propagation errors', async () => {
+  let calls = 0;
+  await assert.rejects(
+    installWithRegistryRetry(['ai-hist@0.9.0'], {
+      ...quiet,
+      attempts: 5,
+      runInstall: () => {
+        calls += 1;
+        return { status: 7, stdout: '', stderr: 'npm error code E401' };
+      },
+      sleep: async () => assert.fail('non-retryable failures must not sleep'),
+    }),
+    (error) => error.exitCode === 7 && /non-registry-visibility/.test(error.message),
+  );
+  assert.equal(calls, 1);
+});
+
+test('fails after the bounded number of registry visibility attempts', async () => {
+  let calls = 0;
+  await assert.rejects(
+    installWithRegistryRetry(['ai-hist@0.9.0'], {
+      ...quiet,
+      attempts: 3,
+      delayMs: 1,
+      runInstall: () => {
+        calls += 1;
+        return { status: 1, stdout: '', stderr: 'npm error code ETARGET' };
+      },
+      sleep: async () => {},
+    }),
+    /after 3 attempts/,
+  );
+  assert.equal(calls, 3);
+});


### PR DESCRIPTION
## Summary

- retry clean installs only for npm ETARGET and E404 registry-visibility failures
- use fresh npm cache state and clear partial installs between bounded attempts
- fail immediately for authentication, permission, network, and package execution errors
- exercise the helper in normal CI

## Context

Release run 33418857733 successfully published ai-hist and ai-hist-mcp 0.9.0, then started its registry smoke install within seconds. The registry read endpoint had not exposed ai-hist 0.9.0 yet and returned ETARGET.

## Verification

- node --test scripts/*.test.mjs
- actionlint .github/workflows/ci.yml .github/workflows/publish-napi.yml
- YAML parse for both workflows
- real clean install of ai-hist 0.9.0 and ai-hist-mcp 0.9.0 using the helper
- installed CLI sessions list smoke test

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

