### PR TITLE
Remove the OpenCode discovery database copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Notable changes to the native `ai-hist` CLI are documented here.
 
 ### Breaking
 
+- Add truthful OpenCode SQL work counters to discovery summaries. The catalog
+  contract is now 3 and the native-addon contract is now 5; `bytes_read` no
+  longer substitutes the OpenCode database file size, and summaries add
+  `provider_queries` plus `records_inspected`.
 - Retire standalone Rust CLI release assets and the curl/source installer.
   npm now distributes the public TypeScript SDK, Node CLI, MCP server, and
   mandatory Node-API engine.
@@ -104,18 +108,22 @@ Notable changes to the native `ai-hist` CLI are documented here.
 
 ### Changed
 
+- Replace OpenCode shallow discovery's full-database SQLite backup with a
+  coherent transaction on the live read-only database. A limited request
+  fetches at most that many candidate sessions and uses only provider-supplied
+  session/message/part indexes for selected-session metadata. Missing optional
+  schema elements or indexes now omit affected shallow fields instead of
+  scanning or mutating provider tables. WAL appends, busy stores, malformed and
+  partial rows, database replacement, and query-plan/scaling regressions have
+  dedicated coverage.
 - Recognize current Codex Desktop `response_item/message` user turns in both
   bounded session discovery and full ingestion. Existing Codex rollout indexes
   are repaired automatically, while adjacent legacy/current mirror records are
   collapsed without removing intentionally repeated prompts.
 - Replace Python-based installer and end-to-end verification with shell,
   SQLite, Node.js, and the public Rust CLI interfaces.
-- The opencode adapter holds its snapshot open on one connection for the whole
-  run and indexes the private copy by `session_id` when the live store isn't,
-  so the per-session excerpt and model queries seek instead of scanning
-  `message` and `part` once per candidate. Cold shallow discovery of 1,000
-  opencode sessions into a fresh database runs in ~43 ms in the native
-  benchmark (was ~290 ms).
+- The earlier OpenCode private-snapshot optimization reduced repeated scans,
+  but has now been superseded by the bounded live read-only path above.
 - Shallow discovery's per-candidate catalog statements (candidate
   classification, skip markers, the discovery upsert) execute through the
   prepared-statement cache, and the upsert hands back the merged catalog row

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -173,6 +173,8 @@ export interface DiscoveryCounters {
   skippedUnchanged: number
   filesOpened: number
   bytesRead: number
+  providerQueries: number
+  recordsInspected: number
 }
 export interface SourceExemption {
   source: string

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -17,7 +17,7 @@ use ai_hist_core::{
 use napi_derive::napi;
 
 /// Bump whenever native object shapes or semantics require an SDK change.
-pub const NATIVE_CONTRACT_VERSION: u32 = 4;
+pub const NATIVE_CONTRACT_VERSION: u32 = 5;
 const DEFAULT_LIMIT: i64 = 50;
 const DEFAULT_EVENT_LIMIT: i64 = 200;
 
@@ -649,6 +649,8 @@ pub struct DiscoveryCounters {
     pub skipped_unchanged: i64,
     pub files_opened: i64,
     pub bytes_read: i64,
+    pub provider_queries: i64,
+    pub records_inspected: i64,
 }
 
 #[napi(object)]
@@ -736,6 +738,8 @@ pub async fn discover_sessions(options: Option<DiscoverOptions>) -> napi::Result
             skipped_unchanged: summary.counters.skipped_unchanged as i64,
             files_opened: summary.counters.files_opened as i64,
             bytes_read: summary.counters.bytes_read as i64,
+            provider_queries: summary.counters.provider_queries as i64,
+            records_inspected: summary.counters.records_inspected as i64,
         },
     })
 }

--- a/crates/ai-hist/src/discover.rs
+++ b/crates/ai-hist/src/discover.rs
@@ -59,9 +59,11 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{LazyLock, Mutex, MutexGuard};
 
-use ai_hist_core::{upsert_session_presence, SessionLocation, SessionScope, SOURCE_CHOICES};
+use ai_hist_core::{
+    open_db_readonly, upsert_session_presence, SessionLocation, SessionScope, SOURCE_CHOICES,
+};
 use anyhow::{Context, Result};
-use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -1209,36 +1211,48 @@ impl OpencodeProvider {
     fn snapshot(&self, scan: &ScanEnv<'_>) -> Result<MutexGuard<'_, Option<OpencodeReadSnapshot>>> {
         let mut guard = self.live.lock().expect("opencode live snapshot lock");
         if guard.is_none() && scan.opencode_db.exists() {
-            let conn = Connection::open_with_flags(
-                scan.opencode_db,
-                OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
-            )
-            .with_context(|| format!("opening {}", scan.opencode_db.display()))?;
-            conn.busy_timeout(std::time::Duration::from_millis(250))?;
-            conn.execute_batch("PRAGMA query_only = ON; BEGIN DEFERRED")?;
-            scan.note_open();
-            let session_columns = table_columns(&conn, "session")?;
-            let message_columns = table_columns(&conn, "message")?;
-            let part_columns = table_columns(&conn, "part")?;
-            let message_by_session = has_leading_index(&conn, "message", "session_id")?;
-            let part_by_session = has_leading_index(&conn, "part", "session_id")?;
-            let part_by_message = has_leading_index(&conn, "part", "message_id")?;
-            let schema_version: i64 =
-                conn.query_row("PRAGMA schema_version", [], |row| row.get(0))?;
-            *guard = Some(OpencodeReadSnapshot {
-                conn,
-                store_identity: opencode_store_identity(scan.opencode_db, schema_version),
-                session_columns,
-                message_columns,
-                part_columns,
-                message_by_session,
-                part_by_session,
-                part_by_message,
-                sessions: BTreeMap::new(),
-            });
+            *guard = Some(open_opencode_snapshot(scan)?);
         }
         Ok(guard)
     }
+}
+
+/// Open a connection whose filesystem generation is known to match the path
+/// we inspected. The before/after check closes the replacement race between
+/// SQLite opening the file and RelayHistory computing the source stamp.
+fn open_opencode_snapshot(scan: &ScanEnv<'_>) -> Result<OpencodeReadSnapshot> {
+    for _ in 0..3 {
+        let generation_before = opencode_store_generation(scan.opencode_db)?;
+        let conn = open_db_readonly(scan.opencode_db)?;
+        scan.note_open();
+        conn.execute_batch("PRAGMA query_only = ON; BEGIN DEFERRED")?;
+        let session_columns = table_columns(&conn, "session")?;
+        let message_columns = table_columns(&conn, "message")?;
+        let part_columns = table_columns(&conn, "part")?;
+        let message_by_session = has_leading_index(&conn, "message", "session_id")?;
+        let part_by_session = has_leading_index(&conn, "part", "session_id")?;
+        let part_by_message = has_leading_index(&conn, "part", "message_id")?;
+        let schema_version: i64 = conn.query_row("PRAGMA schema_version", [], |row| row.get(0))?;
+        let generation_after = opencode_store_generation(scan.opencode_db)?;
+        if generation_before != generation_after {
+            continue;
+        }
+        return Ok(OpencodeReadSnapshot {
+            conn,
+            store_identity: format!("{generation_before}:{schema_version}"),
+            session_columns,
+            message_columns,
+            part_columns,
+            message_by_session,
+            part_by_session,
+            part_by_message,
+            sessions: BTreeMap::new(),
+        });
+    }
+    anyhow::bail!(
+        "OpenCode database {} was repeatedly replaced while discovery opened it",
+        scan.opencode_db.display()
+    )
 }
 
 /// Whether `table` already has an index whose leading column is `column`.
@@ -1253,6 +1267,41 @@ fn has_leading_index(conn: &Connection, table: &str, column: &str) -> Result<boo
         .query_row([column], |_| Ok(()))
         .optional()?
         .is_some())
