### PR TITLE
Hydrate remote session evidence honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Notable changes to the native `ai-hist` CLI are documented here.
 
 ## [Unreleased]
 
+- Add targeted remote hydration for Claude Code web sessions through the
+  provider's bounded teleport-evidence interface, and partial Codex cloud task
+  hydration through `codex cloud diff`. Hydration contract v2 reports honest
+  `full`, `partial`, and `shallow_only` capabilities, file-edit counts, and
+  stable connector/auth/missing/partial failure codes.
+- Relate a Claude remote session to its materialized local continuation only
+  when the local provider record contains the exact `remoteSessionId`; title or
+  repository similarity never creates a canonical relationship.
+
 ### Breaking
 
 - Add truthful OpenCode SQL work counters to discovery summaries. The catalog

--- a/README.md
+++ b/README.md
@@ -112,11 +112,12 @@ await sync({ scope: 'local' }); // explicit full ingestion; local is the default
 ```
 
 `listSessionCatalog` is cache-only. `discoverSessions` performs bounded shallow
-provider discovery and updates the shared ledger. `hydrateSession` fully
-indexes one existing catalog identity and returns evidence counts rather than
-the transcript; repeating it is safe as a live session grows. The tool call and
-file edit pages read that hydrated evidence back as structured rows and require
-both a source and a session ID, because provider session IDs collide. `sync` performs
+provider discovery and updates the shared ledger. `hydrateSession` indexes the
+richest evidence a connector safely exposes for one existing catalog identity
+and reports `full`, `partial`, or `shallow_only` capability with evidence
+counts; repeating it is safe as a live session grows. The tool call and file
+edit pages read that hydrated evidence back as structured rows and require both
+a source and a session ID, because provider session IDs collide. `sync` performs
 full global ingestion. Reads never silently turn into discovery, hydration, or
 sync. Hydration includes linked subagent evidence by default; CLI callers can
 pass `--no-related`.

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -426,6 +426,7 @@ const REQUIRED_TABLES: &[&str] = &[
     "sessions",
     "session_presences",
     "session_hydration_checkpoints",
+    "session_identity_correlations",
     "session_relationships",
     "schema_migrations",
     "discovery_skips",
@@ -533,7 +534,11 @@ const REQUIRED_RELATIONSHIP_READ_INDEXES: &[&str] = &[
     "idx_session_relationships_parent",
     "idx_session_relationships_child",
 ];
-const REQUIRED_TRIGGERS: &[&str] = &["delete_session_presences", "delete_session_hydration_state"];
+const REQUIRED_TRIGGERS: &[&str] = &[
+    "delete_session_presences",
+    "delete_session_hydration_state",
+    "delete_session_identity_correlations",
+];
 const REQUIRED_SCHEMA_MIGRATIONS: &[&str] = &[
     "session_presences_local_backfill_v1",
     "session_relationships_v2",
@@ -797,6 +802,15 @@ CREATE TABLE IF NOT EXISTS session_hydration_checkpoints (
     updated_ms INTEGER NOT NULL,
     PRIMARY KEY (source, session_id, location)
 );
+CREATE TABLE IF NOT EXISTS session_identity_correlations (
+    source TEXT NOT NULL,
+    local_session_id TEXT NOT NULL,
+    remote_session_id TEXT NOT NULL,
+    relationship TEXT NOT NULL,
+    evidence_kind TEXT NOT NULL,
+    updated_ms INTEGER NOT NULL,
+    PRIMARY KEY (source, local_session_id, relationship)
+);
 CREATE TRIGGER IF NOT EXISTS delete_session_presences
 AFTER DELETE ON sessions
 BEGIN
@@ -811,6 +825,12 @@ BEGIN
     DELETE FROM session_relationships
     WHERE source = OLD.source
       AND (parent_session_id = OLD.session_id OR child_session_id = OLD.session_id);
+END;
+CREATE TRIGGER IF NOT EXISTS delete_session_identity_correlations
+AFTER DELETE ON sessions
+BEGIN
+    DELETE FROM session_identity_correlations
+    WHERE source = OLD.source AND local_session_id = OLD.session_id;
 END;
 "#,
     )?;

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -282,6 +282,7 @@ export interface HydrationEvidence {
   prompts: number
   events: number
   toolCalls: number
+  fileEdits: number
   relatedSessions: number
 }
 export interface HydrationDiagnostic {
@@ -296,6 +297,7 @@ export interface HydrateSessionResult {
   source: string
   sessionId: string
   status: string
+  capability: string
   discoveryState: string
   presence: string
   indexedThrough: HydrationIndexedThrough

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -1011,6 +1011,7 @@ pub struct HydrationEvidence {
     pub prompts: i64,
     pub events: i64,
     pub tool_calls: i64,
+    pub file_edits: i64,
     pub related_sessions: i64,
 }
 
@@ -1029,6 +1030,7 @@ pub struct HydrateSessionResult {
     pub source: String,
     pub session_id: String,
     pub status: String,
+    pub capability: String,
     pub discovery_state: String,
     pub presence: String,
     pub indexed_through: HydrationIndexedThrough,
@@ -1044,6 +1046,10 @@ fn hydration_error(error: anyhow::Error) -> napi::Error {
         "SESSION_SOURCE_UNAVAILABLE",
         "SESSION_SOURCE_MISMATCH",
         "HYDRATION_UNSUPPORTED",
+        "CONNECTOR_NOT_CONFIGURED",
+        "AUTHENTICATION_EXPIRED",
+        "EVIDENCE_PARTIAL",
+        "CONNECTOR_FAILURE",
         "INVALID_ARGUMENT",
     ] {
         if let Some(detail) = message.strip_prefix(&format!("{code}: ")) {
@@ -1075,6 +1081,7 @@ pub async fn hydrate_session(options: HydrateSessionOptions) -> napi::Result<Hyd
         source: result.source,
         session_id: result.session_id,
         status: result.status,
+        capability: result.capability,
         discovery_state: result.discovery_state,
         presence: result.presence,
         indexed_through: HydrationIndexedThrough {
@@ -1085,6 +1092,7 @@ pub async fn hydrate_session(options: HydrateSessionOptions) -> napi::Result<Hyd
             prompts: result.evidence.prompts as i64,
             events: result.evidence.events as i64,
             tool_calls: result.evidence.tool_calls as i64,
+            file_edits: result.evidence.file_edits as i64,
             related_sessions: result.evidence.related_sessions as i64,
         },
         related_session_ids: result.related_session_ids,

--- a/crates/ai-hist/src/hydrate.rs
+++ b/crates/ai-hist/src/hydrate.rs
@@ -217,7 +217,23 @@ fn acquire_remote_hydration_lock(
     db_path: &Path,
     options: &HydrateSessionOptions,
 ) -> Result<RemoteHydrationLock> {
-    let lock_dir = db_path
+    let absolute = if db_path.is_absolute() {
+        db_path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(db_path)
+    };
+    let canonical_db = fs::canonicalize(&absolute).or_else(|_| {
+        let parent = absolute.parent().unwrap_or_else(|| Path::new("."));
+        let parent = fs::canonicalize(parent)?;
+        Ok::<_, std::io::Error>(
+            parent.join(
+                absolute
+                    .file_name()
+                    .unwrap_or_else(|| std::ffi::OsStr::new("history.db")),
+            ),
+        )
+    })?;
+    let lock_dir = canonical_db
         .parent()
         .unwrap_or_else(|| Path::new("."))
         .join(".relayhistory-hydration-locks");
@@ -293,30 +309,49 @@ fn classify_remote_error(error: anyhow::Error) -> anyhow::Error {
 
 fn redact_remote_diagnostic(message: &str) -> String {
     let mut redacted = Vec::new();
-    let mut parts = message.split_whitespace();
-    while let Some(part) = parts.next() {
+    let parts = message.split_whitespace().collect::<Vec<_>>();
+    let mut index = 0;
+    while index < parts.len() {
+        let part = parts[index];
         let lower = part.to_ascii_lowercase();
-        let marker = lower.contains("bearer")
-            || lower.contains("authorization")
-            || lower.contains("access_token")
-            || lower.contains("accesstoken")
-            || lower.contains("refresh_token")
-            || lower.contains("refreshtoken");
+        let normalized = lower.trim_matches(|ch: char| !ch.is_ascii_alphanumeric() && ch != '_');
+        let token_key = matches!(
+            normalized,
+            "access_token" | "accesstoken" | "refresh_token" | "refreshtoken"
+        );
+        let bearer = normalized == "bearer";
+        let authorization_bearer = normalized == "authorization"
+            && parts
+                .get(index + 1)
+                .is_some_and(|next| next.eq_ignore_ascii_case("bearer"));
         let inline_secret = lower.contains("sk-ant-")
-            || marker && part.contains(['=', ':']) && !part.ends_with(['=', ':']);
+            || [
+                "access_token",
+                "accesstoken",
+                "refresh_token",
+                "refreshtoken",
+            ]
+            .iter()
+            .any(|key| {
+                lower
+                    .find(key)
+                    .is_some_and(|start| lower[start + key.len()..].starts_with(['=', ':']))
+            });
         if inline_secret || probable_secret(part) {
             redacted.push("[REDACTED]");
-        } else if marker {
+        } else if authorization_bearer {
             redacted.push("[REDACTED]");
-            // `Bearer TOKEN`, `access_token = TOKEN`, and their colon forms
-            // must not leave the value behind as an innocent-looking token.
-            if matches!(parts.clone().next(), Some("=" | ":")) {
-                parts.next();
+            index += 2;
+        } else if bearer || token_key {
+            redacted.push("[REDACTED]");
+            index += 1;
+            if matches!(parts.get(index), Some(&"=") | Some(&":")) {
+                index += 1;
             }
-            parts.next();
         } else {
             redacted.push(part);
         }
+        index += 1;
     }
     redacted.join(" ")
 }
@@ -1514,6 +1549,14 @@ mod tests {
             "INVALID_ARGUMENT: remote Claude session id is malformed"
         ));
         assert!(invalid.to_string().starts_with("INVALID_ARGUMENT:"));
+        assert_eq!(
+            redact_remote_diagnostic("CONNECTOR_FAILURE: authorization failed for provider"),
+            "CONNECTOR_FAILURE: authorization failed for provider"
+        );
+        assert_eq!(
+            redact_remote_diagnostic("CONNECTOR_FAILURE: Authorization Bearer secret-value"),
+            "CONNECTOR_FAILURE: [REDACTED]"
+        );
     }
 
     #[test]
@@ -1530,6 +1573,42 @@ mod tests {
         let (sender, receiver) = std::sync::mpsc::channel();
         let handle = std::thread::spawn(move || {
             let second = acquire_remote_hydration_lock(&db, &request).unwrap();
+            sender.send(()).unwrap();
+            drop(second);
+        });
+        assert!(receiver
+            .recv_timeout(std::time::Duration::from_millis(50))
+            .is_err());
+        drop(first);
+        receiver
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        handle.join().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remote_hydration_file_lock_canonicalizes_database_aliases() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("real");
+        fs::create_dir(&real_dir).unwrap();
+        let db = real_dir.join("history.db");
+        fs::write(&db, []).unwrap();
+        let alias_dir = dir.path().join("alias");
+        symlink(&real_dir, &alias_dir).unwrap();
+        let alias = alias_dir.join("history.db");
+        let request = HydrateSessionOptions {
+            source: "codex".into(),
+            session_id: "task_alias_lock".into(),
+            scope: SessionScope::Remote,
+            include_related: false,
+        };
+        let first = acquire_remote_hydration_lock(&db, &request).unwrap();
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let second = acquire_remote_hydration_lock(&alias, &request).unwrap();
             sender.send(()).unwrap();
             drop(second);
         });

--- a/crates/ai-hist/src/hydrate.rs
+++ b/crates/ai-hist/src/hydrate.rs
@@ -3,9 +3,10 @@
 use super::*;
 use rusqlite::{params, OptionalExtension, TransactionBehavior};
 use serde::Serialize;
+use std::io::Write;
 use std::time::Instant;
 
-pub const SESSION_HYDRATION_CONTRACT_VERSION: u32 = 1;
+pub const SESSION_HYDRATION_CONTRACT_VERSION: u32 = 2;
 /// Bumped to 2 when Claude subagent transcripts that carry an `agentId`
 /// started being indexed under that child id: existing databases re-parse once
 /// and the earlier parent-attributed rows are healed in place.
@@ -30,6 +31,7 @@ pub struct HydrationEvidence {
     pub prompts: u64,
     pub events: u64,
     pub tool_calls: u64,
+    pub file_edits: u64,
     pub related_sessions: u64,
 }
 
@@ -48,6 +50,7 @@ pub struct HydrateSessionResult {
     pub source: String,
     pub session_id: String,
     pub status: String,
+    pub capability: String,
     pub discovery_state: String,
     pub presence: String,
     pub indexed_through: HydrationIndexedThrough,
@@ -97,6 +100,9 @@ fn hydrate_session_at_with_home(
     let started = Instant::now();
     let mut conn = open_db(db_path)?;
     let target = catalog_target(&conn, options)?;
+    if options.scope == SessionScope::Remote {
+        return hydrate_remote_session(&mut conn, options, home, started);
+    }
     let snapshot = source_snapshot(options, &target, home)?;
     let previous: Option<(Option<String>, i64, bool)> = conn
         .query_row(
@@ -189,6 +195,417 @@ fn hydrate_session_at_with_home(
     )
 }
 
+fn hydrate_remote_session(
+    conn: &mut Connection,
+    options: &HydrateSessionOptions,
+    home: &Path,
+    started: Instant,
+) -> Result<HydrateSessionResult> {
+    if !matches!(options.source.as_str(), "claude" | "codex") {
+        return remote_limited_result(
+            conn,
+            options,
+            "CONNECTOR_NOT_CONFIGURED",
+            format!(
+                "no remote hydration connector exists for source '{}'",
+                options.source
+            ),
+            started,
+        );
+    }
+    let evidence =
+        crate::remote::acquire_remote_session_at(home, &options.source, &options.session_id)
+            .map_err(classify_remote_error)?;
+    match evidence {
+        crate::remote::RemoteSessionEvidence::CapabilityLimited { code, message } => {
+            remote_limited_result(conn, options, code, message, started)
+        }
+        crate::remote::RemoteSessionEvidence::ClaudeFull {
+            records,
+            source_stamp,
+            source_bytes,
+        } => hydrate_remote_claude(conn, options, records, source_stamp, source_bytes, started),
+        crate::remote::RemoteSessionEvidence::CodexDiff {
+            diff,
+            source_stamp,
+            source_bytes,
+        } => hydrate_remote_codex_diff(conn, options, &diff, source_stamp, source_bytes, started),
+    }
+}
+
+fn classify_remote_error(error: anyhow::Error) -> anyhow::Error {
+    let message = redact_remote_diagnostic(&format!("{error:#}"));
+    for code in [
+        "AUTHENTICATION_EXPIRED",
+        "SESSION_NOT_FOUND",
+        "EVIDENCE_PARTIAL",
+        "CONNECTOR_FAILURE",
+        "CONNECTOR_NOT_CONFIGURED",
+        "INVALID_ARGUMENT",
+    ] {
+        if message.starts_with(&format!("{code}:")) {
+            return anyhow::anyhow!(message);
+        }
+    }
+    hydration_error("CONNECTOR_FAILURE", message)
+}
+
+fn redact_remote_diagnostic(message: &str) -> String {
+    message
+        .split_whitespace()
+        .map(|part| {
+            let lower = part.to_ascii_lowercase();
+            if lower.contains("sk-ant-")
+                || lower.contains("bearer")
+                || lower.contains("access_token")
+                || lower.contains("accesstoken")
+                || lower.contains("refresh_token")
+                || lower.contains("refreshtoken")
+            {
+                "[REDACTED]"
+            } else {
+                part
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn remote_limited_result(
+    conn: &Connection,
+    options: &HydrateSessionOptions,
+    code: &str,
+    message: String,
+    started: Instant,
+) -> Result<HydrateSessionResult> {
+    let related_session_ids = if options.include_related {
+        related_ids(conn, &options.source, &options.session_id)?
+    } else {
+        Vec::new()
+    };
+    let evidence = evidence_counts(
+        conn,
+        &options.source,
+        std::slice::from_ref(&options.session_id),
+        related_session_ids.len() as u64,
+    )?;
+    Ok(HydrateSessionResult {
+        contract_version: SESSION_HYDRATION_CONTRACT_VERSION,
+        source: options.source.clone(),
+        session_id: options.session_id.clone(),
+        status: "capability_limited".to_string(),
+        capability: "shallow_only".to_string(),
+        discovery_state: "shallow".to_string(),
+        presence: "remote".to_string(),
+        indexed_through: HydrationIndexedThrough::default(),
+        evidence,
+        related_session_ids,
+        diagnostics: vec![HydrationDiagnostic {
+            code: code.to_string(),
+            message: redact_remote_diagnostic(&message),
+            duration_ms: Some(started.elapsed().as_millis() as i64),
+            source_bytes: Some(0),
+            records_parsed: Some(0),
+        }],
+    })
+}
+
+fn hydrate_remote_claude(
+    conn: &mut Connection,
+    options: &HydrateSessionOptions,
+    mut records: Vec<Value>,
+    source_stamp: String,
+    source_bytes: i64,
+    started: Instant,
+) -> Result<HydrateSessionResult> {
+    let previous = hydration_checkpoint(conn, options, "remote")?;
+    if previous.as_deref() == Some(source_stamp.as_str()) {
+        return build_remote_result(
+            conn,
+            options,
+            "unchanged",
+            "full",
+            "full",
+            source_stamp,
+            source_bytes,
+            records.len() as i64,
+            "REMOTE_EVIDENCE_FULL",
+            "all evidence exposed by Claude's teleport interface is indexed",
+            started,
+        );
+    }
+    for record in &mut records {
+        let object = record
+            .as_object_mut()
+            .context("CONNECTOR_FAILURE: Claude teleport evidence contains a non-object record")?;
+        let recorded_id = object
+            .get("sessionId")
+            .or_else(|| object.get("session_id"))
+            .and_then(Value::as_str);
+        match recorded_id {
+            Some(id) if id != options.session_id => anyhow::bail!(
+                "CONNECTOR_FAILURE: Claude teleport record identity does not match the requested session"
+            ),
+            None => {
+                object.insert("sessionId".to_string(), Value::String(options.session_id.clone()));
+            }
+            _ => {}
+        }
+    }
+    let mut transcript = tempfile::NamedTempFile::new()?;
+    for record in &records {
+        serde_json::to_writer(&mut transcript, record)?;
+        transcript.write_all(b"\n")?;
+    }
+    transcript.flush()?;
+    let had_local_presence: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM session_presences WHERE source = ? AND session_id = ? AND location = 'local')",
+        params![options.source, options.session_id],
+        |row| row.get(0),
+    )?;
+    let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    ingest_claude_transcript(&tx, transcript.path())?;
+    if !had_local_presence {
+        tx.execute(
+            "DELETE FROM session_presences WHERE source = ? AND session_id = ? AND location = 'local'",
+            params![options.source, options.session_id],
+        )?;
+    }
+    tx.execute(
+        "UPDATE sessions SET discovery_state = 'full' WHERE source = ? AND session_id = ?",
+        params![options.source, options.session_id],
+    )?;
+    tx.execute(
+        "UPDATE session_presences SET discovery_state = 'full', source_stamp = ? \
+         WHERE source = ? AND session_id = ? AND location = 'remote'",
+        params![source_stamp, options.source, options.session_id],
+    )?;
+    write_hydration_checkpoint(
+        &tx,
+        options,
+        "remote",
+        &source_stamp,
+        source_bytes,
+        records.len() as i64,
+    )?;
+    tx.commit()?;
+    build_remote_result(
+        conn,
+        options,
+        if previous.is_some() {
+            "updated"
+        } else {
+            "hydrated"
+        },
+        "full",
+        "full",
+        source_stamp,
+        source_bytes,
+        records.len() as i64,
+        "REMOTE_EVIDENCE_FULL",
+        "all evidence exposed by Claude's teleport interface is indexed",
+        started,
+    )
+}
+
+fn hydrate_remote_codex_diff(
+    conn: &mut Connection,
+    options: &HydrateSessionOptions,
+    diff: &str,
+    source_stamp: String,
+    source_bytes: i64,
+    started: Instant,
+) -> Result<HydrateSessionResult> {
+    let previous = hydration_checkpoint(conn, options, "remote")?;
+    if previous.as_deref() != Some(source_stamp.as_str()) {
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        tx.execute(
+            "DELETE FROM file_edits WHERE source = 'codex' AND session_id = ? AND tool_name = 'codex cloud diff'",
+            [&options.session_id],
+        )?;
+        for (index, patch) in split_unified_diff(diff).into_iter().enumerate() {
+            let (added, removed) = count_unified_diff_lines(&patch.text);
+            tx.execute(
+                "INSERT INTO file_edits \
+                 (source, session_id, tool_use_id, file_path, tool_name, lines_added, lines_removed, structured_patch_json, ts_ms) \
+                 VALUES ('codex', ?, ?, ?, 'codex cloud diff', ?, ?, ?, ?) \
+                 ON CONFLICT(source, session_id, tool_use_id) DO UPDATE SET \
+                   file_path=excluded.file_path, lines_added=excluded.lines_added, lines_removed=excluded.lines_removed, \
+                   structured_patch_json=excluded.structured_patch_json, ts_ms=excluded.ts_ms",
+                params![
+                    options.session_id,
+                    format!("remote-diff:{index}"),
+                    patch.path,
+                    added,
+                    removed,
+                    serde_json::to_string(&serde_json::json!({"unified_diff": patch.text}))?,
+                    now_ms(),
+                ],
+            )?;
+        }
+        write_hydration_checkpoint(&tx, options, "remote", &source_stamp, source_bytes, 1)?;
+        tx.commit()?;
+    }
+    build_remote_result(
+        conn,
+        options,
+        if previous.as_deref() == Some(source_stamp.as_str()) {
+            "unchanged"
+        } else if previous.is_some() {
+            "updated"
+        } else {
+            "hydrated"
+        },
+        "partial",
+        "shallow",
+        source_stamp,
+        source_bytes,
+        1,
+        "EVIDENCE_PARTIAL",
+        "Codex exposes the task diff but no supported transcript, tool-result, token, model, or agent-relationship export",
+        started,
+    )
+}
+
+struct UnifiedPatch {
+    path: String,
+    text: String,
+}
+
+fn split_unified_diff(diff: &str) -> Vec<UnifiedPatch> {
+    let mut patches = Vec::new();
+    let mut current_path: Option<String> = None;
+    let mut current = String::new();
+    for line in diff.lines() {
+        if let Some(path) = line
+            .strip_prefix("diff --git a/")
+            .and_then(|rest| rest.split(" b/").next())
+        {
+            if let Some(path) = current_path.take() {
+                patches.push(UnifiedPatch {
+                    path,
+                    text: std::mem::take(&mut current),
+                });
+            }
+            current_path = Some(path.to_string());
+        }
+        if current_path.is_some() {
+            current.push_str(line);
+            current.push('\n');
+        }
+    }
+    if let Some(path) = current_path {
+        patches.push(UnifiedPatch {
+            path,
+            text: current,
+        });
+    }
+    if patches.is_empty() && !diff.trim().is_empty() {
+        patches.push(UnifiedPatch {
+            path: "(task diff)".to_string(),
+            text: diff.to_string(),
+        });
+    }
+    patches
+}
+
+fn hydration_checkpoint(
+    conn: &Connection,
+    options: &HydrateSessionOptions,
+    location: &str,
+) -> Result<Option<String>> {
+    Ok(conn
+        .query_row(
+            "SELECT source_stamp FROM session_hydration_checkpoints WHERE source = ? AND session_id = ? AND location = ?",
+            params![options.source, options.session_id, location],
+            |row| row.get(0),
+        )
+        .optional()?
+        .flatten())
+}
+
+fn write_hydration_checkpoint(
+    conn: &Connection,
+    options: &HydrateSessionOptions,
+    location: &str,
+    source_stamp: &str,
+    source_bytes: i64,
+    records_parsed: i64,
+) -> Result<()> {
+    let last_event_at_ms = max_event_time(conn, &options.source, &options.session_id)?;
+    conn.execute(
+        "INSERT INTO session_hydration_checkpoints \
+         (source, session_id, location, source_stamp, parser_version, last_event_at_ms, source_bytes, records_parsed, include_related, updated_ms) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+         ON CONFLICT(source, session_id, location) DO UPDATE SET \
+           source_stamp=excluded.source_stamp, parser_version=excluded.parser_version, last_event_at_ms=excluded.last_event_at_ms, \
+           source_bytes=excluded.source_bytes, records_parsed=excluded.records_parsed, include_related=excluded.include_related, updated_ms=excluded.updated_ms",
+        params![
+            options.source,
+            options.session_id,
+            location,
+            source_stamp,
+            HYDRATION_PARSER_VERSION,
+            last_event_at_ms,
+            source_bytes,
+            records_parsed,
+            options.include_related,
+            now_ms(),
+        ],
+    )?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_remote_result(
+    conn: &Connection,
+    options: &HydrateSessionOptions,
+    status: &str,
+    capability: &str,
+    discovery_state: &str,
+    source_stamp: String,
+    source_bytes: i64,
+    records_parsed: i64,
+    diagnostic_code: &str,
+    diagnostic_message: &str,
+    started: Instant,
+) -> Result<HydrateSessionResult> {
+    let related_session_ids = if options.include_related {
+        related_ids(conn, &options.source, &options.session_id)?
+    } else {
+        Vec::new()
+    };
+    let mut ids = vec![options.session_id.clone()];
+    ids.extend(related_session_ids.iter().cloned());
+    Ok(HydrateSessionResult {
+        contract_version: SESSION_HYDRATION_CONTRACT_VERSION,
+        source: options.source.clone(),
+        session_id: options.session_id.clone(),
+        status: status.to_string(),
+        capability: capability.to_string(),
+        discovery_state: discovery_state.to_string(),
+        presence: "remote".to_string(),
+        indexed_through: HydrationIndexedThrough {
+            source_stamp: Some(source_stamp),
+            last_event_at_ms: max_event_time(conn, &options.source, &options.session_id)?,
+        },
+        evidence: evidence_counts(
+            conn,
+            &options.source,
+            &ids,
+            related_session_ids.len() as u64,
+        )?,
+        related_session_ids,
+        diagnostics: vec![HydrationDiagnostic {
+            code: diagnostic_code.to_string(),
+            message: diagnostic_message.to_string(),
+            duration_ms: Some(started.elapsed().as_millis() as i64),
+            source_bytes: Some(source_bytes),
+            records_parsed: Some(records_parsed),
+        }],
+    })
+}
+
 fn validate_options(options: &HydrateSessionOptions) -> Result<()> {
     if options.session_id.trim().is_empty() {
         return Err(hydration_error(
@@ -205,23 +622,22 @@ fn validate_options(options: &HydrateSessionOptions) -> Result<()> {
             format!("unsupported catalog source '{}'", options.source),
         ));
     }
-    if options.scope == SessionScope::Remote {
-        return Err(hydration_error(
-            "HYDRATION_UNSUPPORTED",
-            "remote session hydration is not available: no remote provider connector is configured",
-        ));
-    }
     Ok(())
 }
 
 fn catalog_target(conn: &Connection, options: &HydrateSessionOptions) -> Result<CatalogTarget> {
+    let location = if options.scope == SessionScope::Remote {
+        "remote"
+    } else {
+        "local"
+    };
     let row = conn
         .query_row(
             "SELECT p.raw_locator, COALESCE(p.discovery_state, s.discovery_state) \
-             FROM sessions s LEFT JOIN session_presences p \
-               ON p.source = s.source AND p.session_id = s.session_id AND p.location = 'local' \
+             FROM sessions s JOIN session_presences p \
+               ON p.source = s.source AND p.session_id = s.session_id AND p.location = ? \
              WHERE s.source = ? AND s.session_id = ?",
-            params![options.source, options.session_id],
+            params![location, options.source, options.session_id],
             |row| {
                 Ok(CatalogTarget {
                     locator: row.get(0)?,
@@ -479,6 +895,7 @@ fn ingest_claude(
         Some(&path.to_string_lossy()),
     )?;
     ingest_claude_transcript(conn, path)?;
+    record_claude_remote_relationship(conn, &meta)?;
     // The snapshot already walked and parsed these sidecars to stamp them, so
     // this pass indexes that evidence instead of finding it a second time.
     for evidence in subagents {
@@ -835,6 +1252,7 @@ fn build_result(
         source: options.source.clone(),
         session_id: options.session_id.clone(),
         status: status.to_string(),
+        capability: "full".to_string(),
         discovery_state: "full".to_string(),
         presence: "local".to_string(),
         indexed_through: HydrationIndexedThrough {
@@ -907,6 +1325,7 @@ fn evidence_counts(
         evidence.prompts += count_table(conn, "history", source, session_id)?;
         evidence.events += count_table(conn, "session_events", source, session_id)?;
         evidence.tool_calls += count_table(conn, "tool_calls", source, session_id)?;
+        evidence.file_edits += count_table(conn, "file_edits", source, session_id)?;
     }
     Ok(evidence)
 }
@@ -1957,5 +2376,261 @@ mod tests {
             )
             .unwrap();
         assert_eq!(counts, (1, 1));
+    }
+
+    fn remote_catalog_row(conn: &Connection, source: &str, session_id: &str) {
+        conn.execute(
+            "INSERT INTO sessions (source, session_id, first_prompt, discovery_state) VALUES (?, ?, 'same title', 'shallow')",
+            params![source, session_id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_presences (source, session_id, location, raw_locator, source_stamp, discovery_state) \
+             VALUES (?, ?, 'remote', ?, 'remote-listing', 'shallow')",
+            params![source, session_id, session_id],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn remote_capability_limit_is_a_structured_supported_result() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        remote_catalog_row(&conn, "cursor", "remote-cursor");
+        drop(conn);
+        let result = hydrate_session_at_with_home(
+            &db,
+            &HydrateSessionOptions {
+                source: "cursor".into(),
+                session_id: "remote-cursor".into(),
+                scope: SessionScope::Remote,
+                include_related: true,
+            },
+            dir.path(),
+        )
+        .unwrap();
+        assert_eq!(result.status, "capability_limited");
+        assert_eq!(result.capability, "shallow_only");
+        assert_eq!(result.discovery_state, "shallow");
+        assert_eq!(result.presence, "remote");
+        assert_eq!(result.diagnostics[0].code, "CONNECTOR_NOT_CONFIGURED");
+    }
+
+    #[test]
+    fn claude_remote_full_evidence_is_atomic_idempotent_and_preserves_remote_presence() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("history.db");
+        let mut conn = open_db(&db).unwrap();
+        remote_catalog_row(&conn, "claude", "session_01full");
+        let options = HydrateSessionOptions {
+            source: "claude".into(),
+            session_id: "session_01full".into(),
+            scope: SessionScope::Remote,
+            include_related: true,
+        };
+        let records = vec![
+            serde_json::json!({
+                "sessionId": "session_01full", "uuid": "u1", "type": "user", "timestamp": 1,
+                "message": {"role": "user", "content": "remote prompt"}
+            }),
+            serde_json::json!({
+                "sessionId": "session_01full", "uuid": "a1", "type": "assistant", "timestamp": 2,
+                "message": {"role": "assistant", "model": "claude-test", "usage": {"input_tokens": 2},
+                    "content": [{"type": "tool_use", "id": "tool-1", "name": "Read", "input": {"file_path": "/work/a"}}]}
+            }),
+        ];
+        let first = hydrate_remote_claude(
+            &mut conn,
+            &options,
+            records.clone(),
+            "teleport:one".into(),
+            100,
+            Instant::now(),
+        )
+        .unwrap();
+        assert_eq!(first.status, "hydrated");
+        assert_eq!(first.capability, "full");
+        assert_eq!(first.evidence.prompts, 1);
+        assert_eq!(first.evidence.events, 2);
+        assert_eq!(first.evidence.tool_calls, 1);
+        let presences = conn
+            .prepare("SELECT location, discovery_state FROM session_presences WHERE source='claude' AND session_id='session_01full' ORDER BY location")
+            .unwrap()
+            .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(presences, vec![("remote".into(), "full".into())]);
+
+        let repeated = hydrate_remote_claude(
+            &mut conn,
+            &options,
+            records,
+            "teleport:one".into(),
+            100,
+            Instant::now(),
+        )
+        .unwrap();
+        assert_eq!(repeated.status, "unchanged");
+        assert_eq!(repeated.evidence.events, 2);
+
+        let before: i64 = conn
+            .query_row("SELECT COUNT(*) FROM session_events", [], |row| row.get(0))
+            .unwrap();
+        let malformed = vec![serde_json::json!({
+            "sessionId": "session_different", "uuid": "bad", "type": "user", "timestamp": 3,
+            "message": {"role": "user", "content": "must roll back"}
+        })];
+        assert!(hydrate_remote_claude(
+            &mut conn,
+            &options,
+            malformed,
+            "teleport:bad".into(),
+            20,
+            Instant::now(),
+        )
+        .is_err());
+        let after: i64 = conn
+            .query_row("SELECT COUNT(*) FROM session_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn codex_diff_hydration_is_idempotent_incremental_and_honestly_partial() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("history.db");
+        let mut conn = open_db(&db).unwrap();
+        remote_catalog_row(&conn, "codex", "task_e_123");
+        let options = HydrateSessionOptions {
+            source: "codex".into(),
+            session_id: "task_e_123".into(),
+            scope: SessionScope::Remote,
+            include_related: true,
+        };
+        let diff =
+            "diff --git a/a.txt b/a.txt\n--- a/a.txt\n+++ b/a.txt\n@@ -1 +1,2 @@\n old\n+new\n";
+        let first = hydrate_remote_codex_diff(
+            &mut conn,
+            &options,
+            diff,
+            "diff:one".into(),
+            diff.len() as i64,
+            Instant::now(),
+        )
+        .unwrap();
+        assert_eq!(first.status, "hydrated");
+        assert_eq!(first.capability, "partial");
+        assert_eq!(first.discovery_state, "shallow");
+        assert_eq!(first.evidence.file_edits, 1);
+        assert_eq!(first.diagnostics[0].code, "EVIDENCE_PARTIAL");
+
+        let repeated = hydrate_remote_codex_diff(
+            &mut conn,
+            &options,
+            diff,
+            "diff:one".into(),
+            diff.len() as i64,
+            Instant::now(),
+        )
+        .unwrap();
+        assert_eq!(repeated.status, "unchanged");
+        assert_eq!(repeated.evidence.file_edits, 1);
+
+        let appended = format!(
+            "{diff}diff --git a/b.txt b/b.txt\n--- /dev/null\n+++ b/b.txt\n@@ -0,0 +1 @@\n+added\n"
+        );
+        let updated = hydrate_remote_codex_diff(
+            &mut conn,
+            &options,
+            &appended,
+            "diff:two".into(),
+            appended.len() as i64,
+            Instant::now(),
+        )
+        .unwrap();
+        assert_eq!(updated.status, "updated");
+        assert_eq!(updated.evidence.file_edits, 2);
+    }
+
+    #[test]
+    fn codex_diff_hydration_rolls_back_partial_file_edits_and_checkpoint() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("history.db");
+        let mut conn = open_db(&db).unwrap();
+        remote_catalog_row(&conn, "codex", "task_e_atomic");
+        conn.execute_batch(
+            "CREATE TRIGGER reject_second_remote_edit BEFORE INSERT ON file_edits \
+             WHEN NEW.file_path = 'b.txt' BEGIN SELECT RAISE(ABORT, 'injected remote edit failure'); END;",
+        )
+        .unwrap();
+        let options = HydrateSessionOptions {
+            source: "codex".into(),
+            session_id: "task_e_atomic".into(),
+            scope: SessionScope::Remote,
+            include_related: true,
+        };
+        let diff = "diff --git a/a.txt b/a.txt\n+one\ndiff --git a/b.txt b/b.txt\n+two\n";
+        assert!(hydrate_remote_codex_diff(
+            &mut conn,
+            &options,
+            diff,
+            "diff:atomic".into(),
+            diff.len() as i64,
+            Instant::now(),
+        )
+        .is_err());
+        let counts: (i64, i64) = conn
+            .query_row(
+                "SELECT (SELECT COUNT(*) FROM file_edits WHERE session_id='task_e_atomic'), \
+                        (SELECT COUNT(*) FROM session_hydration_checkpoints WHERE session_id='task_e_atomic')",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(counts, (0, 0));
+    }
+
+    #[test]
+    fn deterministic_claude_remote_id_correlates_but_title_similarity_does_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("history.db");
+        let transcript = dir.path().join(".claude/projects/app/local.jsonl");
+        fs::create_dir_all(transcript.parent().unwrap()).unwrap();
+        fs::write(
+            &transcript,
+            "{\"sessionId\":\"local-1\",\"remoteSessionId\":\"session_01remote\",\"uuid\":\"u1\",\"cwd\":\"/work/app\",\"type\":\"user\",\"timestamp\":1,\"message\":{\"role\":\"user\",\"content\":\"same title\"}}\n",
+        )
+        .unwrap();
+        let similar = dir.path().join(".claude/projects/app/similar.jsonl");
+        fs::write(
+            &similar,
+            "{\"sessionId\":\"local-2\",\"uuid\":\"u2\",\"cwd\":\"/work/app\",\"type\":\"user\",\"timestamp\":2,\"message\":{\"role\":\"user\",\"content\":\"same title\"}}\n",
+        )
+        .unwrap();
+        let conn = open_db(&db).unwrap();
+        remote_catalog_row(&conn, "claude", "session_01remote");
+        catalog_row(&conn, "claude", "local-1", Some(&transcript));
+        catalog_row(&conn, "claude", "local-2", Some(&similar));
+        drop(conn);
+        hydrate_session_at_with_home(&db, &options("claude", "local-1"), dir.path()).unwrap();
+        hydrate_session_at_with_home(&db, &options("claude", "local-2"), dir.path()).unwrap();
+        let conn = open_db(&db).unwrap();
+        let relationships = conn
+            .prepare("SELECT parent_session_id, child_session_id, relationship FROM session_relationships ORDER BY child_session_id")
+            .unwrap()
+            .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            relationships,
+            vec![(
+                "session_01remote".into(),
+                "local-1".into(),
+                "materialized_local".into()
+            )]
+        );
     }
 }

--- a/crates/ai-hist/src/hydrate.rs
+++ b/crates/ai-hist/src/hydrate.rs
@@ -3,6 +3,7 @@
 use super::*;
 use rusqlite::{params, OptionalExtension, TransactionBehavior};
 use serde::Serialize;
+use std::fs::OpenOptions;
 use std::io::Write;
 use std::time::Instant;
 
@@ -98,6 +99,13 @@ fn hydrate_session_at_with_home(
 ) -> Result<HydrateSessionResult> {
     validate_options(options)?;
     let started = Instant::now();
+    // Acquisition and replacement are one per-session critical section. The
+    // provider call has to be inside it: otherwise an older response can wait
+    // behind a newer writer and then replace that newer evidence. A file lock
+    // covers both threads and independent RelayHistory processes.
+    let _remote_lock = (options.scope == SessionScope::Remote)
+        .then(|| acquire_remote_hydration_lock(db_path, options))
+        .transpose()?;
     let mut conn = open_db(db_path)?;
     let target = catalog_target(&conn, options)?;
     if options.scope == SessionScope::Remote {
@@ -195,6 +203,39 @@ fn hydrate_session_at_with_home(
     )
 }
 
+struct RemoteHydrationLock {
+    file: fs::File,
+}
+
+impl Drop for RemoteHydrationLock {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.file);
+    }
+}
+
+fn acquire_remote_hydration_lock(
+    db_path: &Path,
+    options: &HydrateSessionOptions,
+) -> Result<RemoteHydrationLock> {
+    let lock_dir = db_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join(".relayhistory-hydration-locks");
+    fs::create_dir_all(&lock_dir)?;
+    let key = format!("{}\0{}", options.source, options.session_id);
+    let lock_path = lock_dir.join(format!("{:x}.lock", Sha256::digest(key.as_bytes())));
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .with_context(|| format!("opening hydration lock {}", lock_path.display()))?;
+    fs2::FileExt::lock_exclusive(&file)
+        .with_context(|| format!("locking hydration target {}", lock_path.display()))?;
+    Ok(RemoteHydrationLock { file })
+}
+
 fn hydrate_remote_session(
     conn: &mut Connection,
     options: &HydrateSessionOptions,
@@ -251,42 +292,77 @@ fn classify_remote_error(error: anyhow::Error) -> anyhow::Error {
 }
 
 fn redact_remote_diagnostic(message: &str) -> String {
-    message
-        .split_whitespace()
-        .map(|part| {
-            let lower = part.to_ascii_lowercase();
-            if lower.contains("sk-ant-")
-                || lower.contains("bearer")
-                || lower.contains("access_token")
-                || lower.contains("accesstoken")
-                || lower.contains("refresh_token")
-                || lower.contains("refreshtoken")
-            {
-                "[REDACTED]"
-            } else {
-                part
+    let mut redacted = Vec::new();
+    let mut parts = message.split_whitespace();
+    while let Some(part) = parts.next() {
+        let lower = part.to_ascii_lowercase();
+        let marker = lower.contains("bearer")
+            || lower.contains("authorization")
+            || lower.contains("access_token")
+            || lower.contains("accesstoken")
+            || lower.contains("refresh_token")
+            || lower.contains("refreshtoken");
+        let inline_secret = lower.contains("sk-ant-")
+            || marker && part.contains(['=', ':']) && !part.ends_with(['=', ':']);
+        if inline_secret || probable_secret(part) {
+            redacted.push("[REDACTED]");
+        } else if marker {
+            redacted.push("[REDACTED]");
+            // `Bearer TOKEN`, `access_token = TOKEN`, and their colon forms
+            // must not leave the value behind as an innocent-looking token.
+            if matches!(parts.clone().next(), Some("=" | ":")) {
+                parts.next();
             }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
+            parts.next();
+        } else {
+            redacted.push(part);
+        }
+    }
+    redacted.join(" ")
+}
+
+fn probable_secret(part: &str) -> bool {
+    let value =
+        part.trim_matches(|ch: char| !ch.is_ascii_alphanumeric() && !matches!(ch, '-' | '_' | '.'));
+    value.len() >= 24
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+        && value.bytes().any(|byte| byte.is_ascii_lowercase())
+        && value.bytes().any(|byte| byte.is_ascii_uppercase())
+        && value.bytes().any(|byte| byte.is_ascii_digit())
 }
 
 fn remote_limited_result(
-    conn: &Connection,
+    conn: &mut Connection,
     options: &HydrateSessionOptions,
     code: &str,
     message: String,
     started: Instant,
 ) -> Result<HydrateSessionResult> {
+    if options.source == "codex" && code == "PROVIDER_CAPABILITY_LIMITED" {
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        tx.execute(
+            "DELETE FROM file_edits WHERE source = 'codex' AND session_id = ? AND tool_name = 'codex cloud diff'",
+            [&options.session_id],
+        )?;
+        tx.execute(
+            "DELETE FROM session_hydration_checkpoints WHERE source = 'codex' AND session_id = ? AND location = 'remote'",
+            [&options.session_id],
+        )?;
+        tx.commit()?;
+    }
     let related_session_ids = if options.include_related {
         related_ids(conn, &options.source, &options.session_id)?
     } else {
         Vec::new()
     };
+    let mut ids = vec![options.session_id.clone()];
+    ids.extend(related_session_ids.iter().cloned());
     let evidence = evidence_counts(
         conn,
         &options.source,
-        std::slice::from_ref(&options.session_id),
+        &ids,
         related_session_ids.len() as u64,
     )?;
     Ok(HydrateSessionResult {
@@ -319,7 +395,10 @@ fn hydrate_remote_claude(
     started: Instant,
 ) -> Result<HydrateSessionResult> {
     let previous = hydration_checkpoint(conn, options, "remote")?;
-    if previous.as_deref() == Some(source_stamp.as_str()) {
+    if previous.as_ref().is_some_and(|checkpoint| {
+        checkpoint.source_stamp.as_deref() == Some(source_stamp.as_str())
+            && checkpoint.parser_version == HYDRATION_PARSER_VERSION
+    }) {
         return build_remote_result(
             conn,
             options,
@@ -346,11 +425,15 @@ fn hydrate_remote_claude(
             Some(id) if id != options.session_id => anyhow::bail!(
                 "CONNECTOR_FAILURE: Claude teleport record identity does not match the requested session"
             ),
-            None => {
-                object.insert("sessionId".to_string(), Value::String(options.session_id.clone()));
-            }
+            None => {}
             _ => {}
         }
+        // The shared transcript parser consumes the provider's canonical
+        // camelCase field. Normalize the accepted snake_case wire variant.
+        object.insert(
+            "sessionId".to_string(),
+            Value::String(options.session_id.clone()),
+        );
     }
     let mut transcript = tempfile::NamedTempFile::new()?;
     for record in &records {
@@ -358,12 +441,24 @@ fn hydrate_remote_claude(
         transcript.write_all(b"\n")?;
     }
     transcript.flush()?;
-    let had_local_presence: bool = conn.query_row(
+    let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let had_local_presence: bool = tx.query_row(
         "SELECT EXISTS(SELECT 1 FROM session_presences WHERE source = ? AND session_id = ? AND location = 'local')",
         params![options.source, options.session_id],
         |row| row.get(0),
     )?;
-    let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    // A teleport response is a complete remote snapshot. Remove evidence that
+    // disappeared before inserting the new snapshot. When the canonical id
+    // also has local evidence, do not erase rows whose provenance cannot be
+    // distinguished from the remote copy.
+    if !had_local_presence {
+        for table in ["history", "session_events", "tool_calls", "file_edits"] {
+            tx.execute(
+                &format!("DELETE FROM {table} WHERE source = 'claude' AND session_id = ?"),
+                [&options.session_id],
+            )?;
+        }
+    }
     ingest_claude_transcript(&tx, transcript.path())?;
     if !had_local_presence {
         tx.execute(
@@ -417,7 +512,11 @@ fn hydrate_remote_codex_diff(
     started: Instant,
 ) -> Result<HydrateSessionResult> {
     let previous = hydration_checkpoint(conn, options, "remote")?;
-    if previous.as_deref() != Some(source_stamp.as_str()) {
+    let unchanged = previous.as_ref().is_some_and(|checkpoint| {
+        checkpoint.source_stamp.as_deref() == Some(source_stamp.as_str())
+            && checkpoint.parser_version == HYDRATION_PARSER_VERSION
+    });
+    if !unchanged {
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         tx.execute(
             "DELETE FROM file_edits WHERE source = 'codex' AND session_id = ? AND tool_name = 'codex cloud diff'",
@@ -449,7 +548,7 @@ fn hydrate_remote_codex_diff(
     build_remote_result(
         conn,
         options,
-        if previous.as_deref() == Some(source_stamp.as_str()) {
+        if unchanged {
             "unchanged"
         } else if previous.is_some() {
             "updated"
@@ -477,17 +576,14 @@ fn split_unified_diff(diff: &str) -> Vec<UnifiedPatch> {
     let mut current_path: Option<String> = None;
     let mut current = String::new();
     for line in diff.lines() {
-        if let Some(path) = line
-            .strip_prefix("diff --git a/")
-            .and_then(|rest| rest.split(" b/").next())
-        {
+        if let Some(path) = git_diff_destination_path(line) {
             if let Some(path) = current_path.take() {
                 patches.push(UnifiedPatch {
                     path,
                     text: std::mem::take(&mut current),
                 });
             }
-            current_path = Some(path.to_string());
+            current_path = Some(path);
         }
         if current_path.is_some() {
             current.push_str(line);
@@ -509,19 +605,75 @@ fn split_unified_diff(diff: &str) -> Vec<UnifiedPatch> {
     patches
 }
 
+fn git_diff_destination_path(line: &str) -> Option<String> {
+    let mut rest = line.strip_prefix("diff --git ")?;
+    let _source = take_git_path(&mut rest)?;
+    let destination = take_git_path(&mut rest)?;
+    destination.strip_prefix("b/").map(str::to_string)
+}
+
+fn take_git_path(input: &mut &str) -> Option<String> {
+    *input = input.trim_start();
+    if let Some(quoted) = input.strip_prefix('"') {
+        let mut bytes = Vec::new();
+        let raw = quoted.as_bytes();
+        let mut index = 0;
+        while index < raw.len() {
+            match raw[index] {
+                b'"' => {
+                    *input = &quoted[index + 1..];
+                    return Some(String::from_utf8_lossy(&bytes).into_owned());
+                }
+                b'\\' if index + 1 < raw.len() => {
+                    index += 1;
+                    match raw[index] {
+                        b'n' => bytes.push(b'\n'),
+                        b'r' => bytes.push(b'\r'),
+                        b't' => bytes.push(b'\t'),
+                        b'0'..=b'7' => {
+                            let mut value = raw[index] - b'0';
+                            for _ in 0..2 {
+                                if index + 1 < raw.len() && matches!(raw[index + 1], b'0'..=b'7') {
+                                    index += 1;
+                                    value =
+                                        value.saturating_mul(8).saturating_add(raw[index] - b'0');
+                                }
+                            }
+                            bytes.push(value);
+                        }
+                        escaped => bytes.push(escaped),
+                    }
+                }
+                byte => bytes.push(byte),
+            }
+            index += 1;
+        }
+        None
+    } else {
+        let end = input.find(char::is_whitespace).unwrap_or(input.len());
+        let token = input[..end].to_string();
+        *input = &input[end..];
+        Some(token)
+    }
+}
+
+struct HydrationCheckpoint {
+    source_stamp: Option<String>,
+    parser_version: i64,
+}
+
 fn hydration_checkpoint(
     conn: &Connection,
     options: &HydrateSessionOptions,
     location: &str,
-) -> Result<Option<String>> {
+) -> Result<Option<HydrationCheckpoint>> {
     Ok(conn
         .query_row(
-            "SELECT source_stamp FROM session_hydration_checkpoints WHERE source = ? AND session_id = ? AND location = ?",
+            "SELECT source_stamp, parser_version FROM session_hydration_checkpoints WHERE source = ? AND session_id = ? AND location = ?",
             params![options.source, options.session_id, location],
-            |row| row.get(0),
+            |row| Ok(HydrationCheckpoint { source_stamp: row.get(0)?, parser_version: row.get(1)? }),
         )
-        .optional()?
-        .flatten())
+        .optional()?)
 }
 
 fn write_hydration_checkpoint(
@@ -1351,6 +1503,45 @@ fn max_event_time(conn: &Connection, source: &str, session_id: &str) -> Result<O
 mod tests {
     use super::*;
     use std::io::Write;
+
+    #[test]
+    fn remote_diagnostics_redact_separated_inline_and_probable_secrets() {
+        let message = "Bearer secret-value access_token=inline refresh_token : next-value ALongMixedSecretValue123456";
+        let redacted = redact_remote_diagnostic(message);
+        assert_eq!(redacted, "[REDACTED] [REDACTED] [REDACTED] [REDACTED]");
+        assert!(!redacted.contains("secret"));
+        let invalid = classify_remote_error(anyhow::anyhow!(
+            "INVALID_ARGUMENT: remote Claude session id is malformed"
+        ));
+        assert!(invalid.to_string().starts_with("INVALID_ARGUMENT:"));
+    }
+
+    #[test]
+    fn remote_hydration_file_lock_serializes_the_same_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("history.db");
+        let request = HydrateSessionOptions {
+            source: "codex".into(),
+            session_id: "task_lock".into(),
+            scope: SessionScope::Remote,
+            include_related: false,
+        };
+        let first = acquire_remote_hydration_lock(&db, &request).unwrap();
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let second = acquire_remote_hydration_lock(&db, &request).unwrap();
+            sender.send(()).unwrap();
+            drop(second);
+        });
+        assert!(receiver
+            .recv_timeout(std::time::Duration::from_millis(50))
+            .is_err());
+        drop(first);
+        receiver
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        handle.join().unwrap();
+    }
 
     fn catalog_row(conn: &Connection, source: &str, session_id: &str, path: Option<&Path>) {
         conn.execute(
@@ -2398,6 +2589,31 @@ mod tests {
         let db = dir.path().join("history.db");
         let conn = open_db(&db).unwrap();
         remote_catalog_row(&conn, "cursor", "remote-cursor");
+        record_relationship(
+            &conn,
+            &ObservedRelationship {
+                source: "cursor",
+                parent_session_id: "remote-cursor",
+                child_session_id: Some("related-child"),
+                relationship: "delegated",
+                child_agent_type: None,
+                child_agent_name: None,
+                child_model: None,
+                spawn_depth: None,
+                evidence_kind: "test",
+                evidence_locator: None,
+                evidence_ref: None,
+                child_has_events: true,
+                spawned_at_ms: None,
+            },
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_events (source, session_id, ts_ms, role, kind, text, event_uid) \
+             VALUES ('cursor', 'related-child', 1, 'assistant', 'text', 'child output', 'child-event')",
+            [],
+        )
+        .unwrap();
         drop(conn);
         let result = hydrate_session_at_with_home(
             &db,
@@ -2414,6 +2630,8 @@ mod tests {
         assert_eq!(result.capability, "shallow_only");
         assert_eq!(result.discovery_state, "shallow");
         assert_eq!(result.presence, "remote");
+        assert_eq!(result.related_session_ids, vec!["related-child"]);
+        assert_eq!(result.evidence.events, 1);
         assert_eq!(result.diagnostics[0].code, "CONNECTOR_NOT_CONFIGURED");
     }
 
@@ -2431,7 +2649,7 @@ mod tests {
         };
         let records = vec![
             serde_json::json!({
-                "sessionId": "session_01full", "uuid": "u1", "type": "user", "timestamp": 1,
+                "session_id": "session_01full", "uuid": "u1", "type": "user", "timestamp": 1,
                 "message": {"role": "user", "content": "remote prompt"}
             }),
             serde_json::json!({
@@ -2466,7 +2684,7 @@ mod tests {
         let repeated = hydrate_remote_claude(
             &mut conn,
             &options,
-            records,
+            records.clone(),
             "teleport:one".into(),
             100,
             Instant::now(),
@@ -2474,6 +2692,35 @@ mod tests {
         .unwrap();
         assert_eq!(repeated.status, "unchanged");
         assert_eq!(repeated.evidence.events, 2);
+
+        conn.execute(
+            "UPDATE session_hydration_checkpoints SET parser_version = 0 \
+             WHERE source = 'claude' AND session_id = 'session_01full' AND location = 'remote'",
+            [],
+        )
+        .unwrap();
+        let reparsed = hydrate_remote_claude(
+            &mut conn,
+            &options,
+            records.clone(),
+            "teleport:one".into(),
+            100,
+            Instant::now(),
+        )
+        .unwrap();
+        assert_eq!(reparsed.status, "updated");
+
+        let reduced = hydrate_remote_claude(
+            &mut conn,
+            &options,
+            vec![records[0].clone()],
+            "teleport:two".into(),
+            50,
+            Instant::now(),
+        )
+        .unwrap();
+        assert_eq!(reduced.evidence.events, 1);
+        assert_eq!(reduced.evidence.tool_calls, 0);
 
         let before: i64 = conn
             .query_row("SELECT COUNT(*) FROM session_events", [], |row| row.get(0))
@@ -2538,8 +2785,25 @@ mod tests {
         assert_eq!(repeated.status, "unchanged");
         assert_eq!(repeated.evidence.file_edits, 1);
 
+        conn.execute(
+            "UPDATE session_hydration_checkpoints SET parser_version = 0 \
+             WHERE source = 'codex' AND session_id = 'task_e_123' AND location = 'remote'",
+            [],
+        )
+        .unwrap();
+        let reparsed = hydrate_remote_codex_diff(
+            &mut conn,
+            &options,
+            diff,
+            "diff:one".into(),
+            diff.len() as i64,
+            Instant::now(),
+        )
+        .unwrap();
+        assert_eq!(reparsed.status, "updated");
+
         let appended = format!(
-            "{diff}diff --git a/b.txt b/b.txt\n--- /dev/null\n+++ b/b.txt\n@@ -0,0 +1 @@\n+added\n"
+            "{diff}diff --git \"a/old name.txt\" \"b/new name.txt\"\n--- \"a/old name.txt\"\n+++ \"b/new name.txt\"\n@@ -0,0 +1 @@\n+added\n"
         );
         let updated = hydrate_remote_codex_diff(
             &mut conn,
@@ -2552,6 +2816,32 @@ mod tests {
         .unwrap();
         assert_eq!(updated.status, "updated");
         assert_eq!(updated.evidence.file_edits, 2);
+        let paths = conn
+            .prepare("SELECT file_path FROM file_edits WHERE source='codex' AND session_id='task_e_123' ORDER BY file_path")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(paths, vec!["a.txt", "new name.txt"]);
+
+        let limited = remote_limited_result(
+            &mut conn,
+            &options,
+            "PROVIDER_CAPABILITY_LIMITED",
+            "no diff".into(),
+            Instant::now(),
+        )
+        .unwrap();
+        assert_eq!(limited.evidence.file_edits, 0);
+        let checkpoints: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_hydration_checkpoints WHERE source='codex' AND session_id='task_e_123'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(checkpoints, 0);
     }
 
     #[test]

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -159,6 +159,10 @@ fn sync_remote_connectors(db_path: &Path, scope: SessionScope) -> Result<bool> {
         limit: None,
     };
     let summary = discover_sessions(&conn, &options, |_| {})?;
+    // `all` ingests local transcripts before remote discovery. Correlate again
+    // after the remote presences land so a first local-first run records exact
+    // provider ids even when the local transcript is unchanged thereafter.
+    reconcile_claude_remote_relationships(&conn)?;
     for (source, provider) in &summary.providers {
         sync_note!(
             "  [remote:{source}] {} session(s): {} discovered, {} unchanged",
@@ -6561,13 +6565,17 @@ fn scan_claude_session_file(path: &Path) -> Result<Option<ClaudeSessionMeta>> {
                 .map(str::to_string);
         }
         if remote_session_id.is_none() {
-            remote_session_id = value
-                .get("remoteSessionId")
-                .or_else(|| value.get("remote_session_id"))
-                .or_else(|| value.pointer("/teleportedSessionInfo/sessionId"))
-                .and_then(Value::as_str)
-                .filter(|id| !id.trim().is_empty())
-                .map(str::to_string);
+            remote_session_id = [
+                value.get("remoteSessionId"),
+                value.get("remote_session_id"),
+                value.pointer("/teleportedSessionInfo/sessionId"),
+            ]
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+            .map(str::trim)
+            .find(|id| !id.is_empty())
+            .map(str::to_string);
         }
         if cwd.is_none() {
             cwd = value.get("cwd").and_then(Value::as_str).map(str::to_string);
@@ -6616,6 +6624,22 @@ fn scan_claude_session_file(path: &Path) -> Result<Option<ClaudeSessionMeta>> {
         subagent: identified_records > 0 && sidechain_records == identified_records,
         agent_id,
     }))
+}
+
+fn reconcile_claude_remote_relationships(conn: &Connection) -> Result<()> {
+    let paths = conn
+        .prepare(
+            "SELECT raw_locator FROM session_presences \
+             WHERE source = 'claude' AND location = 'local' AND raw_locator IS NOT NULL",
+        )?
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    for path in paths {
+        if let Some(meta) = scan_claude_session_file(Path::new(&path))? {
+            record_claude_remote_relationship(conn, &meta)?;
+        }
+    }
+    Ok(())
 }
 
 fn record_claude_remote_relationship(conn: &Connection, meta: &ClaudeSessionMeta) -> Result<()> {
@@ -8371,11 +8395,12 @@ mod tests {
         doctor_report, export_history, file_stamp, git_commit_time_ms, git_stdout, import_history,
         ingest_claude_transcript, is_sqlite_contention, link_git_commit, load_sync_state,
         parse_trajectory_file, paths_overlap, prepare_sync_and_push_db,
-        process_status_with_programs, save_sync_state, search_all, service_command_args,
-        shell_single_quote, source_database_path, strip_url_credentials,
-        sync_claude_session_metadata, sync_exclusive, sync_local_at, sync_opencode_exclusive,
-        sync_relaycast, try_acquire_sync_lock, wal_contention_line, write_contention_diagnostic,
-        xml_escape, SearchRole, SyncSourceReport, PUSH_SERVICE, WAL_WARN_BYTES,
+        process_status_with_programs, reconcile_claude_remote_relationships, save_sync_state,
+        search_all, service_command_args, shell_single_quote, source_database_path,
+        strip_url_credentials, sync_claude_session_metadata, sync_exclusive, sync_local_at,
+        sync_opencode_exclusive, sync_relaycast, try_acquire_sync_lock, wal_contention_line,
+        write_contention_diagnostic, xml_escape, SearchRole, SyncSourceReport, PUSH_SERVICE,
+        WAL_WARN_BYTES,
     };
     use ai_hist_core::{
         init_db, insert_history, open_db, prompt_hash, HistoryEntry, QueryFilter,
@@ -9971,6 +9996,62 @@ mod tests {
             },
         )
         .unwrap()
+    }
+
+    #[test]
+    fn local_first_sync_reconciles_a_later_remote_presence_by_exact_trimmed_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = dir.path().join(".claude/projects/app/local.jsonl");
+        fs::create_dir_all(transcript.parent().unwrap()).unwrap();
+        fs::write(
+            &transcript,
+            concat!(
+                r#"{"sessionId":"local-materialized","remoteSessionId":7,"remote_session_id":"  session_01remote  ","uuid":"u1","type":"user","timestamp":1,"message":{"role":"user","content":"hello"}}"#,
+                "\n"
+            ),
+        )
+        .unwrap();
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let mut state = Map::new();
+        sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
+        let before: i64 = conn
+            .query_row("SELECT COUNT(*) FROM session_relationships", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(before, 0);
+        conn.execute(
+            "INSERT INTO sessions (source, session_id, discovery_state) \
+             VALUES ('claude', 'session_01remote', 'shallow')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_presences \
+             (source, session_id, location, raw_locator, discovery_state) \
+             VALUES ('claude', 'session_01remote', 'remote', 'session_01remote', 'shallow')",
+            [],
+        )
+        .unwrap();
+
+        reconcile_claude_remote_relationships(&conn).unwrap();
+        let relationship: (String, String, String) = conn
+            .query_row(
+                "SELECT parent_session_id, child_session_id, relationship \
+                 FROM session_relationships WHERE evidence_kind='claude_remote_session_id'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            relationship,
+            (
+                "session_01remote".into(),
+                "local-materialized".into(),
+                "materialized_local".into()
+            )
+        );
     }
 
     #[test]

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -6428,6 +6428,7 @@ fn sync_claude_session_metadata(
                 Some(&path.to_string_lossy()),
             )?;
             ingest_claude_transcript(conn, &path)?;
+            record_claude_remote_relationship(conn, &meta)?;
             upserted += 1;
         }
     }
@@ -6505,6 +6506,7 @@ fn claude_transcript_events_exist(conn: &Connection, path: &Path) -> Result<bool
 
 struct ClaudeSessionMeta {
     session_id: String,
+    remote_session_id: Option<String>,
     cwd: Option<String>,
     git_branch: Option<String>,
     first_ts: i64,
@@ -6522,6 +6524,7 @@ struct ClaudeSessionMeta {
 fn scan_claude_session_file(path: &Path) -> Result<Option<ClaudeSessionMeta>> {
     let text = fs::read_to_string(path).unwrap_or_default();
     let mut session_id = None;
+    let mut remote_session_id = None;
     let mut cwd = None;
     let mut git_branch = None;
     let mut first_ts = None;
@@ -6555,6 +6558,15 @@ fn scan_claude_session_file(path: &Path) -> Result<Option<ClaudeSessionMeta>> {
             session_id = value
                 .get("sessionId")
                 .and_then(Value::as_str)
+                .map(str::to_string);
+        }
+        if remote_session_id.is_none() {
+            remote_session_id = value
+                .get("remoteSessionId")
+                .or_else(|| value.get("remote_session_id"))
+                .or_else(|| value.pointer("/teleportedSessionInfo/sessionId"))
+                .and_then(Value::as_str)
+                .filter(|id| !id.trim().is_empty())
                 .map(str::to_string);
         }
         if cwd.is_none() {
@@ -6595,6 +6607,7 @@ fn scan_claude_session_file(path: &Path) -> Result<Option<ClaudeSessionMeta>> {
     let first = first_ts.unwrap_or(0);
     Ok(Some(ClaudeSessionMeta {
         session_id,
+        remote_session_id,
         cwd,
         git_branch,
         first_ts: first,
@@ -6603,6 +6616,42 @@ fn scan_claude_session_file(path: &Path) -> Result<Option<ClaudeSessionMeta>> {
         subagent: identified_records > 0 && sidechain_records == identified_records,
         agent_id,
     }))
+}
+
+fn record_claude_remote_relationship(conn: &Connection, meta: &ClaudeSessionMeta) -> Result<()> {
+    let Some(remote_id) = meta.remote_session_id.as_deref() else {
+        return Ok(());
+    };
+    if remote_id == meta.session_id {
+        return Ok(());
+    }
+    let remote_exists: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM session_presences \
+         WHERE source = 'claude' AND session_id = ? AND location = 'remote')",
+        [remote_id],
+        |row| row.get(0),
+    )?;
+    if remote_exists {
+        record_relationship(
+            conn,
+            &ObservedRelationship {
+                source: "claude",
+                parent_session_id: remote_id,
+                child_session_id: Some(&meta.session_id),
+                relationship: "materialized_local",
+                child_agent_type: None,
+                child_agent_name: None,
+                child_model: None,
+                spawn_depth: None,
+                evidence_kind: "claude_remote_session_id",
+                evidence_locator: None,
+                evidence_ref: Some(remote_id),
+                child_has_events: session_events_exist(conn, "claude", &meta.session_id)?,
+                spawned_at_ms: None,
+            },
+        )?;
+    }
+    Ok(())
 }
 
 fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -159,9 +159,9 @@ fn sync_remote_connectors(db_path: &Path, scope: SessionScope) -> Result<bool> {
         limit: None,
     };
     let summary = discover_sessions(&conn, &options, |_| {})?;
-    // `all` ingests local transcripts before remote discovery. Correlate again
-    // after the remote presences land so a first local-first run records exact
-    // provider ids even when the local transcript is unchanged thereafter.
+    // `all` ingests local transcripts before remote discovery. Correlate from
+    // the exact ids cached by that local pass; remote-only sync never opens a
+    // local transcript merely to repair topology.
     reconcile_claude_remote_relationships(&conn)?;
     for (source, provider) in &summary.providers {
         sync_note!(
@@ -6381,15 +6381,16 @@ fn sync_claude_session_metadata(
     if !root.exists() {
         return Ok(());
     }
-    // The v2 key forces one full re-scan on upgrade: transcripts whose
-    // stamps never change again still need the sidechain healing pass that
-    // removes previously ingested fake user turns.
+    // The v3 key forces one full re-scan on upgrade so exact remote/local ids
+    // are cached for bounded post-discovery correlation. The earlier v2 pass
+    // healed sidechains that had been attributed to their parent.
     let mut session_state = state
-        .get("claude_sessions_v2")
+        .get("claude_sessions_v3")
         .and_then(Value::as_object)
         .cloned()
         .unwrap_or_default();
     state.remove("claude_sessions");
+    state.remove("claude_sessions_v2");
     let mut scanned = 0;
     let mut upserted = 0;
     for path in collect_matching_files(root, "", "jsonl")? {
@@ -6437,7 +6438,7 @@ fn sync_claude_session_metadata(
         }
     }
     state.insert(
-        "claude_sessions_v2".to_string(),
+        "claude_sessions_v3".to_string(),
         Value::Object(session_state),
     );
     if scanned > 0 {
@@ -6627,17 +6628,21 @@ fn scan_claude_session_file(path: &Path) -> Result<Option<ClaudeSessionMeta>> {
 }
 
 fn reconcile_claude_remote_relationships(conn: &Connection) -> Result<()> {
-    let paths = conn
+    let correlations = conn
         .prepare(
-            "SELECT raw_locator FROM session_presences \
-             WHERE source = 'claude' AND location = 'local' AND raw_locator IS NOT NULL",
+            "SELECT c.remote_session_id, c.local_session_id \
+             FROM session_identity_correlations c \
+             JOIN session_presences p \
+               ON p.source = c.source AND p.session_id = c.remote_session_id \
+              AND p.location = 'remote' \
+             WHERE c.source = 'claude' AND c.relationship = 'materialized_local'",
         )?
-        .query_map([], |row| row.get::<_, String>(0))?
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
         .collect::<rusqlite::Result<Vec<_>>>()?;
-    for path in paths {
-        if let Some(meta) = scan_claude_session_file(Path::new(&path))? {
-            record_claude_remote_relationship(conn, &meta)?;
-        }
+    for (remote_id, local_id) in correlations {
+        record_claude_materialized_relationship(conn, &remote_id, &local_id)?;
     }
     Ok(())
 }
@@ -6649,6 +6654,15 @@ fn record_claude_remote_relationship(conn: &Connection, meta: &ClaudeSessionMeta
     if remote_id == meta.session_id {
         return Ok(());
     }
+    conn.execute(
+        "INSERT INTO session_identity_correlations \
+         (source, local_session_id, remote_session_id, relationship, evidence_kind, updated_ms) \
+         VALUES ('claude', ?, ?, 'materialized_local', 'claude_remote_session_id', ?) \
+         ON CONFLICT(source, local_session_id, relationship) DO UPDATE SET \
+           remote_session_id = excluded.remote_session_id, \
+           evidence_kind = excluded.evidence_kind, updated_ms = excluded.updated_ms",
+        params![meta.session_id, remote_id, (now_ns() / 1_000_000) as i64],
+    )?;
     let remote_exists: bool = conn.query_row(
         "SELECT EXISTS(SELECT 1 FROM session_presences \
          WHERE source = 'claude' AND session_id = ? AND location = 'remote')",
@@ -6656,26 +6670,34 @@ fn record_claude_remote_relationship(conn: &Connection, meta: &ClaudeSessionMeta
         |row| row.get(0),
     )?;
     if remote_exists {
-        record_relationship(
-            conn,
-            &ObservedRelationship {
-                source: "claude",
-                parent_session_id: remote_id,
-                child_session_id: Some(&meta.session_id),
-                relationship: "materialized_local",
-                child_agent_type: None,
-                child_agent_name: None,
-                child_model: None,
-                spawn_depth: None,
-                evidence_kind: "claude_remote_session_id",
-                evidence_locator: None,
-                evidence_ref: Some(remote_id),
-                child_has_events: session_events_exist(conn, "claude", &meta.session_id)?,
-                spawned_at_ms: None,
-            },
-        )?;
+        record_claude_materialized_relationship(conn, remote_id, &meta.session_id)?;
     }
     Ok(())
+}
+
+fn record_claude_materialized_relationship(
+    conn: &Connection,
+    remote_id: &str,
+    local_id: &str,
+) -> Result<()> {
+    record_relationship(
+        conn,
+        &ObservedRelationship {
+            source: "claude",
+            parent_session_id: remote_id,
+            child_session_id: Some(local_id),
+            relationship: "materialized_local",
+            child_agent_type: None,
+            child_agent_name: None,
+            child_model: None,
+            spawn_depth: None,
+            evidence_kind: "claude_remote_session_id",
+            evidence_locator: None,
+            evidence_ref: Some(remote_id),
+            child_has_events: session_events_exist(conn, "claude", local_id)?,
+            spawned_at_ms: None,
+        },
+    )
 }
 
 fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
@@ -8795,20 +8817,20 @@ mod tests {
         let path = dir.path().join(".sync-state.json");
         let mut on_disk = Map::new();
         on_disk.insert(
-            "claude_sessions_v2".into(),
+            "claude_sessions_v3".into(),
             json!({"first.jsonl": "old", "nested": {"left": 1}}),
         );
         save_sync_state(&path, &on_disk).unwrap();
 
         let mut ours = Map::new();
         ours.insert(
-            "claude_sessions_v2".into(),
+            "claude_sessions_v3".into(),
             json!({"second.jsonl": "new", "nested": {"right": 2}}),
         );
         checkpoint_sync_state(&path, &ours);
 
         assert_eq!(
-            load_sync_state(&path).unwrap()["claude_sessions_v2"],
+            load_sync_state(&path).unwrap()["claude_sessions_v3"],
             json!({
                 "first.jsonl": "old",
                 "second.jsonl": "new",
@@ -9898,7 +9920,7 @@ mod tests {
         );
         let mut state = Map::new();
         state.insert(
-            "claude_sessions_v2".to_string(),
+            "claude_sessions_v3".to_string(),
             Value::Object(claude_sessions),
         );
 
@@ -10015,6 +10037,18 @@ mod tests {
         init_db(&conn).unwrap();
         let mut state = Map::new();
         sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
+        let cached: (String, String) = conn
+            .query_row(
+                "SELECT local_session_id, remote_session_id \
+                 FROM session_identity_correlations WHERE source = 'claude'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            cached,
+            ("local-materialized".into(), "session_01remote".into())
+        );
         let before: i64 = conn
             .query_row("SELECT COUNT(*) FROM session_relationships", [], |row| {
                 row.get(0)
@@ -10034,6 +10068,10 @@ mod tests {
             [],
         )
         .unwrap();
+
+        // Remote reconciliation must use the observed identity cache. The
+        // transcript may have disappeared between local and remote syncs.
+        fs::remove_file(&transcript).unwrap();
 
         reconcile_claude_remote_relationships(&conn).unwrap();
         let relationship: (String, String, String) = conn
@@ -10201,7 +10239,7 @@ mod tests {
         .unwrap();
         let key = named.to_string_lossy().to_string();
         state
-            .get_mut("claude_sessions_v2")
+            .get_mut("claude_sessions_v3")
             .and_then(Value::as_object_mut)
             .unwrap()
             .insert(key, json!(claude_sync_stamp(&named).unwrap()));
@@ -10290,7 +10328,7 @@ mod tests {
         }
         let mut state = Map::new();
         state.insert(
-            "claude_sessions_v2".to_string(),
+            "claude_sessions_v3".to_string(),
             Value::Object(claude_sessions),
         );
 

--- a/crates/ai-hist/src/remote.rs
+++ b/crates/ai-hist/src/remote.rs
@@ -46,7 +46,7 @@ use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{mpsc, Mutex};
 use std::time::{Duration, Instant};
 
 use ai_hist_core::{SessionLocation, SOURCE_CHOICES};
@@ -292,26 +292,17 @@ pub(crate) struct ClaudeHttpResponse {
 /// The HTTP side of the claude.ai session listing, abstracted so mapping and
 /// pagination are testable without a network.
 pub(crate) trait ClaudeSessionsTransport: Send + Sync {
-    fn get(&self, url: &str, bearer_token: &str) -> Result<ClaudeHttpResponse>;
-
     fn get_with_headers(
         &self,
         url: &str,
         bearer_token: &str,
         headers: &[(&str, &str)],
-    ) -> Result<ClaudeHttpResponse> {
-        let _ = headers;
-        self.get(url, bearer_token)
-    }
+    ) -> Result<ClaudeHttpResponse>;
 }
 
 struct UreqClaudeTransport;
 
 impl ClaudeSessionsTransport for UreqClaudeTransport {
-    fn get(&self, url: &str, bearer_token: &str) -> Result<ClaudeHttpResponse> {
-        self.get_with_headers(url, bearer_token, &[])
-    }
-
     fn get_with_headers(
         &self,
         url: &str,
@@ -369,7 +360,11 @@ pub(crate) fn acquire_remote_session_at(
             &claude_api_base_url(),
             &UreqClaudeTransport,
         ),
-        "codex" => acquire_codex_remote_session(session_id),
+        "codex" if codex_auth_path(home).is_file() => acquire_codex_remote_session(session_id),
+        "codex" => Ok(RemoteSessionEvidence::CapabilityLimited {
+            code: "CONNECTOR_NOT_CONFIGURED",
+            message: "codex-cloud is not configured; run `codex login`".to_string(),
+        }),
         _ => Ok(RemoteSessionEvidence::CapabilityLimited {
             code: "CONNECTOR_NOT_CONFIGURED",
             message: format!("no remote hydration connector exists for source '{source}'"),
@@ -392,7 +387,7 @@ fn acquire_claude_remote_session_at(
     }
     anyhow::ensure!(
         is_claude_web_session_id(session_id),
-        "remote Claude session id is malformed"
+        "INVALID_ARGUMENT: remote Claude session id is malformed"
     );
     require_https_or_loopback(base_url)?;
     let oauth = load_claude_oauth(&credentials_path)?;
@@ -408,7 +403,7 @@ fn acquire_claude_remote_session_at(
     // teleport-events. Both interfaces are private implementation contracts,
     // so parser failures are explicit rather than treated as empty evidence.
     let profile_url = format!("{base_url}/api/oauth/profile");
-    let profile = transport.get(&profile_url, &oauth.access_token)?;
+    let profile = transport.get_with_headers(&profile_url, &oauth.access_token, &[])?;
     match profile.status {
         200 => {}
         401 | 403 => anyhow::bail!(
@@ -692,7 +687,9 @@ impl ShallowSessionProvider for ClaudeWebProvider {
                 url.push_str("&cursor=");
                 url.push_str(&urlencode(cursor));
             }
-            let response = self.transport.get(&url, &oauth.access_token)?;
+            let response = self
+                .transport
+                .get_with_headers(&url, &oauth.access_token, &[])?;
             match response.status {
                 200 => {}
                 401 | 403 => anyhow::bail!(
@@ -768,6 +765,14 @@ fn acquire_codex_remote_session_with_command(
     session_id: &str,
     command: &OsStr,
 ) -> Result<RemoteSessionEvidence> {
+    acquire_codex_remote_session_with_command_timeout(session_id, command, REMOTE_COMMAND_TIMEOUT)
+}
+
+fn acquire_codex_remote_session_with_command_timeout(
+    session_id: &str,
+    command: &OsStr,
+    timeout: Duration,
+) -> Result<RemoteSessionEvidence> {
     if !session_id.starts_with("task_")
         || !session_id
             .bytes()
@@ -797,14 +802,26 @@ fn acquire_codex_remote_session_with_command(
         .take()
         .context("CONNECTOR_FAILURE: no Codex stderr pipe")?;
     let read_bounded = |mut stream: Box<dyn Read + Send>| {
+        let (sender, receiver) = mpsc::sync_channel(1);
         std::thread::spawn(move || {
             let mut bytes = Vec::new();
-            stream
-                .by_ref()
-                .take((MAX_REMOTE_EVIDENCE_BYTES + 1) as u64)
-                .read_to_end(&mut bytes)?;
-            Ok::<Vec<u8>, std::io::Error>(bytes)
-        })
+            let mut buffer = [0u8; 64 * 1024];
+            let result = loop {
+                match stream.read(&mut buffer) {
+                    Ok(0) => break Ok(bytes),
+                    Ok(read) => {
+                        // Retain only enough to detect the limit, but keep
+                        // draining so an oversized child cannot block on a
+                        // full pipe and masquerade as a command timeout.
+                        let remaining = (MAX_REMOTE_EVIDENCE_BYTES + 1).saturating_sub(bytes.len());
+                        bytes.extend_from_slice(&buffer[..read.min(remaining)]);
+                    }
+                    Err(error) => break Err(error),
+                }
+            };
+            let _ = sender.send(result);
+        });
+        receiver
     };
     let stdout_reader = read_bounded(Box::new(stdout));
     let stderr_reader = read_bounded(Box::new(stderr));
@@ -813,19 +830,26 @@ fn acquire_codex_remote_session_with_command(
         if let Some(status) = child.try_wait()? {
             break status;
         }
-        if started.elapsed() >= REMOTE_COMMAND_TIMEOUT {
+        if started.elapsed() >= timeout {
             let _ = child.kill();
             let _ = child.wait();
             anyhow::bail!("CONNECTOR_FAILURE: `codex cloud diff` exceeded the 30 second timeout");
         }
         std::thread::sleep(Duration::from_millis(25));
     };
-    let stdout = stdout_reader
-        .join()
-        .map_err(|_| anyhow::anyhow!("CONNECTOR_FAILURE: Codex stdout reader panicked"))??;
-    let stderr = stderr_reader
-        .join()
-        .map_err(|_| anyhow::anyhow!("CONNECTOR_FAILURE: Codex stderr reader panicked"))??;
+    let receive = |reader: mpsc::Receiver<std::io::Result<Vec<u8>>>, name: &str| {
+        let remaining = timeout.checked_sub(started.elapsed()).unwrap_or_default();
+        reader
+            .recv_timeout(remaining)
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "CONNECTOR_FAILURE: Codex {name} pipe remained open past the 30 second timeout"
+                )
+            })?
+            .map_err(anyhow::Error::from)
+    };
+    let stdout = receive(stdout_reader, "stdout")?;
+    let stderr = receive(stderr_reader, "stderr")?;
     anyhow::ensure!(
         stdout.len() <= MAX_REMOTE_EVIDENCE_BYTES && stderr.len() <= MAX_REMOTE_EVIDENCE_BYTES,
         "CONNECTOR_FAILURE: `codex cloud diff` exceeded the 16 MiB response-size limit"

--- a/crates/ai-hist/src/remote.rs
+++ b/crates/ai-hist/src/remote.rs
@@ -43,13 +43,17 @@
 //! reported as connector diagnostics, never silently swallowed.
 
 use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use ai_hist_core::{SessionLocation, SOURCE_CHOICES};
 use anyhow::{Context, Result};
 use rusqlite::Connection;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 use crate::discover::{
     excerpt, Candidate, DiscoveryEnv, ScanEnv, ShallowSession, ShallowSessionProvider,
@@ -64,6 +68,27 @@ pub const CODEX_CLOUD_CONNECTOR: &str = "codex-cloud";
 const MAX_LIST_PAGES: usize = 100;
 /// Rows requested per claude.ai listing page (the endpoint's own maximum).
 const CLAUDE_PAGE_LIMIT: usize = 100;
+const CLAUDE_EVIDENCE_PAGE_LIMIT: usize = 1_000;
+const MAX_REMOTE_EVIDENCE_BYTES: usize = 16 * 1024 * 1024;
+const REMOTE_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug)]
+pub(crate) enum RemoteSessionEvidence {
+    ClaudeFull {
+        records: Vec<Value>,
+        source_stamp: String,
+        source_bytes: i64,
+    },
+    CodexDiff {
+        diff: String,
+        source_stamp: String,
+        source_bytes: i64,
+    },
+    CapabilityLimited {
+        code: &'static str,
+        message: String,
+    },
+}
 
 /// Whether one remote connector can run on this machine, and why not when it
 /// cannot.
@@ -268,36 +293,204 @@ pub(crate) struct ClaudeHttpResponse {
 /// pagination are testable without a network.
 pub(crate) trait ClaudeSessionsTransport: Send + Sync {
     fn get(&self, url: &str, bearer_token: &str) -> Result<ClaudeHttpResponse>;
+
+    fn get_with_headers(
+        &self,
+        url: &str,
+        bearer_token: &str,
+        headers: &[(&str, &str)],
+    ) -> Result<ClaudeHttpResponse> {
+        let _ = headers;
+        self.get(url, bearer_token)
+    }
 }
 
 struct UreqClaudeTransport;
 
 impl ClaudeSessionsTransport for UreqClaudeTransport {
     fn get(&self, url: &str, bearer_token: &str) -> Result<ClaudeHttpResponse> {
+        self.get_with_headers(url, bearer_token, &[])
+    }
+
+    fn get_with_headers(
+        &self,
+        url: &str,
+        bearer_token: &str,
+        headers: &[(&str, &str)],
+    ) -> Result<ClaudeHttpResponse> {
         // Redirects are never followed: ureq would re-send the Authorization
         // header to the redirect target, so a redirecting endpoint could move
         // the stored OAuth token to a host the https-or-loopback guard never
         // saw. A 3xx therefore surfaces as a failed listing, not a hop.
         let agent = ureq::AgentBuilder::new().redirects(0).build();
-        let request = agent
+        let mut request = agent
             .get(url)
             .timeout(std::time::Duration::from_secs(30))
             .set("Authorization", &format!("Bearer {bearer_token}"))
             .set("Content-Type", "application/json")
             .set("anthropic-version", "2023-06-01")
             .set("anthropic-beta", "oauth-2025-04-20");
+        for (name, value) in headers {
+            request = request.set(name, value);
+        }
         match request.call() {
-            Ok(response) => Ok(ClaudeHttpResponse {
-                status: response.status(),
-                body: response.into_string().unwrap_or_default(),
-            }),
-            Err(ureq::Error::Status(status, response)) => Ok(ClaudeHttpResponse {
-                status,
-                body: response.into_string().unwrap_or_default(),
-            }),
+            Ok(response) => bounded_claude_response(response.status(), response),
+            Err(ureq::Error::Status(status, response)) => bounded_claude_response(status, response),
             Err(error) => Err(anyhow::Error::from(error).context("claude.ai session list request")),
         }
     }
+}
+
+fn bounded_claude_response(status: u16, response: ureq::Response) -> Result<ClaudeHttpResponse> {
+    let mut bytes = Vec::new();
+    response
+        .into_reader()
+        .take((MAX_REMOTE_EVIDENCE_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    anyhow::ensure!(
+        bytes.len() <= MAX_REMOTE_EVIDENCE_BYTES,
+        "Claude response exceeded the 16 MiB response-size limit"
+    );
+    Ok(ClaudeHttpResponse {
+        status,
+        body: String::from_utf8_lossy(&bytes).into_owned(),
+    })
+}
+
+pub(crate) fn acquire_remote_session_at(
+    home: &Path,
+    source: &str,
+    session_id: &str,
+) -> Result<RemoteSessionEvidence> {
+    match source {
+        "claude" => acquire_claude_remote_session_at(
+            home,
+            session_id,
+            &claude_api_base_url(),
+            &UreqClaudeTransport,
+        ),
+        "codex" => acquire_codex_remote_session(session_id),
+        _ => Ok(RemoteSessionEvidence::CapabilityLimited {
+            code: "CONNECTOR_NOT_CONFIGURED",
+            message: format!("no remote hydration connector exists for source '{source}'"),
+        }),
+    }
+}
+
+fn acquire_claude_remote_session_at(
+    home: &Path,
+    session_id: &str,
+    base_url: &str,
+    transport: &dyn ClaudeSessionsTransport,
+) -> Result<RemoteSessionEvidence> {
+    let credentials_path = claude_credentials_path(home);
+    if !credentials_path.is_file() {
+        return Ok(RemoteSessionEvidence::CapabilityLimited {
+            code: "CONNECTOR_NOT_CONFIGURED",
+            message: "claude-web is not configured; sign in with Claude Code or set RELAYHISTORY_CLAUDE_CREDENTIALS".to_string(),
+        });
+    }
+    anyhow::ensure!(
+        is_claude_web_session_id(session_id),
+        "remote Claude session id is malformed"
+    );
+    require_https_or_loopback(base_url)?;
+    let oauth = load_claude_oauth(&credentials_path)?;
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+    if oauth.expires_at_ms.is_some_and(|expires| expires <= now_ms) {
+        anyhow::bail!("AUTHENTICATION_EXPIRED: the stored claude.ai OAuth token has expired; run Claude Code once to refresh it");
+    }
+
+    // Claude Code itself resolves the organization this way before calling
+    // teleport-events. Both interfaces are private implementation contracts,
+    // so parser failures are explicit rather than treated as empty evidence.
+    let profile_url = format!("{base_url}/api/oauth/profile");
+    let profile = transport.get(&profile_url, &oauth.access_token)?;
+    match profile.status {
+        200 => {}
+        401 | 403 => anyhow::bail!(
+            "AUTHENTICATION_EXPIRED: claude.ai rejected the stored OAuth token (HTTP {})",
+            profile.status
+        ),
+        status => anyhow::bail!("CONNECTOR_FAILURE: Claude OAuth profile failed (HTTP {status})"),
+    }
+    anyhow::ensure!(
+        profile.body.len() <= MAX_REMOTE_EVIDENCE_BYTES,
+        "CONNECTOR_FAILURE: Claude OAuth profile exceeded the response-size limit"
+    );
+    let profile_json: Value = serde_json::from_str(&profile.body)
+        .context("CONNECTOR_FAILURE: Claude OAuth profile returned malformed JSON")?;
+    let org_uuid = profile_json
+        .pointer("/organization/uuid")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .context("CONNECTOR_FAILURE: Claude OAuth profile omitted organization.uuid")?;
+
+    let mut records = Vec::new();
+    let mut cursor: Option<String> = None;
+    let mut source_bytes = profile.body.len();
+    for _ in 0..MAX_LIST_PAGES {
+        let mut url = format!(
+            "{base_url}/v1/code/sessions/{session_id}/teleport-events?limit={CLAUDE_EVIDENCE_PAGE_LIMIT}"
+        );
+        if let Some(value) = cursor.as_deref() {
+            url.push_str("&cursor=");
+            url.push_str(&urlencode(value));
+        }
+        let response = transport.get_with_headers(
+            &url,
+            &oauth.access_token,
+            &[("x-organization-uuid", org_uuid)],
+        )?;
+        match response.status {
+            200 => {}
+            401 => anyhow::bail!(
+                "AUTHENTICATION_EXPIRED: Claude teleport evidence was rejected (HTTP {})",
+                response.status
+            ),
+            403 => anyhow::bail!(
+                "CONNECTOR_FAILURE: Claude teleport evidence was denied; the session may require trusted-device enrollment"
+            ),
+            404 => anyhow::bail!("SESSION_NOT_FOUND: remote Claude session no longer exists"),
+            status => anyhow::bail!(
+                "CONNECTOR_FAILURE: Claude teleport evidence failed (HTTP {status})"
+            ),
+        }
+        source_bytes = source_bytes.saturating_add(response.body.len());
+        anyhow::ensure!(
+            source_bytes <= MAX_REMOTE_EVIDENCE_BYTES,
+            "CONNECTOR_FAILURE: remote Claude evidence exceeded the 16 MiB response-size limit"
+        );
+        let payload: Value = serde_json::from_str(&response.body)
+            .context("CONNECTOR_FAILURE: Claude teleport evidence returned malformed JSON")?;
+        let page = payload
+            .get("data")
+            .and_then(Value::as_array)
+            .context("CONNECTOR_FAILURE: Claude teleport evidence response has no data array")?;
+        for entry in page {
+            let record = entry
+                .get("payload")
+                .filter(|value| value.is_object())
+                .context(
+                    "CONNECTOR_FAILURE: Claude teleport evidence contains a malformed record",
+                )?;
+            records.push(record.clone());
+        }
+        cursor = string_field(&payload, "next_cursor");
+        if cursor.is_none() {
+            let encoded = serde_json::to_vec(&records)?;
+            let source_stamp = format!("teleport:{:x}", Sha256::digest(&encoded));
+            return Ok(RemoteSessionEvidence::ClaudeFull {
+                records,
+                source_stamp,
+                source_bytes: source_bytes as i64,
+            });
+        }
+    }
+    anyhow::bail!("EVIDENCE_PARTIAL: Claude teleport evidence exceeded the 100-page bound")
 }
 
 fn claude_api_base_url() -> String {
@@ -565,6 +758,104 @@ fn excerpt_one_line(raw: &str) -> String {
         out.push('…');
     }
     out
+}
+
+fn acquire_codex_remote_session(session_id: &str) -> Result<RemoteSessionEvidence> {
+    acquire_codex_remote_session_with_command(session_id, OsStr::new("codex"))
+}
+
+fn acquire_codex_remote_session_with_command(
+    session_id: &str,
+    command: &OsStr,
+) -> Result<RemoteSessionEvidence> {
+    if !session_id.starts_with("task_")
+        || !session_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    {
+        anyhow::bail!("INVALID_ARGUMENT: remote Codex task id is malformed");
+    }
+    let mut child = std::process::Command::new(command)
+        .args(["cloud", "diff", session_id])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|error| match error.kind() {
+            std::io::ErrorKind::NotFound => {
+                anyhow::anyhow!("CONNECTOR_NOT_CONFIGURED: the `codex` CLI is not on PATH")
+            }
+            _ => anyhow::Error::from(error)
+                .context("CONNECTOR_FAILURE: could not run `codex cloud diff`"),
+        })?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("CONNECTOR_FAILURE: no Codex stdout pipe")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("CONNECTOR_FAILURE: no Codex stderr pipe")?;
+    let read_bounded = |mut stream: Box<dyn Read + Send>| {
+        std::thread::spawn(move || {
+            let mut bytes = Vec::new();
+            stream
+                .by_ref()
+                .take((MAX_REMOTE_EVIDENCE_BYTES + 1) as u64)
+                .read_to_end(&mut bytes)?;
+            Ok::<Vec<u8>, std::io::Error>(bytes)
+        })
+    };
+    let stdout_reader = read_bounded(Box::new(stdout));
+    let stderr_reader = read_bounded(Box::new(stderr));
+    let started = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if started.elapsed() >= REMOTE_COMMAND_TIMEOUT {
+            let _ = child.kill();
+            let _ = child.wait();
+            anyhow::bail!("CONNECTOR_FAILURE: `codex cloud diff` exceeded the 30 second timeout");
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    };
+    let stdout = stdout_reader
+        .join()
+        .map_err(|_| anyhow::anyhow!("CONNECTOR_FAILURE: Codex stdout reader panicked"))??;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| anyhow::anyhow!("CONNECTOR_FAILURE: Codex stderr reader panicked"))??;
+    anyhow::ensure!(
+        stdout.len() <= MAX_REMOTE_EVIDENCE_BYTES && stderr.len() <= MAX_REMOTE_EVIDENCE_BYTES,
+        "CONNECTOR_FAILURE: `codex cloud diff` exceeded the 16 MiB response-size limit"
+    );
+    if !status.success() {
+        let detail = excerpt_one_line(&String::from_utf8_lossy(&stderr));
+        let lower = detail.to_ascii_lowercase();
+        if lower.contains("login") || lower.contains("unauthorized") || lower.contains("expired") {
+            anyhow::bail!("AUTHENTICATION_EXPIRED: Codex CLI authentication was rejected");
+        }
+        if lower.contains("not found") || lower.contains("no task") {
+            anyhow::bail!("SESSION_NOT_FOUND: remote Codex task no longer exists");
+        }
+        anyhow::bail!("CONNECTOR_FAILURE: `codex cloud diff` failed ({status}): {detail}");
+    }
+    let diff = String::from_utf8(stdout)
+        .context("CONNECTOR_FAILURE: `codex cloud diff` returned non-UTF-8 output")?;
+    if diff.trim().is_empty() {
+        return Ok(RemoteSessionEvidence::CapabilityLimited {
+            code: "PROVIDER_CAPABILITY_LIMITED",
+            message: "Codex exposes no transcript API and this task has no available diff"
+                .to_string(),
+        });
+    }
+    let source_stamp = format!("diff:{:x}", Sha256::digest(diff.as_bytes()));
+    Ok(RemoteSessionEvidence::CodexDiff {
+        source_bytes: diff.len() as i64,
+        diff,
+        source_stamp,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ai-hist/src/remote/tests.rs
+++ b/crates/ai-hist/src/remote/tests.rs
@@ -75,9 +75,15 @@ impl Drop for ClearedCredentialsOverride {
 // ---------------------------------------------------------------------------
 
 /// Serves a fixed sequence of responses and records each requested URL.
+struct TransportCall {
+    url: String,
+    bearer_token: String,
+    headers: Vec<(String, String)>,
+}
+
 struct ScriptedTransport {
     responses: Vec<(u16, String)>,
-    calls: Mutex<Vec<(String, String)>>,
+    calls: Mutex<Vec<TransportCall>>,
     next: AtomicUsize,
 }
 
@@ -92,11 +98,20 @@ impl ScriptedTransport {
 }
 
 impl ClaudeSessionsTransport for Arc<ScriptedTransport> {
-    fn get(&self, url: &str, bearer_token: &str) -> Result<ClaudeHttpResponse> {
-        self.calls
-            .lock()
-            .unwrap()
-            .push((url.to_string(), bearer_token.to_string()));
+    fn get_with_headers(
+        &self,
+        url: &str,
+        bearer_token: &str,
+        headers: &[(&str, &str)],
+    ) -> Result<ClaudeHttpResponse> {
+        self.calls.lock().unwrap().push(TransportCall {
+            url: url.to_string(),
+            bearer_token: bearer_token.to_string(),
+            headers: headers
+                .iter()
+                .map(|(name, value)| ((*name).to_string(), (*value).to_string()))
+                .collect(),
+        });
         let index = self.next.fetch_add(1, Ordering::Relaxed);
         let (status, body) = self
             .responses
@@ -194,6 +209,7 @@ fn claude_mapping_skips_bridges_and_malformed_ids() {
 
 #[test]
 fn claude_enumeration_pages_until_the_cursor_ends() {
+    let _credentials = without_credentials_override();
     let home = tempfile::tempdir().unwrap();
     let transport = Arc::new(ScriptedTransport::new(vec![
         (
@@ -218,13 +234,16 @@ fn claude_enumeration_pages_until_the_cursor_ends() {
     assert_eq!(candidates.len(), 2);
     let calls = transport.calls.lock().unwrap();
     assert_eq!(calls.len(), 2);
-    assert!(calls[0].0.ends_with("/v1/code/sessions?limit=100"));
-    assert!(calls[1].0.contains("cursor=cursor%20with%20spaces"));
-    assert!(calls.iter().all(|(_, token)| token == "sk-ant-oat01-test"));
+    assert!(calls[0].url.ends_with("/v1/code/sessions?limit=100"));
+    assert!(calls[1].url.contains("cursor=cursor%20with%20spaces"));
+    assert!(calls
+        .iter()
+        .all(|call| call.bearer_token == "sk-ant-oat01-test"));
 }
 
 #[test]
 fn claude_enumeration_respects_the_row_limit() {
+    let _credentials = without_credentials_override();
     let home = tempfile::tempdir().unwrap();
     let transport = Arc::new(ScriptedTransport::new(vec![(
         200,
@@ -244,11 +263,12 @@ fn claude_enumeration_respects_the_row_limit() {
     assert_eq!(candidates.len(), 2);
     let calls = transport.calls.lock().unwrap();
     assert_eq!(calls.len(), 1);
-    assert!(calls[0].0.ends_with("?limit=2"));
+    assert!(calls[0].url.ends_with("?limit=2"));
 }
 
 #[test]
 fn claude_enumeration_reports_a_rejected_token() {
+    let _credentials = without_credentials_override();
     let home = tempfile::tempdir().unwrap();
     let transport = Arc::new(ScriptedTransport::new(vec![(401, "{}".to_string())]));
     let provider = claude_provider(home.path(), &transport, None);
@@ -260,6 +280,7 @@ fn claude_enumeration_reports_a_rejected_token() {
 
 #[test]
 fn claude_enumeration_reports_an_expired_token_without_a_request() {
+    let _credentials = without_credentials_override();
     let home = tempfile::tempdir().unwrap();
     let transport = Arc::new(ScriptedTransport::new(vec![]));
     let provider = ClaudeWebProvider::new(
@@ -292,6 +313,7 @@ fn claude_transport_refuses_plaintext_off_loopback() {
 
 #[test]
 fn claude_targeted_evidence_hydrates_one_session_across_pages() {
+    let _credentials = without_credentials_override();
     let home = tempfile::tempdir().unwrap();
     write_claude_credentials(home.path(), FAR_FUTURE_MS);
     let transport = Arc::new(ScriptedTransport::new(vec![
@@ -339,16 +361,24 @@ fn claude_targeted_evidence_hydrates_one_session_across_pages() {
     assert!(source_bytes > 0);
     let calls = transport.calls.lock().unwrap();
     assert_eq!(calls.len(), 3);
-    assert!(calls[0].0.ends_with("/api/oauth/profile"));
+    assert!(calls[0].url.ends_with("/api/oauth/profile"));
     assert!(calls[1]
-        .0
+        .url
         .contains("session_01abc/teleport-events?limit=1000"));
-    assert!(calls[2].0.contains("cursor=next%20page"));
-    assert!(calls.iter().all(|(_, token)| token == "sk-ant-oat01-test"));
+    assert!(calls[2].url.contains("cursor=next%20page"));
+    assert!(calls
+        .iter()
+        .all(|call| call.bearer_token == "sk-ant-oat01-test"));
+    assert_eq!(
+        calls[1].headers,
+        vec![("x-organization-uuid".to_string(), "org-test".to_string())]
+    );
+    assert_eq!(calls[2].headers, calls[1].headers);
 }
 
 #[test]
 fn claude_targeted_evidence_distinguishes_auth_missing_and_malformed_records() {
+    let _credentials = without_credentials_override();
     let home = tempfile::tempdir().unwrap();
     let unconfigured = acquire_claude_remote_session_at(
         home.path(),
@@ -401,6 +431,7 @@ fn claude_targeted_evidence_distinguishes_auth_missing_and_malformed_records() {
 
 #[test]
 fn claude_targeted_evidence_rejects_redirects_and_is_page_bounded() {
+    let _credentials = without_credentials_override();
     let home = tempfile::tempdir().unwrap();
     write_claude_credentials(home.path(), FAR_FUTURE_MS);
     let redirect = Arc::new(ScriptedTransport::new(vec![(
@@ -432,6 +463,45 @@ fn claude_targeted_evidence_rejects_redirects_and_is_page_bounded() {
     .to_string();
     assert!(error.starts_with("EVIDENCE_PARTIAL:"), "{error}");
     assert_eq!(bounded.calls.lock().unwrap().len(), MAX_LIST_PAGES + 1);
+}
+
+#[test]
+fn real_claude_transport_never_follows_a_redirect_with_credentials() {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    let _credentials = without_credentials_override();
+    let home = tempfile::tempdir().unwrap();
+    write_claude_credentials(home.path(), FAR_FUTURE_MS);
+    let target = TcpListener::bind("127.0.0.1:0").unwrap();
+    target.set_nonblocking(true).unwrap();
+    let target_url = format!("http://{}", target.local_addr().unwrap());
+    let origin = TcpListener::bind("127.0.0.1:0").unwrap();
+    let origin_url = format!("http://{}", origin.local_addr().unwrap());
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = origin.accept().unwrap();
+        let mut request = [0u8; 4096];
+        let _ = stream.read(&mut request).unwrap();
+        write!(
+            stream,
+            "HTTP/1.1 302 Found\r\nLocation: {target_url}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        )
+        .unwrap();
+    });
+    let error = acquire_claude_remote_session_at(
+        home.path(),
+        "session_01abc",
+        &origin_url,
+        &UreqClaudeTransport,
+    )
+    .unwrap_err()
+    .to_string();
+    server.join().unwrap();
+    assert!(error.contains("HTTP 302"), "{error}");
+    std::thread::sleep(Duration::from_millis(50));
+    assert!(
+        matches!(target.accept(), Err(error) if error.kind() == std::io::ErrorKind::WouldBlock)
+    );
 }
 
 #[cfg(unix)]
@@ -475,6 +545,63 @@ fn codex_targeted_evidence_uses_the_cli_diff_and_reports_an_empty_diff_honestly(
             ..
         }
     ));
+}
+
+#[test]
+fn codex_targeted_evidence_requires_the_supplied_homes_login() {
+    let home = tempfile::tempdir().unwrap();
+    let evidence = acquire_remote_session_at(home.path(), "codex", "task_fixture").unwrap();
+    assert!(matches!(
+        evidence,
+        RemoteSessionEvidence::CapabilityLimited {
+            code: "CONNECTOR_NOT_CONFIGURED",
+            ..
+        }
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn codex_output_limit_drains_the_pipe_and_reports_size_not_timeout() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let command = dir.path().join("codex-oversized");
+    std::fs::write(&command, "#!/bin/sh\nhead -c 16777217 /dev/zero\n").unwrap();
+    std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let error = acquire_codex_remote_session_with_command_timeout(
+        "task_fixture",
+        command.as_os_str(),
+        Duration::from_secs(5),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("16 MiB response-size limit"), "{error}");
+}
+
+#[cfg(unix)]
+#[test]
+fn codex_inherited_pipe_is_bounded_after_the_direct_child_exits() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let command = dir.path().join("codex-inherited-pipe");
+    std::fs::write(
+        &command,
+        "#!/usr/bin/env python3\nimport os, time\nif os.fork() == 0:\n    time.sleep(2)\nelse:\n    os._exit(0)\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+    let started = Instant::now();
+    let error = acquire_codex_remote_session_with_command_timeout(
+        "task_fixture",
+        command.as_os_str(),
+        Duration::from_millis(500),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(started.elapsed() < Duration::from_secs(2));
+    assert!(error.contains("pipe remained open"), "{error}");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ai-hist/src/remote/tests.rs
+++ b/crates/ai-hist/src/remote/tests.rs
@@ -290,6 +290,193 @@ fn claude_transport_refuses_plaintext_off_loopback() {
     assert!(require_https_or_loopback("http://127.0.0.1@evil.test").is_err());
 }
 
+#[test]
+fn claude_targeted_evidence_hydrates_one_session_across_pages() {
+    let home = tempfile::tempdir().unwrap();
+    write_claude_credentials(home.path(), FAR_FUTURE_MS);
+    let transport = Arc::new(ScriptedTransport::new(vec![
+        (
+            200,
+            serde_json::json!({
+                "account": {"uuid": "account-test", "email": "test@example.test"},
+                "organization": {"uuid": "org-test"}
+            })
+            .to_string(),
+        ),
+        (
+            200,
+            serde_json::json!({
+                "data": [{"payload": {"sessionId": "session_01abc", "uuid": "u1", "type": "user", "timestamp": 1, "message": {"role": "user", "content": "hello"}}}],
+                "next_cursor": "next page"
+            })
+            .to_string(),
+        ),
+        (
+            200,
+            serde_json::json!({
+                "data": [{"payload": {"sessionId": "session_01abc", "uuid": "a1", "type": "assistant", "timestamp": 2, "message": {"role": "assistant", "content": [{"type": "text", "text": "done"}]}}}],
+                "next_cursor": null
+            })
+            .to_string(),
+        ),
+    ]));
+    let acquired = acquire_claude_remote_session_at(
+        home.path(),
+        "session_01abc",
+        "https://api.example.test",
+        &transport,
+    )
+    .unwrap();
+    let RemoteSessionEvidence::ClaudeFull {
+        records,
+        source_bytes,
+        ..
+    } = acquired
+    else {
+        panic!("expected full Claude evidence")
+    };
+    assert_eq!(records.len(), 2);
+    assert!(source_bytes > 0);
+    let calls = transport.calls.lock().unwrap();
+    assert_eq!(calls.len(), 3);
+    assert!(calls[0].0.ends_with("/api/oauth/profile"));
+    assert!(calls[1]
+        .0
+        .contains("session_01abc/teleport-events?limit=1000"));
+    assert!(calls[2].0.contains("cursor=next%20page"));
+    assert!(calls.iter().all(|(_, token)| token == "sk-ant-oat01-test"));
+}
+
+#[test]
+fn claude_targeted_evidence_distinguishes_auth_missing_and_malformed_records() {
+    let home = tempfile::tempdir().unwrap();
+    let unconfigured = acquire_claude_remote_session_at(
+        home.path(),
+        "session_01abc",
+        "https://api.example.test",
+        &Arc::new(ScriptedTransport::new(vec![])),
+    )
+    .unwrap();
+    assert!(matches!(
+        unconfigured,
+        RemoteSessionEvidence::CapabilityLimited {
+            code: "CONNECTOR_NOT_CONFIGURED",
+            ..
+        }
+    ));
+
+    write_claude_credentials(home.path(), FAR_FUTURE_MS);
+    let expired = Arc::new(ScriptedTransport::new(vec![(
+        401,
+        "token-secret-must-not-escape".into(),
+    )]));
+    let error = acquire_claude_remote_session_at(
+        home.path(),
+        "session_01abc",
+        "https://api.example.test",
+        &expired,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.starts_with("AUTHENTICATION_EXPIRED:"), "{error}");
+    assert!(!error.contains("token-secret"), "{error}");
+
+    let malformed = Arc::new(ScriptedTransport::new(vec![
+        (200, r#"{"organization":{"uuid":"org-test"}}"#.into()),
+        (
+            200,
+            r#"{"data":[{"payload":"not-an-object"}],"next_cursor":null}"#.into(),
+        ),
+    ]));
+    let error = acquire_claude_remote_session_at(
+        home.path(),
+        "session_01abc",
+        "https://api.example.test",
+        &malformed,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("malformed record"), "{error}");
+}
+
+#[test]
+fn claude_targeted_evidence_rejects_redirects_and_is_page_bounded() {
+    let home = tempfile::tempdir().unwrap();
+    write_claude_credentials(home.path(), FAR_FUTURE_MS);
+    let redirect = Arc::new(ScriptedTransport::new(vec![(
+        302,
+        "https://evil.test".into(),
+    )]));
+    let error = acquire_claude_remote_session_at(
+        home.path(),
+        "session_01abc",
+        "https://api.example.test",
+        &redirect,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("OAuth profile failed (HTTP 302)"), "{error}");
+
+    let mut pages = vec![(200, r#"{"organization":{"uuid":"org-test"}}"#.into())];
+    pages.extend(
+        (0..MAX_LIST_PAGES).map(|_| (200, r#"{"data":[],"next_cursor":"again"}"#.to_string())),
+    );
+    let bounded = Arc::new(ScriptedTransport::new(pages));
+    let error = acquire_claude_remote_session_at(
+        home.path(),
+        "session_01abc",
+        "https://api.example.test",
+        &bounded,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.starts_with("EVIDENCE_PARTIAL:"), "{error}");
+    assert_eq!(bounded.calls.lock().unwrap().len(), MAX_LIST_PAGES + 1);
+}
+
+#[cfg(unix)]
+#[test]
+fn codex_targeted_evidence_uses_the_cli_diff_and_reports_an_empty_diff_honestly() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let command = dir.path().join("codex-fixture");
+    std::fs::write(
+        &command,
+        "#!/bin/sh\n\
+         test \"$1\" = cloud && test \"$2\" = diff && test \"$3\" = task_fixture || exit 2\n\
+         printf 'diff --git a/src/lib.rs b/src/lib.rs\\n--- a/src/lib.rs\\n+++ b/src/lib.rs\\n@@ -1 +1,2 @@\\n old\\n+new\\n'\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let evidence =
+        acquire_codex_remote_session_with_command("task_fixture", command.as_os_str()).unwrap();
+    let RemoteSessionEvidence::CodexDiff {
+        diff, source_bytes, ..
+    } = evidence
+    else {
+        panic!("expected the supported task diff")
+    };
+    assert!(diff.contains("diff --git a/src/lib.rs b/src/lib.rs"));
+    assert_eq!(source_bytes, diff.len() as i64);
+
+    std::fs::write(
+        &command,
+        "#!/bin/sh\ntest \"$1\" = cloud && test \"$2\" = diff && test \"$3\" = task_fixture\n",
+    )
+    .unwrap();
+    let evidence =
+        acquire_codex_remote_session_with_command("task_fixture", command.as_os_str()).unwrap();
+    assert!(matches!(
+        evidence,
+        RemoteSessionEvidence::CapabilityLimited {
+            code: "PROVIDER_CAPABILITY_LIMITED",
+            ..
+        }
+    ));
+}
+
 // ---------------------------------------------------------------------------
 // codex-cloud
 // ---------------------------------------------------------------------------

--- a/crates/ai-hist/src/remote/tests.rs
+++ b/crates/ai-hist/src/remote/tests.rs
@@ -586,11 +586,7 @@ fn codex_inherited_pipe_is_bounded_after_the_direct_child_exits() {
 
     let dir = tempfile::tempdir().unwrap();
     let command = dir.path().join("codex-inherited-pipe");
-    std::fs::write(
-        &command,
-        "#!/usr/bin/env python3\nimport os, time\nif os.fork() == 0:\n    time.sleep(2)\nelse:\n    os._exit(0)\n",
-    )
-    .unwrap();
+    std::fs::write(&command, "#!/bin/sh\nsleep 2 &\nexit 0\n").unwrap();
     std::fs::set_permissions(&command, std::fs::Permissions::from_mode(0o755)).unwrap();
     let started = Instant::now();
     let error = acquire_codex_remote_session_with_command_timeout(

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ Rust owns provider discovery/parsing, schema creation and migration, direct
 SQLite connections, catalog queries, history/event queries, search,
 statistics, and sync. Blocking filesystem and SQLite work is dispatched away
 from Node's event loop. TypeScript validates inputs, validates native contract
-version 7, catalog contract version 3, hydration contract version 1,
+version 7, catalog contract version 3, hydration contract version 2,
 session-relationship contract version 1, and session evidence contract version
 1, normalizes nullable fields, maps native errors, and supplies pagination
 helpers.
@@ -88,7 +88,10 @@ await hydrateSession({ source: sessions[0].source, sessionId: sessions[0].sessio
 Global sync owns enumeration while targeted hydration resolves one persisted
 catalog presence. Both call the same Rust provider normalization helpers.
 TypeScript never parses a provider source or opens SQLite. Per-session
-checkpoints make unchanged calls constant-work after source resolution.
+checkpoints make unchanged calls constant-work after source resolution. Remote
+hydration stays provider-bounded: Claude uses the CLI's private
+teleport-evidence contract, while Codex indexes the supported cloud diff and
+reports partial capability because no transcript export exists.
 
 ## Delegation topology
 
@@ -146,7 +149,10 @@ Unlinked rows are reported in `unlinked` with a `RELATIONSHIP_UNLINKED_CHILD`
 diagnostic rather than traversed — at every depth, the boundary included, so a
 node whose only children are unlinked evidence is complete rather than
 truncated. Only a session the tree has not already emitted is charged against
-`maxNodes`, so a diamond is never reported as a budget truncation. The SDK's
+`maxNodes`, so a diamond is never reported as a budget truncation. Deterministic
+Claude remote-to-local materialization is also recorded as a
+`materialized_local` relationship; title or prompt similarity is never used to
+infer one. The SDK's
 `sessionDescendants` walker applies the same `childCount` and `truncated`
 rules to the nodes it yields.
 

--- a/docs/remote-connectors.md
+++ b/docs/remote-connectors.md
@@ -77,7 +77,8 @@ tool-result, token/model, or parent/child export. Remote hydration therefore
 runs bounded `codex cloud diff TASK_ID`, stores per-file patches in
 `file_edits`, and returns `capability: "partial"` with
 `discoveryState: "shallow"`. A task without an available diff returns
-`capability_limited`. RelayHistory does not call private Codex service APIs.
+status `capability_limited` with `capability: "shallow_only"`. RelayHistory
+does not call private Codex service APIs.
 
 Both paths cap responses at 16 MiB and execution at 30 seconds where a child
 process is involved. Claude pagination is capped at 100 pages of 1,000 records.

--- a/docs/remote-connectors.md
+++ b/docs/remote-connectors.md
@@ -8,8 +8,8 @@ two connectors:
 
 | Connector | Source | Lists | Interface |
 |---|---|---|---|
-| `claude-web` | `claude` | Claude Code sessions on claude.ai/code | `GET {base}/v1/code/sessions` with the CLI's stored OAuth token |
-| `codex-cloud` | `codex` | Codex cloud tasks | `codex cloud list --json` (the Codex CLI's scripting contract) |
+| `claude-web` | `claude` | Claude Code sessions on claude.ai/code | listing plus the CLI's private teleport-evidence interface, with its stored OAuth token |
+| `codex-cloud` | `codex` | Codex cloud tasks | `codex cloud list --json` and `codex cloud diff TASK_ID` |
 
 Local and remote stay presences of one session ledger: a session observed
 both by a local file adapter and by a connector is one catalog row whose
@@ -51,7 +51,41 @@ exhausted. Both connectors bound one enumeration to 100 pages (10,000 claude
 sessions, 2,000 codex tasks) — bounded work is part of the discovery
 contract; a later run continues from fresher listings.
 
-## What remote rows carry
+## Targeted remote hydration
+
+`hydrateSession({ source, sessionId, scope: "remote" })` addresses exactly one
+cataloged remote session. It never runs discovery or enumerates other tasks.
+Results report `capability` as `full`, `partial`, or `shallow_only`; a provider
+limitation is a successful `capability_limited` result rather than a fabricated
+empty transcript. Authentication, missing-session, bounded-partial, and parser
+failures use the stable codes `AUTHENTICATION_EXPIRED`, `SESSION_NOT_FOUND`,
+`EVIDENCE_PARTIAL`, and `CONNECTOR_FAILURE`.
+
+Claude Code currently fetches a teleported session from
+`GET /v1/code/sessions/{id}/teleport-events`, after resolving the signed-in
+organization through `GET /api/oauth/profile`. RelayHistory uses the same
+provider-owned OAuth credential and normalizes those records through the same
+Rust ingestion path as a local Claude transcript. This can include messages,
+assistant output, tool calls/results, file edits, model/token fields, and
+sidechain markers when Claude supplies them. The endpoint is an observed Claude
+Code implementation contract, **not a documented public Anthropic API**. It may
+change without notice; malformed or incomplete responses fail explicitly and
+never upgrade the remote presence to `full`.
+
+Codex's supported cloud CLI exposes a unified diff, but no task transcript,
+tool-result, token/model, or parent/child export. Remote hydration therefore
+runs bounded `codex cloud diff TASK_ID`, stores per-file patches in
+`file_edits`, and returns `capability: "partial"` with
+`discoveryState: "shallow"`. A task without an available diff returns
+`capability_limited`. RelayHistory does not call private Codex service APIs.
+
+Both paths cap responses at 16 MiB and execution at 30 seconds where a child
+process is involved. Claude pagination is capped at 100 pages of 1,000 records.
+HTTP redirects are not followed, preventing authorization headers from moving
+to another host. Work is checkpointed by remote presence and repeated
+hydration is idempotent.
+
+## What remote rows carry before hydration
 
 Remote listings carry less than a local transcript, and nothing is invented
 to fill the gap:
@@ -69,11 +103,19 @@ to fill the gap:
   service records one.
 - Timestamps — `created_at`/`last_event_at` (claude), `updated_at` (codex).
 
-Remote rows stay `discovery_state: "shallow"`. Neither provider serves full
-transcripts through a supported listing interface, so per-message events,
-tool calls, and full-text search over remote-only sessions require the
-session's evidence to reach a local provider first (for example teleporting a
-claude.ai session into a terminal, which writes a normal local transcript).
+Discovery rows stay `discovery_state: "shallow"`. Claude can be upgraded by
+targeted hydration through teleport evidence. Codex stays shallow even after
+its available diff is indexed because no transcript export exists.
+
+## Remote/local identity correlation
+
+Remote and local sessions remain separate rows. A Claude transcript containing
+the provider-recorded `remoteSessionId` creates a `materialized_local`
+relationship from the remote ID to the local session ID, but only when that
+exact remote presence already exists. Titles, repositories, prompts, and
+timestamps never create canonical relationships. Current Codex CLI apply/diff
+output does not record a local rollout ID, so RelayHistory does not guess a
+Codex remote-to-local relationship.
 
 Claude Remote Control **bridge** sessions (`environment_kind: "bridge"`) are
 views of sessions running in a local terminal; their evidence is local, so
@@ -90,9 +132,8 @@ served from the catalog with zero fresh work beyond the listing itself.
 
 ## Contract stability
 
-`codex-cloud` speaks the Codex CLI's documented scripting interface, which is
-as stable as Codex chooses to keep it. `claude-web` speaks the same
-session-list endpoint the Claude Code CLI's `--teleport` picker uses; that
-endpoint is **not a documented public API** and can change with any Claude
-Code release. A change surfaces as a connector diagnostic (or a failed
-remote-only run) — never as silently missing data mixed into local results.
+`codex-cloud` speaks supported Codex CLI commands, which are as stable as Codex
+chooses to keep them. Claude listing and teleport evidence are observed private
+Claude Code interfaces. A change surfaces as a connector diagnostic (or a
+failed remote-only run), never as silently missing data mixed into local
+results.

--- a/docs/session-catalog.md
+++ b/docs/session-catalog.md
@@ -26,8 +26,8 @@ argument; provider `--source` filters remain orthogonal to location scope.
 
 ## The two operations
 
-After those two catalog operations, targeted hydration acquires full evidence
-for one selected identity:
+After those two catalog operations, targeted hydration acquires the richest
+available evidence for one selected identity:
 
 ```ts
 const sessions = await listSessionCatalog({ limit: 100 });
