### PR TITLE
fix: discover standalone Codex subagents

### DIFF
--- a/crates/ai-hist/src/discover.rs
+++ b/crates/ai-hist/src/discover.rs
@@ -79,7 +79,14 @@ pub const SESSION_CATALOG_CONTRACT_VERSION: u32 = 3;
 /// invalidates every stored stamp, so a scanner that learns to extract a new
 /// field re-reads sources whose bytes never changed. `parser_version` keeps its
 /// existing meaning (full-ingest parser generation) and is untouched.
-pub const SHALLOW_SCANNER_VERSION: u32 = 2;
+pub const SHALLOW_SCANNER_VERSION: u32 = 3;
+
+/// Version 2 shipped the classification that hid standalone guardians (see
+/// [`crate::codex_is_subagent`]). Their rollouts never change on disk, so the
+/// only thing that can invalidate an upgraded install's stored `discovery_skips`
+/// is this version, and reusing 2 would leave those catalogs permanently missing
+/// the sessions. Kept as a compile-time guard so the pair cannot drift apart.
+const _: () = assert!(SHALLOW_SCANNER_VERSION > 2);
 
 /// Most bytes a shallow head read may consume from one transcript.
 pub const HEAD_SCAN_MAX_BYTES: u64 = 256 * 1024;

