### PR TITLE
feat: structured tool-call and file-edit access through the TypeScript SDK

### DIFF
--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -123,12 +123,12 @@ jobs:
       - name: Execute native contract smoke test
         if: matrix.test_native
         shell: bash
-        run: node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==4) process.exit(1)"
+        run: node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==5) process.exit(1)"
 
       - name: Execute musl native contract smoke test
         if: matrix.test_musl
         shell: bash
-        run: docker run --rm -v "$PWD:/work" -w /work node:22-alpine node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==4) process.exit(1)"
+        run: docker run --rm -v "$PWD:/work" -w /work node:22-alpine node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==5) process.exit(1)"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@ Notable changes to the native `ai-hist` CLI are documented here.
 
 ### Added
 
+- Add first-class structured access to a hydrated session's recorded tool
+  calls and file edits: `session_tool_calls_page` / `session_file_edits_page`
+  in the Rust engine, `getSessionToolCallsPage` / `getSessionFileEditsPage`
+  (plus the `sessionToolCalls` / `sessionFileEdits` async iterators and the
+  `getSessionToolCalls` / `getSessionFileEdits` collecting conveniences) in the
+  TypeScript SDK, `ai-hist sessions tools` and `ai-hist sessions edits`, and
+  MCP `get_session_tool_calls` / `get_session_file_edits`. Every one of them
+  requires both a source and a session ID, because provider session IDs
+  collide and evidence from two providers must never merge. Pages are keyset
+  paginated over `(ts_ms IS NULL, ts_ms, id)` — undated rows sort last and the
+  cursor's `ts_ms` is nullable — and carry session evidence contract 1.
+  File edit rows now also expose `message_id`, `structured_patch_json`,
+  `git_branch`, and `cwd`. Stored provider JSON reaches the SDK as the raw
+  indexed string and is parsed into `args` / `structuredPatch`; an absent or
+  unparseable value becomes `null` while `argsJson` / `structuredPatchJson`
+  keep the original, so one bad payload cannot fail a page. New
+  `idx_tool_calls_page` and `idx_file_edits_page` indexes back the access
+  path; existing databases add them on their next writable open. The
+  native-addon contract is now 5.
 - Add remote provider connectors behind the existing `--remote` / `--all`
   acquisition scopes: `claude-web` lists claude.ai/code web sessions with the
   OAuth sign-in the Claude Code CLI stored (`~/.claude/.credentials.json`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,14 @@ Notable changes to the native `ai-hist` CLI are documented here.
   indexed string and is parsed into `args` / `structuredPatch`; an absent or
   unparseable value becomes `null` while `argsJson` / `structuredPatchJson`
   keep the original, so one bad payload cannot fail a page. New
-  `idx_tool_calls_page` and `idx_file_edits_page` indexes back the access
-  path; existing databases add them on their next writable open. The
-  native-addon contract is now 5.
+  `idx_tool_calls_page_v2` and `idx_file_edits_page_v2` indexes back the access
+  path, ordering on `(source, session_id, (ts_ms IS NULL), ts_ms, id)` so a
+  page is read in order rather than sorted; existing databases add them, and
+  drop the superseded `idx_tool_calls_page` / `idx_file_edits_page` and the
+  now-redundant `idx_tool_calls_session` / `idx_file_edits_session`, on their
+  next writable open. The native-addon contract is now 5.
+- `ai-hist events --json` file-edit records additively carry `message_id`,
+  `structured_patch_json`, `git_branch`, and `cwd`.
 - Add remote provider connectors behind the existing `--remote` / `--all`
   acquisition scopes: `claude-web` lists claude.ai/code web sessions with the
   OAuth sign-in the Claude Code CLI stored (`~/.claude/.credentials.json`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ Notable changes to the native `ai-hist` CLI are documented here.
   TypeScript SDK, `ai-hist sessions tools` and `ai-hist sessions edits`, and
   MCP `get_session_tool_calls` / `get_session_file_edits`. Every one of them
   requires both a source and a session ID, because provider session IDs
-  collide and evidence from two providers must never merge. Pages are keyset
+  collide and evidence from two providers must never merge; a source this
+  build has no provider for is rejected rather than answered with an empty
+  page. Pages are keyset
   paginated over `(ts_ms IS NULL, ts_ms, id)` — undated rows sort last and the
   cursor's `ts_ms` is nullable — and carry session evidence contract 1.
   File edit rows now also expose `message_id`, `structured_patch_json`,

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ npm install --global ai-hist
 ai-hist sessions discover --limit 100
 ai-hist sessions list --limit 100
 ai-hist sessions hydrate codex 01a04f0c-... --json
+ai-hist sessions tools codex 01a04f0c-... --limit 50 --json
+ai-hist sessions edits codex 01a04f0c-... --limit 50 --json
 ```
 
 Session-set commands share one mutually exclusive location scope:
@@ -77,6 +79,8 @@ import {
   hydrateSession,
   listSessionCatalog,
   getSessionEventsPage,
+  getSessionToolCallsPage,
+  getSessionFileEditsPage,
   search,
   sync,
 } from 'ai-hist';
@@ -92,6 +96,12 @@ const firstEvents = sessions[0]
       limit: 200,
     })
   : null;
+const firstTools = sessions[0]
+  ? await getSessionToolCallsPage(sessions[0].source, sessions[0].sessionId, { limit: 200 })
+  : null;
+const firstEdits = sessions[0]
+  ? await getSessionFileEditsPage(sessions[0].source, sessions[0].sessionId, { limit: 200 })
+  : null;
 const matches = await search('migration', { limit: 20, scope: 'all' });
 await sync({ scope: 'local' }); // explicit full ingestion; local is the default
 ```
@@ -99,7 +109,9 @@ await sync({ scope: 'local' }); // explicit full ingestion; local is the default
 `listSessionCatalog` is cache-only. `discoverSessions` performs bounded shallow
 provider discovery and updates the shared ledger. `hydrateSession` fully
 indexes one existing catalog identity and returns evidence counts rather than
-the transcript; repeating it is safe as a live session grows. `sync` performs
+the transcript; repeating it is safe as a live session grows. The tool call and
+file edit pages read that hydrated evidence back as structured rows and require
+both a source and a session ID, because provider session IDs collide. `sync` performs
 full global ingestion. Reads never silently turn into discovery, hydration, or
 sync. Hydration includes linked subagent evidence by default; CLI callers can
 pass `--no-related`.
@@ -111,7 +123,8 @@ npx -y ai-hist-mcp
 ```
 
 MCP exposes thin adapters for search, recent history, catalog listing,
-discovery, targeted hydration, sessions, paged events, statistics, and sync.
+discovery, targeted hydration, sessions, paged events, paged tool calls and
+file edits, statistics, and sync.
 
 ## Supported production matrix
 

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -437,21 +437,27 @@ const REQUIRED_SESSIONS_COLUMNS: &[&str] = &[
 const REQUIRED_SESSION_PRESENCE_COLUMNS: &[&str] =
     &["raw_locator", "source_stamp", "discovery_state"];
 
-/// Indexes the session catalog's fast paths depend on.
+/// Every index a fast path depends on, across all of them.
 ///
 /// The pre-existing guard checks tables and columns only. These are listed
-/// because each one carries a promise the catalog makes: the two recency
-/// indexes make a listing an indexed, sort-free read, and `idx_sessions_raw_path`
+/// because each one carries a promise some read makes: the two recency indexes
+/// make a catalog listing an indexed, sort-free read, `idx_sessions_raw_path`
 /// makes discovery's "has this transcript changed?" lookup a search rather than
-/// a scan of every session on every candidate. A database that somehow has the
+/// a scan of every session on every candidate, and the event and evidence page
+/// indexes carry their pagination's ordering. A database that somehow has the
 /// columns but not an index would otherwise be served with silently degraded
 /// plans. Missing means "not current", which routes the caller through the
 /// writable open that recreates them.
 ///
+/// This is the *writable* bar: [`init_db`]'s lock-free fast path skips the
+/// migration only when every one is present. Read paths are each gated on
+/// their own scoped subset below, so a database missing one index keeps its
+/// read-only handle for every read that does not need it.
+///
 /// The older `idx_sessions_cwd` / `idx_sessions_branch` / `idx_sessions_last` /
 /// `idx_sessions_source_last` are deliberately absent: nothing in the catalog
 /// path depends on them any more.
-const REQUIRED_SESSIONS_INDEXES: &[&str] = &[
+const REQUIRED_INDEXES: &[&str] = &[
     "idx_sessions_recency",
     "idx_sessions_source_recency",
     "idx_sessions_raw_path",
@@ -511,7 +517,7 @@ const REQUIRED_SCHEMA_MIGRATIONS: &[&str] = &["session_presences_local_backfill_
 /// first search instead of a silent migration. Callers fall back to a writable
 /// open (which migrates) when this returns false.
 pub fn schema_is_current(conn: &Connection) -> Result<bool> {
-    schema_has_required_indexes(conn, REQUIRED_SESSIONS_INDEXES)
+    schema_has_required_indexes(conn, REQUIRED_INDEXES)
 }
 
 /// Whether read-only APIs can safely and efficiently query this database.
@@ -1596,11 +1602,20 @@ fn row_to_file_edit(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionFileEdit
 }
 
 /// One page's SQL and bound parameters, in the canonical
-/// `ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC` order.
+/// `ts_ms IS NULL, ts_ms ASC, id ASC` order.
 ///
 /// A dated cursor must still admit the whole undated tail, and an undated one
 /// must never walk back into the dated head, so the two continuation cases are
 /// different predicates rather than one comparison over a coalesced timestamp.
+///
+/// The undated continuation is also a different *shape*. Its rows are exactly
+/// the ones the page index stores under `(ts_ms IS NULL) = 1`, so it names that
+/// indexed expression itself -- SQLite does not infer it from the bare
+/// `ts_ms IS NULL` term -- and, since the first two order keys are then
+/// constant, orders on `id` alone. Written the obvious way instead, SQLite
+/// cannot reach `id` in the index and re-sorts the whole remaining tail in a
+/// temp b-tree on every page. Both spellings return the same rows in the same
+/// order.
 ///
 /// Both page readers and the query-plan test build their SQL here, so a plan
 /// assertion cannot pass against a restated copy while the real query drifts.
@@ -1621,14 +1636,18 @@ fn evidence_page_query(
             params.push(ts_ms.into());
             params.push(ts_ms.into());
             params.push(id.into());
+            sql.push_str(" ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC");
         }
         Some((None, id)) => {
-            sql.push_str(" AND (ts_ms IS NULL AND id > ?)");
+            sql.push_str(" AND ((ts_ms IS NULL) = 1 AND ts_ms IS NULL AND id > ?)");
             params.push(id.into());
+            sql.push_str(" ORDER BY id ASC");
         }
-        None => {}
+        None => {
+            sql.push_str(" ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC");
+        }
     }
-    sql.push_str(" ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC LIMIT ?");
+    sql.push_str(" LIMIT ?");
     params.push((limit + 1).into());
     (sql, params)
 }
@@ -3032,9 +3051,15 @@ mod tests {
             .unwrap();
         assert!(!schema_is_evidence_read_current(&conn).unwrap());
         assert!(!schema_is_current(&conn).unwrap());
-        // Unrelated read paths keep working while that migration is pending.
+        // Every unrelated read path keeps its read-only handle while that
+        // migration is pending: each is gated on its own scoped guard, so
+        // only the evidence pages and the next writable open see the gap.
         assert!(schema_is_event_read_current(&conn).unwrap());
+        assert!(schema_is_catalog_read_current(&conn).unwrap());
+        assert!(schema_is_read_current(&conn).unwrap());
 
+        // One writable open migrates it, exactly as the session-events page
+        // indexes did when they joined the required list.
         init_db(&conn).unwrap();
         assert!(schema_is_evidence_read_current(&conn).unwrap());
         assert!(schema_is_current(&conn).unwrap());
@@ -3084,62 +3109,66 @@ mod tests {
         }
     }
 
-    /// The evidence page promises an indexed, sort-free read. The plan is
-    /// taken from the same builder the readers run, so it cannot pass against
-    /// a restated copy of the query.
+    /// The evidence page promises an indexed, sort-free read on all three
+    /// query shapes: the first page, a dated continuation, and a continuation
+    /// already inside the undated tail. The last one is the shape that walks
+    /// the longest, so a temp b-tree there would re-sort the remaining tail on
+    /// every page. The plan is taken from the same builder the readers run, so
+    /// it cannot pass against a restated copy of the query.
+    ///
+    /// Each shape is checked with and without `sqlite_stat1`: the repository
+    /// never runs `ANALYZE`, but a user's database may carry stats, and the
+    /// planner picks differently once it has them.
     #[test]
     fn evidence_pages_are_served_by_an_index_without_sorting() {
-        let conn = Connection::open_in_memory().unwrap();
-        init_db(&conn).unwrap();
-        seed_evidence(&conn);
+        for analyze in [false, true] {
+            let conn = Connection::open_in_memory().unwrap();
+            init_db(&conn).unwrap();
+            seed_evidence(&conn);
+            if analyze {
+                conn.execute_batch("ANALYZE").unwrap();
+            }
 
-        let plan = |table: &str, columns: &str, after: Option<&SessionEvidenceCursor>| -> String {
-            let (sql, params) = evidence_page_query(columns, table, "claude", "s1", 10, after);
-            let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).unwrap();
-            stmt.query_map(rusqlite::params_from_iter(params), |row| {
-                row.get::<_, String>(3)
-            })
-            .unwrap()
-            .collect::<rusqlite::Result<Vec<_>>>()
-            .unwrap()
-            .join(" | ")
-        };
+            let plan = |table: &str, columns: &str, after: Option<&SessionEvidenceCursor>| {
+                let (sql, params) = evidence_page_query(columns, table, "claude", "s1", 10, after);
+                let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).unwrap();
+                stmt.query_map(rusqlite::params_from_iter(params), |row| {
+                    row.get::<_, String>(3)
+                })
+                .unwrap()
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .unwrap()
+                .join(" | ")
+            };
 
-        for (table, columns, index) in [
-            ("tool_calls", TOOL_CALL_COLUMNS, "idx_tool_calls_page_v2"),
-            ("file_edits", FILE_EDIT_COLUMNS, "idx_file_edits_page_v2"),
-        ] {
-            let first = plan(table, columns, None);
-            assert!(
-                first.contains(index) && !first.contains("TEMP B-TREE"),
-                "the first {table} page must be index-ordered: {first}"
-            );
-            // The dated continuation is the plan that runs on every page after
-            // the first; its extra predicate must not cost the ordering.
-            let dated = plan(
-                table,
-                columns,
-                Some(&SessionEvidenceCursor {
-                    ts_ms: Some(100),
-                    id: 1,
-                }),
-            );
-            assert!(
-                dated.contains(index) && !dated.contains("TEMP B-TREE"),
-                "a dated {table} continuation must stay index-ordered: {dated}"
-            );
-            // A cursor already inside the undated tail pins `ts_ms IS NULL`,
-            // so SQLite orders that one narrow slice by id itself; the lookup
-            // is still a search on the same index rather than a table scan.
-            let undated = plan(
-                table,
-                columns,
-                Some(&SessionEvidenceCursor { ts_ms: None, id: 1 }),
-            );
-            assert!(
-                undated.contains(index) && !undated.contains("SCAN"),
-                "an undated {table} continuation must still be a search: {undated}"
-            );
+            for (table, columns, index) in [
+                ("tool_calls", TOOL_CALL_COLUMNS, "idx_tool_calls_page_v2"),
+                ("file_edits", FILE_EDIT_COLUMNS, "idx_file_edits_page_v2"),
+            ] {
+                for (shape, after) in [
+                    ("the first page", None),
+                    (
+                        "a dated continuation",
+                        Some(SessionEvidenceCursor {
+                            ts_ms: Some(100),
+                            id: 1,
+                        }),
+                    ),
+                    (
+                        "an undated continuation",
+                        Some(SessionEvidenceCursor { ts_ms: None, id: 1 }),
+                    ),
+                ] {
+                    let plan = plan(table, columns, after.as_ref());
+                    assert!(
+                        plan.contains(index)
+                            && !plan.contains("TEMP B-TREE")
+                            && !plan.contains("SCAN"),
+                        "{shape} of {table} must be an index-ordered search \
+                         (analyze={analyze}): {plan}"
+                    );
+                }
+            }
         }
     }
 
@@ -3417,11 +3446,11 @@ mod tests {
             "idx_sessions_raw_path",
         ] {
             assert!(
-                REQUIRED_SESSIONS_INDEXES.contains(&needed),
+                REQUIRED_INDEXES.contains(&needed),
                 "{needed} is load-bearing and must stay in the guard"
             );
         }
-        for index in REQUIRED_SESSIONS_INDEXES {
+        for index in REQUIRED_INDEXES {
             conn.execute_batch(&format!("DROP INDEX {index}")).unwrap();
             assert!(
                 !schema_is_current(&conn).unwrap(),

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -457,6 +457,8 @@ const REQUIRED_SESSIONS_INDEXES: &[&str] = &[
     "idx_sessions_raw_path",
     "idx_session_events_source_page",
     "idx_session_events_page",
+    "idx_tool_calls_page",
+    "idx_file_edits_page",
     "idx_session_presences_location",
     "idx_session_presences_locator",
 ];
@@ -479,6 +481,10 @@ const REQUIRED_CATALOG_READ_INDEXES: &[&str] = &[
 ];
 const REQUIRED_EVENT_READ_INDEXES: &[&str] =
     &["idx_session_events_source_page", "idx_session_events_page"];
+/// Indexes the session-scoped tool call and file edit pages depend on. Both
+/// pages always name one source and one session, so a single composite index
+/// per table carries the whole lookup.
+const REQUIRED_EVIDENCE_READ_INDEXES: &[&str] = &["idx_tool_calls_page", "idx_file_edits_page"];
 const REQUIRED_SCOPE_READ_INDEXES: &[&str] = &["idx_session_presences_location"];
 const REQUIRED_TRIGGERS: &[&str] = &["delete_session_presences", "delete_session_hydration_state"];
 const REQUIRED_SCHEMA_MIGRATIONS: &[&str] = &["session_presences_local_backfill_v1"];
@@ -507,6 +513,11 @@ pub fn schema_is_catalog_read_current(conn: &Connection) -> Result<bool> {
 /// Whether bounded event pagination has both source-scoped and source-less indexes.
 pub fn schema_is_event_read_current(conn: &Connection) -> Result<bool> {
     schema_has_required_indexes(conn, REQUIRED_EVENT_READ_INDEXES)
+}
+
+/// Whether bounded tool call and file edit pagination has its page indexes.
+pub fn schema_is_evidence_read_current(conn: &Connection) -> Result<bool> {
+    schema_has_required_indexes(conn, REQUIRED_EVIDENCE_READ_INDEXES)
 }
 
 fn schema_has_required_indexes(conn: &Connection, required_indexes: &[&str]) -> Result<bool> {
@@ -845,6 +856,18 @@ VALUES ('session_presences_local_backfill_v1');
     )?;
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_file_edits_session ON file_edits(source, session_id)",
+        [],
+    )?;
+    // Evidence pages always name one source and one session and continue on
+    // `(ts_ms, id)`. Both timestamps are nullable, so the index cannot also
+    // carry the "nulls last" half of the order; it still turns each page into
+    // a search over one session's rows instead of a scan of the table.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tool_calls_page ON tool_calls(source, session_id, ts_ms, id)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_file_edits_page ON file_edits(source, session_id, ts_ms, id)",
         [],
     )?;
     conn.execute(
@@ -1343,13 +1366,45 @@ pub struct SessionFileEdit {
     pub id: i64,
     pub source: String,
     pub session_id: String,
+    pub message_id: Option<String>,
     pub tool_use_id: String,
     pub file_path: String,
     pub tool_name: Option<String>,
     pub lines_added: Option<i64>,
     pub lines_removed: Option<i64>,
+    pub structured_patch_json: Option<String>,
     pub user_modified: Option<i64>,
     pub ts_ms: Option<i64>,
+    pub git_branch: Option<String>,
+    pub cwd: Option<String>,
+}
+
+/// Bump whenever the tool call / file edit page row shapes, ordering, or
+/// cursor semantics require an SDK change.
+pub const SESSION_EVIDENCE_CONTRACT_VERSION: u32 = 1;
+
+/// Stable continuation for tool calls and file edits.
+///
+/// Neither table requires a timestamp, and the canonical order places the
+/// undated tail last, so a cursor that only carried an `i64` could not say
+/// whether it stands before or inside that tail. `ts_ms: None` means "already
+/// inside the undated tail, continue by id".
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionEvidenceCursor {
+    pub ts_ms: Option<i64>,
+    pub id: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionToolCallPage {
+    pub tool_calls: Vec<SessionToolCall>,
+    pub next_cursor: Option<SessionEvidenceCursor>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionFileEditPage {
+    pub file_edits: Vec<SessionFileEdit>,
+    pub next_cursor: Option<SessionEvidenceCursor>,
 }
 
 /// All normalized events for one session, oldest first. Rows sharing a
@@ -1462,8 +1517,7 @@ pub fn session_tool_calls(
     session_id: &str,
     source: Option<&str>,
 ) -> Result<Vec<SessionToolCall>> {
-    let mut sql = "SELECT id, source, session_id, message_id, tool_use_id, name, target,                    args_json, is_error, ts_ms                    FROM tool_calls WHERE session_id = ?"
-        .to_string();
+    let mut sql = format!("SELECT {TOOL_CALL_COLUMNS} FROM tool_calls WHERE session_id = ?");
     let mut params_vec = vec![session_id.to_string()];
     if let Some(source) = source {
         sql.push_str(" AND source = ?");
@@ -1471,20 +1525,7 @@ pub fn session_tool_calls(
     }
     sql.push_str(" ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC");
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), |row| {
-        Ok(SessionToolCall {
-            id: row.get(0)?,
-            source: row.get(1)?,
-            session_id: row.get(2)?,
-            message_id: row.get(3)?,
-            tool_use_id: row.get(4)?,
-            name: row.get(5)?,
-            target: row.get(6)?,
-            args_json: row.get(7)?,
-            is_error: row.get(8)?,
-            ts_ms: row.get(9)?,
-        })
-    })?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), row_to_tool_call)?;
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
@@ -1493,8 +1534,7 @@ pub fn session_file_edits(
     session_id: &str,
     source: Option<&str>,
 ) -> Result<Vec<SessionFileEdit>> {
-    let mut sql = "SELECT id, source, session_id, tool_use_id, file_path, tool_name,                    lines_added, lines_removed, user_modified, ts_ms                    FROM file_edits WHERE session_id = ?"
-        .to_string();
+    let mut sql = format!("SELECT {FILE_EDIT_COLUMNS} FROM file_edits WHERE session_id = ?");
     let mut params_vec = vec![session_id.to_string()];
     if let Some(source) = source {
         sql.push_str(" AND source = ?");
@@ -1502,21 +1542,156 @@ pub fn session_file_edits(
     }
     sql.push_str(" ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC");
     let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), |row| {
-        Ok(SessionFileEdit {
-            id: row.get(0)?,
-            source: row.get(1)?,
-            session_id: row.get(2)?,
-            tool_use_id: row.get(3)?,
-            file_path: row.get(4)?,
-            tool_name: row.get(5)?,
-            lines_added: row.get(6)?,
-            lines_removed: row.get(7)?,
-            user_modified: row.get(8)?,
-            ts_ms: row.get(9)?,
-        })
-    })?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), row_to_file_edit)?;
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+const TOOL_CALL_COLUMNS: &str = "id, source, session_id, message_id, tool_use_id, name, target, \
+                                 args_json, is_error, ts_ms";
+const FILE_EDIT_COLUMNS: &str =
+    "id, source, session_id, message_id, tool_use_id, file_path, tool_name, lines_added, \
+     lines_removed, structured_patch_json, user_modified, ts_ms, git_branch, cwd";
+
+fn row_to_tool_call(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionToolCall> {
+    Ok(SessionToolCall {
+        id: row.get(0)?,
+        source: row.get(1)?,
+        session_id: row.get(2)?,
+        message_id: row.get(3)?,
+        tool_use_id: row.get(4)?,
+        name: row.get(5)?,
+        target: row.get(6)?,
+        args_json: row.get(7)?,
+        is_error: row.get(8)?,
+        ts_ms: row.get(9)?,
+    })
+}
+
+fn row_to_file_edit(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionFileEdit> {
+    Ok(SessionFileEdit {
+        id: row.get(0)?,
+        source: row.get(1)?,
+        session_id: row.get(2)?,
+        message_id: row.get(3)?,
+        tool_use_id: row.get(4)?,
+        file_path: row.get(5)?,
+        tool_name: row.get(6)?,
+        lines_added: row.get(7)?,
+        lines_removed: row.get(8)?,
+        structured_patch_json: row.get(9)?,
+        user_modified: row.get(10)?,
+        ts_ms: row.get(11)?,
+        git_branch: row.get(12)?,
+        cwd: row.get(13)?,
+    })
+}
+
+/// Keyset continuation for the canonical
+/// `ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC` order.
+///
+/// A dated cursor must still admit the whole undated tail, and an undated one
+/// must never walk back into the dated head, so the two cases are different
+/// predicates rather than one comparison over a coalesced timestamp.
+fn push_evidence_cursor(
+    sql: &mut String,
+    params: &mut Vec<rusqlite::types::Value>,
+    cursor: &SessionEvidenceCursor,
+) {
+    match cursor.ts_ms {
+        Some(ts_ms) => {
+            sql.push_str(" AND (ts_ms IS NULL OR ts_ms > ? OR (ts_ms = ? AND id > ?))");
+            params.push(ts_ms.into());
+            params.push(ts_ms.into());
+            params.push(cursor.id.into());
+        }
+        None => {
+            sql.push_str(" AND (ts_ms IS NULL AND id > ?)");
+            params.push(cursor.id.into());
+        }
+    }
+}
+
+fn evidence_next_cursor(ts_ms: Option<i64>, id: i64) -> SessionEvidenceCursor {
+    SessionEvidenceCursor { ts_ms, id }
+}
+
+/// One bounded page of recorded tool calls for one session, oldest first.
+///
+/// Both `source` and `session_id` are required: native session ids collide
+/// across providers, and a page that filtered on the id alone would interleave
+/// two unrelated sessions.
+pub fn session_tool_calls_page(
+    conn: &Connection,
+    source: &str,
+    session_id: &str,
+    limit: i64,
+    after: Option<&SessionEvidenceCursor>,
+) -> Result<SessionToolCallPage> {
+    let limit = limit.clamp(1, 1_000);
+    let mut sql =
+        format!("SELECT {TOOL_CALL_COLUMNS} FROM tool_calls WHERE source = ? AND session_id = ?");
+    let mut params_vec: Vec<rusqlite::types::Value> =
+        vec![source.to_string().into(), session_id.to_string().into()];
+    if let Some(cursor) = after {
+        push_evidence_cursor(&mut sql, &mut params_vec, cursor);
+    }
+    sql.push_str(" ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC LIMIT ?");
+    params_vec.push((limit + 1).into());
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), row_to_tool_call)?;
+    let mut tool_calls = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+    let has_more = tool_calls.len() > limit as usize;
+    if has_more {
+        tool_calls.truncate(limit as usize);
+    }
+    let next_cursor = (has_more && !tool_calls.is_empty()).then(|| {
+        let last = tool_calls.last().expect("non-empty page");
+        evidence_next_cursor(last.ts_ms, last.id)
+    });
+    Ok(SessionToolCallPage {
+        tool_calls,
+        next_cursor,
+    })
+}
+
+/// One bounded page of recorded file edits for one session, oldest first.
+///
+/// Scoped to one `source` for the same reason as
+/// [`session_tool_calls_page`].
+pub fn session_file_edits_page(
+    conn: &Connection,
+    source: &str,
+    session_id: &str,
+    limit: i64,
+    after: Option<&SessionEvidenceCursor>,
+) -> Result<SessionFileEditPage> {
+    let limit = limit.clamp(1, 1_000);
+    let mut sql =
+        format!("SELECT {FILE_EDIT_COLUMNS} FROM file_edits WHERE source = ? AND session_id = ?");
+    let mut params_vec: Vec<rusqlite::types::Value> =
+        vec![source.to_string().into(), session_id.to_string().into()];
+    if let Some(cursor) = after {
+        push_evidence_cursor(&mut sql, &mut params_vec, cursor);
+    }
+    sql.push_str(" ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC LIMIT ?");
+    params_vec.push((limit + 1).into());
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), row_to_file_edit)?;
+    let mut file_edits = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+    let has_more = file_edits.len() > limit as usize;
+    if has_more {
+        file_edits.truncate(limit as usize);
+    }
+    let next_cursor = (has_more && !file_edits.is_empty()).then(|| {
+        let last = file_edits.last().expect("non-empty page");
+        evidence_next_cursor(last.ts_ms, last.id)
+    });
+    Ok(SessionFileEditPage {
+        file_edits,
+        next_cursor,
+    })
 }
 
 pub fn stats(conn: &Connection, tag: Option<&str>) -> Result<Stats> {
@@ -2582,6 +2757,300 @@ mod tests {
         assert_eq!(edits[0].user_modified, Some(1));
         assert_eq!(session_file_edits(&conn, "s1", None).unwrap().len(), 3);
         assert!(session_file_edits(&conn, "nope", None).unwrap().is_empty());
+    }
+
+    /// Two providers whose native session ids collide, one shared timestamp
+    /// per table, and an undated tail: the shapes every page assertion below
+    /// depends on.
+    fn seed_evidence(conn: &Connection) {
+        conn.execute_batch(
+            r#"
+            INSERT INTO tool_calls (source, session_id, message_id, tool_use_id, name, target, args_json, is_error, ts_ms)
+            VALUES ('claude', 's1', 'm1', 'tu-a', 'Bash', 'cargo test', '{"command":"cargo test"}', 1, 200),
+                   ('claude', 's1', 'm1', 'tu-b', 'Read', '/tmp/p/a.rs', '{"file_path":"/tmp/p/a.rs"}', 0, 100),
+                   ('claude', 's1', 'm2', 'tu-c', 'Grep', 'needle', '{"pattern":"needle"}', NULL, 200),
+                   ('claude', 's1', 'm2', 'tu-d', 'Glob', '*.rs', '{"pattern":"*.rs"}', 0, NULL),
+                   ('claude', 's1', 'm3', 'tu-e', 'Write', '/tmp/p/b.rs', 'not json', 0, 100),
+                   ('claude', 's1', 'm3', 'tu-f', 'Edit', '/tmp/p/c.rs', NULL, NULL, NULL),
+                   ('codex', 's1', 'm9', 'tu-x', 'Shell', 'ls', '{}', 0, 150),
+                   ('claude', 's2', 'm8', 'tu-y', 'Read', '/tmp/q/a.rs', '{}', 0, 150);
+            INSERT INTO file_edits (source, session_id, message_id, tool_use_id, file_path, tool_name, lines_added, lines_removed, structured_patch_json, user_modified, ts_ms, git_branch, cwd)
+            VALUES ('claude', 's1', 'm1', 'fe-a', '/tmp/p/a.rs', 'Write', 10, 0, '[{"lines":["+a"]}]', 1, 200, 'main', '/tmp/p'),
+                   ('claude', 's1', 'm1', 'fe-b', '/tmp/p/b.rs', 'Edit', 2, 1, 'not json', 0, 100, 'main', '/tmp/p'),
+                   ('claude', 's1', 'm2', 'fe-c', '/tmp/p/c.rs', 'Edit', 1, 1, NULL, NULL, 200, NULL, NULL),
+                   ('claude', 's1', 'm2', 'fe-d', '/tmp/p/d.rs', 'Edit', 0, 0, NULL, NULL, NULL, NULL, NULL),
+                   ('claude', 's1', 'm3', 'fe-e', '/tmp/p/e.rs', 'Edit', 3, 3, NULL, 1, 100, 'main', '/tmp/p'),
+                   ('claude', 's1', 'm3', 'fe-f', '/tmp/p/f.rs', 'Edit', 0, 1, NULL, NULL, NULL, NULL, NULL),
+                   ('codex', 's1', 'm9', 'fe-x', '/tmp/p/z.rs', 'apply_patch', 1, 1, NULL, NULL, 150, NULL, NULL),
+                   ('claude', 's2', 'm8', 'fe-y', '/tmp/q/a.rs', 'Edit', 1, 0, NULL, NULL, 150, NULL, NULL);
+            "#,
+        )
+        .unwrap();
+    }
+
+    /// Every page of a full walk, plus the ids it yielded in order. Pages are
+    /// bounded, so a cursor that failed to advance would hang rather than
+    /// fail; the iteration guard turns that into an assertion.
+    fn walk_tool_calls(conn: &Connection, source: &str, session_id: &str, limit: i64) -> Vec<i64> {
+        let mut ids = Vec::new();
+        let mut cursor = None;
+        for _ in 0..100 {
+            let page =
+                session_tool_calls_page(conn, source, session_id, limit, cursor.as_ref()).unwrap();
+            assert!(page.tool_calls.len() as i64 <= limit.clamp(1, 1_000));
+            ids.extend(page.tool_calls.iter().map(|call| call.id));
+            match page.next_cursor {
+                Some(next) => cursor = Some(next),
+                None => return ids,
+            }
+        }
+        panic!("tool call pagination did not terminate");
+    }
+
+    fn walk_file_edits(conn: &Connection, source: &str, session_id: &str, limit: i64) -> Vec<i64> {
+        let mut ids = Vec::new();
+        let mut cursor = None;
+        for _ in 0..100 {
+            let page =
+                session_file_edits_page(conn, source, session_id, limit, cursor.as_ref()).unwrap();
+            assert!(page.file_edits.len() as i64 <= limit.clamp(1, 1_000));
+            ids.extend(page.file_edits.iter().map(|edit| edit.id));
+            match page.next_cursor {
+                Some(next) => cursor = Some(next),
+                None => return ids,
+            }
+        }
+        panic!("file edit pagination did not terminate");
+    }
+
+    #[test]
+    fn evidence_pages_scope_to_one_source_and_session() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        seed_evidence(&conn);
+
+        let calls = session_tool_calls_page(&conn, "claude", "s1", 100, None).unwrap();
+        assert!(calls
+            .tool_calls
+            .iter()
+            .all(|call| call.source == "claude" && call.session_id == "s1"));
+        assert_eq!(calls.tool_calls.len(), 6);
+        assert_eq!(
+            session_tool_calls_page(&conn, "codex", "s1", 100, None)
+                .unwrap()
+                .tool_calls
+                .iter()
+                .map(|call| call.tool_use_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["tu-x"]
+        );
+
+        let edits = session_file_edits_page(&conn, "claude", "s1", 100, None).unwrap();
+        assert!(edits
+            .file_edits
+            .iter()
+            .all(|edit| edit.source == "claude" && edit.session_id == "s1"));
+        assert_eq!(edits.file_edits.len(), 6);
+        let first = &edits.file_edits[0];
+        assert_eq!(first.tool_use_id, "fe-b");
+        assert_eq!(first.message_id.as_deref(), Some("m1"));
+        assert_eq!(first.structured_patch_json.as_deref(), Some("not json"));
+        assert_eq!(first.git_branch.as_deref(), Some("main"));
+        assert_eq!(first.cwd.as_deref(), Some("/tmp/p"));
+        assert_eq!(
+            session_file_edits_page(&conn, "codex", "s1", 100, None)
+                .unwrap()
+                .file_edits
+                .iter()
+                .map(|edit| edit.tool_use_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["fe-x"]
+        );
+    }
+
+    #[test]
+    fn evidence_pages_walk_tied_timestamps_and_undated_tails_without_gaps() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        seed_evidence(&conn);
+
+        let expected_calls = session_tool_calls(&conn, "s1", Some("claude"))
+            .unwrap()
+            .iter()
+            .map(|call| call.id)
+            .collect::<Vec<_>>();
+        let expected_edits = session_file_edits(&conn, "s1", Some("claude"))
+            .unwrap()
+            .iter()
+            .map(|edit| edit.id)
+            .collect::<Vec<_>>();
+        // Tied timestamps ahead of an undated tail: the order the unpaginated
+        // readers already promise.
+        assert_eq!(expected_calls.len(), 6);
+        assert_eq!(expected_edits.len(), 6);
+
+        for limit in [1, 2, 3, 5, 6, 7, 1_000] {
+            assert_eq!(
+                walk_tool_calls(&conn, "claude", "s1", limit),
+                expected_calls,
+                "tool calls at limit {limit}"
+            );
+            assert_eq!(
+                walk_file_edits(&conn, "claude", "s1", limit),
+                expected_edits,
+                "file edits at limit {limit}"
+            );
+        }
+    }
+
+    #[test]
+    fn evidence_page_cursors_are_exact_at_page_boundaries() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        seed_evidence(&conn);
+
+        // A page that exactly consumes the rows reports no continuation.
+        let exact = session_tool_calls_page(&conn, "claude", "s1", 6, None).unwrap();
+        assert_eq!(exact.tool_calls.len(), 6);
+        assert_eq!(exact.next_cursor, None);
+
+        // A cursor taken mid-tie resumes at the tie's next row, not after it.
+        let first = session_tool_calls_page(&conn, "claude", "s1", 1, None).unwrap();
+        let cursor = first.next_cursor.clone().unwrap();
+        assert_eq!(cursor.ts_ms, Some(100));
+        let second = session_tool_calls_page(&conn, "claude", "s1", 1, Some(&cursor)).unwrap();
+        assert_eq!(second.tool_calls[0].ts_ms, Some(100));
+        assert!(second.tool_calls[0].id > first.tool_calls[0].id);
+
+        // A cursor on the last dated row admits the whole undated tail.
+        let dated = session_tool_calls_page(&conn, "claude", "s1", 4, None).unwrap();
+        let tail = session_tool_calls_page(&conn, "claude", "s1", 100, dated.next_cursor.as_ref())
+            .unwrap();
+        assert!(tail.tool_calls.iter().all(|call| call.ts_ms.is_none()));
+        assert_eq!(tail.tool_calls.len(), 2);
+        assert_eq!(tail.next_cursor, None);
+
+        // A cursor already inside the undated tail never walks back into the
+        // dated head.
+        let undated = SessionEvidenceCursor {
+            ts_ms: None,
+            id: tail.tool_calls[0].id,
+        };
+        let rest = session_file_edits_page(&conn, "claude", "s1", 100, None).unwrap();
+        let last_undated = rest.file_edits.last().unwrap();
+        let after_all = session_file_edits_page(
+            &conn,
+            "claude",
+            "s1",
+            100,
+            Some(&SessionEvidenceCursor {
+                ts_ms: last_undated.ts_ms,
+                id: last_undated.id,
+            }),
+        )
+        .unwrap();
+        assert!(after_all.file_edits.is_empty());
+        assert_eq!(after_all.next_cursor, None);
+        let continued =
+            session_tool_calls_page(&conn, "claude", "s1", 100, Some(&undated)).unwrap();
+        assert_eq!(continued.tool_calls.len(), 1);
+        assert!(continued.tool_calls[0].ts_ms.is_none());
+    }
+
+    #[test]
+    fn evidence_pages_clamp_limits_and_read_unknown_sessions_empty() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        seed_evidence(&conn);
+
+        // Out-of-range limits clamp instead of erroring or returning nothing.
+        assert_eq!(
+            session_tool_calls_page(&conn, "claude", "s1", 0, None)
+                .unwrap()
+                .tool_calls
+                .len(),
+            1
+        );
+        assert_eq!(
+            session_file_edits_page(&conn, "claude", "s1", -5, None)
+                .unwrap()
+                .file_edits
+                .len(),
+            1
+        );
+        assert_eq!(
+            session_tool_calls_page(&conn, "claude", "s1", 10_000, None)
+                .unwrap()
+                .tool_calls
+                .len(),
+            6
+        );
+
+        for (source, session_id) in [("claude", "nope"), ("nope", "s1")] {
+            let calls = session_tool_calls_page(&conn, source, session_id, 10, None).unwrap();
+            assert!(calls.tool_calls.is_empty());
+            assert_eq!(calls.next_cursor, None);
+            let edits = session_file_edits_page(&conn, source, session_id, 10, None).unwrap();
+            assert!(edits.file_edits.is_empty());
+            assert_eq!(edits.next_cursor, None);
+        }
+    }
+
+    /// A database predating the evidence page indexes has outstanding
+    /// migration work: the read guard must refuse it so the caller is routed
+    /// through the writable open that creates them, rather than serving the
+    /// page from a full table scan.
+    #[test]
+    fn evidence_page_indexes_migrate_onto_an_existing_database() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        assert!(schema_is_evidence_read_current(&conn).unwrap());
+
+        conn.execute_batch("DROP INDEX idx_tool_calls_page; DROP INDEX idx_file_edits_page;")
+            .unwrap();
+        assert!(!schema_is_evidence_read_current(&conn).unwrap());
+        assert!(!schema_is_current(&conn).unwrap());
+        // Unrelated read paths keep working while that migration is pending.
+        assert!(schema_is_event_read_current(&conn).unwrap());
+
+        init_db(&conn).unwrap();
+        assert!(schema_is_evidence_read_current(&conn).unwrap());
+        assert!(schema_is_current(&conn).unwrap());
+    }
+
+    #[test]
+    fn evidence_pages_return_stored_json_verbatim() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        seed_evidence(&conn);
+
+        // The core never parses stored provider JSON: unparseable and absent
+        // values are distinct, and both reach the caller intact.
+        let calls = session_tool_calls_page(&conn, "claude", "s1", 100, None).unwrap();
+        let by_id = |tool_use_id: &str| {
+            calls
+                .tool_calls
+                .iter()
+                .find(|call| call.tool_use_id == tool_use_id)
+                .unwrap()
+        };
+        assert_eq!(by_id("tu-e").args_json.as_deref(), Some("not json"));
+        assert_eq!(by_id("tu-f").args_json, None);
+        assert_eq!(by_id("tu-a").is_error, Some(1));
+        assert_eq!(by_id("tu-b").is_error, Some(0));
+        assert_eq!(by_id("tu-c").is_error, None);
+
+        let edits = session_file_edits_page(&conn, "claude", "s1", 100, None).unwrap();
+        let patched = edits
+            .file_edits
+            .iter()
+            .find(|edit| edit.tool_use_id == "fe-a")
+            .unwrap();
+        assert_eq!(
+            patched.structured_patch_json.as_deref(),
+            Some(r#"[{"lines":["+a"]}]"#)
+        );
+        assert_eq!(patched.user_modified, Some(1));
     }
 
     #[test]

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -457,21 +457,34 @@ const REQUIRED_SESSIONS_INDEXES: &[&str] = &[
     "idx_sessions_raw_path",
     "idx_session_events_source_page",
     "idx_session_events_page",
-    "idx_tool_calls_page",
-    "idx_file_edits_page",
+    "idx_tool_calls_page_v2",
+    "idx_file_edits_page_v2",
     "idx_session_presences_location",
     "idx_session_presences_locator",
 ];
 
-/// Indexes retired from `sessions`: nothing queries them, and each was one
-/// more btree per catalog write. [`init_db`] drops them so existing databases
-/// shed the write amplification too; while one is still present the database
-/// has outstanding migration work, and the lock-free fast path must not run.
-const RETIRED_SESSIONS_INDEXES: &[&str] = &[
+/// Indexes no longer created: nothing queries them, or a replacement covers
+/// strictly more, and each was one more btree per write. [`init_db`] drops
+/// them so existing databases shed the write amplification too; while one is
+/// still present the database has outstanding migration work, and the
+/// lock-free fast path must not run.
+///
+/// The `sessions` four were never read by the catalog. The evidence four are
+/// prefixes of, or superseded by, the `_v2` page indexes: `(source,
+/// session_id)` is a strict prefix of the page index, and the original page
+/// indexes ordered on the bare `ts_ms` column, which cannot serve the
+/// canonical `ts_ms IS NULL, ts_ms, id` order. Because the schema guard
+/// compares index *names*, the corrected shape had to take a new name — a
+/// same-named old index would otherwise be read as current.
+const RETIRED_INDEXES: &[&str] = &[
     "idx_sessions_cwd",
     "idx_sessions_branch",
     "idx_sessions_last",
     "idx_sessions_source_last",
+    "idx_tool_calls_session",
+    "idx_file_edits_session",
+    "idx_tool_calls_page",
+    "idx_file_edits_page",
 ];
 
 const REQUIRED_CATALOG_READ_INDEXES: &[&str] = &[
@@ -483,8 +496,9 @@ const REQUIRED_EVENT_READ_INDEXES: &[&str] =
     &["idx_session_events_source_page", "idx_session_events_page"];
 /// Indexes the session-scoped tool call and file edit pages depend on. Both
 /// pages always name one source and one session, so a single composite index
-/// per table carries the whole lookup.
-const REQUIRED_EVIDENCE_READ_INDEXES: &[&str] = &["idx_tool_calls_page", "idx_file_edits_page"];
+/// per table carries the whole lookup and its ordering.
+const REQUIRED_EVIDENCE_READ_INDEXES: &[&str] =
+    &["idx_tool_calls_page_v2", "idx_file_edits_page_v2"];
 const REQUIRED_SCOPE_READ_INDEXES: &[&str] = &["idx_session_presences_location"];
 const REQUIRED_TRIGGERS: &[&str] = &["delete_session_presences", "delete_session_hydration_state"];
 const REQUIRED_SCHEMA_MIGRATIONS: &[&str] = &["session_presences_local_backfill_v1"];
@@ -578,11 +592,11 @@ fn schema_has_required_indexes(conn: &Connection, required_indexes: &[&str]) -> 
     Ok(true)
 }
 
-/// Whether any [`RETIRED_SESSIONS_INDEXES`] entry still exists.
+/// Whether any [`RETIRED_INDEXES`] entry still exists.
 fn retired_indexes_present(conn: &Connection) -> Result<bool> {
     let mut index =
         conn.prepare("SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ? LIMIT 1")?;
-    for name in RETIRED_SESSIONS_INDEXES {
+    for name in RETIRED_INDEXES {
         if index.exists([name])? {
             return Ok(true);
         }
@@ -795,8 +809,8 @@ VALUES ('session_presences_local_backfill_v1');
         [],
     )?;
     // The write cost of the retired indexes showed up directly in
-    // cold-discovery profiles; see RETIRED_SESSIONS_INDEXES.
-    for name in RETIRED_SESSIONS_INDEXES {
+    // cold-discovery profiles; see RETIRED_INDEXES.
+    for name in RETIRED_INDEXES {
         conn.execute(&format!("DROP INDEX IF EXISTS {name}"), [])?;
     }
     // The catalog's total order is (last_activity_ms DESC, source, session_id):
@@ -850,24 +864,19 @@ VALUES ('session_presences_local_backfill_v1');
         "CREATE INDEX IF NOT EXISTS idx_session_events_role ON session_events(role)",
         [],
     )?;
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_tool_calls_session ON tool_calls(source, session_id)",
-        [],
-    )?;
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_file_edits_session ON file_edits(source, session_id)",
-        [],
-    )?;
     // Evidence pages always name one source and one session and continue on
-    // `(ts_ms, id)`. Both timestamps are nullable, so the index cannot also
-    // carry the "nulls last" half of the order; it still turns each page into
-    // a search over one session's rows instead of a scan of the table.
+    // `(ts_ms, id)` within the canonical `ts_ms IS NULL, ts_ms, id` order.
+    // Both timestamps are nullable, so the "nulls last" half of that order is
+    // carried by indexing the `ts_ms IS NULL` expression itself: an index over
+    // the bare column still leaves SQLite sorting every page in a temp b-tree.
+    // These also subsume the retired `(source, session_id)` indexes, which
+    // were strict prefixes of them.
     conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_tool_calls_page ON tool_calls(source, session_id, ts_ms, id)",
+        "CREATE INDEX IF NOT EXISTS idx_tool_calls_page_v2 ON tool_calls(source, session_id, (ts_ms IS NULL), ts_ms, id)",
         [],
     )?;
     conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_file_edits_page ON file_edits(source, session_id, ts_ms, id)",
+        "CREATE INDEX IF NOT EXISTS idx_file_edits_page_v2 ON file_edits(source, session_id, (ts_ms IS NULL), ts_ms, id)",
         [],
     )?;
     conn.execute(
@@ -1586,33 +1595,42 @@ fn row_to_file_edit(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionFileEdit
     })
 }
 
