### PR TITLE
Fix native contract smoke tests

### DIFF
--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -123,12 +123,12 @@ jobs:
       - name: Execute native contract smoke test
         if: matrix.test_native
         shell: bash
-        run: node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==3) process.exit(1)"
+        run: node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==4) process.exit(1)"
 
       - name: Execute musl native contract smoke test
         if: matrix.test_musl
         shell: bash
-        run: docker run --rm -v "$PWD:/work" -w /work node:22-alpine node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==3) process.exit(1)"
+        run: docker run --rm -v "$PWD:/work" -w /work node:22-alpine node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==4) process.exit(1)"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- update GNU native addon smoke test to expect contract version 4
- update musl native addon smoke test to expect contract version 4

## Why
The native addon and TypeScript SDK were bumped to contract version 4, but the publish workflow still asserted version 3, causing successful builds to exit with code 1 during smoke testing.

## Validation
- actionlint .github/workflows/publish-napi.yml
- git diff --check

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