+}
+
+/// Whether an existing provider index has exactly the ordered prefix needed
+/// to apply a deterministic SQL LIMIT without sorting an unbounded tie group.
+fn has_ordered_index_prefix(
+    conn: &Connection,
+    table: &str,
+    prefix: &[(&str, bool)],
+) -> Result<bool> {
+    let mut indexes = conn.prepare(&format!("SELECT name FROM pragma_index_list('{table}')"))?;
+    let names = indexes
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    for name in names {
+        let mut columns = conn.prepare(
+            "SELECT name, desc FROM pragma_index_xinfo(?) \
+             WHERE key = 1 ORDER BY seqno",
+        )?;
+        let ordered = columns
+            .query_map([name], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, bool>(1)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        if ordered.len() >= prefix.len()
+            && ordered
+                .iter()
+                .zip(prefix)
+                .all(|((actual_name, actual_desc), (name, desc))| {
+                    actual_name == name && actual_desc == desc
+                })
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn table_columns(conn: &Connection, table: &str) -> Result<BTreeSet<String>> {
@@ -1297,14 +1346,18 @@ impl ShallowSessionProvider for OpencodeProvider {
             "NULL"
         };
         // Current OpenCode releases index the session primary key but do not
-        // all index `time_updated`. Prefer exact update recency where that
-        // index exists. Otherwise the provider's descending, time-encoded
-        // `ses_` ids make PRIMARY KEY ASC a bounded newest-created fallback;
-        // resumed old sessions can be delayed on that schema (documented).
+        // all provide the compound ordering needed to apply both update
+        // recency and the global id tie-break before LIMIT. Otherwise the
+        // provider's descending, time-encoded `ses_` ids make PRIMARY KEY ASC
+        // a bounded newest-created fallback; resumed old sessions can be
+        // delayed on that schema (documented).
         let recency_order = if columns.contains("time_updated")
-            && has_leading_index(&snapshot.conn, "session", "time_updated")?
-        {
-            "time_updated DESC"
+            && has_ordered_index_prefix(
+                &snapshot.conn,
+                "session",
+                &[("time_updated", true), ("id", false)],
+            )? {
+            "time_updated DESC, id ASC"
         } else {
             "id ASC"
         };
@@ -1412,17 +1465,22 @@ impl ShallowSessionProvider for OpencodeProvider {
                  WHERE {keyed_predicate} AND json_valid(m.data) AND json_valid(p.data) \
                  AND json_extract(m.data, '$.role') = 'user' \
                  AND json_extract(p.data, '$.type') = 'text' \
+                 AND json_type(p.data, '$.text') = 'text' \
+                 AND trim(substr(json_extract(p.data, '$.text'), 1, ?)) <> '' \
                  ORDER BY {order} ASC LIMIT 1"
             );
             scan.note_query();
             let prompt = {
                 let mut stmt = conn.prepare_cached(&sql)?;
                 stmt.query_row(
-                    params![EXCERPT_MAX_CHARS as i64, &candidate.locator],
-                    |row| row.get::<_, Option<String>>(0),
+                    params![
+                        EXCERPT_MAX_CHARS as i64,
+                        &candidate.locator,
+                        EXCERPT_MAX_CHARS as i64
+                    ],
+                    |row| row.get::<_, String>(0),
                 )
                 .optional()?
-                .flatten()
             };
             scan.note_records(u64::from(prompt.is_some()));
             prompt
@@ -1468,27 +1526,36 @@ impl ShallowSessionProvider for OpencodeProvider {
     }
 }
 
+fn file_generation_time(metadata: &fs::Metadata) -> u128 {
+    metadata
+        .created()
+        .or_else(|_| metadata.modified())
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default()
+}
+
 #[cfg(unix)]
-fn opencode_store_identity(path: &Path, schema_version: i64) -> String {
+fn opencode_store_generation(path: &Path) -> Result<String> {
     use std::os::unix::fs::MetadataExt;
-    fs::metadata(path)
-        .map(|metadata| format!("{}:{}:{schema_version}", metadata.dev(), metadata.ino()))
-        .unwrap_or_else(|_| format!("unknown:{schema_version}"))
+    let metadata = fs::metadata(path)?;
+    Ok(format!(
+        "{}:{}:{}",
+        metadata.dev(),
+        metadata.ino(),
+        file_generation_time(&metadata)
+    ))
 }
 
 #[cfg(not(unix))]
-fn opencode_store_identity(path: &Path, schema_version: i64) -> String {
-    fs::metadata(path)
-        .map(|metadata| {
-            let modified = metadata
-                .modified()
-                .ok()
-                .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|duration| duration.as_nanos())
-                .unwrap_or_default();
-            format!("{}:{modified}:{schema_version}", metadata.len())
-        })
-        .unwrap_or_else(|_| format!("unknown:{schema_version}"))
+fn opencode_store_generation(path: &Path) -> Result<String> {
+    let metadata = fs::metadata(path)?;
+    Ok(format!(
+        "{}:{}",
+        metadata.len(),
+        file_generation_time(&metadata)
+    ))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ai-hist/src/discover.rs
+++ b/crates/ai-hist/src/discover.rs
@@ -89,6 +89,16 @@ pub const HEAD_SCAN_MAX_LINES: usize = 400;
 pub const TAIL_SCAN_MAX_BYTES: u64 = 64 * 1024;
 /// Character cap for stored text excerpts, matching `last_assistant_text`.
 pub const EXCERPT_MAX_CHARS: usize = 4096;
+/// Unicode White_Space characters recognized by Rust's `str::trim`.
+///
+/// SQLite's one-argument `trim` removes only U+0020, so SQL predicates that
+/// decide whether an excerpt is substantive must pass this exact character
+/// set explicitly to stay in lockstep with [`excerpt`].
+pub const EXCERPT_TRIM_WHITESPACE: &str = concat!(
+    "\u{0009}\u{000A}\u{000B}\u{000C}\u{000D}\u{0020}\u{0085}\u{00A0}",
+    "\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\u{2004}\u{2005}\u{2006}",
+    "\u{2007}\u{2008}\u{2009}\u{200A}\u{2028}\u{2029}\u{202F}\u{205F}\u{3000}"
+);
 /// Default row cap for `list_session_catalog` when the caller gives none.
 pub const DEFAULT_CATALOG_LIMIT: i64 = 50;
 
@@ -1466,7 +1476,7 @@ impl ShallowSessionProvider for OpencodeProvider {
                  AND json_extract(m.data, '$.role') = 'user' \
                  AND json_extract(p.data, '$.type') = 'text' \
                  AND json_type(p.data, '$.text') = 'text' \
-                 AND trim(substr(json_extract(p.data, '$.text'), 1, ?)) <> '' \
+                 AND trim(substr(json_extract(p.data, '$.text'), 1, ?), ?) <> '' \
                  ORDER BY {order} ASC LIMIT 1"
             );
             scan.note_query();
@@ -1476,7 +1486,8 @@ impl ShallowSessionProvider for OpencodeProvider {
                     params![
                         EXCERPT_MAX_CHARS as i64,
                         &candidate.locator,
-                        EXCERPT_MAX_CHARS as i64
+                        EXCERPT_MAX_CHARS as i64,
+                        EXCERPT_TRIM_WHITESPACE
                     ],
                     |row| row.get::<_, String>(0),
                 )

--- a/crates/ai-hist/src/discover.rs
+++ b/crates/ai-hist/src/discover.rs
@@ -58,11 +58,10 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{LazyLock, Mutex, MutexGuard};
-use std::time::Duration;
 
 use ai_hist_core::{upsert_session_presence, SessionLocation, SessionScope, SOURCE_CHOICES};
 use anyhow::{Context, Result};
-use rusqlite::{params, Connection, DatabaseName, OpenFlags, OptionalExtension};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -70,7 +69,7 @@ use serde_json::Value;
 ///
 /// Bumped when the shape or meaning of [`ShallowSession`] / the CLI JSON
 /// payloads changes in a way a consumer must notice.
-pub const SESSION_CATALOG_CONTRACT_VERSION: u32 = 2;
+pub const SESSION_CATALOG_CONTRACT_VERSION: u32 = 3;
 
 /// Version of the shallow scanners themselves.
 ///
@@ -189,10 +188,18 @@ pub struct DiscoveryCounters {
     pub shallow_reads: u64,
     /// Candidates served from the catalog because their stamp was unchanged.
     pub skipped_unchanged: u64,
-    /// Provider files (and database snapshots) opened for reading.
+    /// Provider files and live provider databases opened for reading.
     pub files_opened: u64,
-    /// Bytes read out of provider sources.
+    /// Bytes read explicitly from file-backed provider sources. SQLite does
+    /// not expose exact filesystem bytes, so database reads never contribute.
     pub bytes_read: u64,
+    /// Bounded provider data queries issued. Schema-capability introspection is
+    /// excluded. Currently used by OpenCode.
+    pub provider_queries: u64,
+    /// Rows returned by bounded provider data queries. Currently used by
+    /// OpenCode to make session/message/part work visible without pretending
+    /// SQLite reports exact bytes.
+    pub records_inspected: u64,
 }
 
 /// Thread-safe accumulator behind [`DiscoveryCounters`], shared with the read
@@ -204,6 +211,8 @@ struct CounterCell {
     skipped_unchanged: AtomicU64,
     files_opened: AtomicU64,
     bytes_read: AtomicU64,
+    provider_queries: AtomicU64,
+    records_inspected: AtomicU64,
 }
 
 impl CounterCell {
@@ -214,6 +223,8 @@ impl CounterCell {
             skipped_unchanged: self.skipped_unchanged.load(Ordering::Relaxed),
             files_opened: self.files_opened.load(Ordering::Relaxed),
             bytes_read: self.bytes_read.load(Ordering::Relaxed),
+            provider_queries: self.provider_queries.load(Ordering::Relaxed),
+            records_inspected: self.records_inspected.load(Ordering::Relaxed),
         }
     }
 }
@@ -311,6 +322,18 @@ impl ScanEnv<'_> {
     fn note_bytes(&self, bytes: u64) {
         self.counters.bytes_read.fetch_add(bytes, Ordering::Relaxed);
     }
+
+    fn note_query(&self) {
+        self.counters
+            .provider_queries
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn note_records(&self, records: u64) {
+        self.counters
+            .records_inspected
+            .fetch_add(records, Ordering::Relaxed);
+    }
 }
 
 /// What a provider's [`read_shallow`](ShallowSessionProvider::read_shallow)
@@ -345,7 +368,11 @@ pub trait ShallowSessionProvider: Sync {
     /// Cheap enumeration: directory walk + stat, or one indexed query. For a
     /// remote connector the bounded service listing *is* the enumeration —
     /// there is no cheaper way to learn what exists.
-    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>>;
+    fn enumerate(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        requested_limit: Option<usize>,
+    ) -> Result<Vec<Candidate>>;
     /// What [`read_shallow`](ShallowSessionProvider::read_shallow) touches.
     fn read_access(&self) -> ShallowReadAccess {
         ShallowReadAccess::Filesystem
@@ -629,7 +656,11 @@ impl ShallowSessionProvider for ClaudeProvider {
         "claude"
     }
 
-    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+    fn enumerate(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        _requested_limit: Option<usize>,
+    ) -> Result<Vec<Candidate>> {
         file_candidates(
             "claude",
             crate::collect_matching_files(&env.home.join(".claude/projects"), "", "jsonl")?,
@@ -788,7 +819,11 @@ impl ShallowSessionProvider for CodexProvider {
         "codex"
     }
 
-    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+    fn enumerate(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        _requested_limit: Option<usize>,
+    ) -> Result<Vec<Candidate>> {
         let mut files = Vec::new();
         for root in [
             env.home.join(".codex/sessions"),
@@ -934,7 +969,11 @@ impl ShallowSessionProvider for CursorProvider {
         "cursor"
     }
 
-    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+    fn enumerate(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        _requested_limit: Option<usize>,
+    ) -> Result<Vec<Candidate>> {
         let root = env.home.join(".cursor/projects");
         let mut out = Vec::new();
         for project_dir in crate::sorted_dirs(&root)? {
@@ -1016,7 +1055,11 @@ impl ShallowSessionProvider for GrokProvider {
         "grok"
     }
 
-    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+    fn enumerate(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        _requested_limit: Option<usize>,
+    ) -> Result<Vec<Candidate>> {
         file_candidates(
             "grok",
             crate::collect_matching_files(
@@ -1123,101 +1166,100 @@ impl ShallowSessionProvider for GrokProvider {
 // opencode
 // ---------------------------------------------------------------------------
 
-/// Shallow adapter over the opencode SQLite store.
+/// Shallow adapter over the live OpenCode SQLite store.
 ///
-/// Reads the `session` table directly instead of the full sync's
-/// session/message/part join. The database is snapshotted once per run with
-/// `Connection::backup`, exactly as the full sync does, so an in-flight WAL
-/// never yields a torn read.
+/// One read-only connection and one deferred transaction live for the whole
+/// discovery run. The first schema read establishes a coherent SQLite
+/// snapshot; candidate enumeration and every selected-session query therefore
+/// see the same committed state even while OpenCode appends in WAL mode.
 ///
-/// The snapshot is held open on one connection for the whole run, and —
-/// because it is a private throwaway copy — indexed by `session_id` up
-/// front when the live store isn't: the per-candidate excerpt and model
-/// queries then seek instead of scanning `message` and `part` once per
-/// session, which made a cold discovery quadratic in store size.
+/// No provider DDL is ever issued. Before querying `message` or `part`, the
+/// adapter verifies that an existing provider index can seek by session (or by
+/// message after a session seek). Metadata remains available on older schemas,
+/// but prompt/model extraction is omitted when it would require a table scan.
 #[derive(Default)]
 struct OpencodeProvider {
-    snapshot: Mutex<Option<OpencodeSnapshot>>,
+    live: Mutex<Option<OpencodeReadSnapshot>>,
 }
 
-/// One run's open snapshot: the connection, plus per-store facts that are
-/// invariant across candidates and so are read exactly once.
-struct OpencodeSnapshot {
+#[derive(Clone)]
+struct OpencodeSessionSeed {
+    directory: Option<String>,
+    created: Option<i64>,
+    updated: Option<i64>,
+}
+
+/// One run's coherent live snapshot and the schema/index facts that are
+/// invariant across its selected candidates.
+struct OpencodeReadSnapshot {
     conn: Connection,
+    store_identity: String,
     session_columns: BTreeSet<String>,
-    /// Keeps the snapshot file on disk for as long as the connection lives.
-    _file: tempfile::TempPath,
+    message_columns: BTreeSet<String>,
+    part_columns: BTreeSet<String>,
+    message_by_session: bool,
+    part_by_session: bool,
+    part_by_message: bool,
+    sessions: BTreeMap<String, OpencodeSessionSeed>,
 }
 
 impl OpencodeProvider {
-    /// The run's snapshot, created on first use. `None` inside the guard
-    /// means there is no opencode store on this machine.
-    fn snapshot(&self, scan: &ScanEnv<'_>) -> Result<MutexGuard<'_, Option<OpencodeSnapshot>>> {
-        let mut guard = self.snapshot.lock().expect("opencode snapshot lock");
+    /// Open the provider once, read-only, and start the transaction that pins
+    /// the run's SQLite snapshot. `None` means there is no OpenCode store.
+    fn snapshot(&self, scan: &ScanEnv<'_>) -> Result<MutexGuard<'_, Option<OpencodeReadSnapshot>>> {
+        let mut guard = self.live.lock().expect("opencode live snapshot lock");
         if guard.is_none() && scan.opencode_db.exists() {
-            let file = tempfile::NamedTempFile::new()?.into_temp_path();
-            let live = Connection::open_with_flags(
+            let conn = Connection::open_with_flags(
                 scan.opencode_db,
                 OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
             )
             .with_context(|| format!("opening {}", scan.opencode_db.display()))?;
-            live.busy_timeout(Duration::from_secs(5))?;
-            live.backup(DatabaseName::Main, &file, None)
-                .with_context(|| format!("snapshotting {}", scan.opencode_db.display()))?;
+            conn.busy_timeout(std::time::Duration::from_millis(250))?;
+            conn.execute_batch("PRAGMA query_only = ON; BEGIN DEFERRED")?;
             scan.note_open();
-            scan.note_bytes(fs::metadata(scan.opencode_db).map(|m| m.len()).unwrap_or(0));
-            let conn = Connection::open(&file)?;
-            index_opencode_snapshot(&conn)?;
-            let session_columns = table_columns(&conn, "session");
-            *guard = Some(OpencodeSnapshot {
+            let session_columns = table_columns(&conn, "session")?;
+            let message_columns = table_columns(&conn, "message")?;
+            let part_columns = table_columns(&conn, "part")?;
+            let message_by_session = has_leading_index(&conn, "message", "session_id")?;
+            let part_by_session = has_leading_index(&conn, "part", "session_id")?;
+            let part_by_message = has_leading_index(&conn, "part", "message_id")?;
+            let schema_version: i64 =
+                conn.query_row("PRAGMA schema_version", [], |row| row.get(0))?;
+            *guard = Some(OpencodeReadSnapshot {
                 conn,
+                store_identity: opencode_store_identity(scan.opencode_db, schema_version),
                 session_columns,
-                _file: file,
+                message_columns,
+                part_columns,
+                message_by_session,
+                part_by_session,
+                part_by_message,
+                sessions: BTreeMap::new(),
             });
         }
         Ok(guard)
     }
 }
 
-/// Give the snapshot the `session_id` seeks the per-candidate queries need,
-/// unless the store already ships an equivalent index. Nobody else reads the
-/// snapshot and it never outlives the run, so durability is turned off: the
-/// build costs one scan per table instead of one scan per candidate.
-fn index_opencode_snapshot(conn: &Connection) -> Result<()> {
-    let mut ddl = String::new();
-    for table in ["message", "part"] {
-        if table_columns(conn, table).contains("session_id") && !has_session_id_index(conn, table) {
-            ddl.push_str(&format!(
-                "CREATE INDEX ai_hist_{table}_session ON {table}(session_id);"
-            ));
-        }
-    }
-    if !ddl.is_empty() {
-        conn.execute_batch(&format!(
-            "PRAGMA journal_mode = OFF; PRAGMA synchronous = OFF; {ddl}"
-        ))?;
-    }
-    Ok(())
-}
-
-/// Whether `table` already has an index whose leading column is `session_id`.
-fn has_session_id_index(conn: &Connection, table: &str) -> bool {
-    conn.prepare(&format!(
-        "SELECT 1 FROM pragma_index_list('{table}') indexes \
+/// Whether `table` already has an index whose leading column is `column`.
+/// SQLite's primary-key autoindexes are included by the pragma.
+fn has_leading_index(conn: &Connection, table: &str, column: &str) -> Result<bool> {
+    Ok(conn
+        .prepare(&format!(
+            "SELECT 1 FROM pragma_index_list('{table}') indexes \
          JOIN pragma_index_info(indexes.name) columns \
-         WHERE columns.seqno = 0 AND columns.name = 'session_id' LIMIT 1"
-    ))
-    .and_then(|mut stmt| stmt.query_row([], |_| Ok(())))
-    .is_ok()
+         WHERE columns.seqno = 0 AND columns.name = ? LIMIT 1"
+        ))?
+        .query_row([column], |_| Ok(()))
+        .optional()?
+        .is_some())
 }
 
-fn table_columns(conn: &Connection, table: &str) -> BTreeSet<String> {
-    conn.prepare(&format!("SELECT name FROM pragma_table_info('{table}')"))
-        .and_then(|mut stmt| {
-            stmt.query_map([], |row| row.get::<_, String>(0))?
-                .collect::<rusqlite::Result<BTreeSet<String>>>()
-        })
-        .unwrap_or_default()
+fn table_columns(conn: &Connection, table: &str) -> Result<BTreeSet<String>> {
+    Ok(conn
+        .prepare(&format!("SELECT name FROM pragma_table_info('{table}')"))?
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<BTreeSet<String>>>()?)
 }
 
 impl ShallowSessionProvider for OpencodeProvider {
@@ -1225,9 +1267,14 @@ impl ShallowSessionProvider for OpencodeProvider {
         "opencode"
     }
 
-    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
-        let guard = self.snapshot(&env.scan())?;
-        let Some(snapshot) = guard.as_ref() else {
+    fn enumerate(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        requested_limit: Option<usize>,
+    ) -> Result<Vec<Candidate>> {
+        let scan = env.scan();
+        let mut guard = self.snapshot(&scan)?;
+        let Some(snapshot) = guard.as_mut() else {
             return Ok(Vec::new());
         };
         let columns = &snapshot.session_columns;
@@ -1244,29 +1291,77 @@ impl ShallowSessionProvider for OpencodeProvider {
         } else {
             "NULL"
         };
+        let directory = if columns.contains("directory") {
+            "directory"
+        } else {
+            "NULL"
+        };
+        // Current OpenCode releases index the session primary key but do not
+        // all index `time_updated`. Prefer exact update recency where that
+        // index exists. Otherwise the provider's descending, time-encoded
+        // `ses_` ids make PRIMARY KEY ASC a bounded newest-created fallback;
+        // resumed old sessions can be delayed on that schema (documented).
+        let recency_order = if columns.contains("time_updated")
+            && has_leading_index(&snapshot.conn, "session", "time_updated")?
+        {
+            "time_updated DESC"
+        } else {
+            "id ASC"
+        };
+        let sqlite_limit = requested_limit
+            .map(i64::try_from)
+            .transpose()
+            .context("OpenCode discovery limit exceeds SQLite's signed 64-bit range")?;
+        let limit_sql = sqlite_limit.map(|_| " LIMIT ?").unwrap_or_default();
         let sql = format!(
-            "SELECT id, {created}, {updated} FROM session WHERE id IS NOT NULL AND id <> ''"
+            "SELECT id, {directory}, {created}, {updated} FROM session \
+             WHERE id IS NOT NULL AND id <> '' ORDER BY {recency_order}{limit_sql}"
         );
         let mut stmt = snapshot.conn.prepare(&sql)?;
-        let rows = stmt
-            .query_map([], |row| {
-                Ok((
-                    row.get::<_, String>(0)?,
-                    row.get::<_, Option<i64>>(1)?,
-                    row.get::<_, Option<i64>>(2)?,
-                ))
-            })?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
+        scan.note_query();
+        let collect = |row: &rusqlite::Row<'_>| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<i64>>(2)?,
+                row.get::<_, Option<i64>>(3)?,
+            ))
+        };
+        let rows = match sqlite_limit {
+            Some(limit) => stmt
+                .query_map([limit], collect)?
+                .collect::<rusqlite::Result<Vec<_>>>()?,
+            None => stmt
+                .query_map([], collect)?
+                .collect::<rusqlite::Result<Vec<_>>>()?,
+        };
+        scan.note_records(rows.len() as u64);
+        snapshot.sessions = rows
+            .iter()
+            .map(|(id, directory, created, updated)| {
+                (
+                    id.clone(),
+                    OpencodeSessionSeed {
+                        directory: directory.clone(),
+                        created: *created,
+                        updated: *updated,
+                    },
+                )
+            })
+            .collect();
         Ok(rows
             .into_iter()
-            .map(|(id, created, updated)| Candidate {
+            .map(|(id, _directory, created, updated)| Candidate {
                 source: "opencode",
                 locator: id.clone(),
                 session_id: Some(id),
                 recency_hint_ms: updated.or(created),
-                // Opencode has no file per session; the session's own
-                // created/updated stamps are its change marker.
-                stamp: format!("{}:{}", created.unwrap_or(0), updated.unwrap_or(0)),
+                stamp: format!(
+                    "{}:{}:{}",
+                    snapshot.store_identity,
+                    created.unwrap_or(0),
+                    updated.unwrap_or(0)
+                ),
             })
             .collect())
     }
@@ -1282,78 +1377,87 @@ impl ShallowSessionProvider for OpencodeProvider {
             return Ok(None);
         };
         let conn = &snapshot.conn;
-        let columns = &snapshot.session_columns;
-        let directory = if columns.contains("directory") {
-            "directory"
-        } else {
-            "NULL"
-        };
-        let created = if columns.contains("time_created") {
-            "time_created"
-        } else {
-            "NULL"
-        };
-        let updated = if columns.contains("time_updated") {
-            "time_updated"
-        } else {
-            "NULL"
-        };
-        let sql = format!("SELECT {directory}, {created}, {updated} FROM session WHERE id = ?");
-        let row = conn
-            .prepare_cached(&sql)
-            .and_then(|mut stmt| {
-                stmt.query_row([&candidate.locator], |row| {
-                    Ok((
-                        row.get::<_, Option<String>>(0)?,
-                        row.get::<_, Option<i64>>(1)?,
-                        row.get::<_, Option<i64>>(2)?,
-                    ))
-                })
-            })
-            .ok();
-        let Some((directory, created, updated)) = row else {
+        let Some(seed) = snapshot.sessions.get(&candidate.locator).cloned() else {
             return Ok(None);
         };
         // The excerpt is cut in SQL, not in Rust: a single opencode part can
         // hold a whole pasted file, and materializing it just to take the
         // first 4096 characters would break the bounded-read promise for a
         // catalog entry.
-        let first_prompt = conn
-            .prepare_cached(
+        let prompt_schema = snapshot.part_columns.contains("data")
+            && snapshot.part_columns.contains("message_id")
+            && snapshot.message_columns.contains("id")
+            && snapshot.message_columns.contains("data");
+        let first_prompt = if prompt_schema
+            && (snapshot.part_by_session
+                || (snapshot.message_by_session && snapshot.part_by_message))
+        {
+            let keyed_predicate = if snapshot.part_by_session {
+                "p.session_id = ?"
+            } else {
+                "m.session_id = ?"
+            };
+            let order = match (
+                snapshot.part_columns.contains("time_created"),
+                snapshot.message_columns.contains("time_created"),
+            ) {
+                (true, true) => "COALESCE(p.time_created, m.time_created)",
+                (true, false) => "p.time_created",
+                (false, true) => "m.time_created",
+                (false, false) => "p.id",
+            };
+            let sql = format!(
                 "SELECT substr(json_extract(p.data, '$.text'), 1, ?) \
                  FROM part p JOIN message m ON m.id = p.message_id \
-                 WHERE p.session_id = ? AND json_extract(m.data, '$.role') = 'user' \
+                 WHERE {keyed_predicate} AND json_valid(m.data) AND json_valid(p.data) \
+                 AND json_extract(m.data, '$.role') = 'user' \
                  AND json_extract(p.data, '$.type') = 'text' \
-                 ORDER BY COALESCE(p.time_created, m.time_created) ASC LIMIT 1",
-            )
-            .and_then(|mut stmt| {
+                 ORDER BY {order} ASC LIMIT 1"
+            );
+            scan.note_query();
+            let prompt = {
+                let mut stmt = conn.prepare_cached(&sql)?;
                 stmt.query_row(
                     params![EXCERPT_MAX_CHARS as i64, &candidate.locator],
                     |row| row.get::<_, Option<String>>(0),
                 )
-            })
-            .ok()
-            .flatten()
-            .map(|text| excerpt(&text))
-            .filter(|text| !text.is_empty());
+                .optional()?
+                .flatten()
+            };
+            scan.note_records(u64::from(prompt.is_some()));
+            prompt
+                .map(|text| excerpt(&text))
+                .filter(|text| !text.is_empty())
+        } else {
+            None
+        };
         let mut models = Vec::new();
-        if let Ok(model) = conn
-            .prepare_cached(
-                "SELECT json_extract(data, '$.modelID') FROM message \
-                 WHERE session_id = ? AND json_extract(data, '$.modelID') IS NOT NULL LIMIT 1",
-            )
-            .and_then(|mut stmt| {
-                stmt.query_row([&candidate.locator], |row| row.get::<_, Option<String>>(0))
-            })
+        if snapshot.message_by_session
+            && snapshot.message_columns.contains("session_id")
+            && snapshot.message_columns.contains("data")
         {
+            scan.note_query();
+            let model = {
+                let mut stmt = conn.prepare_cached(
+                    "SELECT COALESCE(json_extract(data, '$.modelID'), \
+                                            json_extract(data, '$.model.modelID')) \
+                     FROM message WHERE session_id = ? AND json_valid(data) \
+                     AND COALESCE(json_extract(data, '$.modelID'), \
+                                  json_extract(data, '$.model.modelID')) IS NOT NULL LIMIT 1",
+                )?;
+                stmt.query_row([&candidate.locator], |row| row.get::<_, Option<String>>(0))
+                    .optional()?
+                    .flatten()
+            };
+            scan.note_records(u64::from(model.is_some()));
             push_unique(&mut models, model.as_deref());
         }
         Ok(Some(ShallowSession {
             source: "opencode".into(),
             session_id: candidate.locator.clone(),
-            cwd: directory,
-            first_activity_ms: created,
-            last_activity_ms: updated.or(created),
+            cwd: seed.directory,
+            first_activity_ms: seed.created,
+            last_activity_ms: seed.updated.or(seed.created),
             first_prompt,
             models,
             // Preserve which concrete OpenCode store produced this catalog
@@ -1362,6 +1466,29 @@ impl ShallowSessionProvider for OpencodeProvider {
             ..Default::default()
         }))
     }
+}
+
+#[cfg(unix)]
+fn opencode_store_identity(path: &Path, schema_version: i64) -> String {
+    use std::os::unix::fs::MetadataExt;
+    fs::metadata(path)
+        .map(|metadata| format!("{}:{}:{schema_version}", metadata.dev(), metadata.ino()))
+        .unwrap_or_else(|_| format!("unknown:{schema_version}"))
+}
+
+#[cfg(not(unix))]
+fn opencode_store_identity(path: &Path, schema_version: i64) -> String {
+    fs::metadata(path)
+        .map(|metadata| {
+            let modified = metadata
+                .modified()
+                .ok()
+                .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|duration| duration.as_nanos())
+                .unwrap_or_default();
+            format!("{}:{modified}:{schema_version}", metadata.len())
+        })
+        .unwrap_or_else(|_| format!("unknown:{schema_version}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -1382,7 +1509,11 @@ impl ShallowSessionProvider for RelayProvider {
         "relay"
     }
 
-    fn enumerate(&self, env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+    fn enumerate(
+        &self,
+        env: &DiscoveryEnv<'_>,
+        _requested_limit: Option<usize>,
+    ) -> Result<Vec<Candidate>> {
         let mut stmt = env.conn().prepare(
             "SELECT session_id, MAX(timestamp_ms), COUNT(*) FROM history \
              WHERE source = 'relay' AND session_id IS NOT NULL AND session_id <> '' \
@@ -2150,7 +2281,7 @@ pub fn discover_sessions_with_providers(
             .providers
             .entry(provider.source().to_string())
             .or_default();
-        match provider.enumerate(env) {
+        match provider.enumerate(env, options.limit) {
             Ok(found) => {
                 entry.candidates += found.len();
                 env.note_candidates(found.len() as u64);

--- a/crates/ai-hist/src/discover/tests.rs
+++ b/crates/ai-hist/src/discover/tests.rs
@@ -820,6 +820,14 @@ fn a_huge_opencode_part_is_truncated_before_it_reaches_rust() {
 }
 
 #[test]
+fn opencode_sql_uses_the_same_whitespace_set_as_rust_excerpts() {
+    let rust_whitespace: String = ('\0'..=char::MAX)
+        .filter(|character| character.is_whitespace())
+        .collect();
+    assert_eq!(EXCERPT_TRIM_WHITESPACE, rust_whitespace);
+}
+
+#[test]
 fn empty_and_minimal_opencode_schemas_are_tolerated() {
     let conn = catalog();
     let home = tempfile::tempdir().unwrap();
@@ -992,7 +1000,10 @@ fn opencode_selected_session_queries_use_provider_indexes() {
            AND json_extract(m.data, '$.role') = 'user'
            AND json_extract(p.data, '$.type') = 'text'
            AND json_type(p.data, '$.text') = 'text'
-           AND trim(substr(json_extract(p.data, '$.text'), 1, 4096)) <> ''
+           AND trim(substr(json_extract(p.data, '$.text'), 1, 4096),
+                    char(9,10,11,12,13,32,133,160,5760,8192,8193,8194,8195,
+                         8196,8197,8198,8199,8200,8201,8202,8232,8233,8239,
+                         8287,12288)) <> ''
          ORDER BY COALESCE(p.time_created, m.time_created) ASC LIMIT 1",
     );
     assert!(
@@ -1168,6 +1179,8 @@ fn malformed_and_partial_opencode_rows_do_not_hide_an_older_complete_prompt() {
     opencode_db(
         home.path(),
         "INSERT INTO session VALUES ('ses_partial', '/work/oc', 1, 4);
+         INSERT INTO message VALUES ('m_ws', 'ses_partial', -1, '{\"role\":\"user\"}');
+         INSERT INTO part VALUES ('p_ws', 'm_ws', 'ses_partial', -1, '{\"type\":\"text\",\"text\":\"\\t\\n\\r  \"}');
          INSERT INTO message VALUES ('m0', 'ses_partial', 0, '{\"role\":\"user\"}');
          INSERT INTO part VALUES ('p0', 'm0', 'ses_partial', 0, '{\"type\":\"text\"}');
          INSERT INTO message VALUES ('m1', 'ses_partial', 1, '{\"role\":\"user\",\"modelID\":\"ok\"}');

--- a/crates/ai-hist/src/discover/tests.rs
+++ b/crates/ai-hist/src/discover/tests.rs
@@ -977,10 +977,10 @@ fn opencode_applies_the_global_id_tiebreak_before_its_limit() {
     assert_eq!(found.ids(), vec!["opencode:ses_a", "opencode:ses_b"]);
 }
 
-fn explain_details(conn: &Connection, sql: &str) -> String {
+fn explain_details<P: rusqlite::Params>(conn: &Connection, sql: &str, params: P) -> String {
     conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
         .unwrap()
-        .query_map([], |row| row.get::<_, String>(3))
+        .query_map(params, |row| row.get::<_, String>(3))
         .unwrap()
         .collect::<rusqlite::Result<Vec<_>>>()
         .unwrap()
@@ -994,17 +994,20 @@ fn opencode_selected_session_queries_use_provider_indexes() {
     let db = Connection::open(home.path().join("opencode.db")).unwrap();
     let prompt = explain_details(
         &db,
-        "SELECT substr(json_extract(p.data, '$.text'), 1, 4096)
+        "SELECT substr(json_extract(p.data, '$.text'), 1, ?)
          FROM part p JOIN message m ON m.id = p.message_id
-         WHERE p.session_id = 'selected' AND json_valid(m.data) AND json_valid(p.data)
+         WHERE p.session_id = ? AND json_valid(m.data) AND json_valid(p.data)
            AND json_extract(m.data, '$.role') = 'user'
            AND json_extract(p.data, '$.type') = 'text'
            AND json_type(p.data, '$.text') = 'text'
-           AND trim(substr(json_extract(p.data, '$.text'), 1, 4096),
-                    char(9,10,11,12,13,32,133,160,5760,8192,8193,8194,8195,
-                         8196,8197,8198,8199,8200,8201,8202,8232,8233,8239,
-                         8287,12288)) <> ''
+           AND trim(substr(json_extract(p.data, '$.text'), 1, ?), ?) <> ''
          ORDER BY COALESCE(p.time_created, m.time_created) ASC LIMIT 1",
+        rusqlite::params![
+            EXCERPT_MAX_CHARS as i64,
+            "selected",
+            EXCERPT_MAX_CHARS as i64,
+            EXCERPT_TRIM_WHITESPACE
+        ],
     );
     assert!(
         prompt.contains("SEARCH p USING INDEX part_session_idx"),
@@ -1020,6 +1023,7 @@ fn opencode_selected_session_queries_use_provider_indexes() {
          FROM message WHERE session_id = 'selected' AND json_valid(data)
          AND COALESCE(json_extract(data, '$.modelID'),
                       json_extract(data, '$.model.modelID')) IS NOT NULL LIMIT 1",
+        [],
     );
     assert!(
         model.contains("SEARCH message USING INDEX message_session_time_created_id_idx"),
@@ -1116,6 +1120,7 @@ fn current_opencode_schema_without_recency_index_uses_primary_key_fallback() {
         &db,
         "SELECT id, directory, time_created, time_updated FROM session
          WHERE id IS NOT NULL AND id <> '' ORDER BY id ASC LIMIT 1",
+        [],
     );
     assert!(plan.contains("sqlite_autoindex_session_1"), "{plan}");
     drop(db);

--- a/crates/ai-hist/src/discover/tests.rs
+++ b/crates/ai-hist/src/discover/tests.rs
@@ -947,6 +947,28 @@ fn opencode_fixed_limit_does_not_inspect_unrelated_history() {
     assert_eq!(unchanged.summary.counters.bytes_read, 0);
 }
 
+#[test]
+fn opencode_applies_the_global_id_tiebreak_before_its_limit() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    opencode_db(
+        home.path(),
+        "INSERT INTO session VALUES ('ses_c', '/c', 1, 10);
+         INSERT INTO session VALUES ('ses_a', '/a', 1, 10);
+         INSERT INTO session VALUES ('ses_b', '/b', 1, 10);",
+    );
+    let found = discover(
+        &conn,
+        home.path(),
+        &DiscoverOptions {
+            sources: vec!["opencode".into()],
+            limit: Some(2),
+            ..Default::default()
+        },
+    );
+    assert_eq!(found.ids(), vec!["opencode:ses_a", "opencode:ses_b"]);
+}
+
 fn explain_details(conn: &Connection, sql: &str) -> String {
     conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
         .unwrap()
@@ -969,6 +991,8 @@ fn opencode_selected_session_queries_use_provider_indexes() {
          WHERE p.session_id = 'selected' AND json_valid(m.data) AND json_valid(p.data)
            AND json_extract(m.data, '$.role') = 'user'
            AND json_extract(p.data, '$.type') = 'text'
+           AND json_type(p.data, '$.text') = 'text'
+           AND trim(substr(json_extract(p.data, '$.text'), 1, 4096)) <> ''
          ORDER BY COALESCE(p.time_created, m.time_created) ASC LIMIT 1",
     );
     assert!(
@@ -981,8 +1005,10 @@ fn opencode_selected_session_queries_use_provider_indexes() {
 
     let model = explain_details(
         &db,
-        "SELECT json_extract(data, '$.modelID') FROM message
-         WHERE session_id = 'selected' AND json_valid(data) LIMIT 1",
+        "SELECT COALESCE(json_extract(data, '$.modelID'), json_extract(data, '$.model.modelID'))
+         FROM message WHERE session_id = 'selected' AND json_valid(data)
+         AND COALESCE(json_extract(data, '$.modelID'),
+                      json_extract(data, '$.model.modelID')) IS NOT NULL LIMIT 1",
     );
     assert!(
         model.contains("SEARCH message USING INDEX message_session_time_created_id_idx"),
@@ -1142,6 +1168,8 @@ fn malformed_and_partial_opencode_rows_do_not_hide_an_older_complete_prompt() {
     opencode_db(
         home.path(),
         "INSERT INTO session VALUES ('ses_partial', '/work/oc', 1, 4);
+         INSERT INTO message VALUES ('m0', 'ses_partial', 0, '{\"role\":\"user\"}');
+         INSERT INTO part VALUES ('p0', 'm0', 'ses_partial', 0, '{\"type\":\"text\"}');
          INSERT INTO message VALUES ('m1', 'ses_partial', 1, '{\"role\":\"user\",\"modelID\":\"ok\"}');
          INSERT INTO part VALUES ('p1', 'm1', 'ses_partial', 1, '{\"type\":\"text\",\"text\":\"complete prompt\"}');
          INSERT INTO message VALUES ('m2', 'ses_partial', 2, '{broken');
@@ -1189,7 +1217,7 @@ fn replacing_the_opencode_database_invalidates_same_timestamp_stamps() {
 }
 
 #[test]
-fn busy_opencode_database_reports_a_bounded_failure() {
+fn opencode_waits_for_a_transient_busy_writer() {
     let conn = catalog();
     let home = tempfile::tempdir().unwrap();
     opencode_db(home.path(), "");
@@ -1198,18 +1226,21 @@ fn busy_opencode_database_reports_a_bounded_failure() {
         .pragma_update(None, "journal_mode", "DELETE")
         .unwrap();
     blocker.execute_batch("BEGIN EXCLUSIVE").unwrap();
+    let release = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(350));
+        blocker.execute_batch("COMMIT").unwrap();
+    });
     let env = env_at(&conn, home.path());
+    let provider = OpencodeProvider::default();
     let started = std::time::Instant::now();
-    let error = discover_sessions_with_env(&env, &only(&["opencode"]), |_| {}).unwrap_err();
-    assert!(started.elapsed() < std::time::Duration::from_secs(2));
-    let failure = error
-        .downcast_ref::<AllProvidersFailed>()
-        .expect("the single provider failure carries diagnostics");
+    assert!(provider.enumerate(&env, Some(1)).is_ok());
+    let elapsed = started.elapsed();
+    release.join().unwrap();
     assert!(
-        failure.summary.diagnostics[0].error.contains("locked"),
-        "{:?}",
-        failure.summary.diagnostics
+        elapsed >= std::time::Duration::from_millis(250),
+        "{elapsed:?}"
     );
+    assert!(elapsed < std::time::Duration::from_secs(2), "{elapsed:?}");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ai-hist/src/discover/tests.rs
+++ b/crates/ai-hist/src/discover/tests.rs
@@ -84,6 +84,10 @@ fn opencode_db(home: &Path, statements: &str) {
         "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, time_created INTEGER, time_updated INTEGER);
          CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
          CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+         CREATE INDEX session_time_updated_id_idx ON session(time_updated DESC, id);
+         CREATE INDEX message_session_time_created_id_idx ON message(session_id, time_created, id);
+         CREATE INDEX part_session_idx ON part(session_id);
+         CREATE INDEX part_message_id_id_idx ON part(message_id, id);
          {statements}"
     ))
     .expect("opencode fixture");
@@ -813,6 +817,399 @@ fn a_huge_opencode_part_is_truncated_before_it_reaches_rust() {
         )
         .unwrap();
     assert_eq!(stored.chars().count(), EXCERPT_MAX_CHARS);
+}
+
+#[test]
+fn empty_and_minimal_opencode_schemas_are_tolerated() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    opencode_db(home.path(), "");
+    let empty = discover(&conn, home.path(), &only(&["opencode"]));
+    assert!(empty.rows.is_empty());
+    assert_eq!(empty.summary.counters.provider_queries, 1);
+    assert_eq!(empty.summary.counters.records_inspected, 0);
+
+    fs::remove_file(home.path().join("opencode.db")).unwrap();
+    let db = Connection::open(home.path().join("opencode.db")).unwrap();
+    db.execute_batch(
+        "CREATE TABLE session (id TEXT PRIMARY KEY); INSERT INTO session VALUES ('ses_minimal');",
+    )
+    .unwrap();
+    drop(db);
+    let minimal = discover(&conn, home.path(), &only(&["opencode"]));
+    assert_eq!(minimal.ids(), vec!["opencode:ses_minimal"]);
+    let row = minimal.row("ses_minimal");
+    assert_eq!(row.cwd, None);
+    assert_eq!(row.first_prompt, None);
+    assert!(row.models.is_empty());
+}
+
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn opencode_rejects_a_limit_that_sqlite_cannot_represent() {
+    let catalog = catalog();
+    let home = tempfile::tempdir().unwrap();
+    opencode_db(home.path(), "");
+    let env = env_at(&catalog, home.path());
+    let error = OpencodeProvider::default()
+        .enumerate(&env, Some(usize::MAX))
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("limit exceeds SQLite's signed 64-bit range"),
+        "{error:#}"
+    );
+}
+
+#[test]
+fn opencode_fixed_limit_does_not_inspect_unrelated_history() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    let db = Connection::open(home.path().join("opencode.db")).unwrap();
+    db.execute_batch(
+        "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, time_created INTEGER, time_updated INTEGER);
+         CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+         CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+         CREATE INDEX session_time_updated_id_idx ON session(time_updated DESC, id);
+         CREATE INDEX message_session_time_created_id_idx ON message(session_id, time_created, id);
+         CREATE INDEX part_session_idx ON part(session_id);
+         CREATE INDEX part_message_id_id_idx ON part(message_id, id);
+         BEGIN",
+    )
+    .unwrap();
+    for index in 0..2_000_i64 {
+        let id = format!("ses_{index:06}");
+        let message = format!("msg_{index:06}");
+        db.execute(
+            "INSERT INTO session VALUES (?, '/work/oc', ?, ?)",
+            params![id, index, index],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO message VALUES (?, ?, ?, '{\"role\":\"user\",\"modelID\":\"bounded-model\"}')",
+            params![message, id, index],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO part VALUES (?, ?, ?, ?, '{\"type\":\"text\",\"text\":\"bounded prompt\"}')",
+            params![format!("prt_{index:06}"), message, id, index],
+        )
+        .unwrap();
+        // Large unrelated histories make an accidental scan expensive and
+        // visible to the query-plan assertions below.
+        for extra in 0..3 {
+            db.execute(
+                "INSERT INTO part VALUES (?, ?, ?, ?, '{\"type\":\"tool\"}')",
+                params![
+                    format!("prt_{index:06}_{extra}"),
+                    message,
+                    id,
+                    index + extra
+                ],
+            )
+            .unwrap();
+        }
+    }
+    db.execute_batch("COMMIT").unwrap();
+    drop(db);
+
+    let found = discover(
+        &conn,
+        home.path(),
+        &DiscoverOptions {
+            sources: vec!["opencode".into()],
+            limit: Some(20),
+            ..Default::default()
+        },
+    );
+    assert_eq!(found.rows.len(), 20);
+    assert_eq!(found.summary.counters.candidates_enumerated, 20);
+    assert_eq!(found.summary.counters.shallow_reads, 20);
+    assert_eq!(found.summary.counters.provider_queries, 41);
+    assert_eq!(found.summary.counters.records_inspected, 60);
+    assert_eq!(found.summary.counters.bytes_read, 0);
+    assert_eq!(found.summary.counters.files_opened, 1);
+
+    let unchanged = discover(
+        &conn,
+        home.path(),
+        &DiscoverOptions {
+            sources: vec!["opencode".into()],
+            limit: Some(20),
+            ..Default::default()
+        },
+    );
+    assert_eq!(unchanged.summary.counters.candidates_enumerated, 20);
+    assert_eq!(unchanged.summary.counters.shallow_reads, 0);
+    assert_eq!(unchanged.summary.counters.provider_queries, 1);
+    assert_eq!(unchanged.summary.counters.records_inspected, 20);
+    assert_eq!(unchanged.summary.counters.bytes_read, 0);
+}
+
+fn explain_details(conn: &Connection, sql: &str) -> String {
+    conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(3))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap()
+        .join("\n")
+}
+
+#[test]
+fn opencode_selected_session_queries_use_provider_indexes() {
+    let home = tempfile::tempdir().unwrap();
+    opencode_db(home.path(), "");
+    let db = Connection::open(home.path().join("opencode.db")).unwrap();
+    let prompt = explain_details(
+        &db,
+        "SELECT substr(json_extract(p.data, '$.text'), 1, 4096)
+         FROM part p JOIN message m ON m.id = p.message_id
+         WHERE p.session_id = 'selected' AND json_valid(m.data) AND json_valid(p.data)
+           AND json_extract(m.data, '$.role') = 'user'
+           AND json_extract(p.data, '$.type') = 'text'
+         ORDER BY COALESCE(p.time_created, m.time_created) ASC LIMIT 1",
+    );
+    assert!(
+        prompt.contains("SEARCH p USING INDEX part_session_idx"),
+        "{prompt}"
+    );
+    assert!(prompt.contains("SEARCH m USING INDEX"), "{prompt}");
+    assert!(!prompt.contains("SCAN p"), "{prompt}");
+    assert!(!prompt.contains("SCAN m"), "{prompt}");
+
+    let model = explain_details(
+        &db,
+        "SELECT json_extract(data, '$.modelID') FROM message
+         WHERE session_id = 'selected' AND json_valid(data) LIMIT 1",
+    );
+    assert!(
+        model.contains("SEARCH message USING INDEX message_session_time_created_id_idx"),
+        "{model}"
+    );
+    assert!(!model.contains("SCAN message"), "{model}");
+}
+
+#[test]
+fn unindexed_opencode_history_is_not_scanned_or_mutated() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    let db_path = home.path().join("opencode.db");
+    let db = Connection::open(&db_path).unwrap();
+    db.execute_batch(
+        "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, time_created INTEGER, time_updated INTEGER);
+         CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+         CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+         INSERT INTO session VALUES ('ses_ffffffffffffold', '/work/legacy', 1, 2);
+         INSERT INTO message VALUES ('m1', 'ses_ffffffffffffold', 1, '{\"role\":\"user\",\"modelID\":\"would-require-scan\"}');
+         INSERT INTO part VALUES ('p1', 'm1', 'ses_ffffffffffffold', 1, '{\"type\":\"text\",\"text\":\"would require scan\"}');",
+    )
+    .unwrap();
+    let schema_before: String = db
+        .query_row(
+            "SELECT group_concat(sql, ';') FROM sqlite_schema WHERE sql IS NOT NULL ORDER BY name",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let bytes_before = fs::read(&db_path).unwrap();
+    let files_before: BTreeSet<_> = fs::read_dir(home.path())
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    drop(db);
+
+    let found = discover(&conn, home.path(), &only(&["opencode"]));
+    let row = found.row("ses_ffffffffffffold");
+    assert_eq!(row.cwd.as_deref(), Some("/work/legacy"));
+    assert_eq!(row.first_prompt, None);
+    assert!(row.models.is_empty());
+    assert_eq!(found.summary.counters.provider_queries, 1);
+    assert_eq!(found.summary.counters.records_inspected, 1);
+    assert_eq!(found.summary.counters.bytes_read, 0);
+
+    let db = Connection::open(&db_path).unwrap();
+    let schema_after: String = db
+        .query_row(
+            "SELECT group_concat(sql, ';') FROM sqlite_schema WHERE sql IS NOT NULL ORDER BY name",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        schema_after, schema_before,
+        "discovery must issue no provider DDL"
+    );
+    drop(db);
+    assert_eq!(
+        fs::read(&db_path).unwrap(),
+        bytes_before,
+        "provider bytes changed"
+    );
+    let files_after: BTreeSet<_> = fs::read_dir(home.path())
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    assert_eq!(
+        files_after, files_before,
+        "discovery created a database copy or sidecar"
+    );
+}
+
+#[test]
+fn current_opencode_schema_without_recency_index_uses_primary_key_fallback() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    let db = Connection::open(home.path().join("opencode.db")).unwrap();
+    db.execute_batch(
+        "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, time_created INTEGER, time_updated INTEGER);
+         CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+         CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+         CREATE INDEX message_session_time_created_id_idx ON message(session_id, time_created, id);
+         CREATE INDEX part_session_idx ON part(session_id);
+         CREATE INDEX part_message_id_id_idx ON part(message_id, id);
+         INSERT INTO session VALUES ('ses_ffffffffffffold', '/old', 1, 1000);
+         INSERT INTO session VALUES ('ses_000000000000new', '/new', 2, 2);
+         INSERT INTO message VALUES ('m_new', 'ses_000000000000new', 2, '{\"role\":\"user\",\"modelID\":\"fallback-model\"}');
+         INSERT INTO part VALUES ('p_new', 'm_new', 'ses_000000000000new', 2, '{\"type\":\"text\",\"text\":\"fallback prompt\"}');",
+    )
+    .unwrap();
+    let plan = explain_details(
+        &db,
+        "SELECT id, directory, time_created, time_updated FROM session
+         WHERE id IS NOT NULL AND id <> '' ORDER BY id ASC LIMIT 1",
+    );
+    assert!(plan.contains("sqlite_autoindex_session_1"), "{plan}");
+    drop(db);
+
+    let found = discover(
+        &conn,
+        home.path(),
+        &DiscoverOptions {
+            sources: vec!["opencode".into()],
+            limit: Some(1),
+            ..Default::default()
+        },
+    );
+    assert_eq!(found.ids(), vec!["opencode:ses_000000000000new"]);
+    assert_eq!(
+        found.row("ses_000000000000new").first_prompt.as_deref(),
+        Some("fallback prompt")
+    );
+    assert_eq!(
+        found.row("ses_000000000000new").models,
+        vec!["fallback-model"]
+    );
+}
+
+#[test]
+fn opencode_wal_append_does_not_tear_the_read_snapshot() {
+    let catalog = catalog();
+    let home = tempfile::tempdir().unwrap();
+    opencode_db(
+        home.path(),
+        "INSERT INTO session VALUES ('ses_snapshot', '/work/oc', 10, 20);
+         INSERT INTO message VALUES ('m_old', 'ses_snapshot', 10, '{\"role\":\"user\",\"modelID\":\"old-model\"}');
+         INSERT INTO part VALUES ('p_old', 'm_old', 'ses_snapshot', 10, '{\"type\":\"text\",\"text\":\"coherent old prompt\"}');",
+    );
+    let writer = Connection::open(home.path().join("opencode.db")).unwrap();
+    writer.pragma_update(None, "journal_mode", "WAL").unwrap();
+
+    let env = env_at(&catalog, home.path());
+    let provider = OpencodeProvider::default();
+    let candidate = provider.enumerate(&env, Some(1)).unwrap().remove(0);
+    writer
+        .execute_batch(
+            "INSERT INTO message VALUES ('m_new', 'ses_snapshot', 5, '{\"role\":\"user\",\"modelID\":\"new-model\"}');
+             INSERT INTO part VALUES ('p_new', 'm_new', 'ses_snapshot', 5, '{\"type\":\"text\",\"text\":\"new prompt outside snapshot\"}');
+             UPDATE session SET time_updated = 30 WHERE id = 'ses_snapshot';",
+        )
+        .unwrap();
+    let row = provider
+        .read_shallow(&env.scan(), None, &candidate)
+        .unwrap()
+        .unwrap();
+    assert_eq!(row.first_prompt.as_deref(), Some("coherent old prompt"));
+    assert_eq!(row.models, vec!["old-model"]);
+    assert_eq!(row.last_activity_ms, Some(20));
+}
+
+#[test]
+fn malformed_and_partial_opencode_rows_do_not_hide_an_older_complete_prompt() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    opencode_db(
+        home.path(),
+        "INSERT INTO session VALUES ('ses_partial', '/work/oc', 1, 4);
+         INSERT INTO message VALUES ('m1', 'ses_partial', 1, '{\"role\":\"user\",\"modelID\":\"ok\"}');
+         INSERT INTO part VALUES ('p1', 'm1', 'ses_partial', 1, '{\"type\":\"text\",\"text\":\"complete prompt\"}');
+         INSERT INTO message VALUES ('m2', 'ses_partial', 2, '{broken');
+         INSERT INTO part VALUES ('p2', 'm2', 'ses_partial', 2, '{broken');
+         INSERT INTO message VALUES ('m3', 'ses_partial', 3, '{\"role\":\"user\"}');",
+    );
+    let found = discover(&conn, home.path(), &only(&["opencode"]));
+    assert_eq!(
+        found.row("ses_partial").first_prompt.as_deref(),
+        Some("complete prompt")
+    );
+    assert!(found.summary.diagnostics.is_empty());
+}
+
+#[test]
+fn replacing_the_opencode_database_invalidates_same_timestamp_stamps() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    opencode_db(
+        home.path(),
+        "INSERT INTO session VALUES ('ses_replaced', '/old', 1, 2);
+         INSERT INTO message VALUES ('m1', 'ses_replaced', 1, '{\"role\":\"user\"}');
+         INSERT INTO part VALUES ('p1', 'm1', 'ses_replaced', 1, '{\"type\":\"text\",\"text\":\"old prompt\"}');",
+    );
+    let first = discover(&conn, home.path(), &only(&["opencode"]));
+    assert_eq!(
+        first.row("ses_replaced").first_prompt.as_deref(),
+        Some("old prompt")
+    );
+
+    fs::remove_file(home.path().join("opencode.db")).unwrap();
+    opencode_db(
+        home.path(),
+        "INSERT INTO session VALUES ('ses_replaced', '/new', 1, 2);
+         INSERT INTO message VALUES ('m1', 'ses_replaced', 1, '{\"role\":\"user\"}');
+         INSERT INTO part VALUES ('p1', 'm1', 'ses_replaced', 1, '{\"type\":\"text\",\"text\":\"new prompt\"}');",
+    );
+    let second = discover(&conn, home.path(), &only(&["opencode"]));
+    assert_eq!(second.summary.counters.shallow_reads, 1);
+    assert_eq!(second.row("ses_replaced").cwd.as_deref(), Some("/new"));
+    assert_eq!(
+        second.row("ses_replaced").first_prompt.as_deref(),
+        Some("new prompt")
+    );
+}
+
+#[test]
+fn busy_opencode_database_reports_a_bounded_failure() {
+    let conn = catalog();
+    let home = tempfile::tempdir().unwrap();
+    opencode_db(home.path(), "");
+    let blocker = Connection::open(home.path().join("opencode.db")).unwrap();
+    blocker
+        .pragma_update(None, "journal_mode", "DELETE")
+        .unwrap();
+    blocker.execute_batch("BEGIN EXCLUSIVE").unwrap();
+    let env = env_at(&conn, home.path());
+    let started = std::time::Instant::now();
+    let error = discover_sessions_with_env(&env, &only(&["opencode"]), |_| {}).unwrap_err();
+    assert!(started.elapsed() < std::time::Duration::from_secs(2));
+    let failure = error
+        .downcast_ref::<AllProvidersFailed>()
+        .expect("the single provider failure carries diagnostics");
+    assert!(
+        failure.summary.diagnostics[0].error.contains("locked"),
+        "{:?}",
+        failure.summary.diagnostics
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -1596,7 +1596,7 @@ pub fn run() -> Result<()> {
 ///
 /// The JSON form is one object, not a bare array, so the contract version and
 /// the pagination cursor travel with the payload:
-/// `{"contract_version":2,"scope":"local","sessions":[…],"next_cursor":{…}|null}`. Feed
+/// `{"contract_version":3,"scope":"local","sessions":[…],"next_cursor":{…}|null}`. Feed
 /// `next_cursor` back as `--after-ms/--after-source/--after-session-id` to get
 /// the next page; it is null once the catalog is exhausted.
 fn print_session_catalog(page: &SessionCatalogPage, as_json: bool) -> Result<()> {

--- a/crates/ai-hist/src/remote.rs
+++ b/crates/ai-hist/src/remote.rs
@@ -467,7 +467,11 @@ impl ShallowSessionProvider for ClaudeWebProvider {
         SessionLocation::Remote
     }
 
-    fn enumerate(&self, _env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+    fn enumerate(
+        &self,
+        _env: &DiscoveryEnv<'_>,
+        _requested_limit: Option<usize>,
+    ) -> Result<Vec<Candidate>> {
         require_https_or_loopback(&self.base_url)?;
         let oauth = load_claude_oauth(&self.credentials_path)?;
         if let Some(expires_at_ms) = oauth.expires_at_ms {
@@ -703,7 +707,11 @@ impl ShallowSessionProvider for CodexCloudProvider {
         SessionLocation::Remote
     }
 
-    fn enumerate(&self, _env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+    fn enumerate(
+        &self,
+        _env: &DiscoveryEnv<'_>,
+        _requested_limit: Option<usize>,
+    ) -> Result<Vec<Candidate>> {
         let mut candidates = Vec::new();
         let mut rows = BTreeMap::new();
         let mut cursor: Option<String> = None;

--- a/crates/ai-hist/src/remote/tests.rs
+++ b/crates/ai-hist/src/remote/tests.rs
@@ -214,7 +214,7 @@ fn claude_enumeration_pages_until_the_cursor_ends() {
     let provider = claude_provider(home.path(), &transport, None);
     let conn = catalog();
     let env = env_at(&conn, home.path());
-    let candidates = provider.enumerate(&env).unwrap();
+    let candidates = provider.enumerate(&env, None).unwrap();
     assert_eq!(candidates.len(), 2);
     let calls = transport.calls.lock().unwrap();
     assert_eq!(calls.len(), 2);
@@ -239,7 +239,7 @@ fn claude_enumeration_respects_the_row_limit() {
     let provider = claude_provider(home.path(), &transport, Some(2));
     let conn = catalog();
     let env = env_at(&conn, home.path());
-    let candidates = provider.enumerate(&env).unwrap();
+    let candidates = provider.enumerate(&env, None).unwrap();
     // The limit is satisfied by the first page, so the cursor is not followed.
     assert_eq!(candidates.len(), 2);
     let calls = transport.calls.lock().unwrap();
@@ -254,7 +254,7 @@ fn claude_enumeration_reports_a_rejected_token() {
     let provider = claude_provider(home.path(), &transport, None);
     let conn = catalog();
     let env = env_at(&conn, home.path());
-    let error = provider.enumerate(&env).unwrap_err().to_string();
+    let error = provider.enumerate(&env, None).unwrap_err().to_string();
     assert!(error.contains("rejected the stored OAuth token"), "{error}");
 }
 
@@ -270,7 +270,7 @@ fn claude_enumeration_reports_an_expired_token_without_a_request() {
     );
     let conn = catalog();
     let env = env_at(&conn, home.path());
-    let error = provider.enumerate(&env).unwrap_err().to_string();
+    let error = provider.enumerate(&env, None).unwrap_err().to_string();
     assert!(error.contains("expired"), "{error}");
     assert!(
         transport.calls.lock().unwrap().is_empty(),
@@ -406,7 +406,7 @@ fn codex_provider_forwards_a_bounded_page_limit_to_the_cli() {
     let home = tempfile::tempdir().unwrap();
     let conn = catalog();
     let env = env_at(&conn, home.path());
-    let candidates = provider.enumerate(&env).unwrap();
+    let candidates = provider.enumerate(&env, None).unwrap();
     assert_eq!(candidates.len(), 1);
     assert_eq!(*lister.calls.lock().unwrap(), vec![(7, None)]);
 
@@ -415,7 +415,7 @@ fn codex_provider_forwards_a_bounded_page_limit_to_the_cli() {
     let lister = Arc::new(ScriptedLister::new(vec![CODEX_LISTING.to_string()]));
     let provider = CodexCloudProvider::new(Box::new(Arc::clone(&lister)), Some(500));
     let env = env_at(&conn, home.path());
-    provider.enumerate(&env).unwrap();
+    provider.enumerate(&env, None).unwrap();
     assert_eq!(*lister.calls.lock().unwrap(), vec![(20, None)]);
 }
 
@@ -431,7 +431,7 @@ fn codex_provider_follows_the_cursor_across_pages() {
     let home = tempfile::tempdir().unwrap();
     let conn = catalog();
     let env = env_at(&conn, home.path());
-    let candidates = provider.enumerate(&env).unwrap();
+    let candidates = provider.enumerate(&env, None).unwrap();
     assert_eq!(candidates.len(), 2);
     assert_eq!(
         *lister.calls.lock().unwrap(),
@@ -445,7 +445,7 @@ fn codex_provider_follows_the_cursor_across_pages() {
     ]));
     let provider = CodexCloudProvider::new(Box::new(Arc::clone(&lister)), Some(1));
     let env = env_at(&conn, home.path());
-    let candidates = provider.enumerate(&env).unwrap();
+    let candidates = provider.enumerate(&env, None).unwrap();
     assert_eq!(candidates.len(), 1);
     assert_eq!(*lister.calls.lock().unwrap(), vec![(1, None)]);
 }
@@ -583,7 +583,11 @@ impl ShallowSessionProvider for FakeLocalProvider {
         "codex"
     }
 
-    fn enumerate(&self, _env: &DiscoveryEnv<'_>) -> Result<Vec<Candidate>> {
+    fn enumerate(
+        &self,
+        _env: &DiscoveryEnv<'_>,
+        _requested_limit: Option<usize>,
+    ) -> Result<Vec<Candidate>> {
         Ok(vec![Candidate {
             source: "codex",
             locator: self.session.raw_path.clone().unwrap_or_default(),

--- a/crates/ai-hist/tests/discovery_bench.rs
+++ b/crates/ai-hist/tests/discovery_bench.rs
@@ -53,6 +53,8 @@ use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 // ---------------------------------------------------------------------------
@@ -213,7 +215,11 @@ impl ArchiveBuilder {
         db.execute_batch(
             "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, time_created INTEGER, time_updated INTEGER);
              CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
-             CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);",
+             CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+             CREATE INDEX session_time_updated_id_idx ON session(time_updated DESC, id);
+             CREATE INDEX message_session_time_created_id_idx ON message(session_id, time_created, id);
+             CREATE INDEX part_session_idx ON part(session_id);
+             CREATE INDEX part_message_id_id_idx ON part(message_id, id);",
         )
         .expect("opencode schema");
         for index in 0..sessions {
@@ -400,6 +406,191 @@ fn session_catalog_performance_report() {
     measure_cache_only_listing(home.path());
     println!(
         "\nAll assertions above are operation counts. Timings are reported, never asserted.\n"
+    );
+}
+
+fn create_opencode_scaling_fixture(path: &Path, unrelated_sessions: usize) {
+    let db = Connection::open(path).expect("scaling opencode db");
+    db.pragma_update(None, "journal_mode", "WAL").unwrap();
+    db.execute_batch(
+        "CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, time_created INTEGER, time_updated INTEGER);
+         CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+         CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);
+         CREATE INDEX session_time_updated_id_idx ON session(time_updated DESC, id);
+         CREATE INDEX message_session_time_created_id_idx ON message(session_id, time_created, id);
+         CREATE INDEX part_session_idx ON part(session_id);
+         CREATE INDEX part_message_id_id_idx ON part(message_id, id);
+         BEGIN",
+    )
+    .unwrap();
+    let padding = "x".repeat(384);
+    for index in 0..unrelated_sessions {
+        let id = format!("ses_old_{index:06}");
+        let message = format!("msg_old_{index:06}");
+        db.execute(
+            "INSERT INTO session VALUES (?, '/work/old', ?, ?)",
+            rusqlite::params![id, index as i64, index as i64],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO message VALUES (?, ?, ?, ?)",
+            rusqlite::params![
+                message,
+                id,
+                index as i64,
+                r#"{"role":"user","modelID":"old-model"}"#
+            ],
+        )
+        .unwrap();
+        for part in 0..8 {
+            db.execute(
+                "INSERT INTO part VALUES (?, ?, ?, ?, ?)",
+                rusqlite::params![
+                    format!("prt_old_{index:06}_{part}"),
+                    message,
+                    id,
+                    index as i64,
+                    format!(r#"{{"type":"tool","padding":"{padding}"}}"#)
+                ],
+            )
+            .unwrap();
+        }
+    }
+    for index in 0..20 {
+        let id = format!("ses_newest_{index:02}");
+        let message = format!("msg_newest_{index:02}");
+        let timestamp = 2_000_000_000_000_i64 + index as i64;
+        db.execute(
+            "INSERT INTO session VALUES (?, '/work/newest', ?, ?)",
+            rusqlite::params![id, timestamp, timestamp],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO message VALUES (?, ?, ?, '{\"role\":\"user\",\"modelID\":\"new-model\"}')",
+            rusqlite::params![message, id, timestamp],
+        )
+        .unwrap();
+        db.execute(
+            "INSERT INTO part VALUES (?, ?, ?, ?, '{\"type\":\"text\",\"text\":\"same newest prompt\"}')",
+            rusqlite::params![format!("prt_newest_{index:02}"), message, id, timestamp],
+        )
+        .unwrap();
+    }
+    db.execute_batch("COMMIT").unwrap();
+}
+
+fn opencode_plan(conn: &Connection, sql: &str) -> String {
+    conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(3))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap()
+        .join(" | ")
+}
+
+/// Fixed-limit OpenCode discovery against 1,000 and 10,000-session stores.
+/// Both stores contain the same newest 20 sessions; only unrelated message and
+/// part history grows. WAL commits run concurrently with each measurement.
+#[test]
+#[ignore = "benchmark: creates a 10,000-session OpenCode store with large unrelated histories"]
+fn opencode_fixed_limit_scaling_report() {
+    let root = tempfile::tempdir().unwrap();
+    let mut rows = Vec::new();
+    for unrelated in [1_000_usize, 10_000] {
+        let provider_path = root.path().join(format!("opencode-{unrelated}.db"));
+        create_opencode_scaling_fixture(&provider_path, unrelated);
+        let provider_bytes = fs::metadata(&provider_path).unwrap().len();
+
+        let planning = Connection::open(&provider_path).unwrap();
+        let candidate_plan = opencode_plan(
+            &planning,
+            "SELECT id, directory, time_created, time_updated FROM session
+             WHERE id IS NOT NULL AND id <> '' ORDER BY time_updated DESC LIMIT 20",
+        );
+        let prompt_plan = opencode_plan(
+            &planning,
+            "SELECT p.data FROM part p JOIN message m ON m.id = p.message_id
+             WHERE p.session_id = 'ses_newest_19' AND json_valid(m.data) AND json_valid(p.data)
+             ORDER BY COALESCE(p.time_created, m.time_created) LIMIT 1",
+        );
+        assert!(
+            candidate_plan.contains("session_time_updated_id_idx"),
+            "{candidate_plan}"
+        );
+        assert!(
+            prompt_plan.contains("SEARCH p USING INDEX part_session_idx"),
+            "{prompt_plan}"
+        );
+        assert!(!prompt_plan.contains("SCAN p"), "{prompt_plan}");
+        assert!(!prompt_plan.contains("SCAN m"), "{prompt_plan}");
+        drop(planning);
+
+        let running = Arc::new(AtomicBool::new(true));
+        let writer_running = Arc::clone(&running);
+        let writer_path = provider_path.clone();
+        let writer = std::thread::spawn(move || {
+            let writer = Connection::open(writer_path).unwrap();
+            writer.busy_timeout(Duration::from_secs(1)).unwrap();
+            while writer_running.load(Ordering::Relaxed) {
+                writer
+                    .execute(
+                        "UPDATE session SET directory = CASE directory WHEN '/work/old' THEN '/work/old.' ELSE '/work/old' END WHERE id = 'ses_old_000000'",
+                        [],
+                    )
+                    .unwrap();
+            }
+        });
+
+        let mut samples = Vec::new();
+        let mut last_summary = None;
+        for _ in 0..5 {
+            let ledger = tempfile::tempdir().unwrap();
+            let conn = open_db(&ledger.path().join("catalog.db")).unwrap();
+            let env =
+                DiscoveryEnv::with_roots(&conn, root.path().to_path_buf(), provider_path.clone());
+            let options = DiscoverOptions {
+                sources: vec!["opencode".into()],
+                limit: Some(20),
+                ..Default::default()
+            };
+            let started = Instant::now();
+            let summary = discover_sessions_with_env(&env, &options, |_| {}).unwrap();
+            samples.push(started.elapsed());
+            last_summary = Some(summary);
+        }
+        running.store(false, Ordering::Relaxed);
+        writer.join().unwrap();
+
+        let summary = last_summary.unwrap();
+        assert_eq!(summary.discovered, 20);
+        assert_eq!(summary.counters.candidates_enumerated, 20);
+        assert_eq!(summary.counters.shallow_reads, 20);
+        assert_eq!(summary.counters.provider_queries, 41);
+        assert_eq!(summary.counters.records_inspected, 60);
+        assert_eq!(summary.counters.bytes_read, 0);
+        rows.push(vec![
+            unrelated.to_string(),
+            bytes(provider_bytes),
+            summary.counters.candidates_enumerated.to_string(),
+            summary.counters.provider_queries.to_string(),
+            summary.counters.records_inspected.to_string(),
+            micros(median(samples)),
+        ]);
+        println!("  {unrelated} session candidate plan: {candidate_plan}");
+        println!("  {unrelated} session prompt plan: {prompt_plan}");
+    }
+    table(
+        "OpenCode fixed-limit cold discovery with concurrent WAL writes",
+        &[
+            "unrelated sessions",
+            "database",
+            "candidates",
+            "queries",
+            "records",
+            "median",
+        ],
+        &rows,
     );
 }
 
@@ -660,7 +851,7 @@ fn measure_bounded_request(home: &Path, counts: &ArchiveCounts) {
     );
     assert!(
         counter(&small, "bytes_read") <= budget + 64 * 1024,
-        "five bounded reads must stay inside {} plus the opencode snapshot",
+        "five bounded reads must stay inside the documented file-read budget of {}",
         bytes(budget)
     );
     assert!(

--- a/crates/ai-hist/tests/discovery_bench.rs
+++ b/crates/ai-hist/tests/discovery_bench.rs
@@ -43,7 +43,7 @@
 //!    same bytes from a 5x larger archive.
 
 use ai_hist_core::open_db;
-use ai_hist_engine::discover::{HEAD_SCAN_MAX_BYTES, TAIL_SCAN_MAX_BYTES};
+use ai_hist_engine::discover::{EXCERPT_TRIM_WHITESPACE, HEAD_SCAN_MAX_BYTES, TAIL_SCAN_MAX_BYTES};
 use ai_hist_engine::{
     discover_sessions_with_env, list_session_catalog, CatalogListOptions, DiscoverOptions,
     DiscoveryEnv, DiscoverySummary,
@@ -518,9 +518,9 @@ fn opencode_fixed_limit_scaling_report() {
              AND json_extract(m.data, '$.role') = 'user'
              AND json_extract(p.data, '$.type') = 'text'
              AND json_type(p.data, '$.text') = 'text'
-             AND trim(substr(json_extract(p.data, '$.text'), 1, ?)) <> ''
+             AND trim(substr(json_extract(p.data, '$.text'), 1, ?), ?) <> ''
              ORDER BY COALESCE(p.time_created, m.time_created) ASC LIMIT 1",
-            rusqlite::params![4096_i64, "ses_newest_19", 4096_i64],
+            rusqlite::params![4096_i64, "ses_newest_19", 4096_i64, EXCERPT_TRIM_WHITESPACE],
         );
         let model_plan = opencode_plan(
             &planning,

--- a/crates/ai-hist/tests/discovery_bench.rs
+++ b/crates/ai-hist/tests/discovery_bench.rs
@@ -479,10 +479,10 @@ fn create_opencode_scaling_fixture(path: &Path, unrelated_sessions: usize) {
     db.execute_batch("COMMIT").unwrap();
 }
 
-fn opencode_plan(conn: &Connection, sql: &str) -> String {
+fn opencode_plan<P: rusqlite::Params>(conn: &Connection, sql: &str, params: P) -> String {
     conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
         .unwrap()
-        .query_map([], |row| row.get::<_, String>(3))
+        .query_map(params, |row| row.get::<_, String>(3))
         .unwrap()
         .collect::<rusqlite::Result<Vec<_>>>()
         .unwrap()
@@ -506,13 +506,30 @@ fn opencode_fixed_limit_scaling_report() {
         let candidate_plan = opencode_plan(
             &planning,
             "SELECT id, directory, time_created, time_updated FROM session
-             WHERE id IS NOT NULL AND id <> '' ORDER BY time_updated DESC LIMIT 20",
+             WHERE id IS NOT NULL AND id <> ''
+             ORDER BY time_updated DESC, id ASC LIMIT ?",
+            rusqlite::params![20_i64],
         );
         let prompt_plan = opencode_plan(
             &planning,
-            "SELECT p.data FROM part p JOIN message m ON m.id = p.message_id
-             WHERE p.session_id = 'ses_newest_19' AND json_valid(m.data) AND json_valid(p.data)
-             ORDER BY COALESCE(p.time_created, m.time_created) LIMIT 1",
+            "SELECT substr(json_extract(p.data, '$.text'), 1, ?)
+             FROM part p JOIN message m ON m.id = p.message_id
+             WHERE p.session_id = ? AND json_valid(m.data) AND json_valid(p.data)
+             AND json_extract(m.data, '$.role') = 'user'
+             AND json_extract(p.data, '$.type') = 'text'
+             AND json_type(p.data, '$.text') = 'text'
+             AND trim(substr(json_extract(p.data, '$.text'), 1, ?)) <> ''
+             ORDER BY COALESCE(p.time_created, m.time_created) ASC LIMIT 1",
+            rusqlite::params![4096_i64, "ses_newest_19", 4096_i64],
+        );
+        let model_plan = opencode_plan(
+            &planning,
+            "SELECT COALESCE(json_extract(data, '$.modelID'),
+                             json_extract(data, '$.model.modelID'))
+             FROM message WHERE session_id = ? AND json_valid(data)
+             AND COALESCE(json_extract(data, '$.modelID'),
+                          json_extract(data, '$.model.modelID')) IS NOT NULL LIMIT 1",
+            rusqlite::params!["ses_newest_19"],
         );
         assert!(
             candidate_plan.contains("session_time_updated_id_idx"),
@@ -524,6 +541,11 @@ fn opencode_fixed_limit_scaling_report() {
         );
         assert!(!prompt_plan.contains("SCAN p"), "{prompt_plan}");
         assert!(!prompt_plan.contains("SCAN m"), "{prompt_plan}");
+        assert!(
+            model_plan.contains("SEARCH message USING INDEX message_session_time_created_id_idx"),
+            "{model_plan}"
+        );
+        assert!(!model_plan.contains("SCAN message"), "{model_plan}");
         drop(planning);
 
         let running = Arc::new(AtomicBool::new(true));

--- a/crates/ai-hist/tests/session_discovery.rs
+++ b/crates/ai-hist/tests/session_discovery.rs
@@ -106,7 +106,7 @@ fn discover_streams_jsonl_rows_then_a_summary() {
 
     let summary = lines.last().expect("a summary line");
     assert_eq!(summary["type"], "summary");
-    assert_eq!(summary["contract_version"], 2);
+    assert_eq!(summary["contract_version"], 3);
     assert_eq!(summary["scope"], "local");
     assert_eq!(summary["discovered"], 2);
     assert_eq!(summary["skipped_unchanged"], 0);
@@ -162,7 +162,7 @@ fn list_serves_the_catalog_after_the_provider_files_are_gone() {
         String::from_utf8_lossy(&output.stderr)
     );
     let payload: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(payload["contract_version"], 2);
+    assert_eq!(payload["contract_version"], 3);
     assert_eq!(payload["scope"], "local");
     let sessions = payload["sessions"].as_array().unwrap();
     assert_eq!(sessions.len(), 2);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ Rust owns provider discovery/parsing, schema creation and migration, direct
 SQLite connections, catalog queries, history/event queries, search,
 statistics, and sync. Blocking filesystem and SQLite work is dispatched away
 from Node's event loop. TypeScript validates inputs, validates native contract
-version 4, catalog contract version 2, and hydration contract version 1, normalizes nullable fields, maps
+version 5, catalog contract version 3, and hydration contract version 1, normalizes nullable fields, maps
 native errors, and supplies pagination helpers.
 
 The CLI and MCP server import only the SDK's public functions. They do not

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -73,7 +73,7 @@ report preserves that status rather than describing it as cold.
 ## Benchmark definitions
 
 Discovery benchmarks use a generated home directory containing 1,000 valid,
-minimal Claude session transcripts and an opencode SQLite store
+minimal Claude session transcripts and an OpenCode SQLite store
 (`.local/share/opencode/opencode.db`) holding 1,000 minimal sessions with one
 message and one part each. Setup, fixture creation, and source-file changes
 happen outside the timed regions. The fixture makes each run repeatable and
@@ -90,9 +90,9 @@ requested session or event limit, not a cache size.
 | `cold shallow discovery N` | Fresh fixture; database does not exist | Create/migrate the database, enumerate the 1,000 candidates, shallow-read the newest N files, and upsert N catalog rows through SDK -> N-API -> Rust |
 | `unchanged shallow discovery N` | Run one cold discovery of N into a fresh database | Enumerate candidates, match source stamps, and return N cached rows without opening unchanged transcripts |
 | `cold->changed shallow discovery N` | Run one cold discovery of N, then append a valid assistant record to those N fixture transcripts | Enumerate candidates, detect changed stamps, shallow-read the N changed files, and update their catalog rows |
-| `opencode cold shallow discovery N` | Fresh fixture; database does not exist | Create/migrate the database, snapshot the opencode store, enumerate the 1,000 sessions, shallow-read the newest N from the snapshot, and upsert N catalog rows |
-| `opencode unchanged shallow discovery N` | Run one cold discovery of N into a fresh database | Snapshot the store, enumerate sessions, match `time_created`/`time_updated` stamps, and return N cached rows |
-| `opencode cold->changed shallow discovery N` | Run one cold discovery of N, then insert an assistant message and bump `time_updated` for those N sessions | Snapshot the store, detect the N changed stamps, re-read those sessions, and update their catalog rows |
+| `opencode cold shallow discovery N` | Fresh RelayHistory catalog; provider fixture already exists | Open one live read-only transaction, fetch at most N candidates, run indexed session-keyed prompt/model queries, and upsert N catalog rows |
+| `opencode unchanged shallow discovery N` | Run one cold discovery of N into a fresh catalog | Open a new coherent read snapshot, fetch at most N candidates, match source stamps, and return N cached rows without message/part queries |
+| `opencode cold->changed shallow discovery N` | Run one cold discovery of N, then insert an assistant message and bump `time_updated` for those N sessions | Open the live store read-only, detect the N changed stamps, run selected-session queries, and update those catalog rows |
 | `warm session events N` | Select a full session from the configured real database and make one untimed 200-event request | Open the database and return up to N cached events through SDK -> N-API -> Rust; provider transcripts are not read |
 | `CLI startup + cold shallow discovery 20` | Fresh database and the generated fixture | Start a new Node process, load the CLI and native addon, then perform cold discovery of 20 sessions and serialize JSON |
 | `MCP cold shallow discovery 20` | Start and initialize the MCP server with a fresh database and the generated fixture | Perform one MCP `tools/call` round trip that cold-discovers 20 sessions; MCP process startup and initialization are excluded |
@@ -137,6 +137,39 @@ Measured on macOS arm64 (Apple M2 Max) with Node.js 22.22.2 against a real
 | MCP cold shallow discovery | 16.23 ms | 20 rows |
 
 The event queries did not load or copy the 2.9 GiB database: Rust opened it
-directly and returned a bounded indexed page. Every opencode run, including
-unchanged, snapshots the whole store once with SQLite backup, so its
-`filesOpened` is always 1 and its `bytesRead` is the store's size.
+directly and returned a bounded indexed page. The OpenCode numbers in this
+2026-08-31 table are the historical pre-live-query baseline; the implementation
+no longer creates a SQLite backup or reports the provider database size as
+`bytesRead`.
+
+## 2026-09-01 OpenCode fixed-limit scaling
+
+Run only this benchmark with:
+
+```bash
+cargo test -p ai-hist-engine --test discovery_bench \
+  opencode_fixed_limit_scaling_report -- --ignored --nocapture
+```
+
+The two WAL-mode fixtures contain the same newest 20 sessions. The larger one
+adds 9,000 unrelated sessions and grows unrelated message/part history from
+roughly 4.9 MB to 49.3 MB. A writer commits concurrently throughout each
+measurement. These debug-build wall clocks are supporting evidence; the
+operation counts and query-plan assertions are the acceptance gates.
+
+| Provider store | Median cold discovery, limit 20 | Candidates | Provider queries | Records returned by provider SQL | SQLite bytes claimed |
+|---:|---:|---:|---:|---:|---:|
+| 1,000 unrelated sessions (4.9 MB) | 3.263 ms | 20 | 41 | 60 | 0 |
+| 10,000 unrelated sessions (49.3 MB) | 3.332 ms | 20 | 41 | 60 | 0 |
+
+Representative query plans:
+
+```text
+candidate: SCAN session USING INDEX session_time_updated_id_idx
+prompt:    SEARCH p USING INDEX part_session_idx (session_id=?)
+           SEARCH m USING INDEX sqlite_autoindex_message_1 (id=?)
+```
+
+The selected-session assertions fail if `message` or `part` regresses to a
+full table scan. The prompt query may use a temporary B-tree to order the few
+parts belonging to the selected session; it never sorts unrelated history.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,7 @@
 # Release and platform validation
 
 All public packages use one version: `ai-hist`, `ai-hist-native`, each native
-platform package, and `ai-hist-mcp`. The SDK checks native contract version 3
+platform package, and `ai-hist-mcp`. The SDK checks native contract version 5
 at initialization.
 
 The `Publish RelayHistory npm packages` workflow:

--- a/docs/session-catalog.md
+++ b/docs/session-catalog.md
@@ -87,7 +87,7 @@ ai-hist sessions discover --json      # JSONL: sessions, diagnostics, summary
 
 ## The output contract
 
-Both operations carry `contract_version` — currently **2**
+Both operations carry `contract_version` — currently **3**
 (`SESSION_CATALOG_CONTRACT_VERSION`). It is bumped whenever the shape or the
 meaning of a row changes in a way a consumer must notice, so parse it and fail
 loudly on a version you do not know rather than guessing.
@@ -98,7 +98,7 @@ One object, never a bare array, so the version travels with the payload:
 
 ```jsonc
 {
-  "contract_version": 2,
+  "contract_version": 3,
   "scope": "local",
   "sessions": [
     {
@@ -117,7 +117,7 @@ One object, never a bare array, so the version travels with the payload:
       "initial_commit": "abc1234def",
       "workspace_roots": ["/Users/you/Projects/api"],
       "raw_path": "/Users/you/.codex/sessions/2026/06/21/rollout-codex.jsonl",
-      "source_stamp": "v1:1788042670103317900:569",
+      "source_stamp": "v2:1788042670103317900:569",
       "discovery_state": "shallow",
       "locations": ["local"],
       "from_cache": true
@@ -160,7 +160,7 @@ types, in this order:
 // so a consumer always sees the reason before the non-zero exit
 {
   "type": "summary",
-  "contract_version": 2,
+  "contract_version": 3,
   "scope": "local",
   "locations_run": ["local"],
   "discovered": 2,
@@ -181,14 +181,20 @@ types, in this order:
     "shallow_reads": 2,
     "skipped_unchanged": 0,
     "files_opened": 2,
-    "bytes_read": 978
+    "bytes_read": 978,
+    "provider_queries": 0,
+    "records_inspected": 0
   }
 }
 ```
 
 `counters` is the run's bill of work, and it is the honest way to check that
-discovery stayed cheap — `bytes_read` and `files_opened` are what a bounded
-request bounds, and `shallow_reads` is `0` on a rescan where nothing changed.
+discovery stayed cheap. `bytes_read` counts explicit reads from file-backed
+providers only; SQLite does not report exact filesystem bytes, so OpenCode
+leaves it at zero instead of substituting the database file size.
+`provider_queries` counts OpenCode's bounded data queries (schema-capability
+introspection is excluded), and `records_inspected` counts the rows those data
+queries return. `shallow_reads` is `0` on a rescan where nothing changed.
 Summary `scope` echoes the requested acquisition scope, and `locations_run`
 enumerates the connector locations that actually executed — `["local"]` on a
 machine with no remote connector configured, `["local", "remote"]` when an
@@ -336,14 +342,30 @@ How each adapter works:
   both timestamps come from `summary.json`; the first prompt comes from the head
   of `chat_history.jsonl`, skipping synthetic reminder turns.
 - **opencode** — the SQLite store at `$OPENCODE_DB` (default
-  `~/.local/share/opencode/opencode.db`). The database is snapshotted once per
-  run with SQLite's backup API, exactly as the full sync does, so an in-flight
-  WAL never yields a torn read. The snapshot stays open on one connection for
-  the whole run and — being a private throwaway copy — is indexed by
-  `session_id` up front when the live store isn't. Enumeration is one query
-  over `session`; the shallow read adds two bounded single-row seeks for the
-  first user text part and a model id, rather than the full
-  session/message/part join the sync does.
+  `~/.local/share/opencode/opencode.db`). Discovery opens the live store with
+  SQLite read-only and `query_only` enforcement, then holds one deferred read
+  transaction for the run. Candidate enumeration and every selected-session
+  query therefore share one committed SQLite snapshot. In WAL mode OpenCode's
+  writer continues normally; a busy or rollback-journal lock is waited for at
+  most 250 ms and then reported as a provider diagnostic. RelayHistory never
+  backs up the database or WAL, creates a temporary database, issues provider
+  DDL, adds indexes, or runs provider migrations.
+
+  With `--limit N`, one indexed query returns at most N candidate sessions.
+  Selected candidates then use the provider's existing `message(session_id,
+  …)`, `part(session_id, …)`, or `part(message_id, …)` indexes for prompt and
+  model extraction. If those indexes or optional tables/columns are absent,
+  discovery still returns session metadata but omits the affected prompt/model
+  field rather than scanning a historical table.
+
+  Exact newest-*updated* enumeration uses an existing index led by
+  `session.time_updated`. Some supported OpenCode schemas do not ship that
+  index. On those schemas the bounded safe fallback reads `session` through
+  its primary key in ascending order, which matches OpenCode's descending,
+  time-encoded generated session IDs and therefore finds newest-created
+  sessions. The limitation is that a much older session resumed recently can
+  be delayed until OpenCode provides a recency index; RelayHistory will not
+  mutate the provider database to repair that gap.
 - **relay** — a **network** source with no local transcript, and discovery must
   work offline. The adapter therefore derives rows only from `history` rows a
   previous `ai-hist sync` already stored locally; it opens no socket. If nothing
@@ -358,7 +380,9 @@ The ordering and the limit are **global**, not per provider:
 
 1. Every selected provider adapter in the requested scope enumerates its
    candidates **cheaply** — a directory walk plus `stat`, or one indexed query.
-   No file content is read.
+   Database providers may cap their own candidate page at the global limit:
+   no single provider can contribute more than that many winners. No file
+   content is read.
 2. Candidates from all providers are merged and sorted by recency hint,
    descending. Candidates with no recency signal sort last; ties break on
    `(source, locator)` so a run is reproducible.
@@ -420,7 +444,7 @@ Each connector presence stores a `source_stamp` —
 |---|---|
 | claude, codex, cursor | `{mtime nanoseconds}:{file length}` |
 | grok | the chat file's marker, `\|`, the `summary.json` marker |
-| opencode | `{time_created}:{time_updated}` |
+| opencode | `{database identity}:{schema version}:{time_created}:{time_updated}` |
 | relay | `{newest synced timestamp}:{synced row count}` |
 
 On a rescan, a candidate whose stamp matches the stamp for that same location
@@ -453,7 +477,7 @@ stamp-guarded upsert into `sessions`:
   `'full'`;
 - the full-sync path only ever upgrades a row to `'full'`;
 - writes go through the normal busy-retry connection, and the opencode
-  provider reads a WAL-safe snapshot rather than the live database.
+  provider reads one coherent snapshot from a live read-only connection.
 
 A concurrent `sync` and `discover` therefore converge on the same row rather
 than fighting over it.
@@ -550,7 +574,8 @@ measurement table. Every assertion it makes is an *operation count* — bytes
 read, files opened, shallow reads, rows returned — because those hold on any
 machine; timings are printed for the reader and never asserted.
 
-Representative numbers from one run (debug build, 450-session archive, 14.7 MB):
+Representative multi-provider numbers from one run (debug build,
+450-session archive, 14.7 MB):
 
 | Measurement | Result |
 |---|---|
@@ -560,22 +585,25 @@ Representative numbers from one run (debug build, 450-session archive, 14.7 MB):
 | `discover --limit 5` over a 90-session / 6.2 MB archive | 5 shallow reads, 1.6 MB read (26% of the archive) |
 | `discover --limit 5` over the same archive grown to 450 sessions / 14.7 MB | 5 shallow reads, **the same 1.6 MB** (11%) |
 | `sessions discover` (cold, whole archive) | 11.9 MB read, 450 rows, ~1.7 s |
-| `sessions discover` (rescan, nothing changed) | 0 shallow reads, 28 KB read, ~0.08 s |
+| `sessions discover` (rescan, nothing changed) | 0 file-backed shallow reads, ~0.08 s |
 | `ai-hist sync` (full ingest, same archive) | reads all 14.7 MB, writes 62 451 history/event rows, ~46 s |
 | Cached listing after the entire archive is deleted | same 50 rows, 0.41 ms |
 
 The shape is what matters, not the absolute numbers: the cached listing tracks
 the rows you asked for and ignores both catalog size and event volume; a
 bounded request's cost is fixed by its limit; and a shallow refresh of a whole
-archive cost roughly 1/27th of a full ingest of the same archive — while a
-rescan of unchanged bytes is nearly free (the 28 KB is the one-per-run opencode
-snapshot, which enumeration always takes).
+archive cost roughly 1/27th of a full ingest of the same archive. OpenCode's
+fixed-limit benchmark is documented separately in `benchmarks.md`; its
+operation counters stay at 20 candidates, 41 queries, 60 returned records, and
+zero claimed bytes for both 1,000- and 10,000-session stores.
 
 Complementary structural coverage lives in the unit tests:
 `the_catalog_listing_is_served_by_an_index_not_a_table_scan` (EXPLAIN QUERY
 PLAN), `the_catalog_query_reads_only_the_sessions_table`,
 `bounded_reads_do_not_grow_with_the_size_of_the_archive`, and
-`a_head_read_stays_inside_its_budget_on_a_very_large_transcript`.
+`a_head_read_stays_inside_its_budget_on_a_very_large_transcript`. OpenCode adds
+`opencode_selected_session_queries_use_provider_indexes` and the ignored
+`opencode_fixed_limit_scaling_report` benchmark.
 
 ---
 

--- a/docs/session-catalog.md
+++ b/docs/session-catalog.md
@@ -346,8 +346,9 @@ How each adapter works:
   SQLite read-only and `query_only` enforcement, then holds one deferred read
   transaction for the run. Candidate enumeration and every selected-session
   query therefore share one committed SQLite snapshot. In WAL mode OpenCode's
-  writer continues normally; a busy or rollback-journal lock is waited for at
-  most 250 ms and then reported as a provider diagnostic. RelayHistory never
+  writer continues normally. Cross-process `SQLITE_BUSY` uses the repository's
+  bounded, jittered retry policy (roughly 30 seconds); non-retryable
+  `SQLITE_LOCKED` conflicts remain distinct diagnostics. RelayHistory never
   backs up the database or WAL, creates a temporary database, issues provider
   DDL, adds indexes, or runs provider migrations.
 
@@ -358,14 +359,15 @@ How each adapter works:
   discovery still returns session metadata but omits the affected prompt/model
   field rather than scanning a historical table.
 
-  Exact newest-*updated* enumeration uses an existing index led by
-  `session.time_updated`. Some supported OpenCode schemas do not ship that
-  index. On those schemas the bounded safe fallback reads `session` through
-  its primary key in ascending order, which matches OpenCode's descending,
+  Exact newest-*updated* enumeration uses an existing index ordered by
+  `session.time_updated DESC, id ASC`, so the global deterministic tie-break is
+  applied before `LIMIT`. Some supported OpenCode schemas do not ship that
+  index. On those schemas the bounded safe fallback reads `session` through its
+  primary key in ascending order, which matches OpenCode's descending,
   time-encoded generated session IDs and therefore finds newest-created
   sessions. The limitation is that a much older session resumed recently can
-  be delayed until OpenCode provides a recency index; RelayHistory will not
-  mutate the provider database to repair that gap.
+  be delayed until OpenCode provides the compound recency index; RelayHistory
+  will not mutate the provider database to repair that gap.
 - **relay** — a **network** source with no local transcript, and discovery must
   work offline. The adapter therefore derives rows only from `history` rows a
   previous `ai-hist sync` already stored locally; it opens no socket. If nothing

--- a/scripts/benchmark-native.mjs
+++ b/scripts/benchmark-native.mjs
@@ -194,7 +194,11 @@ async function createOpencodeFixture(home, count) {
     db.exec(
       'CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, time_created INTEGER, time_updated INTEGER);'
       + 'CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);'
-      + 'CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);',
+      + 'CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT);'
+      + 'CREATE INDEX session_time_updated_id_idx ON session(time_updated DESC, id);'
+      + 'CREATE INDEX message_session_time_created_id_idx ON message(session_id, time_created, id);'
+      + 'CREATE INDEX part_session_idx ON part(session_id);'
+      + 'CREATE INDEX part_message_id_id_idx ON part(message_id, id);',
     );
     const insertSession = db.prepare('INSERT INTO session VALUES (?, ?, ?, ?)');
     const insertMessage = db.prepare('INSERT INTO message VALUES (?, ?, ?, ?)');
@@ -218,8 +222,8 @@ async function createOpencodeFixture(home, count) {
 // A changed opencode session is a bumped `time_updated` stamp plus a new
 // assistant message, mirroring the appended record in the Claude fixture.
 // Restoration is a byte copy of the pristine store, not reversed rows: a
-// DELETE leaves the inserted pages on the freelist, so later cases would
-// snapshot a larger store than the one the first cold case measured.
+// DELETE leaves the inserted pages on the freelist, which would make later
+// cases read a physically different fixture than the first cold case.
 function changeOpencodeSessions(databasePath, sessions) {
   const timestampMs = Date.now();
   const db = new DatabaseSync(databasePath);
@@ -351,6 +355,8 @@ function details(result) {
   if (result.counters) {
     pieces.push(`${result.counters.filesOpened} files opened`);
     pieces.push(`${result.counters.bytesRead} bytes read`);
+    pieces.push(`${result.counters.providerQueries} provider queries`);
+    pieces.push(`${result.counters.recordsInspected} records inspected`);
     pieces.push(`${result.counters.skippedUnchanged} unchanged`);
   }
   return pieces.join('; ');

--- a/scripts/verify-e2e.sh
+++ b/scripts/verify-e2e.sh
@@ -169,7 +169,7 @@ assert_eq "discovered sources" "$discovered_sources" "claude,codex,cursor,grok,o
 
 discover_contract=$(printf '%s\n' "$discover_json" | jsonl_field \
   'd.find((l) => l.type === "summary").contract_version')
-assert_eq "discover contract version" "$discover_contract" "2"
+assert_eq "discover contract version" "$discover_contract" "3"
 
 discover_trailer=$(printf '%s\n' "$discover_json" | jsonl_field 'd[d.length - 1].type')
 assert_eq "discover trailer" "$discover_trailer" "summary"
@@ -215,7 +215,7 @@ assert_eq "global discover limit" "$limited" "2"
 
 list_json=$("$ROOT/ai-hist" sessions list --json)
 list_contract=$(printf '%s\n' "$list_json" | json_field 'd.contract_version')
-assert_eq "sessions list contract version" "$list_contract" "2"
+assert_eq "sessions list contract version" "$list_contract" "3"
 
 list_sessions=$(printf '%s\n' "$list_json" | json_field \
   'd.sessions.map((s) => `${s.source}:${s.session_id}`).sort().join(",")')

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- Advance the native-addon contract to 5 and the session-catalog contract to
+  3. Discovery counters add `providerQueries` and `recordsInspected`; OpenCode
+  no longer reports its database file size as `bytesRead`.
 - Replace the synchronous `openAiHist()`/`AiHist` snapshot API with top-level
   async native-backed functions.
 - Remove `sql.js`, JSONL/trajectory fallback scanners, CLI subprocess bridges,
@@ -20,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Surface bounded OpenCode query and record counters through the typed SDK,
+  CLI JSON, and MCP discovery result.
 - Support remote acquisition through the engine's provider connectors:
   `discoverSessions`/`sync` with `scope: 'remote'` (and the remote half of
   `'all'`) run the claude.ai/code and Codex cloud connectors when the provider

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Surface bounded OpenCode query and record counters through the typed SDK,
+- Surface bounded OpenCode provider-query and inspected-record counters through the typed SDK,
   CLI JSON, and MCP discovery result.
 - Add delegation topology APIs: `getSessionRelationships()`,
   `getSessionTree()`, and `getSessionChildrenPage()`, plus the

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -152,9 +152,11 @@ own `truncated` marks children it did not expand.
 
 For large topologies, `getSessionChildrenPage` is the keyset primitive and
 `sessionDescendants` is the async iterator over it, walking descendants
-breadth-first without materializing a tree. It yields the nodes
-`getSessionTree` emits minus the root, with the same `childCount` (linked
-children only, at the depth boundary included) and the same `truncated` rule.
+breadth-first without materializing a tree. Its `maxNodes` budget has the same
+1,000 default and 10,000 maximum as `getSessionTree`, and includes the root. It
+yields the nodes `getSessionTree` emits minus the root, with the same
+`childCount` (linked children only, at the depth boundary included) and the
+same `truncated` rule.
 The order differs: the walker is breadth-first, the tree is pre-order, so a
 consumer that depends on either the root node or `getSessionTree`'s ordering
 has to account for that. `sessionEventsIncludingDescendants` applies its

--- a/sdk-ts/src/cli-output.test.ts
+++ b/sdk-ts/src/cli-output.test.ts
@@ -49,7 +49,7 @@ test('sessions discover preserves repeated sources and emits JSONL', async () =>
     assert.deepEqual(sessions.map((line) => line.source).sort(), ['claude', 'codex']);
     assert.ok(sessions.every((line) => JSON.stringify(line.locations) === '["local"]'));
     assert.equal(lines.at(-1)?.type, 'summary');
-    assert.equal(lines.at(-1)?.contract_version, 2);
+    assert.equal(lines.at(-1)?.contract_version, 3);
     assert.equal(lines.at(-1)?.scope, 'local');
     assert.equal('sessions' in (lines.at(-1) ?? {}), false);
 
@@ -78,7 +78,7 @@ test('sessions list keeps human and JSON output contracts distinct', async () =>
     const human = await run(process.execPath, [cli, 'sessions', 'list', '--db', db, '--no-warning']);
     assert.match(human.stdout, /No sessions in the catalog/);
     const json = await run(process.execPath, [cli, 'sessions', 'list', '--db', db, '--json', '--no-warning']);
-    assert.deepEqual(JSON.parse(json.stdout), { contract_version: 2, scope: 'local', sessions: [], next_cursor: null });
+    assert.deepEqual(JSON.parse(json.stdout), { contract_version: 3, scope: 'local', sessions: [], next_cursor: null });
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -1229,7 +1229,11 @@ export async function getSessionChildrenPage(options: GetSessionChildrenPageOpti
 export async function* sessionDescendants(options: SessionDescendantsOptions): AsyncGenerator<SessionTreeNode> {
   validateSessionRef(options, 'sessionDescendants');
   const maxDepth = Math.min(Math.max(Math.trunc(options.maxDepth ?? DEFAULT_TREE_MAX_DEPTH), 1), MAX_TREE_MAX_DEPTH);
-  const maxNodes = Math.min(Math.max(Math.trunc(options.maxNodes ?? DEFAULT_TREE_MAX_NODES), 1), MAX_TREE_MAX_NODES);
+  const requestedMaxNodes = options.maxNodes ?? DEFAULT_TREE_MAX_NODES;
+  if (!Number.isFinite(requestedMaxNodes)) {
+    throw new InvalidArgumentError('maxNodes must be a finite number', 'INVALID_ARGUMENT');
+  }
+  const maxNodes = Math.min(Math.max(Math.trunc(requestedMaxNodes), 1), MAX_TREE_MAX_NODES);
   const request = { source: options.source, dbPath: options.dbPath };
   const visited = new Set<string>([options.sessionId]);
   // Each walked session's parent, so a repeated edge can be told apart: back

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -9,8 +9,8 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-export const NATIVE_CONTRACT_VERSION = 4;
-export const SESSION_CATALOG_CONTRACT_VERSION = 2;
+export const NATIVE_CONTRACT_VERSION = 5;
+export const SESSION_CATALOG_CONTRACT_VERSION = 3;
 export const SESSION_HYDRATION_CONTRACT_VERSION = 1;
 
 export type Source = 'claude' | 'codex' | 'cursor' | 'grok' | 'relay' | 'trajectory' | 'opencode';
@@ -132,6 +132,8 @@ export interface DiscoveryCounters {
   skippedUnchanged: number;
   filesOpened: number;
   bytesRead: number;
+  providerQueries: number;
+  recordsInspected: number;
 }
 
 export interface SourceExemption { source: string; reason: string }

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -357,6 +357,8 @@ export interface GetSessionChildrenPageOptions extends GetSessionRelationshipsOp
 
 export interface SessionDescendantsOptions extends GetSessionRelationshipsOptions {
   maxDepth?: number;
+  /** Includes the root. Default 1000, maximum 10000. */
+  maxNodes?: number;
   pageLimit?: number;
 }
 
@@ -366,6 +368,8 @@ export interface DescendantEventsOptions {
   /** Events read per session, not a total for the iteration. */
   limit?: number;
   maxDepth?: number;
+  /** Includes the root. Default 1000, maximum 10000. */
+  maxNodes?: number;
   /** Defaults to true. */
   includeRoot?: boolean;
 }
@@ -481,6 +485,8 @@ interface NativeBinding {
 const RELATIONSHIP_TYPES: readonly string[] = ['delegated'];
 const DEFAULT_TREE_MAX_DEPTH = 32;
 const MAX_TREE_MAX_DEPTH = 64;
+const DEFAULT_TREE_MAX_NODES = 1_000;
+const MAX_TREE_MAX_NODES = 10_000;
 
 const SUPPORTED_PLATFORMS = new Set([
   'darwin-arm64', 'darwin-x64',
@@ -1216,12 +1222,14 @@ export async function getSessionChildrenPage(options: GetSessionChildrenPageOpti
 
 /**
  * Lazily walks a session's descendants breadth-first over the paged children
- * primitive, without materializing a large tree. Unlinked evidence has no
- * traversable identity and is skipped; use `getSessionTree` when you need it.
+ * primitive, with a bounded node queue instead of materializing a large tree.
+ * Unlinked evidence has no traversable identity and is skipped; use
+ * `getSessionTree` when you need it.
  */
 export async function* sessionDescendants(options: SessionDescendantsOptions): AsyncGenerator<SessionTreeNode> {
   validateSessionRef(options, 'sessionDescendants');
   const maxDepth = Math.min(Math.max(Math.trunc(options.maxDepth ?? DEFAULT_TREE_MAX_DEPTH), 1), MAX_TREE_MAX_DEPTH);
+  const maxNodes = Math.min(Math.max(Math.trunc(options.maxNodes ?? DEFAULT_TREE_MAX_NODES), 1), MAX_TREE_MAX_NODES);
   const request = { source: options.source, dbPath: options.dbPath };
   const visited = new Set<string>([options.sessionId]);
   // Each walked session's parent, so a repeated edge can be told apart: back
@@ -1245,35 +1253,34 @@ export async function* sessionDescendants(options: SessionDescendantsOptions): A
     const next: SessionTreeNode[] = [];
     for (const node of frontier) {
       const expand = node.depth < maxDepth;
-      const children: SessionRelationship[] = [];
       let after: RelationshipCursor | undefined;
       do {
         const page = await getSessionChildrenPage({
           ...request, sessionId: node.sessionId, limit: options.pageLimit, after,
         });
-        children.push(...page.children);
+        for (const edge of page.children) {
+          if (edge.identityStatus !== 'observed' || edge.childSessionId === null) continue;
+          node.childCount += 1;
+          if (!expand || isAncestor(node.sessionId, edge.childSessionId)) {
+            node.truncated = true;
+            continue;
+          }
+          if (visited.has(edge.childSessionId)) continue;
+          if (visited.size >= maxNodes) {
+            node.truncated = true;
+            continue;
+          }
+          visited.add(edge.childSessionId);
+          parentOf.set(edge.childSessionId, node.sessionId);
+          next.push({
+            source: edge.source, sessionId: edge.childSessionId, depth: node.depth + 1,
+            parentSessionId: node.sessionId, relationship: edge, childCount: 0,
+            hasEvents: edge.childHasEvents, truncated: false,
+          });
+        }
         after = page.nextCursor ?? undefined;
       } while (after);
-      // Unlinked evidence has no traversable identity, so it is never a child
-      // this walk owes the caller — at the depth boundary included.
-      const linked = children.filter((edge): edge is SessionRelationship & { childSessionId: string } =>
-        edge.identityStatus === 'observed' && edge.childSessionId !== null);
-      node.childCount = linked.length;
-      node.truncated = expand
-        ? linked.some((edge) => isAncestor(node.sessionId, edge.childSessionId))
-        : linked.length > 0;
       if (node.depth > 0) yield node;
-      if (!expand) continue;
-      for (const edge of linked) {
-        if (visited.has(edge.childSessionId)) continue;
-        visited.add(edge.childSessionId);
-        parentOf.set(edge.childSessionId, node.sessionId);
-        next.push({
-          source: edge.source, sessionId: edge.childSessionId, depth: node.depth + 1,
-          parentSessionId: node.sessionId, relationship: edge, childCount: 0,
-          hasEvents: edge.childHasEvents, truncated: false,
-        });
-      }
     }
     frontier = next;
   }
@@ -1295,6 +1302,7 @@ export async function* sessionEventsIncludingDescendants(
   }
   for await (const node of sessionDescendants({
     source: options.source, sessionId: options.sessionId, dbPath: options.dbPath, maxDepth: options.maxDepth,
+    maxNodes: options.maxNodes,
   })) {
     if (!node.hasEvents) continue;
     yield* sessionEvents(node.sessionId, events);

--- a/sdk-ts/src/native-errors.test.ts
+++ b/sdk-ts/src/native-errors.test.ts
@@ -14,7 +14,7 @@ test('missing database reads are explicit empty cache operations', async () => {
   const dbPath = join(root, 'missing', 'history.db');
   try {
     assert.deepEqual(await listSessionCatalogPage({ dbPath, limit: 20 }), {
-      contractVersion: 2, scope: 'local', sessions: [], nextCursor: null,
+      contractVersion: 3, scope: 'local', sessions: [], nextCursor: null,
     });
     assert.deepEqual(await recent({ dbPath, limit: 20 }), []);
     assert.deepEqual(await stats({ dbPath }), {
@@ -44,7 +44,7 @@ test('SDK/native contract mismatch is actionable', () => {
     () => validateNativeContract(999),
     (error: unknown) => error instanceof NativeContractMismatchError
       && error.code === 'NATIVE_CONTRACT_MISMATCH'
-      && /requires native contract 4/.test(error.message),
+      && /requires native contract 5/.test(error.message),
   );
   assert.throws(
     () => validateNativeScope('cloud'),

--- a/sdk-ts/src/relationships.test.ts
+++ b/sdk-ts/src/relationships.test.ts
@@ -146,6 +146,20 @@ test('relationship queries reject invalid identities before reaching the engine'
   }
 });
 
+test('sessionDescendants rejects a non-finite node budget', async () => {
+  const dbPath = join(tmpdir(), 'relayhistory-never-created.db');
+  await assert.rejects(
+    async () => {
+      for await (const _ of sessionDescendants({
+        source: 'codex', sessionId: 'root', dbPath, maxNodes: Number.NaN,
+      })) break;
+    },
+    (error: unknown) => error instanceof InvalidArgumentError
+      && error.code === 'INVALID_ARGUMENT'
+      && /maxNodes must be a finite number/.test(error.message),
+  );
+});
+
 test('codex delegation topology round-trips through discovery and hydration', async () => {
   await withHome('relayhistory-relationships-codex-', async (home, dbPath) => {
     await codexRollout(home, 'root', { at: '2026-08-31T10:00:00Z' });

--- a/sdk-ts/src/relationships.test.ts
+++ b/sdk-ts/src/relationships.test.ts
@@ -411,5 +411,17 @@ test('large trees stay bounded by the node budget', async () => {
     const page = await getSessionChildrenPage({ source: 'codex', sessionId: 'root', dbPath, limit: 100 });
     assert.equal(page.children.length, 100);
     assert.equal(page.nextCursor?.relationshipUid, 'child:child-099');
+
+    const walked: SessionTreeNode[] = [];
+    for await (const node of sessionDescendants({
+      source: 'codex', sessionId: 'root', dbPath, maxNodes: 50, pageLimit: 7,
+    })) {
+      walked.push(node);
+    }
+    assert.equal(walked.length, 49);
+    assert.deepEqual(
+      walked.map((node) => node.sessionId),
+      Array.from({ length: 49 }, (_, index) => `child-${String(index).padStart(3, '0')}`),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- replace OpenCode shallow discovery's full SQLite backup with one coherent live read-only transaction
- bound candidate enumeration by the requested limit and use only provider-supplied indexes for selected-session prompt/model queries
- expose truthful SQL query/record work counters without claiming exact SQLite filesystem bytes
- cover WAL appends, busy/replaced databases, schema variants, malformed rows, no-write/no-copy behavior, and query-plan/scaling regressions
- update native/catalog contracts, SDK types, benchmarks, adapter documentation, and changelogs

## Review fixes

- reject discovery limits that cannot be represented by SQLite's signed 64-bit `LIMIT`, preventing integer wraparound from becoming an unbounded query

## Verification

- `cargo test -p ai-hist-engine --lib` (206 passed)
- `cargo test -p ai-hist-engine --test session_discovery` (19 passed)
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `npm test --prefix sdk-ts` (23 passed)
- `cargo test -p ai-hist-engine --test discovery_bench opencode_fixed_limit_scaling_report -- --ignored --nocapture`

The fixed-limit benchmark returned 20 candidates, 41 provider queries, and 60 provider rows for both 1,000- and 10,000-session fixtures. Median cold discovery was 3.263 ms and 3.332 ms respectively, with indexed query plans and zero claimed SQLite bytes.

## Supported-schema limitation

When a supported OpenCode schema has no `session.time_updated` index, discovery uses the provider's time-encoded session primary key as a bounded newest-created fallback. A resumed older session may therefore be delayed; RelayHistory does not mutate the provider database to add an index.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