-/// Keyset continuation for the canonical
+/// One page's SQL and bound parameters, in the canonical
 /// `ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC` order.
 ///
 /// A dated cursor must still admit the whole undated tail, and an undated one
-/// must never walk back into the dated head, so the two cases are different
-/// predicates rather than one comparison over a coalesced timestamp.
-fn push_evidence_cursor(
-    sql: &mut String,
-    params: &mut Vec<rusqlite::types::Value>,
-    cursor: &SessionEvidenceCursor,
-) {
-    match cursor.ts_ms {
-        Some(ts_ms) => {
+/// must never walk back into the dated head, so the two continuation cases are
+/// different predicates rather than one comparison over a coalesced timestamp.
+///
+/// Both page readers and the query-plan test build their SQL here, so a plan
+/// assertion cannot pass against a restated copy while the real query drifts.
+fn evidence_page_query(
+    columns: &str,
+    table: &str,
+    source: &str,
+    session_id: &str,
+    limit: i64,
+    after: Option<&SessionEvidenceCursor>,
+) -> (String, Vec<rusqlite::types::Value>) {
+    let mut sql = format!("SELECT {columns} FROM {table} WHERE source = ? AND session_id = ?");
+    let mut params: Vec<rusqlite::types::Value> =
+        vec![source.to_string().into(), session_id.to_string().into()];
+    match after.map(|cursor| (cursor.ts_ms, cursor.id)) {
+        Some((Some(ts_ms), id)) => {
             sql.push_str(" AND (ts_ms IS NULL OR ts_ms > ? OR (ts_ms = ? AND id > ?))");
             params.push(ts_ms.into());
             params.push(ts_ms.into());
-            params.push(cursor.id.into());
+            params.push(id.into());
         }
-        None => {
+        Some((None, id)) => {
             sql.push_str(" AND (ts_ms IS NULL AND id > ?)");
-            params.push(cursor.id.into());
+            params.push(id.into());
         }
+        None => {}
     }
-}
-
-fn evidence_next_cursor(ts_ms: Option<i64>, id: i64) -> SessionEvidenceCursor {
-    SessionEvidenceCursor { ts_ms, id }
+    sql.push_str(" ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC LIMIT ?");
+    params.push((limit + 1).into());
+    (sql, params)
 }
 
 /// One bounded page of recorded tool calls for one session, oldest first.
@@ -1628,26 +1646,28 @@ pub fn session_tool_calls_page(
     after: Option<&SessionEvidenceCursor>,
 ) -> Result<SessionToolCallPage> {
     let limit = limit.clamp(1, 1_000);
-    let mut sql =
-        format!("SELECT {TOOL_CALL_COLUMNS} FROM tool_calls WHERE source = ? AND session_id = ?");
-    let mut params_vec: Vec<rusqlite::types::Value> =
-        vec![source.to_string().into(), session_id.to_string().into()];
-    if let Some(cursor) = after {
-        push_evidence_cursor(&mut sql, &mut params_vec, cursor);
-    }
-    sql.push_str(" ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC LIMIT ?");
-    params_vec.push((limit + 1).into());
-
+    let (sql, params_vec) = evidence_page_query(
+        TOOL_CALL_COLUMNS,
+        "tool_calls",
+        source,
+        session_id,
+        limit,
+        after,
+    );
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), row_to_tool_call)?;
     let mut tool_calls = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+    // One extra row was requested, so `has_more` already implies a full page.
     let has_more = tool_calls.len() > limit as usize;
     if has_more {
         tool_calls.truncate(limit as usize);
     }
-    let next_cursor = (has_more && !tool_calls.is_empty()).then(|| {
+    let next_cursor = has_more.then(|| {
         let last = tool_calls.last().expect("non-empty page");
-        evidence_next_cursor(last.ts_ms, last.id)
+        SessionEvidenceCursor {
+            ts_ms: last.ts_ms,
+            id: last.id,
+        }
     });
     Ok(SessionToolCallPage {
         tool_calls,
@@ -1667,26 +1687,28 @@ pub fn session_file_edits_page(
     after: Option<&SessionEvidenceCursor>,
 ) -> Result<SessionFileEditPage> {
     let limit = limit.clamp(1, 1_000);
-    let mut sql =
-        format!("SELECT {FILE_EDIT_COLUMNS} FROM file_edits WHERE source = ? AND session_id = ?");
-    let mut params_vec: Vec<rusqlite::types::Value> =
-        vec![source.to_string().into(), session_id.to_string().into()];
-    if let Some(cursor) = after {
-        push_evidence_cursor(&mut sql, &mut params_vec, cursor);
-    }
-    sql.push_str(" ORDER BY ts_ms IS NULL, ts_ms ASC, id ASC LIMIT ?");
-    params_vec.push((limit + 1).into());
-
+    let (sql, params_vec) = evidence_page_query(
+        FILE_EDIT_COLUMNS,
+        "file_edits",
+        source,
+        session_id,
+        limit,
+        after,
+    );
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(rusqlite::params_from_iter(params_vec), row_to_file_edit)?;
     let mut file_edits = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+    // One extra row was requested, so `has_more` already implies a full page.
     let has_more = file_edits.len() > limit as usize;
     if has_more {
         file_edits.truncate(limit as usize);
     }
-    let next_cursor = (has_more && !file_edits.is_empty()).then(|| {
+    let next_cursor = has_more.then(|| {
         let last = file_edits.last().expect("non-empty page");
-        evidence_next_cursor(last.ts_ms, last.id)
+        SessionEvidenceCursor {
+            ts_ms: last.ts_ms,
+            id: last.id,
+        }
     });
     Ok(SessionFileEditPage {
         file_edits,
@@ -3006,7 +3028,7 @@ mod tests {
         init_db(&conn).unwrap();
         assert!(schema_is_evidence_read_current(&conn).unwrap());
 
-        conn.execute_batch("DROP INDEX idx_tool_calls_page; DROP INDEX idx_file_edits_page;")
+        conn.execute_batch("DROP INDEX idx_tool_calls_page_v2; DROP INDEX idx_file_edits_page_v2;")
             .unwrap();
         assert!(!schema_is_evidence_read_current(&conn).unwrap());
         assert!(!schema_is_current(&conn).unwrap());
@@ -3016,6 +3038,109 @@ mod tests {
         init_db(&conn).unwrap();
         assert!(schema_is_evidence_read_current(&conn).unwrap());
         assert!(schema_is_current(&conn).unwrap());
+    }
+
+    /// A database carrying the first shape of the page indexes -- the same
+    /// names over the bare `ts_ms` column -- must be upgraded, not mistaken
+    /// for current. The guard compares names, so the corrected shape took new
+    /// names and the originals joined the retirement list.
+    #[test]
+    fn the_superseded_evidence_indexes_are_dropped_and_replaced() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn.execute_batch(
+            "DROP INDEX idx_tool_calls_page_v2;
+             DROP INDEX idx_file_edits_page_v2;
+             CREATE INDEX idx_tool_calls_page ON tool_calls(source, session_id, ts_ms, id);
+             CREATE INDEX idx_file_edits_page ON file_edits(source, session_id, ts_ms, id);
+             CREATE INDEX idx_tool_calls_session ON tool_calls(source, session_id);
+             CREATE INDEX idx_file_edits_session ON file_edits(source, session_id);",
+        )
+        .unwrap();
+        assert!(!schema_is_evidence_read_current(&conn).unwrap());
+        assert!(!schema_is_current(&conn).unwrap());
+
+        init_db(&conn).unwrap();
+        assert!(schema_is_evidence_read_current(&conn).unwrap());
+        assert!(schema_is_current(&conn).unwrap());
+        for retired in [
+            "idx_tool_calls_page",
+            "idx_file_edits_page",
+            "idx_tool_calls_session",
+            "idx_file_edits_session",
+        ] {
+            assert!(
+                RETIRED_INDEXES.contains(&retired),
+                "{retired} must be dropped from existing databases"
+            );
+            let present: bool = conn
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = ?)",
+                    [retired],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert!(!present, "{retired} is still present after migration");
+        }
+    }
+
+    /// The evidence page promises an indexed, sort-free read. The plan is
+    /// taken from the same builder the readers run, so it cannot pass against
+    /// a restated copy of the query.
+    #[test]
+    fn evidence_pages_are_served_by_an_index_without_sorting() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        seed_evidence(&conn);
+
+        let plan = |table: &str, columns: &str, after: Option<&SessionEvidenceCursor>| -> String {
+            let (sql, params) = evidence_page_query(columns, table, "claude", "s1", 10, after);
+            let mut stmt = conn.prepare(&format!("EXPLAIN QUERY PLAN {sql}")).unwrap();
+            stmt.query_map(rusqlite::params_from_iter(params), |row| {
+                row.get::<_, String>(3)
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap()
+            .join(" | ")
+        };
+
+        for (table, columns, index) in [
+            ("tool_calls", TOOL_CALL_COLUMNS, "idx_tool_calls_page_v2"),
+            ("file_edits", FILE_EDIT_COLUMNS, "idx_file_edits_page_v2"),
+        ] {
+            let first = plan(table, columns, None);
+            assert!(
+                first.contains(index) && !first.contains("TEMP B-TREE"),
+                "the first {table} page must be index-ordered: {first}"
+            );
+            // The dated continuation is the plan that runs on every page after
+            // the first; its extra predicate must not cost the ordering.
+            let dated = plan(
+                table,
+                columns,
+                Some(&SessionEvidenceCursor {
+                    ts_ms: Some(100),
+                    id: 1,
+                }),
+            );
+            assert!(
+                dated.contains(index) && !dated.contains("TEMP B-TREE"),
+                "a dated {table} continuation must stay index-ordered: {dated}"
+            );
+            // A cursor already inside the undated tail pins `ts_ms IS NULL`,
+            // so SQLite orders that one narrow slice by id itself; the lookup
+            // is still a search on the same index rather than a table scan.
+            let undated = plan(
+                table,
+                columns,
+                Some(&SessionEvidenceCursor { ts_ms: None, id: 1 }),
+            );
+            assert!(
+                undated.contains(index) && !undated.contains("SCAN"),
+                "an undated {table} continuation must still be a search: {undated}"
+            );
+        }
     }
 
     #[test]

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -74,6 +74,66 @@ export interface SessionEventsPage {
   events: Array<NativeSessionEvent>
   nextCursor?: EventCursor
 }
+export interface NativeSessionToolCall {
+  id: number
+  source: string
+  sessionId: string
+  messageId?: string
+  toolUseId: string
+  name: string
+  target?: string
+  /**
+   * Stored provider arguments, unparsed. The SDK owns JSON parsing so an
+   * unreadable value cannot fail a whole page at the boundary.
+   */
+  argsJson?: string
+  isError?: boolean
+  tsMs?: number
+}
+export interface NativeSessionFileEdit {
+  id: number
+  source: string
+  sessionId: string
+  messageId?: string
+  toolUseId: string
+  filePath: string
+  toolName?: string
+  linesAdded?: number
+  linesRemoved?: number
+  /** Stored provider patch, unparsed, for the same reason as `args_json`. */
+  structuredPatchJson?: string
+  userModified?: boolean
+  tsMs?: number
+  gitBranch?: string
+  cwd?: string
+}
+/**
+ * Continuation for tool call and file edit pages. `tsMs` is nullable because
+ * both tables order their undated rows last.
+ */
+export interface EvidenceCursor {
+  tsMs?: number
+  id: number
+}
+export interface EvidencePageOptions {
+  dbPath?: string
+  limit?: number
+  after?: EvidenceCursor
+}
+export interface SessionToolCallsPage {
+  contractVersion: number
+  source: string
+  sessionId: string
+  toolCalls: Array<NativeSessionToolCall>
+  nextCursor?: EvidenceCursor
+}
+export interface SessionFileEditsPage {
+  contractVersion: number
+  source: string
+  sessionId: string
+  fileEdits: Array<NativeSessionFileEdit>
+  nextCursor?: EvidenceCursor
+}
 export interface SourceCount {
   source: string
   count: number
@@ -103,6 +163,15 @@ export declare function recent(options?: HistoryQueryOptions | undefined | null)
 export declare function getSession(sessionId: string, options?: SessionOptions | undefined | null): Promise<Array<NativeHistoryEntry>>
 /** One bounded page of normalized events for a session. */
 export declare function getSessionEventsPage(sessionId: string, options?: EventsPageOptions | undefined | null): Promise<SessionEventsPage>
+/**
+ * One bounded page of recorded tool calls for one session.
+ *
+ * Both `source` and `sessionId` are required: provider session ids are not
+ * globally unique, so an id-only lookup could interleave two sessions.
+ */
+export declare function getSessionToolCallsPage(source: string, sessionId: string, options?: EvidencePageOptions | undefined | null): Promise<SessionToolCallsPage>
+/** One bounded page of recorded file edits for one session. */
+export declare function getSessionFileEditsPage(source: string, sessionId: string, options?: EvidencePageOptions | undefined | null): Promise<SessionFileEditsPage>
 /** Database statistics over already-indexed data. */
 export declare function stats(options?: StatsOptions | undefined | null): Promise<NativeStats>
 export interface CatalogSession {

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -108,8 +108,12 @@ export interface NativeSessionFileEdit {
   cwd?: string
 }
 /**
- * Continuation for tool call and file edit pages. `tsMs` is nullable because
+ * Continuation for tool call and file edit pages. `tsMs` is optional because
  * both tables order their undated rows last.
+ *
+ * Absent-or-`undefined` is how a caller says "inside the undated tail": an
+ * explicit JavaScript `null` cannot be converted to `i64` and fails at the
+ * boundary, so the SDK normalizes `null` to `undefined` before calling in.
  */
 export interface EvidenceCursor {
   tsMs?: number

--- a/crates/ai-hist-napi/index.js
+++ b/crates/ai-hist-napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { nativeContractVersion, nativeBuildProfile, search, recent, getSession, getSessionEventsPage, stats, listSessionCatalogPage, listSessionCatalog, discoverSessions, hydrateSession, sync, syncLocal, syncAndPush } = nativeBinding
+const { nativeContractVersion, nativeBuildProfile, search, recent, getSession, getSessionEventsPage, getSessionToolCallsPage, getSessionFileEditsPage, stats, listSessionCatalogPage, listSessionCatalog, discoverSessions, hydrateSession, sync, syncLocal, syncAndPush } = nativeBinding
 
 module.exports.nativeContractVersion = nativeContractVersion
 module.exports.nativeBuildProfile = nativeBuildProfile
@@ -318,6 +318,8 @@ module.exports.search = search
 module.exports.recent = recent
 module.exports.getSession = getSession
 module.exports.getSessionEventsPage = getSessionEventsPage
+module.exports.getSessionToolCallsPage = getSessionToolCallsPage
+module.exports.getSessionFileEditsPage = getSessionFileEditsPage
 module.exports.stats = stats
 module.exports.listSessionCatalogPage = listSessionCatalogPage
 module.exports.listSessionCatalog = listSessionCatalog

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -57,11 +57,23 @@ fn validate_limit(limit: Option<i64>, default: i64, max: i64) -> napi::Result<i6
 
 /// Session identity is two required strings; an empty one would silently widen
 /// a page to every row a provider ever recorded.
+///
+/// A padded value is rejected rather than trimmed, because the query is an
+/// exact match: trimming for the emptiness check alone would answer
+/// `" sess-1 "` with an empty page, and silently trimming would echo an
+/// identity the caller did not ask for. This boundary rejects every other
+/// invalid argument outright too.
 fn validate_identity(value: String, field: &str) -> napi::Result<String> {
     if value.trim().is_empty() {
         return Err(native_error(
             "INVALID_ARGUMENT",
             format!("{field} must not be empty"),
+        ));
+    }
+    if value.trim() != value {
+        return Err(native_error(
+            "INVALID_ARGUMENT",
+            format!("{field} must not be padded with whitespace"),
         ));
     }
     Ok(value)
@@ -342,8 +354,12 @@ impl From<CoreSessionFileEdit> for NativeSessionFileEdit {
     }
 }
 
-/// Continuation for tool call and file edit pages. `tsMs` is nullable because
+/// Continuation for tool call and file edit pages. `tsMs` is optional because
 /// both tables order their undated rows last.
+///
+/// Absent-or-`undefined` is how a caller says "inside the undated tail": an
+/// explicit JavaScript `null` cannot be converted to `i64` and fails at the
+/// boundary, so the SDK normalizes `null` to `undefined` before calling in.
 #[napi(object)]
 pub struct EvidenceCursor {
     pub ts_ms: Option<i64>,

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -8,16 +8,20 @@ use std::path::{Path, PathBuf};
 
 use ai_hist_core::{
     default_db_path, open_db, open_db_readonly, recent as core_recent,
-    schema_is_catalog_read_current, schema_is_event_read_current, schema_is_read_current,
-    search as core_search, session as core_session,
-    session_events_page as core_session_events_page, session_locations,
-    stats_scoped as core_stats_scoped, HistoryEntry, QueryFilter, SessionEvent as CoreSessionEvent,
-    SessionEventCursor as CoreEventCursor, SessionScope,
+    schema_is_catalog_read_current, schema_is_event_read_current, schema_is_evidence_read_current,
+    schema_is_read_current, search as core_search, session as core_session,
+    session_events_page as core_session_events_page,
+    session_file_edits_page as core_session_file_edits_page, session_locations,
+    session_tool_calls_page as core_session_tool_calls_page, stats_scoped as core_stats_scoped,
+    HistoryEntry, QueryFilter, SessionEvent as CoreSessionEvent,
+    SessionEventCursor as CoreEventCursor, SessionEvidenceCursor as CoreEvidenceCursor,
+    SessionFileEdit as CoreSessionFileEdit, SessionScope, SessionToolCall as CoreSessionToolCall,
+    SESSION_EVIDENCE_CONTRACT_VERSION,
 };
 use napi_derive::napi;
 
 /// Bump whenever native object shapes or semantics require an SDK change.
-pub const NATIVE_CONTRACT_VERSION: u32 = 4;
+pub const NATIVE_CONTRACT_VERSION: u32 = 5;
 const DEFAULT_LIMIT: i64 = 50;
 const DEFAULT_EVENT_LIMIT: i64 = 200;
 
@@ -49,6 +53,32 @@ fn validate_limit(limit: Option<i64>, default: i64, max: i64) -> napi::Result<i6
         ));
     }
     Ok(limit)
+}
+
+/// Session identity is two required strings; an empty one would silently widen
+/// a page to every row a provider ever recorded.
+fn validate_identity(value: String, field: &str) -> napi::Result<String> {
+    if value.trim().is_empty() {
+        return Err(native_error(
+            "INVALID_ARGUMENT",
+            format!("{field} must not be empty"),
+        ));
+    }
+    Ok(value)
+}
+
+fn core_evidence_cursor(cursor: EvidenceCursor) -> CoreEvidenceCursor {
+    CoreEvidenceCursor {
+        ts_ms: cursor.ts_ms,
+        id: cursor.id,
+    }
+}
+
+fn evidence_cursor(cursor: CoreEvidenceCursor) -> EvidenceCursor {
+    EvidenceCursor {
+        ts_ms: cursor.ts_ms,
+        id: cursor.id,
+    }
 }
 
 fn parse_scope(scope: Option<String>) -> napi::Result<SessionScope> {
@@ -237,6 +267,112 @@ pub struct EventsPageOptions {
 pub struct SessionEventsPage {
     pub events: Vec<NativeSessionEvent>,
     pub next_cursor: Option<EventCursor>,
+}
+
+#[napi(object)]
+pub struct NativeSessionToolCall {
+    pub id: i64,
+    pub source: String,
+    pub session_id: String,
+    pub message_id: Option<String>,
+    pub tool_use_id: String,
+    pub name: String,
+    pub target: Option<String>,
+    /// Stored provider arguments, unparsed. The SDK owns JSON parsing so an
+    /// unreadable value cannot fail a whole page at the boundary.
+    pub args_json: Option<String>,
+    pub is_error: Option<bool>,
+    pub ts_ms: Option<i64>,
+}
+
+impl From<CoreSessionToolCall> for NativeSessionToolCall {
+    fn from(call: CoreSessionToolCall) -> Self {
+        Self {
+            id: call.id,
+            source: call.source,
+            session_id: call.session_id,
+            message_id: call.message_id,
+            tool_use_id: call.tool_use_id,
+            name: call.name,
+            target: call.target,
+            args_json: call.args_json,
+            is_error: call.is_error.map(|value| value != 0),
+            ts_ms: call.ts_ms,
+        }
+    }
+}
+
+#[napi(object)]
+pub struct NativeSessionFileEdit {
+    pub id: i64,
+    pub source: String,
+    pub session_id: String,
+    pub message_id: Option<String>,
+    pub tool_use_id: String,
+    pub file_path: String,
+    pub tool_name: Option<String>,
+    pub lines_added: Option<i64>,
+    pub lines_removed: Option<i64>,
+    /// Stored provider patch, unparsed, for the same reason as `args_json`.
+    pub structured_patch_json: Option<String>,
+    pub user_modified: Option<bool>,
+    pub ts_ms: Option<i64>,
+    pub git_branch: Option<String>,
+    pub cwd: Option<String>,
+}
+
+impl From<CoreSessionFileEdit> for NativeSessionFileEdit {
+    fn from(edit: CoreSessionFileEdit) -> Self {
+        Self {
+            id: edit.id,
+            source: edit.source,
+            session_id: edit.session_id,
+            message_id: edit.message_id,
+            tool_use_id: edit.tool_use_id,
+            file_path: edit.file_path,
+            tool_name: edit.tool_name,
+            lines_added: edit.lines_added,
+            lines_removed: edit.lines_removed,
+            structured_patch_json: edit.structured_patch_json,
+            user_modified: edit.user_modified.map(|value| value != 0),
+            ts_ms: edit.ts_ms,
+            git_branch: edit.git_branch,
+            cwd: edit.cwd,
+        }
+    }
+}
+
+/// Continuation for tool call and file edit pages. `tsMs` is nullable because
+/// both tables order their undated rows last.
+#[napi(object)]
+pub struct EvidenceCursor {
+    pub ts_ms: Option<i64>,
+    pub id: i64,
+}
+
+#[napi(object)]
+pub struct EvidencePageOptions {
+    pub db_path: Option<String>,
+    pub limit: Option<i64>,
+    pub after: Option<EvidenceCursor>,
+}
+
+#[napi(object)]
+pub struct SessionToolCallsPage {
+    pub contract_version: u32,
+    pub source: String,
+    pub session_id: String,
+    pub tool_calls: Vec<NativeSessionToolCall>,
+    pub next_cursor: Option<EvidenceCursor>,
+}
+
+#[napi(object)]
+pub struct SessionFileEditsPage {
+    pub contract_version: u32,
+    pub source: String,
+    pub session_id: String,
+    pub file_edits: Vec<NativeSessionFileEdit>,
+    pub next_cursor: Option<EvidenceCursor>,
 }
 
 #[napi(object)]
@@ -438,6 +574,91 @@ pub async fn get_session_events_page(
         },
     )
     .await
+}
+
+/// One bounded page of recorded tool calls for one session.
+///
+/// Both `source` and `sessionId` are required: provider session ids are not
+/// globally unique, so an id-only lookup could interleave two sessions.
+#[napi]
+pub async fn get_session_tool_calls_page(
+    source: String,
+    session_id: String,
+    options: Option<EvidencePageOptions>,
+) -> napi::Result<SessionToolCallsPage> {
+    let options = options.unwrap_or(EvidencePageOptions {
+        db_path: None,
+        limit: None,
+        after: None,
+    });
+    let source = validate_identity(source, "source")?;
+    let session_id = validate_identity(session_id, "sessionId")?;
+    let limit = validate_limit(options.limit, DEFAULT_EVENT_LIMIT, 1_000)?;
+    let path = db_path(options.db_path);
+    let after = options.after.map(core_evidence_cursor);
+    let (page_source, page_session_id) = (source.clone(), session_id.clone());
+    read_database_with_schema(
+        path,
+        ai_hist_core::SessionToolCallPage {
+            tool_calls: Vec::new(),
+            next_cursor: None,
+        },
+        schema_is_evidence_read_current,
+        move |conn| core_session_tool_calls_page(conn, &source, &session_id, limit, after.as_ref()),
+    )
+    .await
+    .map(|page| SessionToolCallsPage {
+        contract_version: SESSION_EVIDENCE_CONTRACT_VERSION,
+        source: page_source,
+        session_id: page_session_id,
+        tool_calls: page
+            .tool_calls
+            .into_iter()
+            .map(NativeSessionToolCall::from)
+            .collect(),
+        next_cursor: page.next_cursor.map(evidence_cursor),
+    })
+}
+
+/// One bounded page of recorded file edits for one session.
+#[napi]
+pub async fn get_session_file_edits_page(
+    source: String,
+    session_id: String,
+    options: Option<EvidencePageOptions>,
+) -> napi::Result<SessionFileEditsPage> {
+    let options = options.unwrap_or(EvidencePageOptions {
+        db_path: None,
+        limit: None,
+        after: None,
+    });
+    let source = validate_identity(source, "source")?;
+    let session_id = validate_identity(session_id, "sessionId")?;
+    let limit = validate_limit(options.limit, DEFAULT_EVENT_LIMIT, 1_000)?;
+    let path = db_path(options.db_path);
+    let after = options.after.map(core_evidence_cursor);
+    let (page_source, page_session_id) = (source.clone(), session_id.clone());
+    read_database_with_schema(
+        path,
+        ai_hist_core::SessionFileEditPage {
+            file_edits: Vec::new(),
+            next_cursor: None,
+        },
+        schema_is_evidence_read_current,
+        move |conn| core_session_file_edits_page(conn, &source, &session_id, limit, after.as_ref()),
+    )
+    .await
+    .map(|page| SessionFileEditsPage {
+        contract_version: SESSION_EVIDENCE_CONTRACT_VERSION,
+        source: page_source,
+        session_id: page_session_id,
+        file_edits: page
+            .file_edits
+            .into_iter()
+            .map(NativeSessionFileEdit::from)
+            .collect(),
+        next_cursor: page.next_cursor.map(evidence_cursor),
+    })
 }
 
 /// Database statistics over already-indexed data.

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -18,6 +18,11 @@ Use these public operations:
   metadata.
 - `search()`, `recent()`, `getSession()`, and `getSessionEventsPage()` for
   indexed history reads.
+- `getSessionToolCallsPage()` / MCP `get_session_tool_calls` and
+  `getSessionFileEditsPage()` / MCP `get_session_file_edits` for bounded,
+  structured reads of one hydrated session's recorded tool calls and file
+  edits. Both name a session by `source` **and** `sessionId`; provider session
+  ids collide, and these pages never merge two providers' records.
 - `sync()` / MCP `sync` for explicit full local ingestion.
 
 Pass `scope` to collection operations when the default local view is not
@@ -39,8 +44,9 @@ connector. Acquisition result `scope` echoes the request and `locationsRun`
 reports which connector locations executed; use session `locations` for
 observed presences.
 
-The CLI equivalents are `sessions list`, `sessions discover`, `search`,
-`recent`, `session`, `events`, `stats`, and `sync`. See
+The CLI equivalents are `sessions list`, `sessions discover`,
+`sessions hydrate`, `sessions tools`, `sessions edits`, `search`, `recent`,
+`session`, `events`, `stats`, and `sync`. See
 [Session catalog](session-catalog.md) for discovery and pagination contracts
 and [Architecture](architecture.md) for the process boundary.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,8 @@ Rust owns provider discovery/parsing, schema creation and migration, direct
 SQLite connections, catalog queries, history/event queries, search,
 statistics, and sync. Blocking filesystem and SQLite work is dispatched away
 from Node's event loop. TypeScript validates inputs, validates native contract
-version 4, catalog contract version 2, and hydration contract version 1, normalizes nullable fields, maps
+version 5, catalog contract version 2, hydration contract version 1, and session
+evidence contract version 1, normalizes nullable fields, maps
 native errors, and supplies pagination helpers.
 
 The CLI and MCP server import only the SDK's public functions. They do not

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,6 +67,7 @@ row's `locations`.
 | `stats` (`local` / `remote` / `all`) | none | indexed aggregate reads | empty result |
 | `getSession` | none | indexed identity read | empty result |
 | `getSessionEventsPage` | none | bounded keyset page | empty page |
+| `getSessionToolCallsPage`, `getSessionFileEditsPage` | none | bounded keyset page over one source's session | empty page |
 | `sync` (`local`, default) | full explicit scan | migrations + ingestion | creates DB |
 | `sync` (`remote`) | configured remote connectors (error when none) | catalog upserts + presences | creates DB |
 | `sync` (`all`) | full local scan + configured remote connectors | migrations + ingestion | creates DB |
@@ -86,7 +87,11 @@ checkpoints make unchanged calls constant-work after source resolution, and
 `session_relationships` preserves Codex child identities without flattening
 their events into the selected root.
 
-Events use `(ts_ms, id)` keyset pagination. Catalog ordering is
+Events use `(ts_ms, id)` keyset pagination. Tool calls and file edits use the
+same keyset shape over `(ts_ms IS NULL, ts_ms, id)`: both tables allow a null
+timestamp, so undated rows sort last and the cursor carries a nullable
+`ts_ms`. Those two pages require a source as well as a session id, because a
+session id alone can name one session per provider. Catalog ordering is
 `(last_activity_ms DESC, source ASC, session_id ASC)`, with null timestamps at
 the tail. These total orders prevent duplicate or omitted rows at timestamp
 ties.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,7 @@
 # Release and platform validation
 
 All public packages use one version: `ai-hist`, `ai-hist-native`, each native
-platform package, and `ai-hist-mcp`. The SDK checks native contract version 3
+platform package, and `ai-hist-mcp`. The SDK checks native contract version 5
 at initialization.
 
 The `Publish RelayHistory npm packages` workflow:

--- a/mcp-package/README.md
+++ b/mcp-package/README.md
@@ -10,9 +10,13 @@ The server imports only `ai-hist` public functions. It never opens SQLite,
 loads the native addon directly, scans provider files, or invokes a CLI.
 
 Tools: `search_history`, `recent_history`, `list_sessions`,
-`discover_sessions`, `hydrate_session`, `get_session`, `get_session_events`, `history_stats`, and
+`discover_sessions`, `hydrate_session`, `get_session`, `get_session_events`,
+`get_session_tool_calls`, `get_session_file_edits`, `history_stats`, and
 `sync`. Search, recent history, session listing, discovery, statistics, and sync accept a
 `scope` of `local`, `remote`, or `all`; scope defaults to `local`.
+`get_session_tool_calls` and `get_session_file_edits` are bounded, cursor-paged
+reads that require both a `source` and a `session_id`, because provider session
+IDs collide.
 
 Cached reads support all three scopes. Remote acquisition runs through
 provider connectors (claude.ai/code web sessions, Codex cloud tasks) that are

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -20,6 +20,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add structured, paginated access to one session's recorded tool calls and
+  file edits: `getSessionToolCallsPage(source, sessionId, options?)` and
+  `getSessionFileEditsPage(source, sessionId, options?)`, the
+  `sessionToolCalls` / `sessionFileEdits` async iterators, and the
+  `getSessionToolCalls` / `getSessionFileEdits` collecting conveniences, plus
+  `ai-hist sessions tools` / `ai-hist sessions edits` and MCP
+  `get_session_tool_calls` / `get_session_file_edits`. Source and session ID
+  are both required so records from two providers that share a session ID
+  never mix. The cursor is `{ tsMs: number | null; id: number }` because a
+  record may be indexed without a timestamp and undated records are ordered
+  last. `args` and `structuredPatch` are parsed JSON; an absent or unparseable
+  value is `null` and the raw string stays in `argsJson` /
+  `structuredPatchJson`. Pages carry session evidence contract 1, and this
+  advances the native-addon contract to 5.
 - Support remote acquisition through the engine's provider connectors:
   `discoverSessions`/`sync` with `scope: 'remote'` (and the remote half of
   `'all'`) run the claude.ai/code and Codex cloud connectors when the provider

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -28,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ai-hist sessions tools` / `ai-hist sessions edits` and MCP
   `get_session_tool_calls` / `get_session_file_edits`. Source and session ID
   are both required so records from two providers that share a session ID
-  never mix. The cursor is `{ tsMs: number | null; id: number }` because a
+  never mix, and a source outside the published `Source` set raises
+  `InvalidArgumentError` rather than reading as an empty session. The cursor is `{ tsMs: number | null; id: number }` because a
   record may be indexed without a timestamp and undated records are ordered
   last. `args` and `structuredPatch` are parsed JSON; an absent or unparseable
   value is `null` and the raw string stays in `argsJson` /

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -32,8 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   record may be indexed without a timestamp and undated records are ordered
   last. `args` and `structuredPatch` are parsed JSON; an absent or unparseable
   value is `null` and the raw string stays in `argsJson` /
-  `structuredPatchJson`. Pages carry session evidence contract 1, and this
-  advances the native-addon contract to 5.
+  `structuredPatchJson`; the same parse is exported as `parseStoredJson(raw)`
+  for callers holding a raw string of their own. A cursor going back in may
+  spell its undated tail either way — `tsMs: null` (what a page hands back) or
+  no `tsMs` at all (what a transport that drops nulls delivers) — so a printed
+  or serialized cursor always feeds back unedited. Pages carry session
+  evidence contract 1, and this advances the native-addon contract to 5.
 - Support remote acquisition through the engine's provider connectors:
   `discoverSessions`/`sync` with `scope: 'remote'` (and the remote half of
   `'all'`) run the claude.ai/code and Codex cloud connectors when the provider

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -79,7 +79,9 @@ large transcript. `getSessionEvents` is an explicit collecting convenience.
 Tool calls and file edits follow the same page / iterator / collect trio
 (`getSessionToolCallsPage`, `sessionToolCalls`, `getSessionToolCalls`, and the
 `...FileEdit...` equivalents), and take both a source and a session ID because
-provider session IDs are not unique across providers. Their cursor is
+provider session IDs are not unique across providers. The source is half of
+that identity, so one outside the `Source` set raises `InvalidArgumentError`
+instead of reading as an empty session. Their cursor is
 `{ tsMs: number | null, id: number }`: a record may be indexed without a
 timestamp, and undated records are ordered last. Feeding a cursor back in
 accepts either spelling of that tail — `tsMs: null` as emitted, or no `tsMs` at

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -81,10 +81,16 @@ Tool calls and file edits follow the same page / iterator / collect trio
 `...FileEdit...` equivalents), and take both a source and a session ID because
 provider session IDs are not unique across providers. Their cursor is
 `{ tsMs: number | null, id: number }`: a record may be indexed without a
-timestamp, and undated records are ordered last. Stored provider JSON is parsed
+timestamp, and undated records are ordered last. Feeding a cursor back in
+accepts either spelling of that tail — `tsMs: null` as emitted, or no `tsMs` at
+all after a transport that drops nulls — so a printed or JSON-serialized cursor
+returns unedited. Stored provider JSON is parsed
 into `args` and `structuredPatch`; a value that is absent or unparseable
 becomes `null` while the raw string stays available as `argsJson` and
 `structuredPatchJson`, so an unreadable payload never fails a page.
+`parseStoredJson(raw)` is that same parse, exported for callers that hold a raw
+stored string of their own: it returns the parsed value, or `null` for anything
+that is not a parseable string.
 
 Native loading failures distinguish unsupported platforms, missing optional
 platform packages, addon load failures, SDK/native contract mismatches, and

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -16,6 +16,10 @@ import {
   getSession,
   getSessionEventsPage,
   sessionEvents,
+  getSessionToolCallsPage,
+  sessionToolCalls,
+  getSessionFileEditsPage,
+  sessionFileEdits,
   search,
   recent,
   stats,
@@ -30,6 +34,10 @@ if (first) {
   const prompts = await getSession(first.sessionId);
   const events = await getSessionEventsPage(first.sessionId, { limit: 200 });
   for await (const event of sessionEvents(first.sessionId)) consume(event);
+  const tools = await getSessionToolCallsPage(first.source, first.sessionId, { limit: 200 });
+  const edits = await getSessionFileEditsPage(first.source, first.sessionId, { limit: 200 });
+  for await (const call of sessionToolCalls(first.source, first.sessionId)) consume(call);
+  for await (const edit of sessionFileEdits(first.source, first.sessionId)) consume(edit);
 }
 ```
 
@@ -67,6 +75,16 @@ local behavior for rows written before provenance tracking.
 The event primitive is page-based and uses `{ tsMs, id }` as a deterministic
 cursor. The `sessionEvents` async iterator walks pages without accumulating a
 large transcript. `getSessionEvents` is an explicit collecting convenience.
+
+Tool calls and file edits follow the same page / iterator / collect trio
+(`getSessionToolCallsPage`, `sessionToolCalls`, `getSessionToolCalls`, and the
+`...FileEdit...` equivalents), and take both a source and a session ID because
+provider session IDs are not unique across providers. Their cursor is
+`{ tsMs: number | null, id: number }`: a record may be indexed without a
+timestamp, and undated records are ordered last. Stored provider JSON is parsed
+into `args` and `structuredPatch`; a value that is absent or unparseable
+becomes `null` while the raw string stays available as `argsJson` and
+`structuredPatchJson`, so an unreadable payload never fails a page.
 
 Native loading failures distinguish unsupported platforms, missing optional
 platform packages, addon load failures, SDK/native contract mismatches, and

--- a/sdk-ts/src/architecture.test.ts
+++ b/sdk-ts/src/architecture.test.ts
@@ -51,3 +51,17 @@ test('MCP session operations expose scope and acquisition is declared open-world
     assert.match(mcp.slice(start, end === -1 ? undefined : end), /LOCAL_WRITE/, 'hydrate_session indexes local provider evidence, closed-world');
   }
 });
+
+test('MCP evidence tools require both halves of a session identity', async () => {
+  const mcp = await readFile(join(sourceDir, 'mcp-server.ts'), 'utf8');
+  for (const tool of ['get_session_tool_calls', 'get_session_file_edits']) {
+    const start = mcp.indexOf(`server.tool('${tool}'`);
+    assert.notEqual(start, -1, `${tool} is registered`);
+    const end = mcp.indexOf("server.tool('", start + 13);
+    const registration = mcp.slice(start, end === -1 ? undefined : end);
+    assert.match(registration, /source: SOURCE,/, `${tool} requires a source`);
+    assert.match(registration, /session_id: z\.string\(\)\.min\(1\)/, `${tool} requires a session id`);
+    assert.match(registration, /after: EVIDENCE_CURSOR\.optional\(\)/, `${tool} paginates`);
+    assert.match(registration, /READ/, `${tool} is a cache-only read`);
+  }
+});

--- a/sdk-ts/src/cli-output.test.ts
+++ b/sdk-ts/src/cli-output.test.ts
@@ -119,6 +119,95 @@ test('sessions hydrate uses the SDK contract and is idempotent', async () => {
   }
 });
 
+test('sessions tools and edits page versioned JSON and continue from a cursor', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'relayhistory-cli-evidence-'));
+  const home = join(root, 'home');
+  const claude = join(home, '.claude', 'projects', 'project');
+  const db = join(root, 'history.db');
+  await mkdir(claude, { recursive: true });
+  const transcript = [
+    { type: 'user', uuid: 'u1', sessionId: 'claude-evidence', cwd: '/work/app', gitBranch: 'main', timestamp: '2026-08-30T10:00:00.000Z', message: { role: 'user', content: 'edit two files' } },
+    { type: 'assistant', uuid: 'a1', parentUuid: 'u1', sessionId: 'claude-evidence', cwd: '/work/app', gitBranch: 'main', timestamp: '2026-08-30T10:00:01.000Z', message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_1', name: 'Edit', input: { file_path: '/work/app/a.ts', old_string: 'a', new_string: 'b' } }] } },
+    { type: 'assistant', uuid: 'a2', parentUuid: 'a1', sessionId: 'claude-evidence', cwd: '/work/app', gitBranch: 'main', timestamp: '2026-08-30T10:00:02.000Z', message: { role: 'assistant', content: [{ type: 'tool_use', id: 'toolu_2', name: 'Write', input: { file_path: '/work/app/b.ts', content: 'b' } }] } },
+  ];
+  await writeFile(join(claude, 'claude-evidence.jsonl'), `${transcript.map((line) => JSON.stringify(line)).join('\n')}\n`);
+  const env = { ...process.env, HOME: home, USERPROFILE: home };
+  try {
+    await run(process.execPath, [cli, 'sync', '--db', db, '--no-warning'], { env });
+
+    const first = await run(process.execPath, [
+      cli, 'sessions', 'tools', 'claude', 'claude-evidence', '--limit', '1', '--db', db, '--json', '--no-warning',
+    ], { env });
+    const page = JSON.parse(first.stdout) as Record<string, unknown>;
+    assert.equal(page.contract_version, 1);
+    assert.equal(page.source, 'claude');
+    assert.equal(page.session_id, 'claude-evidence');
+    const calls = page.tool_calls as Array<Record<string, unknown>>;
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].tool_use_id, 'toolu_1');
+    // Provider argument keys are data and survive the snake_case wire mapping.
+    assert.deepEqual(calls[0].args, { file_path: '/work/app/a.ts', old_string: 'a', new_string: 'b' });
+    const cursor = page.next_cursor as Record<string, unknown>;
+    assert.equal(typeof cursor.id, 'number');
+
+    // The printed cursor feeds straight back into --after, unedited.
+    const second = await run(process.execPath, [
+      cli, 'sessions', 'tools', 'claude', 'claude-evidence', '--after', JSON.stringify(cursor),
+      '--db', db, '--json', '--no-warning',
+    ], { env });
+    const rest = JSON.parse(second.stdout) as Record<string, unknown>;
+    assert.deepEqual((rest.tool_calls as Array<Record<string, unknown>>).map((call) => call.tool_use_id), ['toolu_2']);
+    assert.equal(rest.next_cursor, null);
+
+    const edits = await run(process.execPath, [
+      cli, 'sessions', 'edits', 'claude', 'claude-evidence', '--db', db, '--json', '--no-warning',
+    ], { env });
+    const editPage = JSON.parse(edits.stdout) as Record<string, unknown>;
+    assert.equal(editPage.contract_version, 1);
+    assert.deepEqual((editPage.file_edits as Array<Record<string, unknown>>).map((edit) => edit.file_path), ['/work/app/a.ts', '/work/app/b.ts']);
+
+    const human = await run(process.execPath, [
+      cli, 'sessions', 'edits', 'claude', 'claude-evidence', '--db', db, '--no-warning',
+    ], { env });
+    assert.match(human.stdout, /\/work\/app\/a\.ts/);
+    const empty = await run(process.execPath, [
+      cli, 'sessions', 'tools', 'claude', 'missing-session', '--db', db, '--no-warning',
+    ], { env });
+    assert.match(empty.stdout, /No tool calls\./);
+    // The human continuation hint is the other accepted cursor spelling.
+    const humanPage = await run(process.execPath, [
+      cli, 'sessions', 'tools', 'claude', 'claude-evidence', '--limit', '1', '--db', db, '--no-warning',
+    ], { env });
+    const hint = /more available: --after '(.+)'/.exec(humanPage.stdout)?.[1];
+    assert.ok(hint, 'human output prints a continuation cursor');
+    const continued = await run(process.execPath, [
+      cli, 'sessions', 'tools', 'claude', 'claude-evidence', '--after', hint,
+      '--db', db, '--json', '--no-warning',
+    ], { env });
+    assert.deepEqual(
+      (JSON.parse(continued.stdout).tool_calls as Array<Record<string, unknown>>).map((call) => call.tool_use_id),
+      ['toolu_2'],
+    );
+
+    for (const args of [
+      ['sessions', 'tools', 'claude'],
+      ['sessions', 'edits', 'claude'],
+    ]) {
+      await assert.rejects(
+        run(process.execPath, [cli, ...args, '--db', db, '--no-warning'], { env }),
+        (error: unknown) => isUsageFailure(error, 'requires SOURCE and SESSION_ID'),
+        args.join(' '),
+      );
+    }
+    await assert.rejects(
+      run(process.execPath, [cli, 'sessions', 'tools', 'claude', 'claude-evidence', '--remote', '--db', db, '--no-warning'], { env }),
+      (error: unknown) => isUsageFailure(error, 'sessions tools does not accept --remote'),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('scope flags are boolean, default to local, and are mutually exclusive', async () => {
   const root = await mkdtemp(join(tmpdir(), 'relayhistory-cli-scope-'));
   const db = join(root, 'missing.db');
@@ -152,6 +241,8 @@ test('commands reject surplus positional arguments with usage exit 2', async () 
   for (const args of [
     ['sessions', 'list', 'extra'],
     ['sessions', 'discover', 'extra'],
+    ['sessions', 'tools', 'claude', 'session-id', 'extra'],
+    ['sessions', 'edits', 'claude', 'session-id', 'extra'],
     ['recent', '1', 'extra'],
     ['session', 'session-id', 'extra'],
     ['events', 'session-id', 'extra'],

--- a/sdk-ts/src/cli-output.test.ts
+++ b/sdk-ts/src/cli-output.test.ts
@@ -220,6 +220,31 @@ test('sessions tools and edits page versioned JSON and continue from a cursor', 
       assert.match(tailEdits.stdout, /No file edits\./);
     }
 
+    // A cursor field that is present but not an integer is malformed, not
+    // undated: coercing it to null would move the page into the undated tail
+    // and silently omit every dated record instead of reporting the bad flag.
+    for (const [after, message] of [
+      ['{"ts_ms":"1720000000000","id":1}', '--after cursor ts_ms must be an integer or null'],
+      ['{"tsMs":"1720000000000","id":1}', '--after cursor ts_ms must be an integer or null'],
+      ['{"tsMs":1.5,"id":1}', '--after cursor ts_ms must be an integer or null'],
+      ['{"id":"1"}', '--after must be a JSON cursor with an integer id'],
+      ['{"tsMs":null}', '--after must be a JSON cursor with an integer id'],
+      ['{"tsMs":null,"id":1.5}', '--after must be a JSON cursor with an integer id'],
+    ] as const) {
+      for (const subcommand of ['tools', 'edits']) {
+        await assert.rejects(
+          run(process.execPath, [
+            cli, 'sessions', subcommand, 'claude', 'claude-evidence', '--after', after,
+            '--db', db, '--json', '--no-warning',
+          ], { env }),
+          (error: unknown) => typeof error === 'object' && error !== null
+            && 'code' in error && error.code === 1
+            && 'stderr' in error && String(error.stderr).includes(message),
+          `sessions ${subcommand} --after ${after}`,
+        );
+      }
+    }
+
     for (const args of [
       ['sessions', 'tools', 'claude'],
       ['sessions', 'edits', 'claude'],

--- a/sdk-ts/src/cli-output.test.ts
+++ b/sdk-ts/src/cli-output.test.ts
@@ -170,6 +170,20 @@ test('sessions tools and edits page versioned JSON and continue from a cursor', 
       cli, 'sessions', 'edits', 'claude', 'claude-evidence', '--db', db, '--no-warning',
     ], { env });
     assert.match(human.stdout, /\/work\/app\/a\.ts/);
+    // Human rows are positional: every column is printed, so an absent value
+    // never shifts the ones after it, and an uncounted line delta reads as `?`
+    // rather than a fabricated zero.
+    for (const line of human.stdout.trim().split('\n')) {
+      const columns = line.split('  ');
+      assert.equal(columns.length, 6, `edit row keeps six columns: ${line}`);
+      assert.match(columns[5], /^\+(\d+|\?)\/-(\d+|\?)$/);
+    }
+    const humanTools = await run(process.execPath, [
+      cli, 'sessions', 'tools', 'claude', 'claude-evidence', '--db', db, '--no-warning',
+    ], { env });
+    for (const line of humanTools.stdout.trim().split('\n')) {
+      assert.equal(line.split('  ').length, 6, `tool call row keeps six columns: ${line}`);
+    }
     const empty = await run(process.execPath, [
       cli, 'sessions', 'tools', 'claude', 'missing-session', '--db', db, '--no-warning',
     ], { env });
@@ -188,6 +202,23 @@ test('sessions tools and edits page versioned JSON and continue from a cursor', 
       (JSON.parse(continued.stdout).tool_calls as Array<Record<string, unknown>>).map((call) => call.tool_use_id),
       ['toolu_2'],
     );
+
+    // An undated cursor is spelled either way — `"tsMs": null` as the human
+    // hint and the JSON page print it, or no `tsMs` at all — and both reach
+    // the native boundary, which only accepts an absent one. On this dated
+    // session both name an empty undated tail instead of failing the command.
+    for (const after of [`{"tsMs":null,"id":${cursor.id as number}}`, '{"id":1}', '{"ts_ms":null,"id":1}']) {
+      const tail = await run(process.execPath, [
+        cli, 'sessions', 'tools', 'claude', 'claude-evidence', '--after', after,
+        '--db', db, '--json', '--no-warning',
+      ], { env });
+      assert.deepEqual((JSON.parse(tail.stdout) as Record<string, unknown>).tool_calls, []);
+      const tailEdits = await run(process.execPath, [
+        cli, 'sessions', 'edits', 'claude', 'claude-evidence', '--after', after,
+        '--db', db, '--no-warning',
+      ], { env });
+      assert.match(tailEdits.stdout, /No file edits\./);
+    }
 
     for (const args of [
       ['sessions', 'tools', 'claude'],

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -230,11 +230,18 @@ function catalogCursorFlag(args: Parsed): CatalogCursor | undefined {
 function evidenceCursorFlag(args: Parsed): EvidenceCursor | undefined {
   const raw = cursorFlag<{ tsMs?: unknown; ts_ms?: unknown; id?: unknown }>(args);
   if (raw === undefined) return undefined;
-  if (!raw || typeof raw !== 'object' || typeof raw.id !== 'number') {
-    throw new Error('--after must be a JSON cursor with a numeric id');
+  if (!raw || typeof raw !== 'object' || !Number.isInteger(raw.id)) {
+    throw new Error('--after must be a JSON cursor with an integer id');
   }
-  const tsMs = raw.tsMs ?? raw.ts_ms;
-  return { tsMs: typeof tsMs === 'number' ? tsMs : null, id: raw.id };
+  // An undated cursor spells its timestamp `null` or leaves it out. Any other
+  // non-integer timestamp is a malformed cursor: reading it as null instead
+  // would place the page inside the undated tail and silently drop every dated
+  // record after it.
+  const tsMs = raw.tsMs ?? raw.ts_ms ?? null;
+  if (tsMs !== null && !Number.isInteger(tsMs)) {
+    throw new Error('--after cursor ts_ms must be an integer or null');
+  }
+  return { tsMs: tsMs as number | null, id: raw.id as number };
 }
 
 function outputDiscovery(value: Awaited<ReturnType<typeof discoverSessions>>, json: boolean): void {

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -3,8 +3,10 @@
 import { readFile } from 'node:fs/promises';
 
 import {
-  discoverSessions, getSession, getSessionEventsPage, hydrateSession, listSessionCatalogPage,
-  recent, search, stats, sync, type CatalogCursor, type SessionScope,
+  discoverSessions, getSession, getSessionEventsPage, getSessionFileEditsPage,
+  getSessionToolCallsPage, hydrateSession, listSessionCatalogPage, recent, search, stats, sync,
+  type CatalogCursor, type EvidenceCursor, type SessionFileEditsPage, type SessionScope,
+  type SessionToolCallsPage,
 } from './index.js';
 
 type Parsed = { positional: string[]; flags: Map<string, Array<string | true>> };
@@ -151,10 +153,15 @@ function snakeCase(key: string): string {
   return key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
 }
 
+// Parsed provider payloads are data, not RelayHistory field names: their own
+// keys must reach stdout exactly as the provider wrote them.
+const OPAQUE_JSON_KEYS = new Set(['args', 'structuredPatch']);
+
 function wireValue(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(wireValue);
   if (!value || typeof value !== 'object') return value;
-  return Object.fromEntries(Object.entries(value).map(([key, item]) => [snakeCase(key), wireValue(item)]));
+  return Object.fromEntries(Object.entries(value)
+    .map(([key, item]) => [snakeCase(key), OPAQUE_JSON_KEYS.has(key) ? item : wireValue(item)]));
 }
 
 function humanLine(value: unknown): string {
@@ -190,6 +197,8 @@ function usage(message?: string): never {
   ai-hist sessions list [--local | --remote | --all] [--source SOURCE]... [--limit N] [--before-ms MS] [--after JSON | --after-source SOURCE --after-session-id ID [--after-ms MS]] [--json]
   ai-hist sessions discover [--local | --remote | --all] [--source SOURCE] [--limit N] [--json]
   ai-hist sessions hydrate SOURCE SESSION_ID [--local | --remote | --all] [--no-related] [--db PATH] [--json]
+  ai-hist sessions tools SOURCE SESSION_ID [--limit N] [--after JSON] [--db PATH] [--json]
+  ai-hist sessions edits SOURCE SESSION_ID [--limit N] [--after JSON] [--db PATH] [--json]
   ai-hist search QUERY... [--local | --remote | --all] [--source SOURCE] [--project PATH] [--limit N] [--json]
   ai-hist recent [N] [--local | --remote | --all] [--source SOURCE] [--project PATH] [--json]
   ai-hist session SESSION_ID [--source SOURCE] [--json]
@@ -215,6 +224,19 @@ function catalogCursorFlag(args: Parsed): CatalogCursor | undefined {
   return { lastActivityMs: numberFlag(args, 'after-ms') ?? null, source, sessionId };
 }
 
+// Human output prints the SDK cursor and --json prints its snake_case wire
+// form, so --after accepts either spelling and a printed cursor can be fed
+// back unedited.
+function evidenceCursorFlag(args: Parsed): EvidenceCursor | undefined {
+  const raw = cursorFlag<{ tsMs?: unknown; ts_ms?: unknown; id?: unknown }>(args);
+  if (raw === undefined) return undefined;
+  if (!raw || typeof raw !== 'object' || typeof raw.id !== 'number') {
+    throw new Error('--after must be a JSON cursor with a numeric id');
+  }
+  const tsMs = raw.tsMs ?? raw.ts_ms;
+  return { tsMs: typeof tsMs === 'number' ? tsMs : null, id: raw.id };
+}
+
 function outputDiscovery(value: Awaited<ReturnType<typeof discoverSessions>>, json: boolean): void {
   if (!json) {
     for (const session of value.sessions) process.stdout.write(`${humanLine(session)}\n`);
@@ -230,6 +252,46 @@ function outputDiscovery(value: Awaited<ReturnType<typeof discoverSessions>>, js
   const { sessions: _sessions, diagnostics: _diagnostics, ...summary } = value;
   const providers = Object.fromEntries(summary.providers.map(({ source, ...provider }) => [source, provider]));
   output({ type: 'summary', ...summary, providers }, true);
+}
+
+function continuationNotice(cursor: EvidenceCursor | null): void {
+  if (cursor) process.stdout.write(`more available: --after '${JSON.stringify(cursor)}'\n`);
+}
+
+function outputToolCalls(page: SessionToolCallsPage, json: boolean): void {
+  if (json) {
+    output(page, true);
+    return;
+  }
+  if (page.toolCalls.length === 0) {
+    process.stdout.write('No tool calls.\n');
+    return;
+  }
+  for (const call of page.toolCalls) {
+    process.stdout.write([
+      call.tsMs ?? '-', call.source, call.toolUseId, call.name,
+      call.target ?? '', call.isError === true ? '(error)' : '',
+    ].filter((item) => item !== '').join('  ').concat('\n'));
+  }
+  continuationNotice(page.nextCursor);
+}
+
+function outputFileEdits(page: SessionFileEditsPage, json: boolean): void {
+  if (json) {
+    output(page, true);
+    return;
+  }
+  if (page.fileEdits.length === 0) {
+    process.stdout.write('No file edits.\n');
+    return;
+  }
+  for (const edit of page.fileEdits) {
+    process.stdout.write([
+      edit.tsMs ?? '-', edit.source, edit.toolUseId, edit.toolName ?? '', edit.filePath,
+      `+${edit.linesAdded ?? 0}/-${edit.linesRemoved ?? 0}`,
+    ].filter((item) => item !== '').join('  ').concat('\n'));
+  }
+  continuationNotice(page.nextCursor);
 }
 
 function outputHydration(value: Awaited<ReturnType<typeof hydrateSession>>, json: boolean): void {
@@ -299,6 +361,24 @@ async function main(): Promise<void> {
       dbPath: textFlag(args, 'db'),
       includeRelated: !args.flags.has('no-related'),
     }), json);
+    return;
+  }
+  if (command === 'sessions' && (subcommand === 'tools' || subcommand === 'edits')) {
+    const name = `sessions ${subcommand}`;
+    validateFlags(args, name, ['after', 'db', 'json', 'limit']);
+    const [source, sessionId, ...surplus] = rest;
+    if (!source || !sessionId) usage(`${name} requires SOURCE and SESSION_ID`);
+    rejectSurplusPositionals(surplus, name);
+    const options = {
+      dbPath: textFlag(args, 'db'),
+      limit: numberFlag(args, 'limit'),
+      after: evidenceCursorFlag(args),
+    };
+    if (subcommand === 'tools') {
+      outputToolCalls(await getSessionToolCallsPage(source as never, sessionId, options), json);
+    } else {
+      outputFileEdits(await getSessionFileEditsPage(source as never, sessionId, options), json);
+    }
     return;
   }
   if (command === 'search') {

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -258,6 +258,9 @@ function continuationNotice(cursor: EvidenceCursor | null): void {
   if (cursor) process.stdout.write(`more available: --after '${JSON.stringify(cursor)}'\n`);
 }
 
+// Human rows are positional, so every column is always printed: an absent
+// value is `-` rather than a dropped field that would shift the columns after
+// it, and an uncounted line delta is `?` rather than a fabricated 0.
 function outputToolCalls(page: SessionToolCallsPage, json: boolean): void {
   if (json) {
     output(page, true);
@@ -270,8 +273,8 @@ function outputToolCalls(page: SessionToolCallsPage, json: boolean): void {
   for (const call of page.toolCalls) {
     process.stdout.write([
       call.tsMs ?? '-', call.source, call.toolUseId, call.name,
-      call.target ?? '', call.isError === true ? '(error)' : '',
-    ].filter((item) => item !== '').join('  ').concat('\n'));
+      call.target ?? '-', call.isError === true ? '(error)' : '-',
+    ].join('  ').concat('\n'));
   }
   continuationNotice(page.nextCursor);
 }
@@ -287,9 +290,9 @@ function outputFileEdits(page: SessionFileEditsPage, json: boolean): void {
   }
   for (const edit of page.fileEdits) {
     process.stdout.write([
-      edit.tsMs ?? '-', edit.source, edit.toolUseId, edit.toolName ?? '', edit.filePath,
-      `+${edit.linesAdded ?? 0}/-${edit.linesRemoved ?? 0}`,
-    ].filter((item) => item !== '').join('  ').concat('\n'));
+      edit.tsMs ?? '-', edit.source, edit.toolUseId, edit.toolName ?? '-', edit.filePath,
+      `+${edit.linesAdded ?? '?'}/-${edit.linesRemoved ?? '?'}`,
+    ].join('  ').concat('\n'));
   }
   continuationNotice(page.nextCursor);
 }

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -9,9 +9,10 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-export const NATIVE_CONTRACT_VERSION = 4;
+export const NATIVE_CONTRACT_VERSION = 5;
 export const SESSION_CATALOG_CONTRACT_VERSION = 2;
 export const SESSION_HYDRATION_CONTRACT_VERSION = 1;
+export const SESSION_EVIDENCE_CONTRACT_VERSION = 1;
 
 export type Source = 'claude' | 'codex' | 'cursor' | 'grok' | 'relay' | 'trajectory' | 'opencode';
 export type CatalogSource = Exclude<Source, 'trajectory'>;
@@ -231,6 +232,72 @@ export interface SessionEventsPage {
   nextCursor: EventCursor | null;
 }
 
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+export interface SessionToolCall {
+  id: number;
+  source: Source;
+  sessionId: string;
+  messageId: string | null;
+  toolUseId: string;
+  name: string;
+  target: string | null;
+  /** Parsed provider arguments, or null when absent or unparseable. */
+  args: JsonValue | null;
+  /** The stored argument string exactly as indexed, parseable or not. */
+  argsJson: string | null;
+  isError: boolean | null;
+  tsMs: number | null;
+}
+
+export interface SessionFileEdit {
+  id: number;
+  source: Source;
+  sessionId: string;
+  messageId: string | null;
+  toolUseId: string;
+  filePath: string;
+  toolName: string | null;
+  linesAdded: number | null;
+  linesRemoved: number | null;
+  /** Parsed provider patch, or null when absent or unparseable. */
+  structuredPatch: JsonValue | null;
+  /** The stored patch string exactly as indexed, parseable or not. */
+  structuredPatchJson: string | null;
+  userModified: boolean | null;
+  tsMs: number | null;
+  gitBranch: string | null;
+  cwd: string | null;
+}
+
+/**
+ * Continuation for tool call and file edit pages. `tsMs` is nullable because
+ * both records may be indexed without a timestamp and are ordered last.
+ */
+export interface EvidenceCursor { tsMs: number | null; id: number }
+
+export interface EvidencePageOptions {
+  dbPath?: string;
+  limit?: number;
+  after?: EvidenceCursor;
+}
+
+export interface SessionToolCallsPage {
+  contractVersion: number;
+  source: Source;
+  sessionId: string;
+  toolCalls: SessionToolCall[];
+  nextCursor: EvidenceCursor | null;
+}
+
+export interface SessionFileEditsPage {
+  contractVersion: number;
+  source: Source;
+  sessionId: string;
+  fileEdits: SessionFileEdit[];
+  nextCursor: EvidenceCursor | null;
+}
+
 export interface Stats {
   scope: SessionScope;
   total: number;
@@ -253,6 +320,8 @@ interface NativeBinding {
   recent(options?: object): Promise<UnknownRecord[]>;
   getSession(sessionId: string, options?: object): Promise<UnknownRecord[]>;
   getSessionEventsPage(sessionId: string, options?: object): Promise<UnknownRecord>;
+  getSessionToolCallsPage(source: string, sessionId: string, options?: object): Promise<UnknownRecord>;
+  getSessionFileEditsPage(source: string, sessionId: string, options?: object): Promise<UnknownRecord>;
   stats(options?: object): Promise<UnknownRecord>;
   listSessionCatalog(options?: object): Promise<UnknownRecord[]>;
   listSessionCatalogPage(options?: object): Promise<UnknownRecord>;
@@ -478,6 +547,75 @@ function sessionEvent(value: UnknownRecord): SessionEvent {
   };
 }
 
+/**
+ * Provider JSON is stored as the raw string the provider wrote. A row whose
+ * string cannot be parsed still belongs in its page, so parsing yields null
+ * and the caller reads the raw companion field instead of losing the row.
+ */
+export function parseStoredJson(raw: unknown): JsonValue | null {
+  if (typeof raw !== 'string') return null;
+  try {
+    return JSON.parse(raw) as JsonValue;
+  } catch {
+    return null;
+  }
+}
+
+function nullableNumber(value: unknown): number | null {
+  return typeof value === 'number' ? value : null;
+}
+
+function nullableBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
+function sessionToolCall(value: UnknownRecord): SessionToolCall {
+  return {
+    id: Number(value.id), source: String(value.source) as Source, sessionId: String(value.sessionId),
+    messageId: nullableString(value.messageId), toolUseId: String(value.toolUseId),
+    name: String(value.name), target: nullableString(value.target),
+    args: parseStoredJson(value.argsJson), argsJson: nullableString(value.argsJson),
+    isError: nullableBoolean(value.isError), tsMs: nullableNumber(value.tsMs),
+  };
+}
+
+function sessionFileEdit(value: UnknownRecord): SessionFileEdit {
+  return {
+    id: Number(value.id), source: String(value.source) as Source, sessionId: String(value.sessionId),
+    messageId: nullableString(value.messageId), toolUseId: String(value.toolUseId),
+    filePath: String(value.filePath), toolName: nullableString(value.toolName),
+    linesAdded: nullableNumber(value.linesAdded), linesRemoved: nullableNumber(value.linesRemoved),
+    structuredPatch: parseStoredJson(value.structuredPatchJson),
+    structuredPatchJson: nullableString(value.structuredPatchJson),
+    userModified: nullableBoolean(value.userModified), tsMs: nullableNumber(value.tsMs),
+    gitBranch: nullableString(value.gitBranch), cwd: nullableString(value.cwd),
+  };
+}
+
+function evidenceCursor(value: unknown): EvidenceCursor | null {
+  if (!value || typeof value !== 'object') return null;
+  const row = value as UnknownRecord;
+  return { tsMs: nullableNumber(row.tsMs), id: Number(row.id) };
+}
+
+function assertEvidenceContract(value: number): void {
+  if (value !== SESSION_EVIDENCE_CONTRACT_VERSION) {
+    throw new NativeContractMismatchError(
+      `ai-hist expects session evidence contract ${SESSION_EVIDENCE_CONTRACT_VERSION}, but native returned ${value}.`,
+      'NATIVE_CONTRACT_MISMATCH',
+    );
+  }
+}
+
+function evidenceIdentity(source: unknown, sessionId: unknown, operation: string): void {
+  if (typeof source !== 'string' || source.trim() === '') {
+    throw new InvalidArgumentError(`${operation} requires a source`, 'INVALID_ARGUMENT');
+  }
+  if (typeof sessionId !== 'string' || sessionId.trim() === '') {
+    throw new InvalidArgumentError(`${operation} requires a sessionId`, 'INVALID_ARGUMENT');
+  }
+}
+
 export function defaultDbPath(): string {
   if (process.env.AI_HIST_DB !== undefined) return process.env.AI_HIST_DB;
   if (process.env.XDG_DATA_HOME !== undefined) {
@@ -642,6 +780,78 @@ export async function getSessionEvents(sessionId: string, options: Omit<EventsPa
   const events: SessionEvent[] = [];
   for await (const event of sessionEvents(sessionId, options)) events.push(event);
   return events;
+}
+
+export async function getSessionToolCallsPage(
+  source: Source, sessionId: string, options: EvidencePageOptions = {},
+): Promise<SessionToolCallsPage> {
+  evidenceIdentity(source, sessionId, 'getSessionToolCallsPage');
+  return nativeCall(async (native) => {
+    const page = await native.getSessionToolCallsPage(source, sessionId, options);
+    assertEvidenceContract(Number(page.contractVersion));
+    return {
+      contractVersion: Number(page.contractVersion),
+      source: String(page.source) as Source,
+      sessionId: String(page.sessionId),
+      toolCalls: Array.isArray(page.toolCalls) ? (page.toolCalls as UnknownRecord[]).map(sessionToolCall) : [],
+      nextCursor: evidenceCursor(page.nextCursor),
+    };
+  });
+}
+
+export async function* sessionToolCalls(
+  source: Source, sessionId: string, options: Omit<EvidencePageOptions, 'after'> = {},
+): AsyncGenerator<SessionToolCall> {
+  let after: EvidenceCursor | undefined;
+  do {
+    const page = await getSessionToolCallsPage(source, sessionId, { ...options, after });
+    for (const call of page.toolCalls) yield call;
+    after = page.nextCursor ?? undefined;
+  } while (after);
+}
+
+export async function getSessionToolCalls(
+  source: Source, sessionId: string, options: Omit<EvidencePageOptions, 'after'> = {},
+): Promise<SessionToolCall[]> {
+  const calls: SessionToolCall[] = [];
+  for await (const call of sessionToolCalls(source, sessionId, options)) calls.push(call);
+  return calls;
+}
+
+export async function getSessionFileEditsPage(
+  source: Source, sessionId: string, options: EvidencePageOptions = {},
+): Promise<SessionFileEditsPage> {
+  evidenceIdentity(source, sessionId, 'getSessionFileEditsPage');
+  return nativeCall(async (native) => {
+    const page = await native.getSessionFileEditsPage(source, sessionId, options);
+    assertEvidenceContract(Number(page.contractVersion));
+    return {
+      contractVersion: Number(page.contractVersion),
+      source: String(page.source) as Source,
+      sessionId: String(page.sessionId),
+      fileEdits: Array.isArray(page.fileEdits) ? (page.fileEdits as UnknownRecord[]).map(sessionFileEdit) : [],
+      nextCursor: evidenceCursor(page.nextCursor),
+    };
+  });
+}
+
+export async function* sessionFileEdits(
+  source: Source, sessionId: string, options: Omit<EvidencePageOptions, 'after'> = {},
+): AsyncGenerator<SessionFileEdit> {
+  let after: EvidenceCursor | undefined;
+  do {
+    const page = await getSessionFileEditsPage(source, sessionId, { ...options, after });
+    for (const edit of page.fileEdits) yield edit;
+    after = page.nextCursor ?? undefined;
+  } while (after);
+}
+
+export async function getSessionFileEdits(
+  source: Source, sessionId: string, options: Omit<EvidencePageOptions, 'after'> = {},
+): Promise<SessionFileEdit[]> {
+  const edits: SessionFileEdit[] = [];
+  for await (const edit of sessionFileEdits(source, sessionId, options)) edits.push(edit);
+  return edits;
 }
 
 export async function stats(options: StatsOptions = {}): Promise<Stats> {

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -14,7 +14,15 @@ export const SESSION_CATALOG_CONTRACT_VERSION = 2;
 export const SESSION_HYDRATION_CONTRACT_VERSION = 1;
 export const SESSION_EVIDENCE_CONTRACT_VERSION = 1;
 
-export type Source = 'claude' | 'codex' | 'cursor' | 'grok' | 'relay' | 'trajectory' | 'opencode';
+/**
+ * The provider ids this build knows, as a value. `Source` is derived from it
+ * so the runtime checks below and the compile-time type cannot drift apart,
+ * and it is the same list the MCP server's `SOURCE` enum publishes.
+ */
+const SOURCES = ['claude', 'codex', 'cursor', 'grok', 'relay', 'trajectory', 'opencode'] as const;
+const CATALOG_SOURCES: readonly string[] = SOURCES.filter((source) => source !== 'trajectory');
+
+export type Source = (typeof SOURCES)[number];
 export type CatalogSource = Exclude<Source, 'trajectory'>;
 export type SessionScope = 'local' | 'remote' | 'all';
 export type SessionLocation = Exclude<SessionScope, 'all'>;
@@ -624,9 +632,27 @@ function assertEvidenceContract(value: number): void {
   }
 }
 
+/**
+ * Both halves of an evidence page's identity, checked before the call.
+ *
+ * `source` is half of the identity here, not a filter that narrows a wider
+ * result, so an id this build has no provider for cannot mean "no rows" — it
+ * means the caller named something that does not exist, and an empty page
+ * would report that as an empty session. `hydrateSession` rejects the same
+ * mistake for the same reason.
+ */
 function evidenceIdentity(source: unknown, sessionId: unknown, operation: string): void {
   if (typeof source !== 'string' || source.trim() === '') {
     throw new InvalidArgumentError(`${operation} requires a source`, 'INVALID_ARGUMENT');
+  }
+  // Membership is asked of the trimmed id: whether a *padded* identity is
+  // acceptable is a separate question, and the native layer already answers it
+  // with its own wording for both halves.
+  if (!(SOURCES as readonly string[]).includes(source.trim())) {
+    throw new InvalidArgumentError(
+      `invalid source: ${source} (expected one of ${SOURCES.join(', ')})`,
+      'INVALID_ARGUMENT',
+    );
   }
   if (typeof sessionId !== 'string' || sessionId.trim() === '') {
     throw new InvalidArgumentError(`${operation} requires a sessionId`, 'INVALID_ARGUMENT');
@@ -711,7 +737,7 @@ export async function hydrateSession(options: HydrateSessionOptions): Promise<Hy
   if (!options || typeof options !== 'object') {
     throw new InvalidArgumentError('hydrateSession options are required', 'INVALID_ARGUMENT');
   }
-  if (!['claude', 'codex', 'cursor', 'grok', 'relay', 'opencode'].includes(options.source)) {
+  if (!CATALOG_SOURCES.includes(options.source)) {
     throw new InvalidArgumentError(`invalid catalog source: ${String(options.source)}`, 'INVALID_ARGUMENT');
   }
   if (typeof options.sessionId !== 'string' || options.sessionId.trim() === '') {

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -276,10 +276,17 @@ export interface SessionFileEdit {
  */
 export interface EvidenceCursor { tsMs: number | null; id: number }
 
+/**
+ * A cursor on the way back in. An emitted cursor is always accepted, and so is
+ * one whose `tsMs` was dropped by a transport that omits nulls: absent and
+ * `null` both mean "already inside the undated tail".
+ */
+export interface EvidenceCursorInput { tsMs?: number | null; id: number }
+
 export interface EvidencePageOptions {
   dbPath?: string;
   limit?: number;
-  after?: EvidenceCursor;
+  after?: EvidenceCursorInput;
 }
 
 export interface SessionToolCallsPage {
@@ -598,6 +605,16 @@ function evidenceCursor(value: unknown): EvidenceCursor | null {
   return { tsMs: nullableNumber(row.tsMs), id: Number(row.id) };
 }
 
+/**
+ * The native boundary reads an absent `tsMs` as "inside the undated tail" but
+ * cannot convert an explicit `null` into its integer field, so the cursor this
+ * SDK hands back — `tsMs: null` for an undated row — has to be normalized
+ * before it goes back in. The catalog cursor is normalized the same way.
+ */
+function nativeEvidenceCursor(after: EvidenceCursorInput | undefined): object | undefined {
+  return after ? { ...after, tsMs: after.tsMs ?? undefined } : undefined;
+}
+
 function assertEvidenceContract(value: number): void {
   if (value !== SESSION_EVIDENCE_CONTRACT_VERSION) {
     throw new NativeContractMismatchError(
@@ -787,7 +804,9 @@ export async function getSessionToolCallsPage(
 ): Promise<SessionToolCallsPage> {
   evidenceIdentity(source, sessionId, 'getSessionToolCallsPage');
   return nativeCall(async (native) => {
-    const page = await native.getSessionToolCallsPage(source, sessionId, options);
+    const page = await native.getSessionToolCallsPage(source, sessionId, {
+      ...options, after: nativeEvidenceCursor(options.after),
+    });
     assertEvidenceContract(Number(page.contractVersion));
     return {
       contractVersion: Number(page.contractVersion),
@@ -823,7 +842,9 @@ export async function getSessionFileEditsPage(
 ): Promise<SessionFileEditsPage> {
   evidenceIdentity(source, sessionId, 'getSessionFileEditsPage');
   return nativeCall(async (native) => {
-    const page = await native.getSessionFileEditsPage(source, sessionId, options);
+    const page = await native.getSessionFileEditsPage(source, sessionId, {
+      ...options, after: nativeEvidenceCursor(options.after),
+    });
     assertEvidenceContract(Number(page.contractVersion));
     return {
       contractVersion: Number(page.contractVersion),

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -87,24 +87,22 @@ server.tool('get_session_events', 'Get one bounded page of normalized events.', 
 }, READ, ({ session_id, source, limit, after }) => call(() => getSessionEventsPage(session_id, { source, limit, after })));
 
 // Tool calls and file edits are keyed by (source, session_id): a session id
-// alone can name two sessions from two providers.
+// alone can name two sessions from two providers. A cursor's `tsMs` may be
+// null or absent -- both mean "already inside the undated tail" -- and reaches
+// the SDK exactly as the client sent it.
 const EVIDENCE_CURSOR = z.object({ tsMs: z.number().int().nullable().optional(), id: z.number().int() });
 
 server.tool('get_session_tool_calls', 'Get one bounded page of recorded tool calls for one session.', {
   source: SOURCE, session_id: z.string().min(1),
   limit: z.number().int().min(1).max(1000).optional().default(200),
   after: EVIDENCE_CURSOR.optional(),
-}, READ, ({ source, session_id, limit, after }) => call(() => getSessionToolCallsPage(source, session_id, {
-  limit, after: after ? { ...after, tsMs: after.tsMs ?? null } : undefined,
-})));
+}, READ, ({ source, session_id, limit, after }) => call(() => getSessionToolCallsPage(source, session_id, { limit, after })));
 
 server.tool('get_session_file_edits', 'Get one bounded page of recorded file edits for one session.', {
   source: SOURCE, session_id: z.string().min(1),
   limit: z.number().int().min(1).max(1000).optional().default(200),
   after: EVIDENCE_CURSOR.optional(),
-}, READ, ({ source, session_id, limit, after }) => call(() => getSessionFileEditsPage(source, session_id, {
-  limit, after: after ? { ...after, tsMs: after.tsMs ?? null } : undefined,
-})));
+}, READ, ({ source, session_id, limit, after }) => call(() => getSessionFileEditsPage(source, session_id, { limit, after })));
 
 server.tool('history_stats', 'Statistics for already-indexed RelayHistory data.', {
   scope: SESSION_SCOPE.optional().default('local'),

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -6,8 +6,8 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import {
-  discoverSessions, getSession, getSessionEventsPage, hydrateSession, listSessionCatalogPage,
-  recent, search, stats, sync,
+  discoverSessions, getSession, getSessionEventsPage, getSessionFileEditsPage,
+  getSessionToolCallsPage, hydrateSession, listSessionCatalogPage, recent, search, stats, sync,
 } from './index.js';
 
 const READ = { readOnlyHint: true, idempotentHint: true, openWorldHint: false } as const;
@@ -85,6 +85,26 @@ server.tool('get_session_events', 'Get one bounded page of normalized events.', 
   session_id: z.string(), source: SOURCE.optional(), limit: z.number().int().min(1).max(1000).optional().default(200),
   after: z.object({ tsMs: z.number().int(), id: z.number().int() }).optional(),
 }, READ, ({ session_id, source, limit, after }) => call(() => getSessionEventsPage(session_id, { source, limit, after })));
+
+// Tool calls and file edits are keyed by (source, session_id): a session id
+// alone can name two sessions from two providers.
+const EVIDENCE_CURSOR = z.object({ tsMs: z.number().int().nullable().optional(), id: z.number().int() });
+
+server.tool('get_session_tool_calls', 'Get one bounded page of recorded tool calls for one session.', {
+  source: SOURCE, session_id: z.string().min(1),
+  limit: z.number().int().min(1).max(1000).optional().default(200),
+  after: EVIDENCE_CURSOR.optional(),
+}, READ, ({ source, session_id, limit, after }) => call(() => getSessionToolCallsPage(source, session_id, {
+  limit, after: after ? { ...after, tsMs: after.tsMs ?? null } : undefined,
+})));
+
+server.tool('get_session_file_edits', 'Get one bounded page of recorded file edits for one session.', {
+  source: SOURCE, session_id: z.string().min(1),
+  limit: z.number().int().min(1).max(1000).optional().default(200),
+  after: EVIDENCE_CURSOR.optional(),
+}, READ, ({ source, session_id, limit, after }) => call(() => getSessionFileEditsPage(source, session_id, {
+  limit, after: after ? { ...after, tsMs: after.tsMs ?? null } : undefined,
+})));
 
 server.tool('history_stats', 'Statistics for already-indexed RelayHistory data.', {
   scope: SESSION_SCOPE.optional().default('local'),

--- a/sdk-ts/src/native-errors.test.ts
+++ b/sdk-ts/src/native-errors.test.ts
@@ -115,6 +115,28 @@ test('evidence pages reject out-of-range limits at the native boundary', async (
   }
 });
 
+test('evidence pages reject a padded identity instead of answering it empty', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'relayhistory-evidence-identity-'));
+  const dbPath = join(root, 'history.db');
+  try {
+    // The page matches an identity exactly, so a padded one would silently
+    // read as "no such session" rather than as the caller's mistake.
+    for (const operation of [
+      () => getSessionToolCallsPage('claude', ' sess-1 ', { dbPath }),
+      () => getSessionFileEditsPage(' claude ' as never, 'sess-1', { dbPath }),
+    ]) {
+      await assert.rejects(
+        operation(),
+        (error: unknown) => error instanceof InvalidArgumentError
+          && error.code === 'INVALID_ARGUMENT'
+          && /must not be padded with whitespace/.test(error.message),
+      );
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('database open failures use the stable SDK error', async () => {
   const directory = await mkdtemp(join(tmpdir(), 'relayhistory-not-a-db-'));
   try {

--- a/sdk-ts/src/native-errors.test.ts
+++ b/sdk-ts/src/native-errors.test.ts
@@ -4,8 +4,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import {
-  DatabaseOpenError, NativeContractMismatchError, SessionNotFoundError, UnsupportedOperationError,
-  discoverSessions, hydrateSession, listSessionCatalogPage, recent, stats, sync,
+  DatabaseOpenError, InvalidArgumentError, NativeContractMismatchError, SessionNotFoundError,
+  UnsupportedOperationError, discoverSessions, getSessionFileEditsPage, getSessionToolCallsPage,
+  hydrateSession, listSessionCatalogPage, recent, stats, sync,
   validateNativeContract, validateNativeLocation, validateNativeScope,
 } from './index.js';
 
@@ -15,6 +16,12 @@ test('missing database reads are explicit empty cache operations', async () => {
   try {
     assert.deepEqual(await listSessionCatalogPage({ dbPath, limit: 20 }), {
       contractVersion: 2, scope: 'local', sessions: [], nextCursor: null,
+    });
+    assert.deepEqual(await getSessionToolCallsPage('claude', 'missing', { dbPath }), {
+      contractVersion: 1, source: 'claude', sessionId: 'missing', toolCalls: [], nextCursor: null,
+    });
+    assert.deepEqual(await getSessionFileEditsPage('claude', 'missing', { dbPath }), {
+      contractVersion: 1, source: 'claude', sessionId: 'missing', fileEdits: [], nextCursor: null,
     });
     assert.deepEqual(await recent({ dbPath, limit: 20 }), []);
     assert.deepEqual(await stats({ dbPath }), {
@@ -44,7 +51,7 @@ test('SDK/native contract mismatch is actionable', () => {
     () => validateNativeContract(999),
     (error: unknown) => error instanceof NativeContractMismatchError
       && error.code === 'NATIVE_CONTRACT_MISMATCH'
-      && /requires native contract 4/.test(error.message),
+      && /requires native contract 5/.test(error.message),
   );
   assert.throws(
     () => validateNativeScope('cloud'),
@@ -84,6 +91,26 @@ test('unconfigured remote acquisition has one stable SDK error', async () => {
   } finally {
     if (saved.HOME === undefined) delete process.env.HOME; else process.env.HOME = saved.HOME;
     if (saved.USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = saved.USERPROFILE;
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('evidence pages reject out-of-range limits at the native boundary', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'relayhistory-evidence-limit-'));
+  const dbPath = join(root, 'history.db');
+  try {
+    for (const operation of [
+      () => getSessionToolCallsPage('claude', 'any', { dbPath, limit: 0 }),
+      () => getSessionFileEditsPage('claude', 'any', { dbPath, limit: 5_000 }),
+    ]) {
+      await assert.rejects(
+        operation(),
+        (error: unknown) => error instanceof InvalidArgumentError
+          && error.code === 'INVALID_ARGUMENT'
+          && /limit must be between 1 and 1000/.test(error.message),
+      );
+    }
+  } finally {
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/sdk-ts/src/session-evidence.test.ts
+++ b/sdk-ts/src/session-evidence.test.ts
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import {
+  InvalidArgumentError, SESSION_EVIDENCE_CONTRACT_VERSION,
+  getSessionFileEdits, getSessionFileEditsPage, getSessionToolCalls, getSessionToolCallsPage,
+  parseStoredJson, sessionFileEdits, sessionToolCalls, sync,
+  type EvidenceCursor, type SessionFileEdit, type SessionToolCall,
+} from './index.js';
+
+const SHARED_SESSION = 'shared-1';
+
+const CLAUDE_TRANSCRIPT = [
+  { type: 'user', uuid: 'u1', sessionId: SHARED_SESSION, cwd: '/work/app', gitBranch: 'main', timestamp: '2026-08-30T10:00:00.000Z', message: { role: 'user', content: 'update auth' } },
+  { type: 'assistant', uuid: 'a1', parentUuid: 'u1', sessionId: SHARED_SESSION, cwd: '/work/app', gitBranch: 'main', timestamp: '2026-08-30T10:00:01.000Z', message: { role: 'assistant', model: 'claude-test', content: [{ type: 'tool_use', id: 'toolu_1', name: 'Edit', input: { file_path: '/work/app/auth.ts', old_string: 'old', new_string: 'new' } }] } },
+  { type: 'user', uuid: 'r1', parentUuid: 'a1', sessionId: SHARED_SESSION, cwd: '/work/app', gitBranch: 'main', timestamp: '2026-08-30T10:00:02.000Z', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'ok', toolUseResult: { filePath: '/work/app/auth.ts', structuredPatch: '--- a/auth.ts\n+++ b/auth.ts\n-old\n+new\n', userModified: true } }] } },
+  { type: 'assistant', uuid: 'a2', parentUuid: 'r1', sessionId: SHARED_SESSION, cwd: '/work/app', gitBranch: 'main', timestamp: '2026-08-30T10:00:03.000Z', message: { role: 'assistant', model: 'claude-test', content: [{ type: 'tool_use', id: 'toolu_2', name: 'Write', input: { file_path: '/work/app/notes.md', content: 'notes' } }] } },
+  { type: 'user', uuid: 'r2', parentUuid: 'a2', sessionId: SHARED_SESSION, cwd: '/work/app', gitBranch: 'main', timestamp: '2026-08-30T10:00:04.000Z', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_2', content: 'ok', toolUseResult: { filePath: '/work/app/notes.md', structuredPatch: [{ oldStart: 1, newStart: 1, lines: ['+notes'] }], userModified: false } }] } },
+  { type: 'assistant', uuid: 'a3', parentUuid: 'r2', sessionId: SHARED_SESSION, cwd: '/work/app', gitBranch: 'main', timestamp: '2026-08-30T10:00:05.000Z', message: { role: 'assistant', model: 'claude-test', content: [{ type: 'tool_use', id: 'toolu_3', name: 'Bash', input: { command: 'cargo test' } }] } },
+  { type: 'user', uuid: 'r3', parentUuid: 'a3', sessionId: SHARED_SESSION, cwd: '/work/app', gitBranch: 'main', timestamp: '2026-08-30T10:00:06.000Z', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_3', is_error: true, content: 'failed' }] } },
+];
+
+const CODEX_ROLLOUT = [
+  { timestamp: '2026-08-30T11:00:00.000Z', type: 'session_meta', payload: { id: SHARED_SESSION, cwd: '/work/codex', git: { branch: 'main' } } },
+  { timestamp: '2026-08-30T11:00:01.000Z', type: 'event_msg', payload: { type: 'user_message', message: 'fix the importer' } },
+  { timestamp: '2026-08-30T11:00:02.000Z', type: 'response_item', payload: { type: 'function_call', id: 'fc_1', name: 'exec_command', arguments: '{"cmd":"git status"}', call_id: 'call_1' } },
+  { timestamp: '2026-08-30T11:00:03.000Z', type: 'response_item', payload: { type: 'custom_tool_call', id: 'ctc_1', status: 'completed', call_id: 'call_2', name: 'apply_patch', input: '*** Begin Patch\n*** Update File: /work/codex/a.rs\n@@\n+one\n*** End Patch\n' } },
+  // One apply_patch call touching two files: file_edits is keyed by tool use,
+  // so the writer scopes the key per path rather than losing a file.
+  { timestamp: '2026-08-30T11:00:04.000Z', type: 'event_msg', payload: { type: 'patch_apply_end', call_id: 'call_2', success: true, changes: { '/work/codex/a.rs': { type: 'update', unified_diff: '@@\n+one\n-zero' }, '/work/codex/b.rs': { type: 'update', unified_diff: '@@\n+two' } } } },
+];
+
+async function seededDatabase(): Promise<{ dbPath: string; cleanup: () => Promise<void> }> {
+  const root = await mkdtemp(join(tmpdir(), 'relayhistory-evidence-'));
+  const home = join(root, 'home');
+  const claude = join(home, '.claude', 'projects', 'work-app');
+  const codex = join(home, '.codex', 'sessions', '2026', '08', '30');
+  await mkdir(claude, { recursive: true });
+  await mkdir(codex, { recursive: true });
+  await writeFile(join(claude, `${SHARED_SESSION}.jsonl`), `${CLAUDE_TRANSCRIPT.map((line) => JSON.stringify(line)).join('\n')}\n`);
+  await writeFile(join(codex, `rollout-${SHARED_SESSION}.jsonl`), `${CODEX_ROLLOUT.map((line) => JSON.stringify(line)).join('\n')}\n`);
+  const saved = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  const dbPath = join(root, 'history.db');
+  try {
+    await sync({ dbPath });
+  } finally {
+    if (saved.HOME === undefined) delete process.env.HOME; else process.env.HOME = saved.HOME;
+    if (saved.USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = saved.USERPROFILE;
+  }
+  return { dbPath, cleanup: () => rm(root, { recursive: true, force: true }) };
+}
+
+test('tool call pages expose structured arguments, errors, and identity', async () => {
+  const { dbPath, cleanup } = await seededDatabase();
+  try {
+    const page = await getSessionToolCallsPage('claude', SHARED_SESSION, { dbPath });
+    assert.equal(page.contractVersion, SESSION_EVIDENCE_CONTRACT_VERSION);
+    assert.equal(page.source, 'claude');
+    assert.equal(page.sessionId, SHARED_SESSION);
+    assert.equal(page.nextCursor, null);
+    assert.deepEqual(page.toolCalls.map((call) => call.toolUseId), ['toolu_1', 'toolu_2', 'toolu_3']);
+
+    const [edit, write, bash] = page.toolCalls;
+    assert.deepEqual(edit.args, { file_path: '/work/app/auth.ts', old_string: 'old', new_string: 'new' });
+    assert.deepEqual(JSON.parse(String(edit.argsJson)), edit.args);
+    assert.equal(edit.name, 'Edit');
+    assert.equal(edit.target, '/work/app/auth.ts');
+    assert.equal(edit.messageId, 'a1');
+    assert.equal(typeof edit.tsMs, 'number');
+    // A tool result that never reported a verdict leaves the error unknown
+    // rather than asserting success.
+    assert.equal(edit.isError, null);
+    assert.equal(write.name, 'Write');
+    assert.equal(bash.isError, true);
+    assert.deepEqual(bash.args, { command: 'cargo test' });
+  } finally {
+    await cleanup();
+  }
+});
+
+test('file edit pages expose patches, provenance, and one row per edited file', async () => {
+  const { dbPath, cleanup } = await seededDatabase();
+  try {
+    const claude = await getSessionFileEditsPage('claude', SHARED_SESSION, { dbPath });
+    assert.equal(claude.contractVersion, SESSION_EVIDENCE_CONTRACT_VERSION);
+    assert.deepEqual(claude.fileEdits.map((edit) => edit.filePath), ['/work/app/auth.ts', '/work/app/notes.md']);
+    const [auth, notes] = claude.fileEdits;
+    assert.equal(auth.toolName, 'Edit');
+    assert.equal(auth.messageId, 'a1');
+    assert.equal(auth.gitBranch, 'main');
+    assert.equal(auth.cwd, '/work/app');
+    assert.equal(auth.userModified, true);
+    assert.equal(auth.linesAdded, 1);
+    assert.equal(auth.linesRemoved, 1);
+    assert.equal(auth.structuredPatch, '--- a/auth.ts\n+++ b/auth.ts\n-old\n+new\n');
+    assert.equal(auth.structuredPatchJson, JSON.stringify('--- a/auth.ts\n+++ b/auth.ts\n-old\n+new\n'));
+    assert.equal(notes.userModified, false);
+    assert.deepEqual(notes.structuredPatch, [{ oldStart: 1, newStart: 1, lines: ['+notes'] }]);
+
+    // One codex apply_patch call touching two files stores one row per file,
+    // keyed by `<call id>#<path>` because file_edits is unique per tool use.
+    const codex = await getSessionFileEditsPage('codex', SHARED_SESSION, { dbPath });
+    assert.deepEqual(codex.fileEdits.map((edit) => edit.filePath), ['/work/codex/a.rs', '/work/codex/b.rs']);
+    assert.deepEqual(codex.fileEdits.map((edit) => edit.toolUseId), ['call_2#/work/codex/a.rs', 'call_2#/work/codex/b.rs']);
+    assert.ok(codex.fileEdits.every((edit) => edit.toolName === 'apply_patch'));
+  } finally {
+    await cleanup();
+  }
+});
+
+test('evidence pages never mix two providers that share a session id', async () => {
+  const { dbPath, cleanup } = await seededDatabase();
+  try {
+    const claudeCalls = await getSessionToolCalls('claude', SHARED_SESSION, { dbPath });
+    const codexCalls = await getSessionToolCalls('codex', SHARED_SESSION, { dbPath });
+    assert.ok(claudeCalls.length > 0 && codexCalls.length > 0);
+    assert.ok(claudeCalls.every((call) => call.source === 'claude'));
+    assert.ok(codexCalls.every((call) => call.source === 'codex'));
+    assert.deepEqual(codexCalls.map((call) => call.toolUseId), ['call_1', 'call_2']);
+
+    const claudeEdits = await getSessionFileEdits('claude', SHARED_SESSION, { dbPath });
+    const codexEdits = await getSessionFileEdits('codex', SHARED_SESSION, { dbPath });
+    assert.ok(claudeEdits.every((edit) => edit.source === 'claude'));
+    assert.ok(codexEdits.every((edit) => edit.source === 'codex'));
+  } finally {
+    await cleanup();
+  }
+});
+
+test('paged, iterated, and collected reads agree at every page size', async () => {
+  const { dbPath, cleanup } = await seededDatabase();
+  try {
+    const allCalls = await getSessionToolCalls('claude', SHARED_SESSION, { dbPath });
+    const allEdits = await getSessionFileEdits('claude', SHARED_SESSION, { dbPath });
+    assert.equal(allCalls.length, 3);
+    assert.equal(allEdits.length, 2);
+
+    for (const limit of [1, 2, 3, 1000]) {
+      const calls: SessionToolCall[] = [];
+      for await (const call of sessionToolCalls('claude', SHARED_SESSION, { dbPath, limit })) calls.push(call);
+      assert.deepEqual(calls, allCalls, `tool calls at limit ${limit}`);
+      const edits: SessionFileEdit[] = [];
+      for await (const edit of sessionFileEdits('claude', SHARED_SESSION, { dbPath, limit })) edits.push(edit);
+      assert.deepEqual(edits, allEdits, `file edits at limit ${limit}`);
+    }
+
+    // Cursors survive the JSON round trip the CLI and MCP server use.
+    const first = await getSessionToolCallsPage('claude', SHARED_SESSION, { dbPath, limit: 1 });
+    assert.equal(first.toolCalls.length, 1);
+    const roundTripped = JSON.parse(JSON.stringify(first.nextCursor)) as EvidenceCursor;
+    const second = await getSessionToolCallsPage('claude', SHARED_SESSION, { dbPath, limit: 2, after: roundTripped });
+    assert.deepEqual(second.toolCalls, allCalls.slice(1));
+    assert.equal(second.nextCursor, null);
+  } finally {
+    await cleanup();
+  }
+});
+
+test('evidence pages read unknown sessions empty and require both identity parts', async () => {
+  const { dbPath, cleanup } = await seededDatabase();
+  try {
+    const missing = await getSessionToolCallsPage('claude', 'no-such-session', { dbPath });
+    assert.deepEqual(missing.toolCalls, []);
+    assert.equal(missing.nextCursor, null);
+    assert.deepEqual((await getSessionFileEditsPage('cursor', SHARED_SESSION, { dbPath })).fileEdits, []);
+
+    for (const operation of [
+      () => getSessionToolCallsPage('claude', '', { dbPath }),
+      () => getSessionFileEditsPage('claude', '   ', { dbPath }),
+      () => getSessionToolCallsPage('' as never, SHARED_SESSION, { dbPath }),
+    ]) {
+      await assert.rejects(operation(), (error: unknown) => error instanceof InvalidArgumentError
+        && error.code === 'INVALID_ARGUMENT');
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test('unparseable stored JSON yields null without discarding the raw string', () => {
+  assert.deepEqual(parseStoredJson('{"a":1}'), { a: 1 });
+  assert.equal(parseStoredJson('not json'), null);
+  assert.equal(parseStoredJson(null), null);
+  assert.equal(parseStoredJson(undefined), null);
+  assert.equal(parseStoredJson('null'), null);
+});

--- a/sdk-ts/src/session-evidence.test.ts
+++ b/sdk-ts/src/session-evidence.test.ts
@@ -11,6 +11,14 @@ import {
   type EvidenceCursor, type SessionFileEdit, type SessionToolCall,
 } from './index.js';
 
+// Undated tool calls and file edits are legal — both `ts_ms` columns are
+// nullable — but no provider adapter writes one, so the only way to build the
+// fixture that exercises a null cursor end to end is to add the rows directly.
+// Production code stays SQLite-free; this is test-only, and `node:sqlite`
+// arrived in Node 22 while the SDK still supports Node 20.
+const sqlite = await import('node:sqlite').catch(() => null);
+const needsNodeSqlite = sqlite ? false : 'node:sqlite requires Node >= 22';
+
 const SHARED_SESSION = 'shared-1';
 
 const CLAUDE_TRANSCRIPT = [
@@ -156,6 +164,72 @@ test('paged, iterated, and collected reads agree at every page size', async () =
     const second = await getSessionToolCallsPage('claude', SHARED_SESSION, { dbPath, limit: 2, after: roundTripped });
     assert.deepEqual(second.toolCalls, allCalls.slice(1));
     assert.equal(second.nextCursor, null);
+
+    // Both spellings of the undated tail cross the native boundary, which
+    // takes an absent `tsMs` and cannot convert an explicit null: the cursor
+    // a page hands back for an undated row is `tsMs: null`, and a transport
+    // that drops nulls delivers the same cursor without the field at all.
+    // On this fully dated database both name an empty tail rather than
+    // failing the call.
+    for (const after of [{ tsMs: null, id: allCalls[0].id }, { id: allCalls[0].id }]) {
+      const tail = await getSessionToolCallsPage('claude', SHARED_SESSION, { dbPath, after });
+      assert.deepEqual(tail.toolCalls, []);
+      assert.equal(tail.nextCursor, null);
+      const edits = await getSessionFileEditsPage('claude', SHARED_SESSION, { dbPath, after });
+      assert.deepEqual(edits.fileEdits, []);
+      assert.equal(edits.nextCursor, null);
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+test('undated records page after the dated ones through a null cursor', { skip: needsNodeSqlite }, async () => {
+  const { dbPath, cleanup } = await seededDatabase();
+  try {
+    const database = new sqlite!.DatabaseSync(dbPath);
+    try {
+      database.exec(`
+        INSERT INTO tool_calls (source, session_id, message_id, tool_use_id, name, target, args_json, is_error, ts_ms)
+        VALUES ('claude', '${SHARED_SESSION}', 'a9', 'toolu_undated_1', 'Bash', 'ls', '{"command":"ls"}', 0, NULL),
+               ('claude', '${SHARED_SESSION}', 'a9', 'toolu_undated_2', 'Bash', 'pwd', '{"command":"pwd"}', NULL, NULL);
+        INSERT INTO file_edits (source, session_id, message_id, tool_use_id, file_path, tool_name, lines_added, lines_removed, ts_ms)
+        VALUES ('claude', '${SHARED_SESSION}', 'a9', 'toolu_undated_1', '/work/app/undated-a.ts', 'Edit', NULL, NULL, NULL),
+               ('claude', '${SHARED_SESSION}', 'a9', 'toolu_undated_2', '/work/app/undated-b.ts', 'Edit', 3, 1, NULL);
+      `);
+    } finally {
+      database.close();
+    }
+
+    const allCalls = await getSessionToolCalls('claude', SHARED_SESSION, { dbPath });
+    const allEdits = await getSessionFileEdits('claude', SHARED_SESSION, { dbPath });
+    assert.deepEqual(allCalls.map((call) => call.toolUseId), [
+      'toolu_1', 'toolu_2', 'toolu_3', 'toolu_undated_1', 'toolu_undated_2',
+    ]);
+    assert.deepEqual(allCalls.slice(3).map((call) => call.tsMs), [null, null]);
+    assert.deepEqual(allEdits.map((edit) => edit.filePath), [
+      '/work/app/auth.ts', '/work/app/notes.md', '/work/app/undated-a.ts', '/work/app/undated-b.ts',
+    ]);
+
+    // Every page size crosses from the dated head into the undated tail, so a
+    // cursor whose `tsMs` is null is walked rather than only constructed.
+    for (const limit of [1, 2, 3, 4, 5]) {
+      const calls: SessionToolCall[] = [];
+      for await (const call of sessionToolCalls('claude', SHARED_SESSION, { dbPath, limit })) calls.push(call);
+      assert.deepEqual(calls, allCalls, `tool calls at limit ${limit}`);
+      const edits: SessionFileEdit[] = [];
+      for await (const edit of sessionFileEdits('claude', SHARED_SESSION, { dbPath, limit })) edits.push(edit);
+      assert.deepEqual(edits, allEdits, `file edits at limit ${limit}`);
+    }
+
+    // The cursor that lands inside the tail is the null one, and it round
+    // trips through JSON exactly as the CLI and MCP server send it.
+    const inTail = await getSessionToolCallsPage('claude', SHARED_SESSION, { dbPath, limit: 4 });
+    assert.equal(inTail.nextCursor?.tsMs, null);
+    const resumed = await getSessionToolCallsPage('claude', SHARED_SESSION, {
+      dbPath, after: JSON.parse(JSON.stringify(inTail.nextCursor)) as EvidenceCursor,
+    });
+    assert.deepEqual(resumed.toolCalls.map((call) => call.toolUseId), ['toolu_undated_2']);
   } finally {
     await cleanup();
   }

--- a/sdk-ts/src/session-evidence.test.ts
+++ b/sdk-ts/src/session-evidence.test.ts
@@ -256,6 +256,36 @@ test('evidence pages read unknown sessions empty and require both identity parts
   }
 });
 
+test('an unsupported provider is rejected, not answered with an empty page', async () => {
+  const { dbPath, cleanup } = await seededDatabase();
+  try {
+    // `source` is half the identity of an evidence page, so a provider this
+    // build does not know cannot honestly read as "this session recorded
+    // nothing" -- both page readers reject it the way hydrateSession does.
+    for (const source of ['claud', 'Claude', 'openai', 'sqlite']) {
+      for (const operation of [
+        () => getSessionToolCallsPage(source as never, SHARED_SESSION, { dbPath }),
+        () => getSessionFileEditsPage(source as never, SHARED_SESSION, { dbPath }),
+        () => getSessionToolCalls(source as never, SHARED_SESSION, { dbPath }),
+        () => getSessionFileEdits(source as never, SHARED_SESSION, { dbPath }),
+      ]) {
+        await assert.rejects(operation(), (error: unknown) => error instanceof InvalidArgumentError
+          && error.code === 'INVALID_ARGUMENT'
+          && error.message.includes(source));
+      }
+    }
+
+    // Every id the SDK does publish stays accepted, including `trajectory`,
+    // which the catalog excludes but evidence rows may carry.
+    for (const source of ['claude', 'codex', 'cursor', 'grok', 'relay', 'trajectory', 'opencode'] as const) {
+      assert.equal((await getSessionToolCallsPage(source, 'no-such-session', { dbPath })).source, source);
+      assert.equal((await getSessionFileEditsPage(source, 'no-such-session', { dbPath })).source, source);
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
 test('unparseable stored JSON yields null without discarding the raw string', () => {
   assert.deepEqual(parseStoredJson('{"a":1}'), { a: 1 });
   assert.equal(parseStoredJson('not json'), null);


### PR DESCRIPTION
## Summary

After hydrating a session, a consumer can now retrieve its structured tool calls and file edits entirely through the public TypeScript SDK — no event-text parsing, no direct SQLite access. The production call path stays Rust/SQLite core → N-API → TypeScript SDK → CLI/MCP, with the query logic implemented once in `ai-hist-core`.

## API surface

**Rust core** (`ai-hist-core`)
- `session_tool_calls_page` / `session_file_edits_page`: keyset-paginated (no OFFSET) readers requiring both `source` and `session_id`, so colliding native session IDs from two providers never mix.
- Shared `SessionEvidenceCursor { ts_ms: Option<i64>, id: i64 }`. Ordering is `ts_ms IS NULL, ts_ms ASC, id ASC` with exact continuation predicates for dated and undated cursors, so pagination stays correct across tied and NULL timestamps.
- `SessionFileEdit` now also carries `message_id`, `structured_patch_json`, `git_branch`, `cwd` (previously stored but unread).
- New expression indexes `idx_tool_calls_page_v2` / `idx_file_edits_page_v2` on `(source, session_id, (ts_ms IS NULL), ts_ms, id)` serve the page ordering directly (verified: covering-index search, no temp B-tree); superseded indexes are retired through the existing drop mechanism and old databases upgrade on the next writable open.

**N-API** — `getSessionToolCallsPage` / `getSessionFileEditsPage`; `NATIVE_CONTRACT_VERSION` 4 → 5 (publish smoke gates bumped to match). Pages report a `contract_version` so machine-readable output is versioned at the source of truth.

**TypeScript SDK** — for each of tool calls and file edits: a bounded page function (`getSessionToolCallsPage` / `getSessionFileEditsPage`), an async iterator (`sessionToolCalls` / `sessionFileEdits`), and a collect-all (`getSessionToolCalls` / `getSessionFileEdits`), mirroring the session-events trio. `args` and `structuredPatch` are parsed into typed JSON values; invalid stored JSON never fails a page — the parsed field is `null` and the raw string is preserved in `argsJson` / `structuredPatchJson`. `isError` / `userModified` surface as `boolean | null`, timestamps as `tsMs: number | null`; absent values are `null`, never invented.

**CLI** — `ai-hist sessions tools SOURCE SESSION_ID` and `ai-hist sessions edits SOURCE SESSION_ID` with `--limit`, `--after` (round-trippable JSON cursor, including the undated spelling `{"tsMs":null,"id":N}`), and versioned, paginated `--json` output.

**MCP** — `get_session_tool_calls` / `get_session_file_edits`, thin wrappers over the SDK with zod-validated inputs and versioned, cursor-paged output.

## Notes for reviewers

- A cursor whose `tsMs` is `null` is normalized to `undefined` before crossing the N-API boundary (napi-rs rejects explicit JS `null` for `Option<i64>`), the same normalization the catalog cursor already uses; regression tests cover the SDK iterators, CLI `--after`, and MCP continuations, including cursors with `tsMs` absent.
- `file_edits` keeps its `UNIQUE(source, session_id, tool_use_id)`: Codex scopes multi-file patches as `<call_id>#<file_path>` (one row per file), Claude folds multiple hunks of one call into `structured_patch_json` — both shapes are asserted in tests.
- Additive change: `ai-hist events --json` file-edit records now include the four newly-read columns (noted in the changelog).

## Testing

- `cargo fmt --check`, `cargo clippy --workspace -D warnings`, `cargo test --workspace`: 275 passed, 0 failed — includes source/session isolation, tied-timestamp ordering, full pagination walks against an unpaginated oracle, NULL-timestamp tails, empty results, index-migration and query-plan (no-sort) assertions.
- `sdk-ts`: `npm run typecheck` clean; `npm test` 34 passed — structured/invalid JSON handling, tool errors, multi-edit shapes, cursor JSON round trips, CLI output shape, MCP registration, and the architecture test confirming no SQLite/subprocess in TypeScript.
- `node --test scripts/*.test.mjs`: 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018D8A8J1a9xNbKeJSY2Ekuh

---
_Generated by [Claude Code](https://claude.ai/code/session_018D8A8J1a9xNbKeJSY2Ekuh)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