@@ -35,11 +35,12 @@ await hydrateSession({ source: sessions[0].source, sessionId: sessions[0].sessio
 ```
 
 Hydration requires the catalog row, never invokes discovery or global sync,
-and upgrades `discoveryState` to `full` transactionally. Here `full` means
-indexed through the returned source stamp, not that a live coding session has
-ended. File providers validate the saved locator against the expected provider
-root; OpenCode uses session-keyed queries against its live read-only database.
-Relay reports `HYDRATION_UNSUPPORTED` until a full-evidence connector exists.
+and upgrades `discoveryState` to `full` only when the connector returned all
+available evidence. Here `full` means indexed through the returned source
+stamp, not that a live coding session has ended. Partial remote connectors
+remain `shallow` and report their capability explicitly. File providers
+validate the saved locator against the expected provider root; OpenCode uses
+session-keyed queries against its live read-only database.
 
 Codex child rollouts, and Claude subagent transcripts whose records carry a
 per-child `agentId`, retain their provider-native IDs and are linked through
@@ -270,9 +271,10 @@ These require a full `ai-hist sync` through an available provider connector:
 `discovery_state` tells you which you have: `"full"` means a full ingest has
 run for that session, `"shallow"` means catalog metadata only. Full ingest
 always wins — a shallow rescan refreshes a `full` row's metadata and stamp but
-never downgrades its state. Local connectors provide full sync today; remote
-rows stay shallow because neither provider serves full transcripts through a
-supported listing interface (see [Remote connectors](remote-connectors.md)).
+never downgrades its state. Local connectors provide full sync today. Claude
+remote rows can become full through targeted teleport-evidence hydration;
+Codex remote rows remain shallow after their available diff is indexed because
+the CLI exposes no transcript export (see [Remote connectors](remote-connectors.md)).
 
 ### Product boundary
 

--- a/docs/session-catalog.md
+++ b/docs/session-catalog.md
@@ -260,8 +260,9 @@ Absent metadata stays `null`. Nothing is ever invented to fill a column.
 
 ### What the catalog deliberately does not have
 
-Except for the partial Codex cloud diff exposed by targeted remote hydration,
-these require a full `ai-hist sync` through an available provider connector:
+Except for targeted remote hydration — full Claude teleport evidence or the
+partial Codex cloud diff — these require a full `ai-hist sync` through an
+available provider connector:
 
 - per-message events (`session_events`) and tool calls; file edits are partial
   for a Codex cloud row whose available diff has been hydrated

--- a/docs/session-catalog.md
+++ b/docs/session-catalog.md
@@ -260,9 +260,11 @@ Absent metadata stays `null`. Nothing is ever invented to fill a column.
 
 ### What the catalog deliberately does not have
 
-These require a full `ai-hist sync` through an available provider connector:
+Except for the partial Codex cloud diff exposed by targeted remote hydration,
+these require a full `ai-hist sync` through an available provider connector:
 
-- per-message events (`session_events`), tool calls, file edits
+- per-message events (`session_events`) and tool calls; file edits are partial
+  for a Codex cloud row whose available diff has been hydrated
 - token usage and cost
 - session → commit links
 - full-text search over transcripts

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Expose hydration contract v2 with `capability`, shallow/partial outcomes,
-  file-edit evidence counts, and stable remote connector error classes.
-
 ### Breaking
 
 - Advance the native-addon contract to 7 and the session-catalog contract to
@@ -33,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Surface bounded OpenCode provider-query and inspected-record counters through the typed SDK,
   CLI JSON, and MCP discovery result.
+- Expose hydration contract v2 with `capability`, shallow/partial outcomes,
+  file-edit evidence counts, and stable remote connector error classes.
+
 - Add delegation topology APIs: `getSessionRelationships()`,
   `getSessionTree()`, and `getSessionChildrenPage()`, plus the
   `sessionDescendants()` and `sessionEventsIncludingDescendants()` async

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Expose hydration contract v2 with `capability`, shallow/partial outcomes,
+  file-edit evidence counts, and stable remote connector error classes.
+
 ### Breaking
 
 - Advance the native-addon contract to 7 and the session-catalog contract to

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -44,8 +44,13 @@ if (first) {
 All APIs are async. `listSessionCatalog` and `listSessionCatalogPage` are
 cache-only. `discoverSessions` is shallow discovery. `hydrateSession` is
 targeted evidence acquisition for one existing catalog row. It returns
-`hydrated`, `updated`, or `unchanged`, an indexed source stamp, evidence counts,
-related native session IDs, and bounded-work metrics. `sync` is full ingestion.
+`hydrated`, `updated`, `unchanged`, or `capability_limited`, an indexed source
+stamp, evidence counts, related native session IDs, and bounded-work metrics.
+Targeted remote hydration uses `scope: 'remote'`: Claude web sessions can
+return `capability: 'full'` after complete teleport evidence is acquired;
+Codex cloud tasks return `partial` when their supported unified diff is indexed
+or `shallow_only` when no richer evidence is exposed. Partial results retain
+`discoveryState: 'shallow'`. `sync` is full ingestion.
 Missing databases return empty read results; they do not trigger provider I/O.
 
 Session discovery, listing, search, recent history, statistics, and sync accept
@@ -165,7 +170,9 @@ has to account for that. `sessionEventsIncludingDescendants` applies its
 Native loading failures distinguish unsupported platforms, missing optional
 platform packages, addon load failures, SDK/native contract mismatches, and
 database open failures through stable `RelayHistoryError` subclasses. Provider
-capability failures use `UnsupportedOperationError`.
+capability failures use `UnsupportedOperationError`. Targeted remote hydration
+also distinguishes connector configuration, expired authentication, partial
+evidence, and connector/parser failures with dedicated error subclasses.
 
 The old synchronous `AiHist` class and `openAiHist()` API were removed in 1.0.
 See [the migration guide](https://github.com/AgentWorkforce/relayhistory/blob/main/docs/native-sdk-migration.md).

--- a/sdk-ts/src/cli-output.test.ts
+++ b/sdk-ts/src/cli-output.test.ts
@@ -103,11 +103,12 @@ test('sessions hydrate uses the SDK contract and is idempotent', async () => {
       cli, 'sessions', 'hydrate', 'claude', 'claude-hydrate', '--db', db, '--json', '--no-warning',
     ], { env });
     const hydrated = JSON.parse(first.stdout) as Record<string, unknown>;
-    assert.equal(hydrated.contract_version, 1);
+    assert.equal(hydrated.contract_version, 2);
     assert.equal(hydrated.status, 'hydrated');
+    assert.equal(hydrated.capability, 'full');
     assert.equal(hydrated.discovery_state, 'full');
     assert.deepEqual(hydrated.evidence, {
-      prompts: 1, events: 1, tool_calls: 0, related_sessions: 0,
+      prompts: 1, events: 1, tool_calls: 0, file_edits: 0, related_sessions: 0,
     });
 
     const second = await run(process.execPath, [

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -315,7 +315,7 @@ function outputHydration(value: Awaited<ReturnType<typeof hydrateSession>>, json
   process.stdout.write(`${value.source}/${value.sessionId}: ${value.status}\n`);
   process.stdout.write(
     `evidence: ${value.evidence.prompts} prompt(s), ${value.evidence.events} event(s), ` +
-    `${value.evidence.toolCalls} tool call(s)\n`,
+    `${value.evidence.toolCalls} tool call(s), ${value.evidence.fileEdits} file edit(s)\n`,
   );
   if (value.relatedSessionIds.length) {
     process.stdout.write(`related sessions: ${value.relatedSessionIds.join(', ')}\n`);

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -11,7 +11,7 @@ import { join } from 'node:path';
 
 export const NATIVE_CONTRACT_VERSION = 7;
 export const SESSION_CATALOG_CONTRACT_VERSION = 3;
-export const SESSION_HYDRATION_CONTRACT_VERSION = 1;
+export const SESSION_HYDRATION_CONTRACT_VERSION = 2;
 export const SESSION_RELATIONSHIP_CONTRACT_VERSION = 1;
 export const SESSION_EVIDENCE_CONTRACT_VERSION = 1;
 
@@ -47,6 +47,10 @@ export class SessionSourceUnavailableError extends RelayHistoryError {}
 export class SessionSourceMismatchError extends RelayHistoryError {}
 export class HydrationUnsupportedError extends RelayHistoryError {}
 export class HydrationFailedError extends RelayHistoryError {}
+export class ConnectorNotConfiguredError extends RelayHistoryError {}
+export class AuthenticationExpiredError extends RelayHistoryError {}
+export class EvidencePartialError extends RelayHistoryError {}
+export class ConnectorFailureError extends RelayHistoryError {}
 
 export interface HistoryEntry {
   id: number;
@@ -194,8 +198,9 @@ export interface HydrateSessionResult {
   contractVersion: number;
   source: CatalogSource;
   sessionId: string;
-  status: 'hydrated' | 'updated' | 'unchanged';
-  discoveryState: 'full';
+  status: 'hydrated' | 'updated' | 'unchanged' | 'capability_limited';
+  capability: 'full' | 'partial' | 'shallow_only';
+  discoveryState: 'shallow' | 'full';
   presence: SessionLocation;
   indexedThrough: {
     sourceStamp: string | null;
@@ -205,6 +210,7 @@ export interface HydrateSessionResult {
     prompts: number;
     events: number;
     toolCalls: number;
+    fileEdits: number;
     relatedSessions: number;
   };
   relatedSessionIds: string[];
@@ -600,6 +606,18 @@ async function nativeCall<T>(call: (binding: NativeBinding) => Promise<T>): Prom
     }
     if (native.code === 'HYDRATION_FAILED') {
       throw new HydrationFailedError(native.message, native.code, { cause: error });
+    }
+    if (native.code === 'CONNECTOR_NOT_CONFIGURED') {
+      throw new ConnectorNotConfiguredError(native.message, native.code, { cause: error });
+    }
+    if (native.code === 'AUTHENTICATION_EXPIRED') {
+      throw new AuthenticationExpiredError(native.message, native.code, { cause: error });
+    }
+    if (native.code === 'EVIDENCE_PARTIAL') {
+      throw new EvidencePartialError(native.message, native.code, { cause: error });
+    }
+    if (native.code === 'CONNECTOR_FAILURE') {
+      throw new ConnectorFailureError(native.message, native.code, { cause: error });
     }
     throw new RelayHistoryError(native.message, native.code, { cause: error });
   }
@@ -1020,7 +1038,9 @@ export async function hydrateSession(options: HydrateSessionOptions): Promise<Hy
         'NATIVE_CONTRACT_MISMATCH',
       );
     }
-    if (!['hydrated', 'updated', 'unchanged'].includes(String(value.status)) || value.discoveryState !== 'full') {
+    if (!['hydrated', 'updated', 'unchanged', 'capability_limited'].includes(String(value.status))
+      || !['full', 'partial', 'shallow_only'].includes(String(value.capability))
+      || !['shallow', 'full'].includes(String(value.discoveryState))) {
       throw new NativeContractMismatchError(
         'ai-hist-native returned an invalid hydration result.',
         'NATIVE_CONTRACT_MISMATCH',
@@ -1033,7 +1053,8 @@ export async function hydrateSession(options: HydrateSessionOptions): Promise<Hy
       source: String(value.source) as CatalogSource,
       sessionId: String(value.sessionId),
       status: String(value.status) as HydrateSessionResult['status'],
-      discoveryState: 'full',
+      capability: String(value.capability) as HydrateSessionResult['capability'],
+      discoveryState: String(value.discoveryState) as HydrateSessionResult['discoveryState'],
       presence: value.presence === 'remote' ? 'remote' : 'local',
       indexedThrough: {
         sourceStamp: nullableString(indexed.sourceStamp),
@@ -1043,6 +1064,7 @@ export async function hydrateSession(options: HydrateSessionOptions): Promise<Hy
         prompts: Number(evidence.prompts),
         events: Number(evidence.events),
         toolCalls: Number(evidence.toolCalls),
+        fileEdits: Number(evidence.fileEdits),
         relatedSessions: Number(evidence.relatedSessions),
       },
       relatedSessionIds: Array.isArray(value.relatedSessionIds) ? value.relatedSessionIds.map(String) : [],


### PR DESCRIPTION
## Summary

- hydrate one Claude web session through its bounded teleport-evidence interface and normalize it through the existing Rust ingestion path
- index the supported Codex cloud task diff while reporting the connector as partial instead of inventing transcript completeness
- correlate Claude remote and materialized-local identities only from provider-recorded remote session IDs
- expose capability, file-edit counts, stable diagnostics, and hydration contract v2 through N-API, the TypeScript SDK, and CLI output
- document provider interface limits, the private Claude endpoint stability risk, credential containment, and correlation rules

## Safety and bounds

- reuses provider-owned authentication without persisting token copies
- rejects redirects and non-HTTPS/non-loopback Claude endpoints
- caps Claude hydration at 100 pages and total evidence at 16 MiB
- caps `codex cloud diff` output at 16 MiB and execution at 30 seconds
- preserves remote presence and commits normalized evidence/checkpoints atomically

## Tests

- `cargo test --workspace`
- `npm test` (in `sdk-ts`, after rebuilding the native addon)
- `npm run typecheck` (in `sdk-ts`)
- `git diff --check`

`cargo clippy --workspace --all-targets -- -D warnings` still reports pre-existing `too_many_arguments` warnings in `ai-hist-core`, `cloud.rs`, and `lib.rs`; new warnings found in this change were fixed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