--- a/crates/ai-hist/src/discover.rs
+++ b/crates/ai-hist/src/discover.rs
@@ -868,16 +868,10 @@ impl ShallowSessionProvider for CodexProvider {
         else {
             return Ok(None);
         };
-        // Subagent threads are real rollouts but not user sessions; the full
-        // sync excludes them from `sessions` and so does discovery.
-        let is_subagent = payload
-            .and_then(|p| p.get("thread_source"))
-            .and_then(Value::as_str)
-            == Some("subagent")
-            || payload
-                .and_then(|p| p.get("source"))
-                .and_then(Value::as_object)
-                .is_some_and(|s| s.contains_key("subagent"));
+        // Linked subagent threads are real rollouts but not root sessions;
+        // standalone guardian rollouts may carry `source.subagent` without a
+        // parent and are cataloged under their own payload.id.
+        let is_subagent = crate::codex_is_subagent(payload, session_id);
         if is_subagent {
             return Ok(None);
         }

--- a/crates/ai-hist/src/discover/tests.rs
+++ b/crates/ai-hist/src/discover/tests.rs
@@ -630,6 +630,64 @@ fn codex_subagent_threads_are_not_sessions() {
 }
 
 #[test]
+fn linked_codex_source_marked_subagent_is_not_a_root_session() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    codex_rollout(home.path(), "codex-1", CODEX_BODY, 1_750_000_200_000);
+    codex_rollout(
+        home.path(),
+        "codex-linked-guardian",
+        concat!(
+            r#"{"timestamp":"2026-06-20T11:02:00.000Z","type":"session_meta","payload":{"id":"codex-linked-guardian","cwd":"/work/api","parent_thread_id":"codex-1","source":{"subagent":{"other":"guardian"}}}}"#,
+            "\n"
+        ),
+        1_750_000_300_000,
+    );
+
+    let found = discover(&conn, home.path(), &only(&["codex"]));
+    assert_eq!(found.ids(), vec!["codex:codex-1"]);
+    assert_eq!(found.summary.providers["codex"].candidates, 2);
+    assert_eq!(found.summary.discovered, 1);
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(rows, 1);
+}
+
+#[test]
+fn standalone_codex_guardian_source_marker_is_a_root_session() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    codex_rollout(home.path(), "codex-1", CODEX_BODY, 1_750_000_200_000);
+    let guardian = codex_rollout(
+        home.path(),
+        "codex-guardian",
+        concat!(
+            r#"{"timestamp":"2026-06-20T11:02:00.000Z","type":"session_meta","payload":{"id":"codex-guardian","cwd":"/work/api","source":{"subagent":{"other":"guardian"}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-06-20T11:02:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"guardian prompt"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-06-20T11:02:02.000Z","type":"event_msg","payload":{"type":"agent_message","message":"guardian answer"}}"#,
+            "\n",
+        ),
+        1_750_000_300_000,
+    );
+
+    let found = discover(&conn, home.path(), &only(&["codex"]));
+    assert!(found.ids().contains(&"codex:codex-guardian".to_string()));
+    assert_eq!(found.summary.providers["codex"].candidates, 2);
+    assert_eq!(found.summary.discovered, 2);
+    let row = found.row("codex-guardian");
+    assert_eq!(row.cwd.as_deref(), Some("/work/api"));
+    assert_eq!(row.first_prompt.as_deref(), Some("guardian prompt"));
+    assert_eq!(row.raw_path.as_deref(), Some(guardian.to_str().unwrap()));
+    let rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(rows, 2);
+}
+
+#[test]
 fn codex_rescan_is_stamp_guarded_and_identity_stable() {
     let conn = catalog();
     let home = tempfile::tempdir().unwrap();

--- a/crates/ai-hist/src/discover/tests.rs
+++ b/crates/ai-hist/src/discover/tests.rs
@@ -687,6 +687,72 @@ fn standalone_codex_guardian_source_marker_is_a_root_session() {
     assert_eq!(rows, 2);
 }
 
+/// A guardian an older release classified as a subagent was remembered in
+/// `discovery_skips`. Its bytes never change, so only the scanner version in the
+/// stored stamp can invalidate that memory -- without a bump, upgraded installs
+/// keep skipping the file and the catalog never gains the session.
+#[test]
+fn an_upgrade_re_reads_a_guardian_an_older_scanner_skipped() {
+    const GUARDIAN: &str = concat!(
+        r#"{"timestamp":"2026-06-20T11:02:00.000Z","type":"session_meta","payload":{"id":"codex-guardian","cwd":"/work/api","source":{"subagent":{"other":"guardian"}}}}"#,
+        "\n",
+        r#"{"timestamp":"2026-06-20T11:02:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"guardian prompt"}}"#,
+        "\n",
+    );
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    codex_rollout(home.path(), "codex-1", CODEX_BODY, 1_750_000_200_000);
+    let guardian = codex_rollout(home.path(), "codex-guardian", GUARDIAN, 1_750_000_300_000);
+    let locator = guardian.to_string_lossy().to_string();
+
+    // Learn this fixture's raw stamp the way discovery computes it, so the seeded
+    // skip below differs from a live one *only* by its version prefix.
+    let first = discover(&conn, home.path(), &only(&["codex"]));
+    assert!(first.ids().contains(&"codex:codex-guardian".to_string()));
+    let stored: String = conn
+        .query_row(
+            "SELECT source_stamp FROM sessions WHERE source='codex' AND session_id='codex-guardian'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let raw = stored
+        .split_once(':')
+        .expect("stored stamps carry a version prefix")
+        .1
+        .to_string();
+
+    let seed_skip = |stamp: String| {
+        conn.execute("DELETE FROM sessions", []).unwrap();
+        conn.execute(
+            "INSERT INTO discovery_skips (source, locator, stamp, reason, updated_ms) \
+             VALUES ('codex', ?, ?, 'not-a-session', 0) \
+             ON CONFLICT(source, locator) DO UPDATE SET stamp = excluded.stamp",
+            params![locator, stamp],
+        )
+        .unwrap();
+    };
+
+    // Control: a skip at the current version does suppress the re-read, so the
+    // assertion below is about the version prefix and nothing else.
+    seed_skip(stored_stamp(&raw));
+    let skipped = discover(&conn, home.path(), &only(&["codex"]));
+    assert!(
+        !skipped.ids().contains(&"codex:codex-guardian".to_string()),
+        "a current-version skip is expected to suppress the read"
+    );
+
+    // What an older release left behind: same bytes, its own scanner version.
+    seed_skip(format!("v{}:{raw}", SHALLOW_SCANNER_VERSION - 1));
+    let after_upgrade = discover(&conn, home.path(), &only(&["codex"]));
+    assert!(
+        after_upgrade
+            .ids()
+            .contains(&"codex:codex-guardian".to_string()),
+        "a skip written by an older scanner version must not survive the upgrade"
+    );
+}
+
 #[test]
 fn codex_rescan_is_stamp_guarded_and_identity_stable() {
     let conn = catalog();

--- a/crates/ai-hist/src/hydrate.rs
+++ b/crates/ai-hist/src/hydrate.rs
@@ -2660,6 +2660,58 @@ mod tests {
     }
 
     #[test]
+    fn standalone_codex_guardian_source_marker_hydrates_without_a_relation() {
+        let dir = tempfile::tempdir().unwrap();
+        let day = dir.path().join(".codex/sessions/2026/05/05");
+        fs::create_dir_all(&day).unwrap();
+        let guardian = day.join("rollout-guardian.jsonl");
+        fs::write(
+            &guardian,
+            concat!(
+                "{\"timestamp\":\"2026-05-05T19:13:27Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"guardian\",\"cwd\":\"/work/api\",\"source\":{\"subagent\":{\"other\":\"guardian\"}}}}\n",
+                "{\"timestamp\":\"2026-05-05T19:13:28Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"guardian prompt\"}}\n",
+                "{\"timestamp\":\"2026-05-05T19:13:29Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"guardian answer\"}}\n",
+            ),
+        )
+        .unwrap();
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "codex", "guardian", Some(&guardian));
+        drop(conn);
+
+        let first =
+            hydrate_session_at_with_home(&db, &options("codex", "guardian"), dir.path()).unwrap();
+        assert_eq!(first.status, "hydrated");
+        assert_eq!(first.related_session_ids, Vec::<String>::new());
+        assert_eq!(first.evidence.prompts, 1);
+        assert_eq!(first.evidence.events, 2);
+        assert_eq!(first.evidence.tool_calls, 0);
+
+        let conn = open_db(&db).unwrap();
+        let raw_path: String = conn
+            .query_row(
+                "SELECT raw_path FROM sessions WHERE source='codex' AND session_id='guardian'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(raw_path, guardian.to_string_lossy());
+        let relationships: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_relationships WHERE source='codex'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(relationships, 0);
+        let second =
+            hydrate_session_at_with_home(&db, &options("codex", "guardian"), dir.path()).unwrap();
+        assert_eq!(second.status, "unchanged");
+        assert_eq!(second.evidence.prompts, 1);
+        assert_eq!(second.evidence.events, 2);
+    }
+
+    #[test]
     fn thousands_of_unrelated_catalog_rows_do_not_expand_hydration_work() {
         let dir = tempfile::tempdir().unwrap();
         let transcript = dir.path().join(".claude/projects/app/selected.jsonl");

--- a/crates/ai-hist/src/hydrate.rs
+++ b/crates/ai-hist/src/hydrate.rs
@@ -1752,6 +1752,8 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
+        // Carried from the catalog row seeded above rather than recomputed, so this
+        // stays on that fixture's literal across scanner-version bumps.
         assert_eq!(presence_stamp, "v2:test-discovery-stamp");
 
         let second =

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -5319,10 +5319,12 @@ fn sync_codex(conn: &Connection, state: &mut Map<String, Value>, home: &Path) ->
 ///
 /// Replaces the earlier split walks (state keys `codex_rollouts` and
 /// `codex_rollout_user_messages_v2`) with one stamp map. The current
-/// `codex_rollouts_v4` generation repairs the user-message parser change by
-/// re-reading unchanged files once. Its per-file record carries the session id
-/// so a wiped database forces re-ingestion even when the file stamp is unchanged.
-/// (session cwds, session branches, prompts inserted).
+/// `codex_rollouts_v5` generation repairs the user-message parser change
+/// and reclassifies existing `source.subagent` markers by re-reading unchanged
+/// files once. Its per-file record carries the session id and classification so
+/// a wiped database or an older standalone-guardian classification forces the
+/// necessary re-ingestion even when the file stamp is unchanged. (session cwds,
+/// session branches, prompts inserted).
 type CodexRolloutWalk = (HashMap<String, String>, HashMap<String, String>, usize);
 
 /// Reconcile the catalog registration for a locally observed subagent.
@@ -5410,16 +5412,26 @@ fn sync_codex_rollouts(
 ) -> Result<CodexRolloutWalk> {
     let mut cwds = load_state_string_map(state, "codex_session_cwds");
     let mut branches = load_state_string_map(state, "codex_session_branches");
-    let repair_user_messages = !state.contains_key("codex_rollouts_v4");
+    let has_v5 = state.contains_key("codex_rollouts_v5");
+    let has_v4 = state.contains_key("codex_rollouts_v4");
+    // v4 already repaired user-message parsing. Its only stale knowledge is
+    // the source.subagent classification, so a v4->v5 upgrade must not
+    // re-read the complete archive: invalidate only marked subagent entries.
+    let repair_user_messages = !has_v5 && !has_v4;
     let mut seen = state
-        .get("codex_rollouts_v4")
+        .get("codex_rollouts_v5")
+        .or_else(|| state.get("codex_rollouts_v4"))
         .and_then(Value::as_object)
         .cloned()
         .unwrap_or_default();
+    if !has_v5 && has_v4 {
+        seen.retain(|_, record| record.get("subagent").and_then(Value::as_bool) != Some(true));
+    }
     // Superseded stamp maps from the split-walk era; keeping them would carry
     // three path->stamp maps over the same 2K-file tree in .sync-state.json.
     state.remove("codex_rollouts");
     state.remove("codex_rollout_user_messages_v2");
+    state.remove("codex_rollouts_v4");
     let mut inserted = 0;
     let mut scanned = 0;
     let mut events = 0usize;
@@ -5578,7 +5590,7 @@ fn sync_codex_rollouts(
         ),
     );
     state.remove("codex_rollouts_v3");
-    state.insert("codex_rollouts_v4".to_string(), Value::Object(seen));
+    state.insert("codex_rollouts_v5".to_string(), Value::Object(seen));
     if scanned > 0 {
         sync_note!(
             "  [codex-rollouts] scanned {scanned} files; +{inserted} prompts, +{events} events"
@@ -10979,7 +10991,7 @@ mod tests {
     }
 
     #[test]
-    fn codex_v4_repair_restores_users_without_duplicating_existing_evidence() {
+    fn codex_v5_repair_restores_users_without_duplicating_existing_evidence() {
         let dir = tempfile::tempdir().unwrap();
         let home = dir.path();
         let day = home.join(".codex/sessions/2026/08/31");
@@ -11066,7 +11078,7 @@ mod tests {
             .unwrap();
         assert_eq!(tool_count, 1);
         assert!(state.get("codex_rollouts_v3").is_none());
-        assert!(state.get("codex_rollouts_v4").is_some());
+        assert!(state.get("codex_rollouts_v5").is_some());
 
         super::sync_codex_rollouts(&conn, &mut state, home).unwrap();
         let second_counts: (i64, i64, i64, i64) = conn
@@ -11152,6 +11164,37 @@ mod tests {
         .unwrap();
     }
 
+    fn write_standalone_codex_guardian_rollout(path: &std::path::Path, session_id: &str) {
+        let lines = [
+            json!({
+                "timestamp": "2026-08-01T10:02:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": session_id,
+                    "cwd": "/tmp/proj",
+                    "source": {"subagent": {"other": "guardian"}}
+                }
+            }),
+            json!({
+                "timestamp": "2026-08-01T10:02:01.000Z",
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": "standalone guardian prompt"}
+            }),
+            json!({
+                "timestamp": "2026-08-01T10:02:02.000Z",
+                "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "standalone guardian answer"}
+            }),
+        ];
+        let content = lines
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        fs::write(path, content).unwrap();
+    }
+
     #[test]
     fn unchanged_subagent_state_still_repairs_migrated_local_catalog_rows() {
         let dir = tempfile::tempdir().unwrap();
@@ -11193,7 +11236,7 @@ mod tests {
         let key = rollout.to_string_lossy().to_string();
         let mut state = Map::new();
         state.insert(
-            "codex_rollouts_v4".into(),
+            "codex_rollouts_v5".into(),
             json!({
                 (key): {
                     "stamp": file_stamp(&rollout).unwrap(),
@@ -11364,6 +11407,155 @@ mod tests {
             .collect::<rusqlite::Result<Vec<_>>>()
             .unwrap();
         assert_eq!(edges, vec!["child:grandchild".to_string()]);
+    }
+
+    #[test]
+    fn old_codex_cache_reclassifies_standalone_guardian_before_fast_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        let day = home.join(".codex/sessions/2026/08/01");
+        fs::create_dir_all(&day).unwrap();
+        let root = day.join("rollout-root.jsonl");
+        let standalone = day.join("rollout-standalone-guardian.jsonl");
+        let linked = day.join("rollout-linked-guardian.jsonl");
+        write_rich_codex_rollout(&root);
+        write_standalone_codex_guardian_rollout(&standalone, "sess-standalone-guardian");
+        write_codex_subagent_rollout(&linked, "sess-linked-guardian");
+
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        // Existing events make the old v4 entries eligible for the fast path.
+        for session_id in [
+            "sess-top",
+            "sess-standalone-guardian",
+            "sess-linked-guardian",
+        ] {
+            conn.execute(
+                "INSERT INTO session_events \
+                 (source, session_id, ts_ms, role, kind, text, event_uid) \
+                 VALUES ('codex', ?, 2, 'assistant', 'text', 'retained event', ?)",
+                rusqlite::params![session_id, format!("retained-{session_id}")],
+            )
+            .unwrap();
+        }
+        // The normal root has an existing catalog row and should stay on the
+        // stamp fast path during this targeted migration.
+        conn.execute(
+            "INSERT INTO sessions (session_id, source, cwd) \
+             VALUES ('sess-top', 'codex', '/tmp/proj')",
+            [],
+        )
+        .unwrap();
+        // The linked child also has stale catalog registration from the old
+        // classifier; the upgrade must remove it rather than promote it.
+        conn.execute(
+            "INSERT INTO sessions (session_id, source, cwd) \
+             VALUES ('sess-linked-guardian', 'codex', '/tmp/proj')",
+            [],
+        )
+        .unwrap();
+        ai_hist_core::mark_session_presence(
+            &conn,
+            "codex",
+            "sess-linked-guardian",
+            super::SessionLocation::Local,
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO history (source, session_id, prompt, timestamp_ms) \
+             VALUES ('codex', 'sess-linked-guardian', 'stale child prompt', 1)",
+            [],
+        )
+        .unwrap();
+
+        let mut state = Map::new();
+        let standalone_key = standalone.to_string_lossy().to_string();
+        let linked_key = linked.to_string_lossy().to_string();
+        state.insert(
+            "codex_rollouts_v4".into(),
+            json!({
+                (root.to_string_lossy().to_string()): {
+                    "stamp": super::file_stamp(&root).unwrap(),
+                    "session": "sess-top",
+                    "subagent": false
+                },
+                (standalone_key.clone()): {
+                    "stamp": super::file_stamp(&standalone).unwrap(),
+                    "session": "sess-standalone-guardian",
+                    "subagent": true
+                },
+                (linked_key.clone()): {
+                    "stamp": super::file_stamp(&linked).unwrap(),
+                    "session": "sess-linked-guardian",
+                    "subagent": true
+                }
+            }),
+        );
+        state.insert(
+            "codex_session_cwds".into(),
+            json!({
+                "sess-top": "/tmp/proj",
+                "sess-standalone-guardian": "/tmp/proj",
+                "sess-linked-guardian": "/tmp/proj"
+            }),
+        );
+
+        let (_, _, inserted) = super::sync_codex_rollouts(&conn, &mut state, home).unwrap();
+        assert_eq!(inserted, 1, "standalone guardian prompt is newly indexed");
+        let sessions: Vec<String> = conn
+            .prepare("SELECT session_id FROM sessions WHERE source='codex' ORDER BY session_id")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(sessions, vec!["sess-standalone-guardian", "sess-top"]);
+        let standalone_presence: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_presences \
+                 WHERE source='codex' AND session_id='sess-standalone-guardian' AND location='local'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(standalone_presence, 1);
+        let linked_history: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM history \
+                 WHERE source='codex' AND session_id='sess-linked-guardian'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(linked_history, 0);
+        let root_history: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM history WHERE source='codex' AND session_id='sess-top'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            root_history, 0,
+            "the unchanged root stayed on the fast path"
+        );
+        assert!(state.get("codex_rollouts_v4").is_none());
+        let records = state
+            .get("codex_rollouts_v5")
+            .and_then(Value::as_object)
+            .expect("upgraded rollout cache");
+        assert_eq!(
+            records
+                .get(standalone_key.as_str())
+                .and_then(|record| record.get("subagent")),
+            Some(&Value::Bool(false))
+        );
+        assert_eq!(
+            records
+                .get(linked_key.as_str())
+                .and_then(|record| record.get("subagent")),
+            Some(&Value::Bool(true))
+        );
     }
 
     #[test]

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -5714,14 +5714,39 @@ fn codex_parent_session_id(
     })
 }
 
+/// Codex rollouts marked as subagents are hidden from the root session
+/// catalog.  A `thread_source: subagent` rollout remains a child even when an
+/// older producer omitted its parent fields.  The object form of
+/// `source.subagent` is treated as a child only when an explicit parent is
+/// present, so a standalone guardian remains discoverable under `payload.id`.
+pub(crate) fn codex_is_subagent(payload: Option<&Value>, session_id: &str) -> bool {
+    let thread_source_is_subagent = payload
+        .and_then(|p| p.get("thread_source"))
+        .and_then(Value::as_str)
+        == Some("subagent");
+    let source_marks_subagent = payload
+        .and_then(|p| p.get("source"))
+        .and_then(Value::as_object)
+        .is_some_and(|source| source.contains_key("subagent"));
+
+    // `payload.id` is always the rollout's own identity. A `source.subagent`
+    // marker is not by itself evidence of a parent: standalone guardian rollouts
+    // carry that marker while keeping their own identity, so they stay
+    // discoverable under `payload.id`.
+    thread_source_is_subagent
+        || (source_marks_subagent
+            && codex_parent_session_id(payload.and_then(Value::as_object), session_id).is_some())
+}
+
 /// Read the `session_meta` line that opens every rollout file.
 ///
 /// Sessions key on `payload.id` — the per-thread id. Subagent rollouts can
 /// carry their parent in `parent_thread_id`, a structured thread-spawn source,
 /// or the legacy `session_id`; keying on any of those would collapse every
 /// subagent into its parent. Subagent threads are detected instead
-/// (`thread_source`, or the object form of `payload.source`) and excluded from
-/// session registration.
+/// (`thread_source`, or the object form of `payload.source` *together with* an
+/// explicit parent) and excluded from session registration. A standalone
+/// guardian carries `source.subagent` without a parent and stays discoverable.
 fn read_codex_session_meta(path: &Path) -> Result<Option<CodexSessionMeta>> {
     let first = fs::read_to_string(path)
         .ok()
@@ -5737,7 +5762,8 @@ fn read_codex_session_meta(path: &Path) -> Result<Option<CodexSessionMeta>> {
     if value.get("type").and_then(Value::as_str) != Some("session_meta") {
         return Ok(None);
     }
-    let payload = value.get("payload").and_then(Value::as_object);
+    let payload_value = value.get("payload");
+    let payload = payload_value.and_then(Value::as_object);
     let Some(session_id) = payload
         .and_then(|p| p.get("id"))
         .and_then(Value::as_str)
@@ -5762,11 +5788,7 @@ fn read_codex_session_meta(path: &Path) -> Result<Option<CodexSessionMeta>> {
         .and_then(|p| p.get("source"))
         .and_then(Value::as_object)
         .and_then(|s| s.get("subagent"));
-    let is_subagent = payload
-        .and_then(|p| p.get("thread_source"))
-        .and_then(Value::as_str)
-        == Some("subagent")
-        || subagent.is_some();
+    let is_subagent = codex_is_subagent(payload_value, session_id);
     let parent_thread_id = is_subagent
         .then(|| codex_parent_thread_id(payload, session_id))
         .flatten();

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -4656,6 +4656,25 @@ impl Drop for SyncStateLock {
 ///
 /// Returns `None` when disk already reflects everything here, so a steady-state
 /// run that finds every source up to date does not rewrite the file per source.
+/// State keys earlier versions wrote and no longer maintain.
+///
+/// [`merged_sync_state`] folds this run's keys into what is already on disk and
+/// deliberately never walks the on-disk keys: a run legitimately omits every
+/// source it did not touch, so absence cannot mean "delete". That makes an
+/// in-memory `state.remove(...)` invisible to disk — the retired map is reloaded
+/// and rewritten forever, and the cleanup those migrations intend never
+/// completes. Retirements therefore have to be declared here, where the merge
+/// can act on them, rather than inferred from a key's absence.
+///
+/// Adding a key here is a one-way migration: it is dropped from every state file
+/// it is found in. Only list keys no supported version still reads.
+const RETIRED_SYNC_STATE_KEYS: &[&str] = &[
+    "codex_rollouts",
+    "codex_rollout_user_messages_v2",
+    "codex_rollouts_v3",
+    "codex_rollouts_v4",
+];
+
 fn merged_sync_state(path: &Path, ours: &Map<String, Value>) -> Result<Option<Map<String, Value>>> {
     let mut merged = load_sync_state(path)?;
     let mut changed = false;
@@ -4670,6 +4689,13 @@ fn merged_sync_state(path: &Path, ours: &Map<String, Value>) -> Result<Option<Ma
         }
         merged.insert(key.clone(), next);
         changed = true;
+    }
+    // Runs concurrent with this one may still be writing a retired key, so sweep
+    // after the fold rather than before it.
+    for key in RETIRED_SYNC_STATE_KEYS {
+        if merged.remove(*key).is_some() {
+            changed = true;
+        }
     }
     Ok(if changed { Some(merged) } else { None })
 }
@@ -8968,6 +8994,55 @@ mod tests {
         );
     }
 
+    /// The v4->v5 migration drops `codex_rollouts_v4` from the in-memory map, but
+    /// the merge only folds in the keys a run *has*, so on its own that deletion
+    /// never reaches disk: the retired map is reloaded and rewritten forever.
+    #[test]
+    fn retired_state_keys_are_deleted_from_disk_not_just_from_memory() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".sync-state.json");
+        let mut on_disk = Map::new();
+        on_disk.insert(
+            "codex_rollouts_v4".into(),
+            json!({"a.jsonl": {"stamp": "1:1"}}),
+        );
+        on_disk.insert("codex_rollouts".into(), json!({"legacy.jsonl": "1:1"}));
+        on_disk.insert(
+            "codex_rollout_user_messages_v2".into(),
+            json!({"u.jsonl": "1:1"}),
+        );
+        on_disk.insert("codex_rollouts_v3".into(), json!({"v3.jsonl": "1:1"}));
+        on_disk.insert("claude".into(), json!({"keep.jsonl": 7}));
+        save_sync_state(&path, &on_disk).unwrap();
+
+        // What a post-migration run holds: v5 written, the retired keys removed.
+        let mut ours = Map::new();
+        ours.insert(
+            "codex_rollouts_v5".into(),
+            json!({"a.jsonl": {"stamp": "2:2"}}),
+        );
+        checkpoint_sync_state(&path, &ours);
+
+        let saved = load_sync_state(&path).unwrap();
+        for retired in super::RETIRED_SYNC_STATE_KEYS {
+            assert!(
+                !saved.contains_key(*retired),
+                "{retired} must not survive the migration on disk"
+            );
+        }
+        assert_eq!(
+            saved["codex_rollouts_v5"],
+            json!({"a.jsonl": {"stamp": "2:2"}})
+        );
+        // A source this run never touched must still be preserved -- absence from
+        // `ours` is not a deletion, which is why retirement has to be declared.
+        assert_eq!(saved["claude"], json!({"keep.jsonl": 7}));
+
+        // Idempotent: with nothing retired left on disk, a steady-state run that
+        // changes nothing must not rewrite the file.
+        assert!(super::merged_sync_state(&path, &ours).unwrap().is_none());
+    }
+
     #[test]
     fn an_unchanged_source_does_not_rewrite_the_state_file() {
         let dir = std::env::temp_dir().join(format!("ai-hist-norewrite-{}", std::process::id()));
@@ -10700,8 +10775,16 @@ mod tests {
         }
     }
 
+    /// A `source.subagent` marker with no parent metadata is a standalone
+    /// guardian: it keeps its own identity and stays discoverable as a root.
+    ///
+    /// This inverts the `is_subagent` assertion that ac0b64a
+    /// ("fix: resolve Codex subagent parent IDs") left here, which is the exact
+    /// classification this PR exists to change. That commit's own concern — that
+    /// a marker-only rollout resolves *no* parent — is asserted unchanged below,
+    /// and the linked-child case it protected is covered by the sibling test.
     #[test]
-    fn codex_marker_only_guardian_remains_an_unlinked_subagent() {
+    fn codex_marker_only_guardian_is_a_standalone_root() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("rollout-guardian.jsonl");
         fs::write(
@@ -10714,8 +10797,43 @@ mod tests {
         .unwrap();
 
         let meta = codex_meta(&path);
-        assert!(meta.is_subagent);
+        assert!(
+            !meta.is_subagent,
+            "a marker-only guardian must stay discoverable under its own payload.id"
+        );
         assert_eq!(meta.parent_session_id, None);
+        assert_eq!(meta.parent_thread_id, None);
+        assert_eq!(meta.subagent_label.as_deref(), Some("guardian"));
+    }
+
+    /// The same marker *with* an explicit parent stays a child, including when
+    /// the parent is only reachable through the structured thread-spawn source
+    /// that ac0b64a taught the resolver to read.
+    #[test]
+    fn codex_marker_guardian_with_a_parent_stays_a_subagent() {
+        let dir = tempfile::tempdir().unwrap();
+        for (name, payload) in [
+            (
+                "explicit",
+                r#"{"id":"guardian","cwd":"/tmp/proj","parent_thread_id":"root","source":{"subagent":{"other":"guardian"}}}"#,
+            ),
+            (
+                "thread-spawn",
+                r#"{"id":"guardian","cwd":"/tmp/proj","source":{"subagent":{"other":"guardian","thread_spawn":{"parent_thread_id":"root"}}}}"#,
+            ),
+        ] {
+            let path = dir.path().join(format!("rollout-{name}.jsonl"));
+            fs::write(
+                &path,
+                format!(
+                    "{{\"timestamp\":\"2026-08-31T10:00:00.000Z\",\"type\":\"session_meta\",\"payload\":{payload}}}\n"
+                ),
+            )
+            .unwrap();
+            let meta = codex_meta(&path);
+            assert!(meta.is_subagent, "{name} guardian must remain a child");
+            assert_eq!(meta.parent_session_id.as_deref(), Some("root"), "{name}");
+        }
     }
 
     fn response_user(ts: &str, text: &str) -> String {

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -4656,7 +4656,8 @@ impl Drop for SyncStateLock {
 ///
 /// Returns `None` when disk already reflects everything here, so a steady-state
 /// run that finds every source up to date does not rewrite the file per source.
-/// State keys earlier versions wrote and no longer maintain.
+/// State keys earlier versions wrote and no longer maintain, each paired with the
+/// key that supersedes it.
 ///
 /// [`merged_sync_state`] folds this run's keys into what is already on disk and
 /// deliberately never walks the on-disk keys: a run legitimately omits every
@@ -4666,13 +4667,19 @@ impl Drop for SyncStateLock {
 /// completes. Retirements therefore have to be declared here, where the merge
 /// can act on them, rather than inferred from a key's absence.
 ///
-/// Adding a key here is a one-way migration: it is dropped from every state file
-/// it is found in. Only list keys no supported version still reads.
-const RETIRED_SYNC_STATE_KEYS: &[&str] = &[
-    "codex_rollouts",
-    "codex_rollout_user_messages_v2",
-    "codex_rollouts_v3",
-    "codex_rollouts_v4",
+/// The pairing is an ordering rule, not decoration. `checkpoint_sync_state` runs
+/// once per source against the whole state map, and `codex_rollouts_v4` is still
+/// *read* by this version to seed the v5 migration. Sweeping unconditionally
+/// would drop it during an earlier source's checkpoint, before
+/// `sync_codex_rollouts` has written `codex_rollouts_v5`; a crash or an
+/// overlapping sync in that window would find neither map and force a full
+/// re-read of the archive. Requiring the successor in the same write closes that
+/// gap: the old map only leaves disk once its replacement is on the way there.
+const RETIRED_SYNC_STATE_KEYS: &[(&str, &str)] = &[
+    ("codex_rollouts", "codex_rollouts_v5"),
+    ("codex_rollout_user_messages_v2", "codex_rollouts_v5"),
+    ("codex_rollouts_v3", "codex_rollouts_v5"),
+    ("codex_rollouts_v4", "codex_rollouts_v5"),
 ];
 
 fn merged_sync_state(path: &Path, ours: &Map<String, Value>) -> Result<Option<Map<String, Value>>> {
@@ -4690,10 +4697,13 @@ fn merged_sync_state(path: &Path, ours: &Map<String, Value>) -> Result<Option<Ma
         merged.insert(key.clone(), next);
         changed = true;
     }
-    // Runs concurrent with this one may still be writing a retired key, so sweep
-    // after the fold rather than before it.
-    for key in RETIRED_SYNC_STATE_KEYS {
-        if merged.remove(*key).is_some() {
+    // Sweep after the fold, so a run concurrent with this one cannot resurrect a
+    // retired key, and only once this run actually carries the successor.
+    for (retired, superseded_by) in RETIRED_SYNC_STATE_KEYS {
+        if !ours.contains_key(*superseded_by) {
+            continue;
+        }
+        if merged.remove(*retired).is_some() {
             changed = true;
         }
     }
@@ -9024,7 +9034,7 @@ mod tests {
         checkpoint_sync_state(&path, &ours);
 
         let saved = load_sync_state(&path).unwrap();
-        for retired in super::RETIRED_SYNC_STATE_KEYS {
+        for (retired, _) in super::RETIRED_SYNC_STATE_KEYS {
             assert!(
                 !saved.contains_key(*retired),
                 "{retired} must not survive the migration on disk"
@@ -9041,6 +9051,48 @@ mod tests {
         // Idempotent: with nothing retired left on disk, a steady-state run that
         // changes nothing must not rewrite the file.
         assert!(super::merged_sync_state(&path, &ours).unwrap().is_none());
+    }
+
+    /// `checkpoint_sync_state` runs once per source, and `codex_rollouts_v4` is
+    /// still read to seed the v5 migration. An earlier source's checkpoint must
+    /// therefore not drop it: if a crash landed between that checkpoint and
+    /// `sync_codex_rollouts` writing v5, neither map would survive and the next
+    /// run would re-read the whole archive.
+    #[test]
+    fn a_retired_key_survives_until_its_successor_is_written() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".sync-state.json");
+        let mut on_disk = Map::new();
+        on_disk.insert(
+            "codex_rollouts_v4".into(),
+            json!({"a.jsonl": {"stamp": "1:1"}}),
+        );
+        save_sync_state(&path, &on_disk).unwrap();
+
+        // An earlier source checkpoints first; codex has not run yet, so nothing
+        // in this write supersedes v4.
+        let mut early = Map::new();
+        early.insert("claude".into(), json!({"c.jsonl": 3}));
+        checkpoint_sync_state(&path, &early);
+        assert_eq!(
+            load_sync_state(&path).unwrap()["codex_rollouts_v4"],
+            json!({"a.jsonl": {"stamp": "1:1"}}),
+            "v4 must still be readable until v5 replaces it"
+        );
+
+        // Codex then runs and writes v5 in the same state map.
+        let mut after_codex = early.clone();
+        after_codex.insert(
+            "codex_rollouts_v5".into(),
+            json!({"a.jsonl": {"stamp": "2:2"}}),
+        );
+        checkpoint_sync_state(&path, &after_codex);
+        let saved = load_sync_state(&path).unwrap();
+        assert!(!saved.contains_key("codex_rollouts_v4"));
+        assert_eq!(
+            saved["codex_rollouts_v5"],
+            json!({"a.jsonl": {"stamp": "2:2"}})
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- classify Codex rollouts as child sessions only when explicit parent metadata exists
- catalog `source.subagent` rollouts without a parent as standalone sessions
- reclassify stale v4 subagent cache entries without rereading cached roots
- add discovery and hydration regressions while preserving linked-child behavior

## Why

Codex can emit standalone reviewer or guardian rollouts with
`source.subagent` but without `payload.session_id` or
`payload.parent_thread_id`. Discovery currently treats every such rollout as a
child, so it creates no catalog row and targeted hydration fails with
`SESSION_NOT_FOUND` unless another selected root links to it.

On a bounded 11-file Codex sample, published `0.11.0` discovered 6 roots and
hydrated 10 provider IDs. The omitted standalone guardian was present as a
discovery candidate but could not be hydrated directly.

This change keeps `thread_source: "subagent"` and subagents with an explicit
parent classified as children. Only an unlinked `source.subagent` rollout is
cataloged under its own provider ID.

## Validation

- current upstream base: `7b3666f64f90d26baab67a0d2b56276d10d9dd27`
- Rust engine: 222 tests pass, 0 fail, and the declared performance benchmark
  is the only ignored test (200 library, 19 discovery, 3 resilience)
- TypeScript SDK: 23/23 tests pass
- bounded sample: 7 catalog sessions, all 11 provider IDs, 2,727 events, 30
  prompts, 1,343 tool calls, and 4 existing child relations
- repeat hydration: 7/7 `unchanged`
- full-text checks: 3/3 distinctive prompts resolve to the expected sessions,
  including the standalone guardian

No database schema or public SDK contract changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session classification, discovery stamps, and Codex sync state migration; incorrect logic could miscatalog subagents or skip re-ingestion, but scope is Codex-specific with extensive regression tests.
> 
> **Overview**
> **Standalone Codex guardian rollouts** (`source.subagent` without parent metadata) are now cataloged and hydrated as root sessions instead of being treated like linked subagents.
> 
> Classification is centralized in **`codex_is_subagent`**: a rollout is a child only when `thread_source: "subagent"` or when `source.subagent` is present **and** an explicit parent can be resolved. Shallow discovery bumps **`SHALLOW_SCANNER_VERSION` to 3** so stale `discovery_skips` from the old classifier are invalidated on upgrade.
> 
> Full sync moves **`codex_rollouts_v4` → `codex_rollouts_v5`**, reclassifying cached subagent-marked files without re-reading unchanged roots, and **`RETIRED_SYNC_STATE_KEYS`** ensures legacy Codex rollout state keys are removed from `.sync-state.json` on disk only after the v5 successor is written.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e7deb6a1552babd8764cd78bb84ef5d6720dcd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->