### PR TITLE
Make coding-agent delegation topology first-class and publicly queryable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,12 @@ Notable changes to the native `ai-hist` CLI are documented here.
 - The native-addon contract advances to 5, and Claude subagent transcripts
   whose records carry an `agentId` are now indexed under that child id instead
   of the parent's. Hydration parser version 2 re-parses and heals existing
-  databases in place on the next `sessions hydrate`, moving those events from
-  the parent to the child rather than duplicating them. The
-  `session_relationships_v2` schema marker is required, so the first read of an
-  existing database is routed through a writable open that migrates it.
+  databases in place on the next `sessions hydrate`, moving those events —
+  along with the tool calls and file edits derived from them — from the parent
+  to the child rather than duplicating them, so a parent stops reporting a
+  delegated thread's actions as its own. The `session_relationships_v2` schema
+  marker is required, so the first read of an existing database is routed
+  through a writable open that migrates it.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,10 +43,16 @@ Notable changes to the native `ai-hist` CLI are documented here.
   `ai-hist sessions relationships` and `ai-hist sessions tree` commands, or the
   `get_session_relationships` and `get_session_tree` MCP tools. Traversal is
   pre-order, deterministically ordered by `(spawned_at_ms, relationship_uid)`,
-  cycle-safe, and bounded by `max_depth` / `max_nodes`. Global `sync` now
-  records Codex delegation too, so topology is queryable without targeted
+  cycle-safe, and bounded by `max_depth` / `max_nodes`; a tree always contains
+  its root, and a repeated session reached along a second path is reported as a
+  cycle only when the edge points back into its own ancestry. Global `sync` now
+  records Codex delegation too — including a backfill for rollouts an earlier
+  version already ingested — so topology is queryable without targeted
   hydration, and existing databases migrate automatically through the
-  `session_relationships_v2` marker.
+  `session_relationships_v2` marker. A full `sync` also treats a Claude
+  subagent sidecar as delegated evidence rather than a session: it keeps the
+  child's output under the child, and leaves the parent's own provider locator
+  alone.
 - Add remote provider connectors behind the existing `--remote` / `--all`
   acquisition scopes: `claude-web` lists claude.ai/code web sessions with the
   OAuth sign-in the Claude Code CLI stored (`~/.claude/.credentials.json`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,10 @@ Notable changes to the native `ai-hist` CLI are documented here.
   version already ingested — so topology is queryable without targeted
   hydration, and existing databases migrate automatically through the
   `session_relationships_v2` marker. A full `sync` also treats a Claude
-  subagent sidecar as delegated evidence rather than a session: it keeps the
-  child's output under the child, and leaves the parent's own provider locator
-  alone.
+  subagent sidecar as delegated evidence rather than a session: it records the
+  same observed row (or, for a sidechain the provider never named, the same
+  unlinked evidence) that targeted hydration records, keeps the child's output
+  under the child, and leaves the parent's own provider locator alone.
 - Add remote provider connectors behind the existing `--remote` / `--all`
   acquisition scopes: `claude-web` lists claude.ai/code web sessions with the
   OAuth sign-in the Claude Code CLI stored (`~/.claude/.credentials.json`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,31 @@ Notable changes to the native `ai-hist` CLI are documented here.
   prints a local command; JSON reports it as unavailable and readable mode
   exits with an explanation.
 
+- The native-addon contract advances to 5, and Claude subagent transcripts
+  whose records carry an `agentId` are now indexed under that child id instead
+  of the parent's. Hydration parser version 2 re-parses and heals existing
+  databases in place on the next `sessions hydrate`, moving those events from
+  the parent to the child rather than duplicating them. The
+  `session_relationships_v2` schema marker is required, so the first read of an
+  existing database is routed through a writable open that migrates it.
+
 ### Added
 
+- Add first-class delegation topology. `session_relationships` gains an
+  identity status (`observed` or `unlinked`), child agent type, name, model and
+  spawn depth, the provider evidence that established the link (kind, file
+  locator, and native reference such as a Claude `toolUseId` or a Codex
+  `parent_thread_id`), the provider's spawn time, and whether the child's
+  events are independently addressable. Read it with the new
+  `getSessionRelationships`, `getSessionTree`, and `getSessionChildrenPage`
+  operations (session-relationship contract version 1), the
+  `ai-hist sessions relationships` and `ai-hist sessions tree` commands, or the
+  `get_session_relationships` and `get_session_tree` MCP tools. Traversal is
+  pre-order, deterministically ordered by `(spawned_at_ms, relationship_uid)`,
+  cycle-safe, and bounded by `max_depth` / `max_nodes`. Global `sync` now
+  records Codex delegation too, so topology is queryable without targeted
+  hydration, and existing databases migrate automatically through the
+  `session_relationships_v2` marker.
 - Add remote provider connectors behind the existing `--remote` / `--all`
   acquisition scopes: `claude-web` lists claude.ai/code web sessions with the
   OAuth sign-in the Claude Code CLI stored (`~/.claude/.credentials.json`,

--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ npm install --global ai-hist
 ai-hist sessions discover --limit 100
 ai-hist sessions list --limit 100
 ai-hist sessions hydrate codex 01a04f0c-... --json
+ai-hist sessions tree codex 01a04f0c-...
 ```
+
+`sessions relationships` and `sessions tree` read the delegation topology a
+session recorded: which subagent threads it spawned, what evidence established
+each link, and whether a child's events are addressable on their own.
 
 Session-set commands share one mutually exclusive location scope:
 

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -11,6 +11,18 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 pub mod convergence;
 /// WS-9 cloud-sync increment 2a: outbox builder (local rows → batch, sync logic only).
 pub mod outbox;
+/// Delegation topology: recorded parent/child relationships and bounded,
+/// cycle-safe traversal over them.
+pub mod relationships;
+
+pub use relationships::{
+    relationship_capabilities, session_children, session_children_page, session_parents,
+    session_relationships, session_tree, RelationshipCapabilities, RelationshipCursor,
+    RelationshipDiagnostic, SessionChildrenPage, SessionRelationship, SessionRelationships,
+    SessionTree, SessionTreeNode, SessionTreeOptions, DEFAULT_CHILDREN_PAGE_LIMIT,
+    DEFAULT_TREE_MAX_DEPTH, DEFAULT_TREE_MAX_NODES, MAX_CHILDREN_PAGE_LIMIT, MAX_TREE_MAX_DEPTH,
+    MAX_TREE_MAX_NODES, SESSION_RELATIONSHIP_CONTRACT_VERSION,
+};
 
 pub const SOURCE_CHOICES: &[&str] = &[
     "claude",
@@ -436,6 +448,15 @@ const REQUIRED_SESSIONS_COLUMNS: &[&str] = &[
 ];
 const REQUIRED_SESSION_PRESENCE_COLUMNS: &[&str] =
     &["raw_locator", "source_stamp", "discovery_state"];
+/// Columns the v2 `session_relationships` shape adds. A v1 row set cannot
+/// represent related evidence whose child has no provider-recorded identity,
+/// so a database still carrying the v1 table is not current for any read.
+const REQUIRED_SESSION_RELATIONSHIP_COLUMNS: &[&str] = &[
+    "relationship_uid",
+    "identity_status",
+    "evidence_kind",
+    "child_has_events",
+];
 
 /// Indexes the session catalog's fast paths depend on.
 ///
@@ -459,6 +480,8 @@ const REQUIRED_SESSIONS_INDEXES: &[&str] = &[
     "idx_session_events_page",
     "idx_session_presences_location",
     "idx_session_presences_locator",
+    "idx_session_relationships_parent",
+    "idx_session_relationships_child",
 ];
 
 /// Indexes retired from `sessions`: nothing queries them, and each was one
@@ -480,8 +503,15 @@ const REQUIRED_CATALOG_READ_INDEXES: &[&str] = &[
 const REQUIRED_EVENT_READ_INDEXES: &[&str] =
     &["idx_session_events_source_page", "idx_session_events_page"];
 const REQUIRED_SCOPE_READ_INDEXES: &[&str] = &["idx_session_presences_location"];
+const REQUIRED_RELATIONSHIP_READ_INDEXES: &[&str] = &[
+    "idx_session_relationships_parent",
+    "idx_session_relationships_child",
+];
 const REQUIRED_TRIGGERS: &[&str] = &["delete_session_presences", "delete_session_hydration_state"];
-const REQUIRED_SCHEMA_MIGRATIONS: &[&str] = &["session_presences_local_backfill_v1"];
+const REQUIRED_SCHEMA_MIGRATIONS: &[&str] = &[
+    "session_presences_local_backfill_v1",
+    "session_relationships_v2",
+];
 
 /// Whether this database already has everything [`init_db`] would add.
 ///
@@ -507,6 +537,12 @@ pub fn schema_is_catalog_read_current(conn: &Connection) -> Result<bool> {
 /// Whether bounded event pagination has both source-scoped and source-less indexes.
 pub fn schema_is_event_read_current(conn: &Connection) -> Result<bool> {
     schema_has_required_indexes(conn, REQUIRED_EVENT_READ_INDEXES)
+}
+
+/// Whether delegation-topology reads can use their indexed parent and child
+/// lookups over the v2 `session_relationships` shape.
+pub fn schema_is_relationship_read_current(conn: &Connection) -> Result<bool> {
+    schema_has_required_indexes(conn, REQUIRED_RELATIONSHIP_READ_INDEXES)
 }
 
 fn schema_has_required_indexes(conn: &Connection, required_indexes: &[&str]) -> Result<bool> {
@@ -554,6 +590,16 @@ fn schema_has_required_indexes(conn: &Connection, required_indexes: &[&str]) -> 
     if !REQUIRED_SESSION_PRESENCE_COLUMNS
         .iter()
         .all(|needed| presence_columns.contains(*needed))
+    {
+        return Ok(false);
+    }
+    let relationship_columns: HashSet<String> = conn
+        .prepare("SELECT name FROM pragma_table_info('session_relationships')")?
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<_>>()?;
+    if !REQUIRED_SESSION_RELATIONSHIP_COLUMNS
+        .iter()
+        .all(|needed| relationship_columns.contains(*needed))
     {
         return Ok(false);
     }
@@ -629,8 +675,41 @@ fn init_db_once(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// One observed delegation edge, or one piece of related evidence whose child
+/// has no provider-recorded identity.
+///
+/// Shared by the fresh-database path and the `session_relationships_v2`
+/// rebuild below so the two can never describe different tables. The primary
+/// key is `relationship_uid` rather than the child id: unlinked evidence has
+/// no child id at all, and two sidecars of the same parent must not collapse
+/// into one row.
+const SESSION_RELATIONSHIPS_DDL: &str = r#"
+CREATE TABLE IF NOT EXISTS session_relationships (
+    source TEXT NOT NULL,
+    parent_session_id TEXT NOT NULL,
+    relationship_uid TEXT NOT NULL,
+    child_session_id TEXT,
+    relationship TEXT NOT NULL,
+    identity_status TEXT NOT NULL CHECK(identity_status IN ('observed','unlinked')),
+    child_agent_type TEXT,
+    child_agent_name TEXT,
+    child_model TEXT,
+    spawn_depth INTEGER,
+    evidence_kind TEXT NOT NULL,
+    evidence_locator TEXT,
+    evidence_ref TEXT,
+    child_has_events INTEGER NOT NULL DEFAULT 0,
+    spawned_at_ms INTEGER,
+    created_ms INTEGER NOT NULL,
+    updated_ms INTEGER NOT NULL,
+    PRIMARY KEY (source, parent_session_id, relationship_uid)
+);
+"#;
+
 fn init_db_locked(conn: &Connection) -> Result<()> {
     conn.execute_batch(SCHEMA)?;
+    // Before the trigger below, whose body deletes from this table.
+    conn.execute_batch(SESSION_RELATIONSHIPS_DDL)?;
     conn.execute_batch(
         r#"
 CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -687,14 +766,6 @@ CREATE TABLE IF NOT EXISTS session_hydration_checkpoints (
     updated_ms INTEGER NOT NULL,
     PRIMARY KEY (source, session_id, location)
 );
-CREATE TABLE IF NOT EXISTS session_relationships (
-    source TEXT NOT NULL,
-    parent_session_id TEXT NOT NULL,
-    child_session_id TEXT NOT NULL,
-    relationship TEXT NOT NULL,
-    created_ms INTEGER NOT NULL,
-    PRIMARY KEY (source, parent_session_id, child_session_id)
-);
 CREATE TRIGGER IF NOT EXISTS delete_session_presences
 AFTER DELETE ON sessions
 BEGIN
@@ -720,6 +791,7 @@ END;
     // three declarations of the same nine names (CREATE TABLE, this loop, the
     // read-only guard) is two chances to drift, and every catalog column is
     // TEXT, so the guard list is the migration list.
+    migrate_session_relationships_v2(conn)?;
     ensure_text_columns(conn, "history", REQUIRED_HISTORY_COLUMNS)?;
     ensure_text_columns(conn, "sessions", REQUIRED_SESSIONS_COLUMNS)?;
     ensure_text_columns(conn, "session_presences", REQUIRED_SESSION_PRESENCE_COLUMNS)?;
@@ -820,6 +892,10 @@ VALUES ('session_presences_local_backfill_v1');
         [],
     )?;
     conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_session_relationships_child ON session_relationships(source, child_session_id)",
+        [],
+    )?;
+    conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_session_events_session ON session_events(source, session_id)",
         [],
     )?;
@@ -862,6 +938,70 @@ VALUES ('session_presences_local_backfill_v1');
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_session_commit_links_repo ON session_commit_links(repo, branch)",
         [],
+    )?;
+    Ok(())
+}
+
+/// Rebuild `session_relationships` into its v2 shape once.
+///
+/// The v1 primary key `(source, parent_session_id, child_session_id)` required
+/// a child id, so it could not record related evidence a provider does not
+/// give a stable child identity, and it merged several such observations into
+/// a single row. [`ensure_text_columns`] cannot change a primary key, so the
+/// table is rebuilt behind a `schema_migrations` marker. The caller holds the
+/// immediate migration transaction, which makes this crash-atomic and safe
+/// against concurrent first opens.
+///
+/// `legacy_alter_table` keeps the rename from rewriting the
+/// `delete_session_hydration_state` trigger to point at the temporary name;
+/// its body is already correct for v2, where `child_session_id = OLD.session_id`
+/// is NULL-safe false.
+fn migrate_session_relationships_v2(conn: &Connection) -> Result<()> {
+    let migrated: bool = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE name = 'session_relationships_v2')",
+        [],
+        |row| row.get(0),
+    )?;
+    if migrated {
+        return Ok(());
+    }
+    let uid_columns: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM pragma_table_info('session_relationships') \
+         WHERE name = 'relationship_uid'",
+        [],
+        |row| row.get(0),
+    )?;
+    if uid_columns == 0 {
+        conn.pragma_update(None, "legacy_alter_table", true)?;
+        let rebuild = (|| -> Result<()> {
+            conn.execute_batch(
+                "ALTER TABLE session_relationships RENAME TO session_relationships_v1;",
+            )?;
+            conn.execute_batch(SESSION_RELATIONSHIPS_DDL)?;
+            // Every v1 row named a child, so all of them carry over as
+            // observed identities. The evidence that established them was not
+            // recorded at the time, which `legacy_hydration` states honestly.
+            conn.execute_batch(
+                r#"
+INSERT OR IGNORE INTO session_relationships
+    (source, parent_session_id, relationship_uid, child_session_id, relationship,
+     identity_status, evidence_kind, child_has_events, created_ms, updated_ms)
+SELECT r.source, r.parent_session_id, 'child:' || r.child_session_id, r.child_session_id,
+       r.relationship, 'observed', 'legacy_hydration',
+       EXISTS(SELECT 1 FROM session_events e
+              WHERE e.source = r.source AND e.session_id = r.child_session_id),
+       r.created_ms, r.created_ms
+FROM session_relationships_v1 r;
+DROP TABLE session_relationships_v1;
+"#,
+            )?;
+            Ok(())
+        })();
+        conn.pragma_update(None, "legacy_alter_table", false)?;
+        rebuild?;
+    }
+    conn.execute_batch(
+        "INSERT OR IGNORE INTO schema_migrations (name) VALUES ('session_relationships_v2');",
     )?;
     Ok(())
 }
@@ -1862,6 +2002,87 @@ mod tests {
         assert!(schema_is_current(&current).unwrap());
 
         fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn session_relationships_v1_database_migrates_to_v2() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("v1.db");
+        let old = Connection::open(&path).unwrap();
+        old.execute_batch(
+            "CREATE TABLE session_relationships (
+                 source TEXT NOT NULL,
+                 parent_session_id TEXT NOT NULL,
+                 child_session_id TEXT NOT NULL,
+                 relationship TEXT NOT NULL,
+                 created_ms INTEGER NOT NULL,
+                 PRIMARY KEY (source, parent_session_id, child_session_id)
+             );
+             INSERT INTO session_relationships VALUES ('codex', 'root', 'child', 'delegated', 77);",
+        )
+        .unwrap();
+        drop(old);
+
+        let conn = open_db(&path).unwrap();
+        let row: (String, String, String, i64, i64) = conn
+            .query_row(
+                "SELECT relationship_uid, identity_status, evidence_kind, child_has_events, created_ms \
+                 FROM session_relationships WHERE child_session_id = 'child'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+            )
+            .unwrap();
+        assert_eq!(row.0, "child:child");
+        assert_eq!(row.1, "observed");
+        assert_eq!(row.2, "legacy_hydration");
+        assert_eq!(row.3, 0);
+        assert_eq!(row.4, 77);
+        let marker: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE name = 'session_relationships_v2')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(marker);
+        // The cascade trigger survives the rebuild and still reaches the
+        // rebuilt table rather than the renamed original.
+        conn.execute(
+            "INSERT INTO sessions (session_id, source) VALUES ('root', 'codex')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "DELETE FROM sessions WHERE session_id = 'root' AND source = 'codex'",
+            [],
+        )
+        .unwrap();
+        let remaining: i64 = conn
+            .query_row("SELECT COUNT(*) FROM session_relationships", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(remaining, 0);
+    }
+
+    #[test]
+    fn unmigrated_relationship_schema_is_not_read_current() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stale.db");
+        let current = open_db(&path).unwrap();
+        assert!(schema_is_relationship_read_current(&current).unwrap());
+        current
+            .execute_batch(
+                "DROP INDEX idx_session_relationships_child; \
+                 DELETE FROM schema_migrations WHERE name = 'session_relationships_v2';",
+            )
+            .unwrap();
+        assert!(!schema_is_relationship_read_current(&current).unwrap());
+        assert!(!schema_is_current(&current).unwrap());
+        drop(current);
+
+        let migrated = open_db(&path).unwrap();
+        assert!(schema_is_relationship_read_current(&migrated).unwrap());
     }
 
     #[test]

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -997,8 +997,11 @@ DROP TABLE session_relationships_v1;
             )?;
             Ok(())
         })();
-        conn.pragma_update(None, "legacy_alter_table", false)?;
+        // The rebuild's error is the one that explains a failed migration, so
+        // it is propagated first and restoring the pragma cannot mask it.
+        let restored = conn.pragma_update(None, "legacy_alter_table", false);
         rebuild?;
+        restored?;
     }
     conn.execute_batch(
         "INSERT OR IGNORE INTO schema_migrations (name) VALUES ('session_relationships_v2');",

--- a/crates/ai-hist-core/src/relationships.rs
+++ b/crates/ai-hist-core/src/relationships.rs
@@ -1,0 +1,899 @@
+//! Recorded delegation topology and bounded traversal over it.
+//!
+//! A relationship row is evidence, not inference: it says which provider
+//! artifact established the link, whether the child has a stable identity of
+//! its own, and whether that child's events are independently addressable.
+//! Nothing here fabricates a child id, and no traversal ever rewrites a
+//! child's events as its parent's.
+
+use anyhow::Result;
+use rusqlite::{params, Connection, Row};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// Bump whenever relationship object shapes or semantics require an SDK change.
+pub const SESSION_RELATIONSHIP_CONTRACT_VERSION: u32 = 1;
+
+pub const DEFAULT_TREE_MAX_DEPTH: u32 = 32;
+pub const MAX_TREE_MAX_DEPTH: u32 = 64;
+pub const DEFAULT_TREE_MAX_NODES: u32 = 1_000;
+pub const MAX_TREE_MAX_NODES: u32 = 10_000;
+pub const DEFAULT_CHILDREN_PAGE_LIMIT: i64 = 100;
+pub const MAX_CHILDREN_PAGE_LIMIT: i64 = 1_000;
+
+/// A child observed with a provider-recorded identity of its own.
+pub const IDENTITY_OBSERVED: &str = "observed";
+/// Related evidence the provider records without a stable child identity.
+pub const IDENTITY_UNLINKED: &str = "unlinked";
+
+const RELATIONSHIP_COLUMNS: &str = "source, parent_session_id, child_session_id, relationship, \
+     identity_status, child_agent_type, child_agent_name, child_model, spawn_depth, \
+     evidence_kind, evidence_locator, evidence_ref, child_has_events, \
+     spawned_at_ms, created_ms, relationship_uid";
+
+/// Nulls sort last, matching the catalog's null-timestamps-at-the-tail
+/// convention. `relationship_uid` is unique per parent, so this is a total
+/// order and a keyset cursor over it can never drop or repeat a row.
+const CHILD_ORDER: &str = "ORDER BY spawned_at_ms IS NULL, spawned_at_ms ASC, relationship_uid ASC";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionRelationship {
+    pub source: String,
+    pub parent_session_id: String,
+    /// `None` when the provider recorded related evidence without a stable
+    /// child identity. Never synthesized from a file name.
+    pub child_session_id: Option<String>,
+    pub relationship: String,
+    pub identity_status: String,
+    pub child_agent_type: Option<String>,
+    pub child_agent_name: Option<String>,
+    pub child_model: Option<String>,
+    pub spawn_depth: Option<i64>,
+    pub evidence_kind: String,
+    pub evidence_locator: Option<String>,
+    pub evidence_ref: Option<String>,
+    pub child_has_events: bool,
+    pub spawned_at_ms: Option<i64>,
+    pub created_ms: i64,
+    pub relationship_uid: String,
+}
+
+impl SessionRelationship {
+    fn is_unlinked(&self) -> bool {
+        self.child_session_id.is_none() || self.identity_status == IDENTITY_UNLINKED
+    }
+}
+
+/// What a provider's records can and cannot establish about delegation.
+///
+/// Consumers read this instead of guessing why a field is null: a Codex
+/// subagent always has its own thread id, a Claude subagent has one only on
+/// provider versions that emit `agentId`, and the remaining providers record
+/// no delegation at all.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RelationshipCapabilities {
+    pub source: String,
+    /// `always` | `sometimes` | `never`
+    pub stable_child_identity: String,
+    pub records_agent_type: bool,
+    pub records_spawn_time: bool,
+    pub records_evidence_locator: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RelationshipDiagnostic {
+    pub code: String,
+    pub message: String,
+    pub relationship_uid: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionRelationships {
+    pub contract_version: u32,
+    pub source: String,
+    pub session_id: String,
+    pub as_parent: Vec<SessionRelationship>,
+    pub as_child: Vec<SessionRelationship>,
+    pub capabilities: RelationshipCapabilities,
+    pub diagnostics: Vec<RelationshipDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionTreeNode {
+    pub source: String,
+    pub session_id: String,
+    pub depth: u32,
+    pub parent_session_id: Option<String>,
+    /// The edge that reached this node. `None` for the root.
+    pub relationship: Option<SessionRelationship>,
+    /// Child relationships with a traversable identity. Unlinked evidence is
+    /// reported through [`SessionTree::unlinked`] instead.
+    pub child_count: u32,
+    pub has_events: bool,
+    /// Children exist but were not expanded (depth/node budget or cycle).
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SessionTreeOptions {
+    pub max_depth: u32,
+    pub max_nodes: u32,
+}
+
+impl Default for SessionTreeOptions {
+    fn default() -> Self {
+        Self {
+            max_depth: DEFAULT_TREE_MAX_DEPTH,
+            max_nodes: DEFAULT_TREE_MAX_NODES,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionTree {
+    pub contract_version: u32,
+    pub source: String,
+    pub root_session_id: String,
+    /// Pre-order, deterministic. Always contains the root as `nodes[0]`.
+    pub nodes: Vec<SessionTreeNode>,
+    /// Related evidence with no stable child identity, at any depth.
+    pub unlinked: Vec<SessionRelationship>,
+    pub capabilities: RelationshipCapabilities,
+    pub diagnostics: Vec<RelationshipDiagnostic>,
+    pub truncated: bool,
+    pub max_depth_reached: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RelationshipCursor {
+    pub spawned_at_ms: Option<i64>,
+    pub relationship_uid: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionChildrenPage {
+    pub children: Vec<SessionRelationship>,
+    pub next_cursor: Option<RelationshipCursor>,
+}
+
+/// What each provider's records establish about delegation. A pure table: no
+/// database access, so it answers correctly even for a missing database.
+pub fn relationship_capabilities(source: &str) -> RelationshipCapabilities {
+    let (stable_child_identity, records) = match source {
+        // Every Codex subagent rollout opens with its own thread id.
+        "codex" => ("always", true),
+        // Claude subagent transcripts carry the parent's `sessionId`; only
+        // provider versions that also emit a per-child `agentId` give the
+        // child a stable identity.
+        "claude" => ("sometimes", true),
+        _ => ("never", false),
+    };
+    RelationshipCapabilities {
+        source: source.to_string(),
+        stable_child_identity: stable_child_identity.to_string(),
+        records_agent_type: records,
+        records_spawn_time: records,
+        records_evidence_locator: records,
+    }
+}
+
+fn map_relationship(row: &Row<'_>) -> rusqlite::Result<SessionRelationship> {
+    Ok(SessionRelationship {
+        source: row.get(0)?,
+        parent_session_id: row.get(1)?,
+        child_session_id: row.get(2)?,
+        relationship: row.get(3)?,
+        identity_status: row.get(4)?,
+        child_agent_type: row.get(5)?,
+        child_agent_name: row.get(6)?,
+        child_model: row.get(7)?,
+        spawn_depth: row.get(8)?,
+        evidence_kind: row.get(9)?,
+        evidence_locator: row.get(10)?,
+        evidence_ref: row.get(11)?,
+        child_has_events: row.get(12)?,
+        spawned_at_ms: row.get(13)?,
+        created_ms: row.get(14)?,
+        relationship_uid: row.get(15)?,
+    })
+}
+
+fn unlinked_diagnostic(relationship: &SessionRelationship) -> RelationshipDiagnostic {
+    RelationshipDiagnostic {
+        code: "RELATIONSHIP_UNLINKED_CHILD".to_string(),
+        message: format!(
+            "{} evidence at {} has no stable child identity; events are not independently addressable",
+            relationship.source,
+            relationship.evidence_locator.as_deref().unwrap_or("unknown"),
+        ),
+        relationship_uid: Some(relationship.relationship_uid.clone()),
+    }
+}
+
+/// Direct delegation relationships for one session, in both directions.
+pub fn session_relationships(
+    conn: &Connection,
+    source: &str,
+    session_id: &str,
+) -> Result<SessionRelationships> {
+    let as_parent = session_children(conn, source, session_id)?;
+    let as_child = session_parents(conn, source, session_id)?;
+    let diagnostics = as_parent
+        .iter()
+        .filter(|relationship| relationship.is_unlinked())
+        .map(unlinked_diagnostic)
+        .collect();
+    Ok(SessionRelationships {
+        contract_version: SESSION_RELATIONSHIP_CONTRACT_VERSION,
+        source: source.to_string(),
+        session_id: session_id.to_string(),
+        as_parent,
+        as_child,
+        capabilities: relationship_capabilities(source),
+        diagnostics,
+    })
+}
+
+/// Every recorded child of one parent, in the traversal's total order.
+pub fn session_children(
+    conn: &Connection,
+    source: &str,
+    parent_session_id: &str,
+) -> Result<Vec<SessionRelationship>> {
+    let sql = format!(
+        "SELECT {RELATIONSHIP_COLUMNS} FROM session_relationships \
+         WHERE source = ? AND parent_session_id = ? {CHILD_ORDER}"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params![source, parent_session_id], map_relationship)?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+/// One bounded page of a parent's children, continuing the same total order.
+pub fn session_children_page(
+    conn: &Connection,
+    source: &str,
+    parent_session_id: &str,
+    limit: i64,
+    after: Option<&RelationshipCursor>,
+) -> Result<SessionChildrenPage> {
+    let limit = limit.clamp(1, MAX_CHILDREN_PAGE_LIMIT);
+    let mut sql = format!(
+        "SELECT {RELATIONSHIP_COLUMNS} FROM session_relationships \
+         WHERE source = ? AND parent_session_id = ?"
+    );
+    let mut values: Vec<rusqlite::types::Value> = vec![
+        source.to_string().into(),
+        parent_session_id.to_string().into(),
+    ];
+    if let Some(cursor) = after {
+        match cursor.spawned_at_ms {
+            // Still inside the timestamped region: the rest of that region
+            // follows, and then the whole null-timestamp tail.
+            Some(spawned_at_ms) => {
+                sql.push_str(
+                    " AND (spawned_at_ms IS NULL \
+                       OR spawned_at_ms > ? \
+                       OR (spawned_at_ms = ? AND relationship_uid > ?))",
+                );
+                values.push(spawned_at_ms.into());
+                values.push(spawned_at_ms.into());
+                values.push(cursor.relationship_uid.clone().into());
+            }
+            // Already in the null-timestamp tail, which is ordered by uid.
+            None => {
+                sql.push_str(" AND spawned_at_ms IS NULL AND relationship_uid > ?");
+                values.push(cursor.relationship_uid.clone().into());
+            }
+        }
+    }
+    sql.push(' ');
+    sql.push_str(CHILD_ORDER);
+    sql.push_str(" LIMIT ?");
+    values.push((limit + 1).into());
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(values), map_relationship)?;
+    let mut children = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+    let has_more = children.len() > limit as usize;
+    if has_more {
+        children.truncate(limit as usize);
+    }
+    let next_cursor = (has_more && !children.is_empty()).then(|| {
+        let last = children.last().expect("non-empty page");
+        RelationshipCursor {
+            spawned_at_ms: last.spawned_at_ms,
+            relationship_uid: last.relationship_uid.clone(),
+        }
+    });
+    Ok(SessionChildrenPage {
+        children,
+        next_cursor,
+    })
+}
+
+/// Every recorded parent of one child.
+pub fn session_parents(
+    conn: &Connection,
+    source: &str,
+    child_session_id: &str,
+) -> Result<Vec<SessionRelationship>> {
+    let sql = format!(
+        "SELECT {RELATIONSHIP_COLUMNS} FROM session_relationships \
+         WHERE source = ? AND child_session_id = ? \
+         ORDER BY parent_session_id ASC, relationship_uid ASC"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params![source, child_session_id], map_relationship)?;
+    Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+fn has_children(conn: &Connection, source: &str, parent_session_id: &str) -> Result<bool> {
+    Ok(conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM session_relationships \
+         WHERE source = ? AND parent_session_id = ? LIMIT 1)",
+        params![source, parent_session_id],
+        |row| row.get(0),
+    )?)
+}
+
+fn has_events(conn: &Connection, source: &str, session_id: &str) -> Result<bool> {
+    Ok(conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM session_events \
+         WHERE source = ? AND session_id = ? LIMIT 1)",
+        params![source, session_id],
+        |row| row.get(0),
+    )?)
+}
+
+struct Pending {
+    session_id: String,
+    depth: u32,
+    parent_index: Option<usize>,
+    parent_session_id: Option<String>,
+    relationship: Option<SessionRelationship>,
+}
+
+/// The complete descendant tree of one session, pre-order and bounded.
+///
+/// Traversal is an explicit stack with a visited set, so a cycle in the
+/// recorded evidence costs one diagnostic rather than an unbounded walk, and
+/// each emitted node costs exactly one indexed child query. A session appears
+/// once, at its shallowest reachable depth.
+pub fn session_tree(
+    conn: &Connection,
+    source: &str,
+    session_id: &str,
+    options: &SessionTreeOptions,
+) -> Result<SessionTree> {
+    let max_depth = options.max_depth.clamp(1, MAX_TREE_MAX_DEPTH);
+    let max_nodes = options.max_nodes.clamp(1, MAX_TREE_MAX_NODES) as usize;
+    let mut nodes: Vec<SessionTreeNode> = Vec::new();
+    let mut unlinked: Vec<SessionRelationship> = Vec::new();
+    let mut diagnostics: Vec<RelationshipDiagnostic> = Vec::new();
+    let mut visited: HashSet<String> = HashSet::new();
+    let mut truncated = false;
+    let mut max_depth_reached = 0;
+    let mut stack = vec![Pending {
+        session_id: session_id.to_string(),
+        depth: 0,
+        parent_index: None,
+        parent_session_id: None,
+        relationship: None,
+    }];
+
+    while let Some(pending) = stack.pop() {
+        if nodes.len() >= max_nodes {
+            truncated = true;
+            if let Some(index) = pending.parent_index {
+                nodes[index].truncated = true;
+            }
+            diagnostics.push(RelationshipDiagnostic {
+                code: "RELATIONSHIP_TREE_TRUNCATED".to_string(),
+                message: format!("tree exceeded max_nodes={max_nodes}"),
+                relationship_uid: None,
+            });
+            break;
+        }
+        if !visited.insert(pending.session_id.clone()) {
+            if let Some(index) = pending.parent_index {
+                nodes[index].truncated = true;
+            }
+            truncated = true;
+            diagnostics.push(RelationshipDiagnostic {
+                code: "RELATIONSHIP_CYCLE".to_string(),
+                message: format!(
+                    "{} already appears in this tree; not expanded again",
+                    pending.session_id
+                ),
+                relationship_uid: pending
+                    .relationship
+                    .as_ref()
+                    .map(|relationship| relationship.relationship_uid.clone()),
+            });
+            continue;
+        }
+        // A child's addressability was recorded when the edge was observed;
+        // only the root needs a probe of its own.
+        let node_has_events = match pending.relationship.as_ref() {
+            Some(relationship) => relationship.child_has_events,
+            None => has_events(conn, source, &pending.session_id)?,
+        };
+        let index = nodes.len();
+        max_depth_reached = max_depth_reached.max(pending.depth);
+        nodes.push(SessionTreeNode {
+            source: source.to_string(),
+            session_id: pending.session_id.clone(),
+            depth: pending.depth,
+            parent_session_id: pending.parent_session_id.clone(),
+            relationship: pending.relationship.clone(),
+            child_count: 0,
+            has_events: node_has_events,
+            truncated: false,
+        });
+        if pending.depth >= max_depth {
+            if has_children(conn, source, &pending.session_id)? {
+                nodes[index].truncated = true;
+                truncated = true;
+                diagnostics.push(RelationshipDiagnostic {
+                    code: "RELATIONSHIP_TREE_DEPTH_LIMIT".to_string(),
+                    message: format!(
+                        "{} has children beyond max_depth={max_depth}; not expanded",
+                        pending.session_id
+                    ),
+                    relationship_uid: pending
+                        .relationship
+                        .as_ref()
+                        .map(|relationship| relationship.relationship_uid.clone()),
+                });
+            }
+            continue;
+        }
+        let mut linked = Vec::new();
+        for relationship in session_children(conn, source, &pending.session_id)? {
+            if relationship.is_unlinked() {
+                diagnostics.push(unlinked_diagnostic(&relationship));
+                unlinked.push(relationship);
+            } else {
+                linked.push(relationship);
+            }
+        }
+        nodes[index].child_count = linked.len() as u32;
+        // Pushed in reverse so the stack pops them in the total order above.
+        for relationship in linked.into_iter().rev() {
+            let child_session_id = relationship
+                .child_session_id
+                .clone()
+                .expect("linked relationships carry a child id");
+            stack.push(Pending {
+                session_id: child_session_id,
+                depth: pending.depth + 1,
+                parent_index: Some(index),
+                parent_session_id: Some(pending.session_id.clone()),
+                relationship: Some(relationship),
+            });
+        }
+    }
+
+    Ok(SessionTree {
+        contract_version: SESSION_RELATIONSHIP_CONTRACT_VERSION,
+        source: source.to_string(),
+        root_session_id: session_id.to_string(),
+        nodes,
+        unlinked,
+        capabilities: relationship_capabilities(source),
+        diagnostics,
+        truncated,
+        max_depth_reached,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::open_db;
+
+    struct Edge<'a> {
+        source: &'a str,
+        parent: &'a str,
+        child: Option<&'a str>,
+        uid: &'a str,
+        spawned_at_ms: Option<i64>,
+        has_events: bool,
+    }
+
+    impl<'a> Edge<'a> {
+        fn new(parent: &'a str, child: &'a str) -> Self {
+            Self {
+                source: "codex",
+                parent,
+                child: Some(child),
+                uid: "",
+                spawned_at_ms: None,
+                has_events: true,
+            }
+        }
+    }
+
+    fn insert_edge(conn: &Connection, edge: &Edge<'_>) {
+        let uid = if edge.uid.is_empty() {
+            match edge.child {
+                Some(child) => format!("child:{child}"),
+                None => "evidence:test:unknown".to_string(),
+            }
+        } else {
+            edge.uid.to_string()
+        };
+        let identity_status = if edge.child.is_some() {
+            IDENTITY_OBSERVED
+        } else {
+            IDENTITY_UNLINKED
+        };
+        conn.execute(
+            "INSERT INTO session_relationships \
+             (source, parent_session_id, relationship_uid, child_session_id, relationship, \
+              identity_status, evidence_kind, evidence_locator, child_has_events, \
+              spawned_at_ms, created_ms, updated_ms) \
+             VALUES (?, ?, ?, ?, 'delegated', ?, 'test_evidence', ?, ?, ?, 1, 1)",
+            params![
+                edge.source,
+                edge.parent,
+                uid,
+                edge.child,
+                identity_status,
+                format!("/tmp/{uid}.jsonl"),
+                edge.has_events,
+                edge.spawned_at_ms,
+            ],
+        )
+        .unwrap();
+    }
+
+    fn database() -> (tempfile::TempDir, Connection) {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = open_db(&dir.path().join("history.db")).unwrap();
+        (dir, conn)
+    }
+
+    fn ids(tree: &SessionTree) -> Vec<String> {
+        tree.nodes
+            .iter()
+            .map(|node| node.session_id.clone())
+            .collect()
+    }
+
+    #[test]
+    fn root_with_no_children_returns_empty_relationships() {
+        let (_dir, conn) = database();
+        let result = session_relationships(&conn, "codex", "lonely").unwrap();
+        assert_eq!(
+            result.contract_version,
+            SESSION_RELATIONSHIP_CONTRACT_VERSION
+        );
+        assert!(result.as_parent.is_empty());
+        assert!(result.as_child.is_empty());
+        assert!(result.diagnostics.is_empty());
+        assert_eq!(result.capabilities.stable_child_identity, "always");
+
+        let tree = session_tree(&conn, "codex", "lonely", &SessionTreeOptions::default()).unwrap();
+        assert_eq!(ids(&tree), vec!["lonely".to_string()]);
+        assert!(!tree.truncated);
+        assert_eq!(tree.max_depth_reached, 0);
+    }
+
+    #[test]
+    fn single_child_and_multiple_children_are_ordered() {
+        let (_dir, conn) = database();
+        insert_edge(
+            &conn,
+            &Edge {
+                spawned_at_ms: None,
+                ..Edge::new("root", "no-timestamp")
+            },
+        );
+        insert_edge(
+            &conn,
+            &Edge {
+                spawned_at_ms: Some(300),
+                ..Edge::new("root", "late")
+            },
+        );
+        insert_edge(
+            &conn,
+            &Edge {
+                spawned_at_ms: Some(100),
+                ..Edge::new("root", "early")
+            },
+        );
+        let children = session_children(&conn, "codex", "root").unwrap();
+        assert_eq!(
+            children
+                .iter()
+                .map(|child| child.child_session_id.clone().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["early", "late", "no-timestamp"]
+        );
+        let result = session_relationships(&conn, "codex", "root").unwrap();
+        assert_eq!(result.as_parent.len(), 3);
+    }
+
+    #[test]
+    fn nested_descendants_produce_preorder_nodes() {
+        let (_dir, conn) = database();
+        insert_edge(&conn, &Edge::new("root", "a"));
+        insert_edge(&conn, &Edge::new("a", "b"));
+        insert_edge(&conn, &Edge::new("b", "c"));
+        let tree = session_tree(&conn, "codex", "root", &SessionTreeOptions::default()).unwrap();
+        assert_eq!(ids(&tree), vec!["root", "a", "b", "c"]);
+        assert_eq!(
+            tree.nodes.iter().map(|node| node.depth).collect::<Vec<_>>(),
+            vec![0, 1, 2, 3]
+        );
+        assert_eq!(tree.max_depth_reached, 3);
+        assert!(!tree.truncated);
+        assert_eq!(tree.nodes[1].parent_session_id.as_deref(), Some("root"));
+        assert!(tree.nodes[0].relationship.is_none());
+        assert_eq!(
+            tree.nodes[1]
+                .relationship
+                .as_ref()
+                .map(|edge| edge.relationship_uid.clone()),
+            Some("child:a".to_string())
+        );
+    }
+
+    #[test]
+    fn child_to_parent_lookup_is_symmetric() {
+        let (_dir, conn) = database();
+        insert_edge(&conn, &Edge::new("root", "child"));
+        let parent = session_relationships(&conn, "codex", "root").unwrap();
+        let child = session_relationships(&conn, "codex", "child").unwrap();
+        assert_eq!(parent.as_parent, child.as_child);
+        assert!(child.as_parent.is_empty());
+        assert!(parent.as_child.is_empty());
+    }
+
+    #[test]
+    fn cycle_protection_emits_one_node_per_session() {
+        let (_dir, conn) = database();
+        insert_edge(&conn, &Edge::new("a", "b"));
+        insert_edge(&conn, &Edge::new("b", "a"));
+        let tree = session_tree(&conn, "codex", "a", &SessionTreeOptions::default()).unwrap();
+        assert_eq!(ids(&tree), vec!["a", "b"]);
+        assert!(tree.nodes[1].truncated);
+        assert!(tree
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "RELATIONSHIP_CYCLE"));
+    }
+
+    #[test]
+    fn self_edge_is_not_expanded() {
+        let (_dir, conn) = database();
+        insert_edge(&conn, &Edge::new("a", "a"));
+        let tree = session_tree(&conn, "codex", "a", &SessionTreeOptions::default()).unwrap();
+        assert_eq!(ids(&tree), vec!["a"]);
+        assert!(tree.nodes[0].truncated);
+        assert!(tree
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "RELATIONSHIP_CYCLE"));
+    }
+
+    #[test]
+    fn deterministic_ordering_is_insert_order_independent() {
+        let forward = database();
+        for (parent, child, spawned) in [
+            ("root", "a", Some(10)),
+            ("root", "b", Some(20)),
+            ("a", "a1", Some(30)),
+            ("a", "a2", None),
+        ] {
+            insert_edge(
+                &forward.1,
+                &Edge {
+                    spawned_at_ms: spawned,
+                    ..Edge::new(parent, child)
+                },
+            );
+        }
+        let reverse = database();
+        for (parent, child, spawned) in [
+            ("a", "a2", None),
+            ("a", "a1", Some(30)),
+            ("root", "b", Some(20)),
+            ("root", "a", Some(10)),
+        ] {
+            insert_edge(
+                &reverse.1,
+                &Edge {
+                    spawned_at_ms: spawned,
+                    ..Edge::new(parent, child)
+                },
+            );
+        }
+        let options = SessionTreeOptions::default();
+        let left = session_tree(&forward.1, "codex", "root", &options).unwrap();
+        let right = session_tree(&reverse.1, "codex", "root", &options).unwrap();
+        assert_eq!(ids(&left), vec!["root", "a", "a1", "a2", "b"]);
+        assert_eq!(left.nodes, right.nodes);
+        assert_eq!(
+            session_children(&forward.1, "codex", "root").unwrap(),
+            session_children(&reverse.1, "codex", "root").unwrap()
+        );
+    }
+
+    #[test]
+    fn source_isolation_keeps_matching_native_ids_apart() {
+        let (_dir, conn) = database();
+        insert_edge(&conn, &Edge::new("s1", "codex-child"));
+        insert_edge(
+            &conn,
+            &Edge {
+                source: "claude",
+                ..Edge::new("s1", "claude-child")
+            },
+        );
+        let options = SessionTreeOptions::default();
+        assert_eq!(
+            ids(&session_tree(&conn, "codex", "s1", &options).unwrap()),
+            vec!["s1", "codex-child"]
+        );
+        assert_eq!(
+            ids(&session_tree(&conn, "claude", "s1", &options).unwrap()),
+            vec!["s1", "claude-child"]
+        );
+        assert_eq!(
+            session_parents(&conn, "codex", "claude-child")
+                .unwrap()
+                .len(),
+            0
+        );
+    }
+
+    #[test]
+    fn unlinked_rows_are_reported_not_traversed() {
+        let (_dir, conn) = database();
+        insert_edge(
+            &conn,
+            &Edge {
+                source: "claude",
+                child: None,
+                uid: "evidence:claude_sidechain_records:/tmp/agent-x.jsonl",
+                has_events: false,
+                ..Edge::new("root", "unused")
+            },
+        );
+        let tree = session_tree(&conn, "claude", "root", &SessionTreeOptions::default()).unwrap();
+        assert_eq!(ids(&tree), vec!["root"]);
+        assert_eq!(tree.unlinked.len(), 1);
+        assert_eq!(tree.nodes[0].child_count, 0);
+        assert!(tree
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "RELATIONSHIP_UNLINKED_CHILD"));
+        let result = session_relationships(&conn, "claude", "root").unwrap();
+        assert_eq!(result.as_parent.len(), 1);
+        assert!(result.as_parent[0].child_session_id.is_none());
+        assert_eq!(result.diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn large_tree_traversal_is_bounded() {
+        let (_dir, conn) = database();
+        conn.execute_batch(
+            "WITH RECURSIVE seq(x) AS (VALUES(1) UNION ALL SELECT x + 1 FROM seq WHERE x < 5000) \
+             INSERT INTO session_relationships \
+               (source, parent_session_id, relationship_uid, child_session_id, relationship, \
+                identity_status, evidence_kind, child_has_events, spawned_at_ms, created_ms, updated_ms) \
+             SELECT 'codex', 'root', 'child:c' || x, 'c' || x, 'delegated', 'observed', \
+                    'test_evidence', 1, x, 1, 1 FROM seq;",
+        )
+        .unwrap();
+        let tree = session_tree(
+            &conn,
+            "codex",
+            "root",
+            &SessionTreeOptions {
+                max_depth: DEFAULT_TREE_MAX_DEPTH,
+                max_nodes: 100,
+            },
+        )
+        .unwrap();
+        assert_eq!(tree.nodes.len(), 100);
+        assert!(tree.truncated);
+        assert!(tree
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "RELATIONSHIP_TREE_TRUNCATED"));
+    }
+
+    #[test]
+    fn depth_limit_marks_the_boundary_node_truncated() {
+        let (_dir, conn) = database();
+        for depth in 0..5 {
+            insert_edge(
+                &conn,
+                &Edge::new(&format!("d{depth}"), &format!("d{}", depth + 1)),
+            );
+        }
+        let tree = session_tree(
+            &conn,
+            "codex",
+            "d0",
+            &SessionTreeOptions {
+                max_depth: 2,
+                max_nodes: DEFAULT_TREE_MAX_NODES,
+            },
+        )
+        .unwrap();
+        assert_eq!(ids(&tree), vec!["d0", "d1", "d2"]);
+        assert!(tree.nodes[2].truncated);
+        assert!(tree.truncated);
+        assert_eq!(tree.max_depth_reached, 2);
+        assert!(tree
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "RELATIONSHIP_TREE_DEPTH_LIMIT"));
+    }
+
+    #[test]
+    fn children_page_cursor_covers_every_child_exactly_once() {
+        let (_dir, conn) = database();
+        for index in 0..250 {
+            insert_edge(
+                &conn,
+                &Edge {
+                    // Half the rows have no provider spawn time, exercising
+                    // both regions of the total order and the crossing.
+                    spawned_at_ms: (index % 2 == 0).then_some(index),
+                    ..Edge::new("root", &format!("c{index:03}"))
+                },
+            );
+        }
+        let mut seen = Vec::new();
+        let mut cursor = None;
+        let mut pages = 0;
+        loop {
+            let page = session_children_page(&conn, "codex", "root", 100, cursor.as_ref()).unwrap();
+            pages += 1;
+            seen.extend(
+                page.children
+                    .iter()
+                    .map(|child| child.relationship_uid.clone()),
+            );
+            match page.next_cursor {
+                Some(next) => cursor = Some(next),
+                None => break,
+            }
+        }
+        assert_eq!(pages, 3);
+        assert_eq!(seen.len(), 250);
+        assert_eq!(seen.iter().collect::<HashSet<_>>().len(), 250);
+        let all = session_children(&conn, "codex", "root")
+            .unwrap()
+            .into_iter()
+            .map(|child| child.relationship_uid)
+            .collect::<Vec<_>>();
+        assert_eq!(seen, all);
+    }
+
+    #[test]
+    fn capabilities_are_declared_per_source() {
+        assert_eq!(
+            relationship_capabilities("codex").stable_child_identity,
+            "always"
+        );
+        assert_eq!(
+            relationship_capabilities("claude").stable_child_identity,
+            "sometimes"
+        );
+        for source in ["cursor", "grok", "opencode", "relay"] {
+            let capabilities = relationship_capabilities(source);
+            assert_eq!(capabilities.stable_child_identity, "never");
+            assert!(!capabilities.records_agent_type);
+            assert!(!capabilities.records_spawn_time);
+            assert!(!capabilities.records_evidence_locator);
+        }
+    }
+}

--- a/crates/ai-hist-core/src/relationships.rs
+++ b/crates/ai-hist-core/src/relationships.rs
@@ -140,6 +140,9 @@ pub struct SessionTree {
     pub unlinked: Vec<SessionRelationship>,
     pub capabilities: RelationshipCapabilities,
     pub diagnostics: Vec<RelationshipDiagnostic>,
+    /// A budget stopped the walk short of the recorded evidence. Skipping a
+    /// session already present in the tree is not truncation: nothing is
+    /// missing from the result.
     pub truncated: bool,
     pub max_depth_reached: u32,
 }
@@ -328,15 +331,6 @@ pub fn session_parents(
     Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
 }
 
-fn has_children(conn: &Connection, source: &str, parent_session_id: &str) -> Result<bool> {
-    Ok(conn.query_row(
-        "SELECT EXISTS(SELECT 1 FROM session_relationships \
-         WHERE source = ? AND parent_session_id = ? LIMIT 1)",
-        params![source, parent_session_id],
-        |row| row.get(0),
-    )?)
-}
-
 fn has_events(conn: &Connection, source: &str, session_id: &str) -> Result<bool> {
     Ok(conn.query_row(
         "SELECT EXISTS(SELECT 1 FROM session_events \
@@ -354,12 +348,34 @@ struct Pending {
     relationship: Option<SessionRelationship>,
 }
 
+/// Whether `session_id` is already on the path from the root to `from`.
+///
+/// Only an edge back into the current branch's own ancestry is a cycle. An
+/// edge into a node emitted on a different branch is a diamond in an acyclic
+/// graph, which must not be reported as one.
+fn is_ancestor(
+    nodes: &[SessionTreeNode],
+    parents: &[Option<usize>],
+    from: Option<usize>,
+    session_id: &str,
+) -> bool {
+    let mut index = from;
+    while let Some(current) = index {
+        if nodes[current].session_id == session_id {
+            return true;
+        }
+        index = parents[current];
+    }
+    false
+}
+
 /// The complete descendant tree of one session, pre-order and bounded.
 ///
 /// Traversal is an explicit stack with a visited set, so a cycle in the
 /// recorded evidence costs one diagnostic rather than an unbounded walk, and
 /// each emitted node costs exactly one indexed child query. A session appears
-/// once, at its shallowest reachable depth.
+/// exactly once, at the position pre-order first reaches it; later arrivals by
+/// another path are not expanded again.
 pub fn session_tree(
     conn: &Connection,
     source: &str,
@@ -369,6 +385,8 @@ pub fn session_tree(
     let max_depth = options.max_depth.clamp(1, MAX_TREE_MAX_DEPTH);
     let max_nodes = options.max_nodes.clamp(1, MAX_TREE_MAX_NODES) as usize;
     let mut nodes: Vec<SessionTreeNode> = Vec::new();
+    // Each emitted node's parent index, which `nodes` itself does not carry.
+    let mut parents: Vec<Option<usize>> = Vec::new();
     let mut unlinked: Vec<SessionRelationship> = Vec::new();
     let mut diagnostics: Vec<RelationshipDiagnostic> = Vec::new();
     let mut visited: HashSet<String> = HashSet::new();
@@ -385,8 +403,14 @@ pub fn session_tree(
     while let Some(pending) = stack.pop() {
         if nodes.len() >= max_nodes {
             truncated = true;
-            if let Some(index) = pending.parent_index {
-                nodes[index].truncated = true;
+            // Every parent still waiting on the stack keeps children it will
+            // never get, so all of them are marked, not just the one the
+            // budget happened to stop at.
+            for parent_index in std::iter::once(&pending)
+                .chain(stack.iter())
+                .filter_map(|remaining| remaining.parent_index)
+            {
+                nodes[parent_index].truncated = true;
             }
             diagnostics.push(RelationshipDiagnostic {
                 code: "RELATIONSHIP_TREE_TRUNCATED".to_string(),
@@ -396,21 +420,26 @@ pub fn session_tree(
             break;
         }
         if !visited.insert(pending.session_id.clone()) {
-            if let Some(index) = pending.parent_index {
-                nodes[index].truncated = true;
+            // A repeat is only a cycle when the edge points back into this
+            // branch's own ancestry. Reaching a node already emitted on
+            // another branch is a diamond: nothing is missing from the tree,
+            // so it is neither a cycle nor truncation.
+            if is_ancestor(&nodes, &parents, pending.parent_index, &pending.session_id) {
+                if let Some(index) = pending.parent_index {
+                    nodes[index].truncated = true;
+                }
+                diagnostics.push(RelationshipDiagnostic {
+                    code: "RELATIONSHIP_CYCLE".to_string(),
+                    message: format!(
+                        "{} already appears in this branch; not expanded again",
+                        pending.session_id
+                    ),
+                    relationship_uid: pending
+                        .relationship
+                        .as_ref()
+                        .map(|relationship| relationship.relationship_uid.clone()),
+                });
             }
-            truncated = true;
-            diagnostics.push(RelationshipDiagnostic {
-                code: "RELATIONSHIP_CYCLE".to_string(),
-                message: format!(
-                    "{} already appears in this tree; not expanded again",
-                    pending.session_id
-                ),
-                relationship_uid: pending
-                    .relationship
-                    .as_ref()
-                    .map(|relationship| relationship.relationship_uid.clone()),
-            });
             continue;
         }
         // A child's addressability was recorded when the edge was observed;
@@ -421,6 +450,7 @@ pub fn session_tree(
         };
         let index = nodes.len();
         max_depth_reached = max_depth_reached.max(pending.depth);
+        parents.push(pending.parent_index);
         nodes.push(SessionTreeNode {
             source: source.to_string(),
             session_id: pending.session_id.clone(),
@@ -431,8 +461,24 @@ pub fn session_tree(
             has_events: node_has_events,
             truncated: false,
         });
+        // The children of a node at the depth boundary are still read:
+        // unlinked evidence is reported wherever it hangs, and the boundary
+        // node's own child count is part of the answer either way.
+        let mut linked = Vec::new();
+        for relationship in session_children(conn, source, &pending.session_id)? {
+            if relationship.is_unlinked() {
+                diagnostics.push(unlinked_diagnostic(&relationship));
+                unlinked.push(relationship);
+            } else {
+                linked.push(relationship);
+            }
+        }
+        nodes[index].child_count = linked.len() as u32;
         if pending.depth >= max_depth {
-            if has_children(conn, source, &pending.session_id)? {
+            // Only a traversable child is left unexplored by the budget. A
+            // node whose children are all unlinked evidence is complete: the
+            // evidence is already in `unlinked`.
+            if !linked.is_empty() {
                 nodes[index].truncated = true;
                 truncated = true;
                 diagnostics.push(RelationshipDiagnostic {
@@ -449,16 +495,6 @@ pub fn session_tree(
             }
             continue;
         }
-        let mut linked = Vec::new();
-        for relationship in session_children(conn, source, &pending.session_id)? {
-            if relationship.is_unlinked() {
-                diagnostics.push(unlinked_diagnostic(&relationship));
-                unlinked.push(relationship);
-            } else {
-                linked.push(relationship);
-            }
-        }
-        nodes[index].child_count = linked.len() as u32;
         // Pushed in reverse so the stack pops them in the total order above.
         for relationship in linked.into_iter().rev() {
             let child_session_id = relationship
@@ -661,6 +697,9 @@ mod tests {
         let tree = session_tree(&conn, "codex", "a", &SessionTreeOptions::default()).unwrap();
         assert_eq!(ids(&tree), vec!["a", "b"]);
         assert!(tree.nodes[1].truncated);
+        // The tree holds every session the evidence names, so a loop is not a
+        // budget truncation.
+        assert!(!tree.truncated);
         assert!(tree
             .diagnostics
             .iter()
@@ -674,10 +713,26 @@ mod tests {
         let tree = session_tree(&conn, "codex", "a", &SessionTreeOptions::default()).unwrap();
         assert_eq!(ids(&tree), vec!["a"]);
         assert!(tree.nodes[0].truncated);
+        assert!(!tree.truncated);
         assert!(tree
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.code == "RELATIONSHIP_CYCLE"));
+    }
+
+    #[test]
+    fn a_diamond_is_not_reported_as_a_cycle() {
+        let (_dir, conn) = database();
+        insert_edge(&conn, &Edge::new("root", "b"));
+        insert_edge(&conn, &Edge::new("root", "c"));
+        insert_edge(&conn, &Edge::new("b", "c"));
+        let tree = session_tree(&conn, "codex", "root", &SessionTreeOptions::default()).unwrap();
+        // `c` is reachable twice but is one session, so it is emitted once.
+        assert_eq!(ids(&tree), vec!["root", "b", "c"]);
+        assert!(tree.diagnostics.is_empty());
+        assert!(!tree.truncated);
+        assert!(tree.nodes.iter().all(|node| !node.truncated));
+        assert_eq!(tree.nodes[0].child_count, 2);
     }
 
     #[test]
@@ -835,6 +890,117 @@ mod tests {
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.code == "RELATIONSHIP_TREE_DEPTH_LIMIT"));
+    }
+
+    #[test]
+    fn unlinked_evidence_at_the_depth_boundary_is_still_reported() {
+        let (_dir, conn) = database();
+        insert_edge(&conn, &Edge::new("root", "child"));
+        insert_edge(
+            &conn,
+            &Edge {
+                child: None,
+                uid: "evidence:test:/tmp/agent-boundary.jsonl",
+                has_events: false,
+                ..Edge::new("child", "unused")
+            },
+        );
+        let tree = session_tree(
+            &conn,
+            "codex",
+            "root",
+            &SessionTreeOptions {
+                max_depth: 1,
+                max_nodes: DEFAULT_TREE_MAX_NODES,
+            },
+        )
+        .unwrap();
+        assert_eq!(ids(&tree), vec!["root", "child"]);
+        assert_eq!(tree.unlinked.len(), 1);
+        assert_eq!(
+            tree.diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.code.as_str())
+                .collect::<Vec<_>>(),
+            vec!["RELATIONSHIP_UNLINKED_CHILD"]
+        );
+        // Evidence with no traversable identity is not a subtree the budget
+        // refused to walk.
+        assert!(!tree.nodes[1].truncated);
+        assert!(!tree.truncated);
+        assert_eq!(tree.nodes[1].child_count, 0);
+    }
+
+    #[test]
+    fn depth_boundary_counts_children_it_does_not_expand() {
+        let (_dir, conn) = database();
+        insert_edge(&conn, &Edge::new("root", "child"));
+        insert_edge(&conn, &Edge::new("child", "grandchild"));
+        insert_edge(
+            &conn,
+            &Edge {
+                child: None,
+                uid: "evidence:test:/tmp/agent-boundary.jsonl",
+                has_events: false,
+                ..Edge::new("child", "unused")
+            },
+        );
+        let tree = session_tree(
+            &conn,
+            "codex",
+            "root",
+            &SessionTreeOptions {
+                max_depth: 1,
+                max_nodes: DEFAULT_TREE_MAX_NODES,
+            },
+        )
+        .unwrap();
+        assert_eq!(ids(&tree), vec!["root", "child"]);
+        assert_eq!(tree.nodes[1].child_count, 1);
+        assert!(tree.nodes[1].truncated);
+        assert!(tree.truncated);
+        assert_eq!(tree.unlinked.len(), 1);
+        let codes = tree
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.code.as_str())
+            .collect::<Vec<_>>();
+        assert!(codes.contains(&"RELATIONSHIP_UNLINKED_CHILD"));
+        assert!(codes.contains(&"RELATIONSHIP_TREE_DEPTH_LIMIT"));
+    }
+
+    #[test]
+    fn node_budget_marks_every_parent_left_unexpanded() {
+        let (_dir, conn) = database();
+        for (parent, child) in [
+            ("root", "a"),
+            ("root", "b"),
+            ("a", "a1"),
+            ("a", "a2"),
+            ("b", "b1"),
+        ] {
+            insert_edge(&conn, &Edge::new(parent, child));
+        }
+        let tree = session_tree(
+            &conn,
+            "codex",
+            "root",
+            &SessionTreeOptions {
+                max_depth: DEFAULT_TREE_MAX_DEPTH,
+                max_nodes: 3,
+            },
+        )
+        .unwrap();
+        assert_eq!(ids(&tree), vec!["root", "a", "a1"]);
+        assert!(tree.truncated);
+        // `root` still owes `b` and `a` still owes `a2`; `a1` owes nothing.
+        assert_eq!(
+            tree.nodes
+                .iter()
+                .map(|node| node.truncated)
+                .collect::<Vec<_>>(),
+            vec![true, true, false]
+        );
     }
 
     #[test]

--- a/crates/ai-hist-core/src/relationships.rs
+++ b/crates/ai-hist-core/src/relationships.rs
@@ -401,24 +401,6 @@ pub fn session_tree(
     }];
 
     while let Some(pending) = stack.pop() {
-        if nodes.len() >= max_nodes {
-            truncated = true;
-            // Every parent still waiting on the stack keeps children it will
-            // never get, so all of them are marked, not just the one the
-            // budget happened to stop at.
-            for parent_index in std::iter::once(&pending)
-                .chain(stack.iter())
-                .filter_map(|remaining| remaining.parent_index)
-            {
-                nodes[parent_index].truncated = true;
-            }
-            diagnostics.push(RelationshipDiagnostic {
-                code: "RELATIONSHIP_TREE_TRUNCATED".to_string(),
-                message: format!("tree exceeded max_nodes={max_nodes}"),
-                relationship_uid: None,
-            });
-            break;
-        }
         if !visited.insert(pending.session_id.clone()) {
             // A repeat is only a cycle when the edge points back into this
             // branch's own ancestry. Reaching a node already emitted on
@@ -441,6 +423,27 @@ pub fn session_tree(
                 });
             }
             continue;
+        }
+        // Only a session the tree has not already emitted costs a node, so a
+        // diamond's second arrival at a node — dropped just above — never
+        // spends the budget or reports a complete tree as truncated.
+        if nodes.len() >= max_nodes {
+            truncated = true;
+            // Every parent still waiting on the stack keeps children it will
+            // never get, so all of them are marked, not just the one the
+            // budget happened to stop at.
+            for parent_index in std::iter::once(&pending)
+                .chain(stack.iter())
+                .filter_map(|remaining| remaining.parent_index)
+            {
+                nodes[parent_index].truncated = true;
+            }
+            diagnostics.push(RelationshipDiagnostic {
+                code: "RELATIONSHIP_TREE_TRUNCATED".to_string(),
+                message: format!("tree exceeded max_nodes={max_nodes}"),
+                relationship_uid: None,
+            });
+            break;
         }
         // A child's addressability was recorded when the edge was observed;
         // only the root needs a probe of its own.
@@ -733,6 +736,30 @@ mod tests {
         assert!(!tree.truncated);
         assert!(tree.nodes.iter().all(|node| !node.truncated));
         assert_eq!(tree.nodes[0].child_count, 2);
+    }
+
+    #[test]
+    fn a_diamond_costs_one_node_per_session_against_the_budget() {
+        let (_dir, conn) = database();
+        for (parent, child) in [("root", "b"), ("root", "c"), ("b", "d"), ("c", "d")] {
+            insert_edge(&conn, &Edge::new(parent, child));
+        }
+        // Four unique sessions and a budget of four: the tree is complete, so
+        // the repeated arrival at `d` must not be charged as a fifth node.
+        let tree = session_tree(
+            &conn,
+            "codex",
+            "root",
+            &SessionTreeOptions {
+                max_depth: DEFAULT_TREE_MAX_DEPTH,
+                max_nodes: 4,
+            },
+        )
+        .unwrap();
+        assert_eq!(ids(&tree), vec!["root", "b", "d", "c"]);
+        assert!(!tree.truncated);
+        assert!(tree.diagnostics.is_empty());
+        assert!(tree.nodes.iter().all(|node| !node.truncated));
     }
 
     #[test]

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -230,6 +230,108 @@ export interface HydrateSessionResult {
 }
 /** Fully index one cataloged session without enumerating unrelated sessions. */
 export declare function hydrateSession(options: HydrateSessionOptions): Promise<HydrateSessionResult>
+export interface NativeSessionRelationship {
+  source: string
+  parentSessionId: string
+  childSessionId?: string
+  relationship: string
+  identityStatus: string
+  childAgentType?: string
+  childAgentName?: string
+  childModel?: string
+  spawnDepth?: number
+  evidenceKind: string
+  evidenceLocator?: string
+  evidenceRef?: string
+  childHasEvents: boolean
+  spawnedAtMs?: number
+  createdMs: number
+  relationshipUid: string
+}
+export interface NativeRelationshipCapabilities {
+  source: string
+  stableChildIdentity: string
+  recordsAgentType: boolean
+  recordsSpawnTime: boolean
+  recordsEvidenceLocator: boolean
+}
+export interface NativeRelationshipDiagnostic {
+  code: string
+  message: string
+  relationshipUid?: string
+}
+export interface NativeSessionRelationships {
+  contractVersion: number
+  source: string
+  sessionId: string
+  asParent: Array<NativeSessionRelationship>
+  asChild: Array<NativeSessionRelationship>
+  capabilities: NativeRelationshipCapabilities
+  diagnostics: Array<NativeRelationshipDiagnostic>
+}
+export interface NativeSessionTreeNode {
+  source: string
+  sessionId: string
+  depth: number
+  parentSessionId?: string
+  relationship?: NativeSessionRelationship
+  childCount: number
+  hasEvents: boolean
+  truncated: boolean
+}
+export interface NativeSessionTree {
+  contractVersion: number
+  source: string
+  rootSessionId: string
+  nodes: Array<NativeSessionTreeNode>
+  unlinked: Array<NativeSessionRelationship>
+  capabilities: NativeRelationshipCapabilities
+  diagnostics: Array<NativeRelationshipDiagnostic>
+  truncated: boolean
+  maxDepthReached: number
+}
+export interface RelationshipCursor {
+  spawnedAtMs?: number
+  relationshipUid: string
+}
+export interface NativeSessionChildrenPage {
+  children: Array<NativeSessionRelationship>
+  nextCursor?: RelationshipCursor
+}
+export interface RelationshipOptions {
+  source: string
+  sessionId: string
+  dbPath?: string
+}
+export interface SessionTreeOptions {
+  source: string
+  sessionId: string
+  dbPath?: string
+  maxDepth?: number
+  maxNodes?: number
+}
+export interface SessionChildrenPageOptions {
+  source: string
+  sessionId: string
+  dbPath?: string
+  limit?: number
+  after?: RelationshipCursor
+}
+/**
+ * Direct delegation relationships for one session, in both directions.
+ * A missing database is an empty result, not an error.
+ */
+export declare function getSessionRelationships(options: RelationshipOptions): Promise<NativeSessionRelationships>
+/**
+ * The complete descendant delegation tree for one session: pre-order,
+ * cycle-safe, and bounded by `maxDepth` / `maxNodes`.
+ */
+export declare function getSessionTree(options: SessionTreeOptions): Promise<NativeSessionTree>
+/**
+ * One bounded page of a session's direct children, in the same total order
+ * the tree traversal uses.
+ */
+export declare function getSessionChildrenPage(options: SessionChildrenPageOptions): Promise<NativeSessionChildrenPage>
 export interface SyncOptions {
   dbPath?: string
   scope?: string

--- a/crates/ai-hist-napi/index.js
+++ b/crates/ai-hist-napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { nativeContractVersion, nativeBuildProfile, search, recent, getSession, getSessionEventsPage, stats, listSessionCatalogPage, listSessionCatalog, discoverSessions, hydrateSession, sync, syncLocal, syncAndPush } = nativeBinding
+const { nativeContractVersion, nativeBuildProfile, search, recent, getSession, getSessionEventsPage, stats, listSessionCatalogPage, listSessionCatalog, discoverSessions, hydrateSession, getSessionRelationships, getSessionTree, getSessionChildrenPage, sync, syncLocal, syncAndPush } = nativeBinding
 
 module.exports.nativeContractVersion = nativeContractVersion
 module.exports.nativeBuildProfile = nativeBuildProfile
@@ -323,6 +323,9 @@ module.exports.listSessionCatalogPage = listSessionCatalogPage
 module.exports.listSessionCatalog = listSessionCatalog
 module.exports.discoverSessions = discoverSessions
 module.exports.hydrateSession = hydrateSession
+module.exports.getSessionRelationships = getSessionRelationships
+module.exports.getSessionTree = getSessionTree
+module.exports.getSessionChildrenPage = getSessionChildrenPage
 module.exports.sync = sync
 module.exports.syncLocal = syncLocal
 module.exports.syncAndPush = syncAndPush

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -7,17 +7,27 @@
 use std::path::{Path, PathBuf};
 
 use ai_hist_core::{
-    default_db_path, open_db, open_db_readonly, recent as core_recent,
+    default_db_path, open_db, open_db_readonly, recent as core_recent, relationship_capabilities,
     schema_is_catalog_read_current, schema_is_event_read_current, schema_is_read_current,
-    search as core_search, session as core_session,
+    schema_is_relationship_read_current, search as core_search, session as core_session,
+    session_children_page as core_session_children_page,
     session_events_page as core_session_events_page, session_locations,
-    stats_scoped as core_stats_scoped, HistoryEntry, QueryFilter, SessionEvent as CoreSessionEvent,
-    SessionEventCursor as CoreEventCursor, SessionScope,
+    session_relationships as core_session_relationships, session_tree as core_session_tree,
+    stats_scoped as core_stats_scoped, HistoryEntry, QueryFilter,
+    RelationshipCapabilities as CoreRelationshipCapabilities,
+    RelationshipCursor as CoreRelationshipCursor,
+    RelationshipDiagnostic as CoreRelationshipDiagnostic, SessionEvent as CoreSessionEvent,
+    SessionEventCursor as CoreEventCursor, SessionRelationship as CoreSessionRelationship,
+    SessionRelationships as CoreSessionRelationships, SessionScope, SessionTree as CoreSessionTree,
+    SessionTreeNode as CoreSessionTreeNode, SessionTreeOptions as CoreSessionTreeOptions,
+    DEFAULT_CHILDREN_PAGE_LIMIT, DEFAULT_TREE_MAX_DEPTH, DEFAULT_TREE_MAX_NODES,
+    MAX_CHILDREN_PAGE_LIMIT, MAX_TREE_MAX_DEPTH, MAX_TREE_MAX_NODES,
+    SESSION_RELATIONSHIP_CONTRACT_VERSION,
 };
 use napi_derive::napi;
 
 /// Bump whenever native object shapes or semantics require an SDK change.
-pub const NATIVE_CONTRACT_VERSION: u32 = 4;
+pub const NATIVE_CONTRACT_VERSION: u32 = 5;
 const DEFAULT_LIMIT: i64 = 50;
 const DEFAULT_EVENT_LIMIT: i64 = 200;
 
@@ -849,6 +859,389 @@ pub async fn hydrate_session(options: HydrateSessionOptions) -> napi::Result<Hyd
             })
             .collect(),
     })
+}
+
+const CATALOG_SOURCES: &[&str] = &["claude", "codex", "cursor", "grok", "relay", "opencode"];
+
+/// Reject an unusable identity before opening anything, so a typo is an
+/// argument error rather than an empty result that looks like real data.
+fn validate_identity(source: &str, session_id: &str) -> napi::Result<()> {
+    if session_id.trim().is_empty() {
+        return Err(native_error(
+            "INVALID_ARGUMENT",
+            "sessionId must not be empty",
+        ));
+    }
+    if !CATALOG_SOURCES.contains(&source) {
+        return Err(native_error(
+            "INVALID_ARGUMENT",
+            format!("unsupported catalog source '{source}'"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_bound(value: Option<i64>, name: &str, default: u32, max: u32) -> napi::Result<u32> {
+    let value = match value {
+        Some(value) => value,
+        None => return Ok(default),
+    };
+    if !(1..=i64::from(max)).contains(&value) {
+        return Err(native_error(
+            "INVALID_ARGUMENT",
+            format!("{name} must be between 1 and {max} (got {value})"),
+        ));
+    }
+    Ok(value as u32)
+}
+
+#[napi(object)]
+pub struct NativeSessionRelationship {
+    pub source: String,
+    pub parent_session_id: String,
+    pub child_session_id: Option<String>,
+    pub relationship: String,
+    pub identity_status: String,
+    pub child_agent_type: Option<String>,
+    pub child_agent_name: Option<String>,
+    pub child_model: Option<String>,
+    pub spawn_depth: Option<i64>,
+    pub evidence_kind: String,
+    pub evidence_locator: Option<String>,
+    pub evidence_ref: Option<String>,
+    pub child_has_events: bool,
+    pub spawned_at_ms: Option<i64>,
+    pub created_ms: i64,
+    pub relationship_uid: String,
+}
+
+impl From<CoreSessionRelationship> for NativeSessionRelationship {
+    fn from(relationship: CoreSessionRelationship) -> Self {
+        Self {
+            source: relationship.source,
+            parent_session_id: relationship.parent_session_id,
+            child_session_id: relationship.child_session_id,
+            relationship: relationship.relationship,
+            identity_status: relationship.identity_status,
+            child_agent_type: relationship.child_agent_type,
+            child_agent_name: relationship.child_agent_name,
+            child_model: relationship.child_model,
+            spawn_depth: relationship.spawn_depth,
+            evidence_kind: relationship.evidence_kind,
+            evidence_locator: relationship.evidence_locator,
+            evidence_ref: relationship.evidence_ref,
+            child_has_events: relationship.child_has_events,
+            spawned_at_ms: relationship.spawned_at_ms,
+            created_ms: relationship.created_ms,
+            relationship_uid: relationship.relationship_uid,
+        }
+    }
+}
+
+#[napi(object)]
+pub struct NativeRelationshipCapabilities {
+    pub source: String,
+    pub stable_child_identity: String,
+    pub records_agent_type: bool,
+    pub records_spawn_time: bool,
+    pub records_evidence_locator: bool,
+}
+
+impl From<CoreRelationshipCapabilities> for NativeRelationshipCapabilities {
+    fn from(capabilities: CoreRelationshipCapabilities) -> Self {
+        Self {
+            source: capabilities.source,
+            stable_child_identity: capabilities.stable_child_identity,
+            records_agent_type: capabilities.records_agent_type,
+            records_spawn_time: capabilities.records_spawn_time,
+            records_evidence_locator: capabilities.records_evidence_locator,
+        }
+    }
+}
+
+#[napi(object)]
+pub struct NativeRelationshipDiagnostic {
+    pub code: String,
+    pub message: String,
+    pub relationship_uid: Option<String>,
+}
+
+impl From<CoreRelationshipDiagnostic> for NativeRelationshipDiagnostic {
+    fn from(diagnostic: CoreRelationshipDiagnostic) -> Self {
+        Self {
+            code: diagnostic.code,
+            message: diagnostic.message,
+            relationship_uid: diagnostic.relationship_uid,
+        }
+    }
+}
+
+#[napi(object)]
+pub struct NativeSessionRelationships {
+    pub contract_version: u32,
+    pub source: String,
+    pub session_id: String,
+    pub as_parent: Vec<NativeSessionRelationship>,
+    pub as_child: Vec<NativeSessionRelationship>,
+    pub capabilities: NativeRelationshipCapabilities,
+    pub diagnostics: Vec<NativeRelationshipDiagnostic>,
+}
+
+impl From<CoreSessionRelationships> for NativeSessionRelationships {
+    fn from(relationships: CoreSessionRelationships) -> Self {
+        Self {
+            contract_version: relationships.contract_version,
+            source: relationships.source,
+            session_id: relationships.session_id,
+            as_parent: relationships
+                .as_parent
+                .into_iter()
+                .map(NativeSessionRelationship::from)
+                .collect(),
+            as_child: relationships
+                .as_child
+                .into_iter()
+                .map(NativeSessionRelationship::from)
+                .collect(),
+            capabilities: relationships.capabilities.into(),
+            diagnostics: relationships
+                .diagnostics
+                .into_iter()
+                .map(NativeRelationshipDiagnostic::from)
+                .collect(),
+        }
+    }
+}
+
+#[napi(object)]
+pub struct NativeSessionTreeNode {
+    pub source: String,
+    pub session_id: String,
+    pub depth: u32,
+    pub parent_session_id: Option<String>,
+    pub relationship: Option<NativeSessionRelationship>,
+    pub child_count: u32,
+    pub has_events: bool,
+    pub truncated: bool,
+}
+
+impl From<CoreSessionTreeNode> for NativeSessionTreeNode {
+    fn from(node: CoreSessionTreeNode) -> Self {
+        Self {
+            source: node.source,
+            session_id: node.session_id,
+            depth: node.depth,
+            parent_session_id: node.parent_session_id,
+            relationship: node.relationship.map(NativeSessionRelationship::from),
+            child_count: node.child_count,
+            has_events: node.has_events,
+            truncated: node.truncated,
+        }
+    }
+}
+
+#[napi(object)]
+pub struct NativeSessionTree {
+    pub contract_version: u32,
+    pub source: String,
+    pub root_session_id: String,
+    pub nodes: Vec<NativeSessionTreeNode>,
+    pub unlinked: Vec<NativeSessionRelationship>,
+    pub capabilities: NativeRelationshipCapabilities,
+    pub diagnostics: Vec<NativeRelationshipDiagnostic>,
+    pub truncated: bool,
+    pub max_depth_reached: u32,
+}
+
+impl From<CoreSessionTree> for NativeSessionTree {
+    fn from(tree: CoreSessionTree) -> Self {
+        Self {
+            contract_version: tree.contract_version,
+            source: tree.source,
+            root_session_id: tree.root_session_id,
+            nodes: tree
+                .nodes
+                .into_iter()
+                .map(NativeSessionTreeNode::from)
+                .collect(),
+            unlinked: tree
+                .unlinked
+                .into_iter()
+                .map(NativeSessionRelationship::from)
+                .collect(),
+            capabilities: tree.capabilities.into(),
+            diagnostics: tree
+                .diagnostics
+                .into_iter()
+                .map(NativeRelationshipDiagnostic::from)
+                .collect(),
+            truncated: tree.truncated,
+            max_depth_reached: tree.max_depth_reached,
+        }
+    }
+}
+
+#[napi(object)]
+pub struct RelationshipCursor {
+    pub spawned_at_ms: Option<i64>,
+    pub relationship_uid: String,
+}
+
+#[napi(object)]
+pub struct NativeSessionChildrenPage {
+    pub children: Vec<NativeSessionRelationship>,
+    pub next_cursor: Option<RelationshipCursor>,
+}
+
+#[napi(object)]
+pub struct RelationshipOptions {
+    pub source: String,
+    pub session_id: String,
+    pub db_path: Option<String>,
+}
+
+#[napi(object)]
+pub struct SessionTreeOptions {
+    pub source: String,
+    pub session_id: String,
+    pub db_path: Option<String>,
+    pub max_depth: Option<i64>,
+    pub max_nodes: Option<i64>,
+}
+
+#[napi(object)]
+pub struct SessionChildrenPageOptions {
+    pub source: String,
+    pub session_id: String,
+    pub db_path: Option<String>,
+    pub limit: Option<i64>,
+    pub after: Option<RelationshipCursor>,
+}
+
+/// Direct delegation relationships for one session, in both directions.
+/// A missing database is an empty result, not an error.
+#[napi]
+pub async fn get_session_relationships(
+    options: RelationshipOptions,
+) -> napi::Result<NativeSessionRelationships> {
+    validate_identity(&options.source, &options.session_id)?;
+    let path = db_path(options.db_path);
+    let source = options.source;
+    let session_id = options.session_id;
+    // Capabilities are a property of the provider, not of this database, so
+    // an empty result still answers what the provider could record.
+    let empty = NativeSessionRelationships {
+        contract_version: SESSION_RELATIONSHIP_CONTRACT_VERSION,
+        source: source.clone(),
+        session_id: session_id.clone(),
+        as_parent: Vec::new(),
+        as_child: Vec::new(),
+        capabilities: relationship_capabilities(&source).into(),
+        diagnostics: Vec::new(),
+    };
+    read_database_with_schema(
+        path,
+        empty,
+        schema_is_relationship_read_current,
+        move |conn| Ok(core_session_relationships(conn, &source, &session_id)?.into()),
+    )
+    .await
+}
+
+/// The complete descendant delegation tree for one session: pre-order,
+/// cycle-safe, and bounded by `maxDepth` / `maxNodes`.
+#[napi]
+pub async fn get_session_tree(options: SessionTreeOptions) -> napi::Result<NativeSessionTree> {
+    validate_identity(&options.source, &options.session_id)?;
+    let max_depth = validate_bound(
+        options.max_depth,
+        "maxDepth",
+        DEFAULT_TREE_MAX_DEPTH,
+        MAX_TREE_MAX_DEPTH,
+    )?;
+    let max_nodes = validate_bound(
+        options.max_nodes,
+        "maxNodes",
+        DEFAULT_TREE_MAX_NODES,
+        MAX_TREE_MAX_NODES,
+    )?;
+    let path = db_path(options.db_path);
+    let source = options.source;
+    let session_id = options.session_id;
+    let empty = NativeSessionTree {
+        contract_version: SESSION_RELATIONSHIP_CONTRACT_VERSION,
+        source: source.clone(),
+        root_session_id: session_id.clone(),
+        nodes: Vec::new(),
+        unlinked: Vec::new(),
+        capabilities: relationship_capabilities(&source).into(),
+        diagnostics: Vec::new(),
+        truncated: false,
+        max_depth_reached: 0,
+    };
+    read_database_with_schema(
+        path,
+        empty,
+        schema_is_relationship_read_current,
+        move |conn| {
+            let tree = core_session_tree(
+                conn,
+                &source,
+                &session_id,
+                &CoreSessionTreeOptions {
+                    max_depth,
+                    max_nodes,
+                },
+            )?;
+            Ok(tree.into())
+        },
+    )
+    .await
+}
+
+/// One bounded page of a session's direct children, in the same total order
+/// the tree traversal uses.
+#[napi]
+pub async fn get_session_children_page(
+    options: SessionChildrenPageOptions,
+) -> napi::Result<NativeSessionChildrenPage> {
+    validate_identity(&options.source, &options.session_id)?;
+    let limit = validate_limit(
+        options.limit,
+        DEFAULT_CHILDREN_PAGE_LIMIT,
+        MAX_CHILDREN_PAGE_LIMIT,
+    )?;
+    let path = db_path(options.db_path);
+    let source = options.source;
+    let session_id = options.session_id;
+    let after = options.after.map(|cursor| CoreRelationshipCursor {
+        spawned_at_ms: cursor.spawned_at_ms,
+        relationship_uid: cursor.relationship_uid,
+    });
+    read_database_with_schema(
+        path,
+        NativeSessionChildrenPage {
+            children: Vec::new(),
+            next_cursor: None,
+        },
+        schema_is_relationship_read_current,
+        move |conn| {
+            let page =
+                core_session_children_page(conn, &source, &session_id, limit, after.as_ref())?;
+            Ok(NativeSessionChildrenPage {
+                children: page
+                    .children
+                    .into_iter()
+                    .map(NativeSessionRelationship::from)
+                    .collect(),
+                next_cursor: page.next_cursor.map(|cursor| RelationshipCursor {
+                    spawned_at_ms: cursor.spawned_at_ms,
+                    relationship_uid: cursor.relationship_uid,
+                }),
+            })
+        },
+    )
+    .await
 }
 
 #[napi(object)]

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -1168,11 +1168,22 @@ pub async fn get_session_tree(options: SessionTreeOptions) -> napi::Result<Nativ
     let path = db_path(options.db_path);
     let source = options.source;
     let session_id = options.session_id;
+    // A tree always contains its root, so the missing-database answer is the
+    // same shape a real empty tree has: one node, no descendants.
     let empty = NativeSessionTree {
         contract_version: SESSION_RELATIONSHIP_CONTRACT_VERSION,
         source: source.clone(),
         root_session_id: session_id.clone(),
-        nodes: Vec::new(),
+        nodes: vec![NativeSessionTreeNode {
+            source: source.clone(),
+            session_id: session_id.clone(),
+            depth: 0,
+            parent_session_id: None,
+            relationship: None,
+            child_count: 0,
+            has_events: false,
+            truncated: false,
+        }],
         unlinked: Vec::new(),
         capabilities: relationship_capabilities(&source).into(),
         diagnostics: Vec::new(),

--- a/crates/ai-hist/src/hydrate.rs
+++ b/crates/ai-hist/src/hydrate.rs
@@ -453,7 +453,7 @@ fn ingest_claude(conn: &Connection, options: &HydrateSessionOptions, path: &Path
     ingest_claude_transcript(conn, path)?;
     if options.include_related {
         for evidence in claude_subagents(path, &options.session_id)? {
-            ingest_claude_subagent(conn, options, &evidence)?;
+            ingest_claude_subagent(conn, &options.session_id, &evidence)?;
         }
     }
     Ok(())
@@ -467,9 +467,14 @@ fn ingest_claude(conn: &Connection, options: &HydrateSessionOptions, path: &Path
 /// Without one this provider version simply does not name the child, so the
 /// sidechain assistant output stays on the parent exactly as before and the
 /// row records unlinked evidence rather than a fabricated identity.
-fn ingest_claude_subagent(
+///
+/// Shared with the full sync walk, which meets the same sidecars from the
+/// other direction: one sidecar produces the same events and the same
+/// `session_relationships` row whichever path reaches it first, and the row
+/// is an idempotent upsert so the path that arrives second changes nothing.
+pub(crate) fn ingest_claude_subagent(
     conn: &Connection,
-    options: &HydrateSessionOptions,
+    parent_session_id: &str,
     evidence: &ClaudeSubagentEvidence,
 ) -> Result<()> {
     let locator = evidence.path.to_string_lossy().to_string();
@@ -481,7 +486,7 @@ fn ingest_claude_subagent(
                 conn,
                 &ObservedRelationship {
                     source: "claude",
-                    parent_session_id: &options.session_id,
+                    parent_session_id,
                     child_session_id: Some(agent_id),
                     relationship: "delegated",
                     child_agent_type: evidence.agent_type.as_deref(),
@@ -502,7 +507,7 @@ fn ingest_claude_subagent(
                 conn,
                 &ObservedRelationship {
                     source: "claude",
-                    parent_session_id: &options.session_id,
+                    parent_session_id,
                     child_session_id: None,
                     relationship: "delegated",
                     child_agent_type: evidence.agent_type.as_deref(),
@@ -522,7 +527,7 @@ fn ingest_claude_subagent(
 
 /// One Claude subagent transcript beside a parent's, with whatever identity
 /// and description the provider recorded for it.
-struct ClaudeSubagentEvidence {
+pub(crate) struct ClaudeSubagentEvidence {
     path: PathBuf,
     /// The in-record `agentId`. `None` for provider versions that do not emit
     /// it.
@@ -533,6 +538,56 @@ struct ClaudeSubagentEvidence {
     spawn_depth: Option<i64>,
     tool_use_id: Option<String>,
     first_ts_ms: Option<i64>,
+}
+
+/// Read one subagent sidecar's delegation evidence.
+///
+/// `meta` is the scan of this same file, whose `agent_id` is the child's
+/// identity as the provider recorded it: the file name embeds the same id,
+/// but a name is not evidence, and deriving an identity from it would invent
+/// one for provider versions that never recorded any. Everything else the
+/// delegation is described by comes from the sibling
+/// `agent-<agentId>.meta.json`, or from the transcript's first record when
+/// that sidecar does not exist.
+pub(crate) fn claude_subagent_evidence(
+    path: PathBuf,
+    meta: &ClaudeSessionMeta,
+) -> ClaudeSubagentEvidence {
+    let first = first_claude_record(&path);
+    let record_str = |key: &str| {
+        first
+            .as_ref()
+            .and_then(|value| value.get(key))
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    };
+    let sidecar = claude_subagent_meta(&path);
+    let meta_str = |key: &str| {
+        sidecar
+            .as_ref()
+            .and_then(|value| value.get(key))
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    };
+    ClaudeSubagentEvidence {
+        agent_id: meta.agent_id.clone(),
+        agent_type: meta_str("agentType").or_else(|| record_str("attributionAgent")),
+        description: meta_str("description"),
+        model: meta_str("model"),
+        spawn_depth: sidecar
+            .as_ref()
+            .and_then(|value| value.get("spawnDepth"))
+            .and_then(Value::as_i64),
+        tool_use_id: meta_str("toolUseId"),
+        first_ts_ms: first.as_ref().and_then(|value| {
+            value
+                .get("timestamp")
+                .and_then(|ts| ts.as_str().and_then(parse_iso_ms).or_else(|| ts.as_i64()))
+        }),
+        path,
+    }
 }
 
 /// Every subagent transcript belonging to one parent session.
@@ -551,52 +606,13 @@ fn claude_subagents(transcript: &Path, session_id: &str) -> Result<Vec<ClaudeSub
         }
         // A subagent transcript's records carry the PARENT's sessionId, which
         // is what ties this file to the session being hydrated.
-        let belongs = scan_claude_session_file(&candidate)
-            .ok()
-            .flatten()
-            .is_some_and(|meta| meta.session_id == session_id);
-        if !belongs {
+        let Some(meta) = scan_claude_session_file(&candidate).ok().flatten() else {
+            continue;
+        };
+        if meta.session_id != session_id {
             continue;
         }
-        let first = first_claude_record(&candidate);
-        let record_str = |key: &str| {
-            first
-                .as_ref()
-                .and_then(|value| value.get(key))
-                .and_then(Value::as_str)
-                .filter(|value| !value.is_empty())
-                .map(str::to_string)
-        };
-        // The child's identity is read from the record and from nowhere else.
-        // The file name happens to embed the same id, but a name is not
-        // evidence: deriving an identity from it would invent one for
-        // provider versions that never recorded it.
-        let agent_id = record_str("agentId");
-        let meta = claude_subagent_meta(&candidate);
-        let meta_str = |key: &str| {
-            meta.as_ref()
-                .and_then(|value| value.get(key))
-                .and_then(Value::as_str)
-                .filter(|value| !value.is_empty())
-                .map(str::to_string)
-        };
-        evidence.push(ClaudeSubagentEvidence {
-            agent_id,
-            agent_type: meta_str("agentType").or_else(|| record_str("attributionAgent")),
-            description: meta_str("description"),
-            model: meta_str("model"),
-            spawn_depth: meta
-                .as_ref()
-                .and_then(|value| value.get("spawnDepth"))
-                .and_then(Value::as_i64),
-            tool_use_id: meta_str("toolUseId"),
-            first_ts_ms: first.as_ref().and_then(|value| {
-                value
-                    .get("timestamp")
-                    .and_then(|ts| ts.as_str().and_then(parse_iso_ms).or_else(|| ts.as_i64()))
-            }),
-            path: candidate,
-        });
+        evidence.push(claude_subagent_evidence(candidate, &meta));
     }
     Ok(evidence)
 }

--- a/crates/ai-hist/src/hydrate.rs
+++ b/crates/ai-hist/src/hydrate.rs
@@ -1448,6 +1448,157 @@ mod tests {
     }
 
     #[test]
+    fn a_later_full_sync_leaves_subagent_events_on_the_child() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = claude_parent_with_subagent(
+            dir.path(),
+            CLAUDE_AGENT_RECORDS,
+            Some(CLAUDE_AGENT_META),
+            "agent-abc",
+        );
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "claude", "session-1", Some(&transcript));
+        drop(conn);
+        hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+
+        let conn = open_db(&db).unwrap();
+        let projects = dir.path().join(".claude/projects");
+        // A sidecar walked by the full sync is not a session: it must not
+        // pull the child's output back onto the parent, take over the
+        // parent's catalog locator, or register itself.
+        for _ in 0..2 {
+            sync_claude_session_metadata(&conn, &mut Map::new(), &projects).unwrap();
+            let placement: (i64, i64, i64, String) = conn
+                .query_row(
+                    "SELECT \
+                       (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='abc'), \
+                       (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='session-1' AND event_uid='side-a:0'), \
+                       (SELECT COUNT(*) FROM sessions WHERE source='claude' AND session_id='abc'), \
+                       (SELECT raw_path FROM sessions WHERE source='claude' AND session_id='session-1')",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .unwrap();
+            assert_eq!(
+                placement,
+                (1, 0, 0, transcript.to_string_lossy().to_string())
+            );
+        }
+    }
+
+    #[test]
+    fn healing_a_record_never_matches_another_id_by_wildcard() {
+        let dir = tempfile::tempdir().unwrap();
+        let records = "{\"sessionId\":\"session-1\",\"agentId\":\"abc\",\"isSidechain\":true,\"uuid\":\"side_a%1\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":\"child result\"},\"timestamp\":\"2026-08-31T10:00:03Z\"}\n";
+        let transcript = claude_parent_with_subagent(dir.path(), records, None, "agent-abc");
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "claude", "session-1", Some(&transcript));
+        // The stale row this record left on the parent, plus an unrelated
+        // event whose uid a `LIKE 'side_a%1:%'` pattern would also match.
+        for uid in ["side_a%1:0", "sideXaY1:0"] {
+            conn.execute(
+                "INSERT INTO session_events \
+                 (source, session_id, ts_ms, role, kind, text, event_uid) \
+                 VALUES ('claude', 'session-1', 1, 'assistant', 'text', 'stale', ?)",
+                params![uid],
+            )
+            .unwrap();
+        }
+        drop(conn);
+
+        hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+        let conn = open_db(&db).unwrap();
+        let placement: (i64, i64, i64) = conn
+            .query_row(
+                "SELECT \
+                   (SELECT COUNT(*) FROM session_events WHERE session_id='session-1' AND event_uid='side_a%1:0'), \
+                   (SELECT COUNT(*) FROM session_events WHERE session_id='session-1' AND event_uid='sideXaY1:0'), \
+                   (SELECT COUNT(*) FROM session_events WHERE session_id='abc' AND event_uid='side_a%1:0')",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(placement, (0, 1, 1));
+    }
+
+    #[test]
+    fn a_record_without_a_uuid_is_healed_under_its_derived_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let records = "{\"sessionId\":\"session-1\",\"agentId\":\"abc\",\"isSidechain\":true,\"type\":\"assistant\",\"message\":{\"id\":\"msg_1\",\"role\":\"assistant\",\"content\":\"child result\"},\"timestamp\":\"2026-08-31T10:00:03Z\"}\n";
+        let transcript = claude_parent_with_subagent(dir.path(), records, None, "agent-abc");
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "claude", "session-1", Some(&transcript));
+        // Insertion falls back to the message id when a record carries no
+        // uuid, so healing has to reach the same identity.
+        conn.execute(
+            "INSERT INTO session_events \
+             (source, session_id, ts_ms, role, kind, text, event_uid) \
+             VALUES ('claude', 'session-1', 1, 'assistant', 'text', 'child result', 'msg_1:0')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+        let conn = open_db(&db).unwrap();
+        let placement: (i64, i64) = conn
+            .query_row(
+                "SELECT \
+                   (SELECT COUNT(*) FROM session_events WHERE session_id='session-1' AND event_uid='msg_1:0'), \
+                   (SELECT COUNT(*) FROM session_events WHERE session_id='abc' AND event_uid='msg_1:0')",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(placement, (0, 1));
+    }
+
+    #[test]
+    fn an_upgraded_provider_retires_the_unlinked_row_it_supersedes() {
+        let dir = tempfile::tempdir().unwrap();
+        // First the provider version that records the sidechain without
+        // naming the child.
+        let unnamed = "{\"sessionId\":\"session-1\",\"isSidechain\":true,\"uuid\":\"side-a\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":\"child result\"},\"timestamp\":\"2026-08-31T10:00:03Z\"}\n";
+        let transcript = claude_parent_with_subagent(dir.path(), unnamed, None, "agent-abc");
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "claude", "session-1", Some(&transcript));
+        drop(conn);
+        hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+
+        // Then the same file, rewritten by a version that does name it.
+        let subagents = dir.path().join(".claude/projects/app/session-1/subagents");
+        fs::write(subagents.join("agent-abc.jsonl"), CLAUDE_AGENT_RECORDS).unwrap();
+        fs::write(subagents.join("agent-abc.meta.json"), CLAUDE_AGENT_META).unwrap();
+        let result =
+            hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+        assert_eq!(result.related_session_ids, vec!["abc"]);
+        assert!(!result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "RELATIONSHIP_UNLINKED_CHILD"));
+
+        let conn = open_db(&db).unwrap();
+        let rows: Vec<(Option<String>, String)> = conn
+            .prepare(
+                "SELECT child_session_id, identity_status FROM session_relationships \
+                 WHERE source='claude' AND parent_session_id='session-1'",
+            )
+            .unwrap()
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![(Some("abc".to_string()), "observed".to_string())]
+        );
+    }
+
+    #[test]
     fn root_only_hydration_then_related_hydration() {
         let dir = tempfile::tempdir().unwrap();
         let transcript = claude_parent_with_subagent(

--- a/crates/ai-hist/src/hydrate.rs
+++ b/crates/ai-hist/src/hydrate.rs
@@ -68,6 +68,9 @@ struct SourceSnapshot {
     bytes: i64,
     records: i64,
     path: Option<PathBuf>,
+    /// Claude subagent sidecars, parsed once while stamping the source so the
+    /// ingestion pass does not walk and re-parse the same files.
+    claude_subagents: Vec<ClaudeSubagentEvidence>,
 }
 
 fn hydration_error(code: &str, message: impl std::fmt::Display) -> anyhow::Error {
@@ -126,7 +129,13 @@ fn hydrate_session_at_with_home(
     // has a provider-native uniqueness key, so interruption followed by retry is
     // safe for both new and growing sessions.
     let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-    ingest_selected(&tx, options, &target, snapshot.path.as_deref())?;
+    ingest_selected(
+        &tx,
+        options,
+        &target,
+        snapshot.path.as_deref(),
+        &snapshot.claude_subagents,
+    )?;
     tx.execute(
         "UPDATE sessions SET discovery_state = 'full', source_stamp = ?, parser_version = ? \
          WHERE source = ? AND session_id = ?",
@@ -308,6 +317,7 @@ fn source_snapshot(
             // complete `part` table on older stores missing its usual index.
             records: 0,
             path: Some(path),
+            claude_subagents: Vec::new(),
         });
     }
 
@@ -335,8 +345,10 @@ fn source_snapshot(
     } else {
         file_stamp(&path)?
     };
+    let mut subagents = Vec::new();
     if options.source == "claude" && options.include_related {
-        for evidence in claude_subagents(&path, &options.session_id)? {
+        subagents = claude_subagents(&path, &options.session_id)?;
+        for evidence in &subagents {
             stamp.push('|');
             stamp.push_str(&file_stamp(&evidence.path)?);
             bytes += evidence.path.metadata()?.len() as i64;
@@ -365,6 +377,7 @@ fn source_snapshot(
         bytes,
         records,
         path: Some(path),
+        claude_subagents: subagents,
     })
 }
 
@@ -418,9 +431,10 @@ fn ingest_selected(
     options: &HydrateSessionOptions,
     target: &CatalogTarget,
     path: Option<&Path>,
+    claude_subagents: &[ClaudeSubagentEvidence],
 ) -> Result<()> {
     match options.source.as_str() {
-        "claude" => ingest_claude(conn, options, path.unwrap()),
+        "claude" => ingest_claude(conn, options, path.unwrap(), claude_subagents),
         "codex" => ingest_codex(conn, options, path.unwrap()),
         "cursor" => ingest_cursor(conn, options, target, path.unwrap()),
         "grok" => ingest_grok(conn, options, path.unwrap()),
@@ -435,7 +449,12 @@ fn ingest_selected(
     }
 }
 
-fn ingest_claude(conn: &Connection, options: &HydrateSessionOptions, path: &Path) -> Result<()> {
+fn ingest_claude(
+    conn: &Connection,
+    options: &HydrateSessionOptions,
+    path: &Path,
+    subagents: &[ClaudeSubagentEvidence],
+) -> Result<()> {
     let meta = scan_claude_session_file(path)?.ok_or_else(|| {
         hydration_error(
             "SESSION_SOURCE_MISMATCH",
@@ -460,10 +479,10 @@ fn ingest_claude(conn: &Connection, options: &HydrateSessionOptions, path: &Path
         Some(&path.to_string_lossy()),
     )?;
     ingest_claude_transcript(conn, path)?;
-    if options.include_related {
-        for evidence in claude_subagents(path, &options.session_id)? {
-            ingest_claude_subagent(conn, &options.session_id, &evidence)?;
-        }
+    // The snapshot already walked and parsed these sidecars to stamp them, so
+    // this pass indexes that evidence instead of finding it a second time.
+    for evidence in subagents {
+        ingest_claude_subagent(conn, &options.session_id, evidence)?;
     }
     Ok(())
 }
@@ -536,6 +555,7 @@ pub(crate) fn ingest_claude_subagent(
 
 /// One Claude subagent transcript beside a parent's, with whatever identity
 /// and description the provider recorded for it.
+#[derive(Debug)]
 pub(crate) struct ClaudeSubagentEvidence {
     path: PathBuf,
     /// The in-record `agentId`. `None` for provider versions that do not emit

--- a/crates/ai-hist/src/hydrate.rs
+++ b/crates/ai-hist/src/hydrate.rs
@@ -348,6 +348,7 @@ fn source_snapshot(
             if metadata.is_file() {
                 stamp.push('|');
                 stamp.push_str(&file_stamp(&metadata)?);
+                bytes += metadata.metadata()?.len() as i64;
             }
         }
     }
@@ -634,7 +635,7 @@ fn first_claude_record(path: &Path) -> Option<Value> {
 /// Where the `agent-<agentId>.meta.json` sidecar sits beside a subagent
 /// transcript. The provider version that writes one names it after the
 /// transcript, so the path is derived rather than searched for.
-fn claude_subagent_meta_path(transcript: &Path) -> PathBuf {
+pub(crate) fn claude_subagent_meta_path(transcript: &Path) -> PathBuf {
     transcript.with_extension("meta.json")
 }
 
@@ -1624,6 +1625,41 @@ mod tests {
                 Some(2),
             )
         );
+    }
+
+    #[test]
+    fn hydration_metrics_count_every_file_the_run_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = claude_parent_with_subagent(
+            dir.path(),
+            CLAUDE_AGENT_RECORDS,
+            Some(CLAUDE_AGENT_META),
+            "agent-abc",
+        );
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "claude", "session-1", Some(&transcript));
+        drop(conn);
+
+        let result =
+            hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+        let subagents = dir.path().join(".claude/projects/app/session-1/subagents");
+        // The metadata sidecar is evidence the run acquired like any other, so
+        // its bytes belong in what the metrics report was read.
+        let expected: i64 = [
+            transcript,
+            subagents.join("agent-abc.jsonl"),
+            subagents.join("agent-abc.meta.json"),
+        ]
+        .iter()
+        .map(|path| fs::metadata(path).unwrap().len() as i64)
+        .sum();
+        let metrics = result
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "HYDRATION_METRICS")
+            .unwrap();
+        assert_eq!(metrics.source_bytes, Some(expected));
     }
 
     #[test]

--- a/crates/ai-hist/src/hydrate.rs
+++ b/crates/ai-hist/src/hydrate.rs
@@ -6,7 +6,10 @@ use serde::Serialize;
 use std::time::Instant;
 
 pub const SESSION_HYDRATION_CONTRACT_VERSION: u32 = 1;
-const HYDRATION_PARSER_VERSION: i64 = 1;
+/// Bumped to 2 when Claude subagent transcripts that carry an `agentId`
+/// started being indexed under that child id: existing databases re-parse once
+/// and the earlier parent-attributed rows are healed in place.
+const HYDRATION_PARSER_VERSION: i64 = 2;
 
 #[derive(Debug, Clone)]
 pub struct HydrateSessionOptions {
@@ -333,11 +336,11 @@ fn source_snapshot(
         file_stamp(&path)?
     };
     if options.source == "claude" && options.include_related {
-        for sidecar in claude_sidecars(&path, &options.session_id)? {
+        for evidence in claude_subagents(&path, &options.session_id)? {
             stamp.push('|');
-            stamp.push_str(&file_stamp(&sidecar)?);
-            bytes += sidecar.metadata()?.len() as i64;
-            records += complete_jsonl_records(&sidecar)?;
+            stamp.push_str(&file_stamp(&evidence.path)?);
+            bytes += evidence.path.metadata()?.len() as i64;
+            records += complete_jsonl_records(&evidence.path)?;
         }
     }
     if options.source == "codex" && options.include_related {
@@ -449,27 +452,166 @@ fn ingest_claude(conn: &Connection, options: &HydrateSessionOptions, path: &Path
     )?;
     ingest_claude_transcript(conn, path)?;
     if options.include_related {
-        for sidecar in claude_sidecars(path, &options.session_id)? {
-            ingest_claude_transcript(conn, &sidecar)?;
+        for evidence in claude_subagents(path, &options.session_id)? {
+            ingest_claude_subagent(conn, options, &evidence)?;
         }
     }
     Ok(())
 }
 
-fn claude_sidecars(path: &Path, session_id: &str) -> Result<Vec<PathBuf>> {
-    let Some(directory) = path.parent() else {
+/// Index one Claude subagent transcript and record what established it.
+///
+/// With an `agentId` the child is a session in its own right: its events are
+/// stored under that id so they stay independently addressable, and the id is
+/// kept out of the catalog because a delegated thread is not a human session.
+/// Without one this provider version simply does not name the child, so the
+/// sidechain assistant output stays on the parent exactly as before and the
+/// row records unlinked evidence rather than a fabricated identity.
+fn ingest_claude_subagent(
+    conn: &Connection,
+    options: &HydrateSessionOptions,
+    evidence: &ClaudeSubagentEvidence,
+) -> Result<()> {
+    let locator = evidence.path.to_string_lossy().to_string();
+    match evidence.agent_id.as_deref() {
+        Some(agent_id) => {
+            ingest_claude_transcript_as(conn, &evidence.path, Some(agent_id))?;
+            cleanup_subagent_registration(conn, "claude", agent_id)?;
+            record_relationship(
+                conn,
+                &ObservedRelationship {
+                    source: "claude",
+                    parent_session_id: &options.session_id,
+                    child_session_id: Some(agent_id),
+                    relationship: "delegated",
+                    child_agent_type: evidence.agent_type.as_deref(),
+                    child_agent_name: evidence.description.as_deref(),
+                    child_model: evidence.model.as_deref(),
+                    spawn_depth: evidence.spawn_depth,
+                    evidence_kind: "claude_subagent_meta",
+                    evidence_locator: Some(&locator),
+                    evidence_ref: evidence.tool_use_id.as_deref(),
+                    child_has_events: session_events_exist(conn, "claude", agent_id)?,
+                    spawned_at_ms: evidence.first_ts_ms,
+                },
+            )
+        }
+        None => {
+            ingest_claude_transcript_as(conn, &evidence.path, None)?;
+            record_relationship(
+                conn,
+                &ObservedRelationship {
+                    source: "claude",
+                    parent_session_id: &options.session_id,
+                    child_session_id: None,
+                    relationship: "delegated",
+                    child_agent_type: evidence.agent_type.as_deref(),
+                    child_agent_name: evidence.description.as_deref(),
+                    child_model: evidence.model.as_deref(),
+                    spawn_depth: evidence.spawn_depth,
+                    evidence_kind: "claude_sidechain_records",
+                    evidence_locator: Some(&locator),
+                    evidence_ref: evidence.tool_use_id.as_deref(),
+                    child_has_events: false,
+                    spawned_at_ms: evidence.first_ts_ms,
+                },
+            )
+        }
+    }
+}
+
+/// One Claude subagent transcript beside a parent's, with whatever identity
+/// and description the provider recorded for it.
+struct ClaudeSubagentEvidence {
+    path: PathBuf,
+    /// The in-record `agentId`. `None` for provider versions that do not emit
+    /// it.
+    agent_id: Option<String>,
+    agent_type: Option<String>,
+    description: Option<String>,
+    model: Option<String>,
+    spawn_depth: Option<i64>,
+    tool_use_id: Option<String>,
+    first_ts_ms: Option<i64>,
+}
+
+/// Every subagent transcript belonging to one parent session.
+///
+/// `collect_matching_files` is recursive, so this reaches both the flat
+/// `agent-*.jsonl` layout and `<parentSessionId>/subagents/agent-*.jsonl`, and
+/// returns them sorted by path so ingestion is deterministic.
+fn claude_subagents(transcript: &Path, session_id: &str) -> Result<Vec<ClaudeSubagentEvidence>> {
+    let Some(directory) = transcript.parent() else {
         return Ok(Vec::new());
     };
-    Ok(collect_matching_files(directory, "agent-", "jsonl")?
-        .into_iter()
-        .filter(|candidate| candidate != path)
-        .filter(|candidate| {
-            scan_claude_session_file(candidate)
-                .ok()
-                .flatten()
-                .is_some_and(|meta| meta.session_id == session_id)
-        })
-        .collect())
+    let mut evidence = Vec::new();
+    for candidate in collect_matching_files(directory, "agent-", "jsonl")? {
+        if candidate == transcript {
+            continue;
+        }
+        // A subagent transcript's records carry the PARENT's sessionId, which
+        // is what ties this file to the session being hydrated.
+        let belongs = scan_claude_session_file(&candidate)
+            .ok()
+            .flatten()
+            .is_some_and(|meta| meta.session_id == session_id);
+        if !belongs {
+            continue;
+        }
+        let first = first_claude_record(&candidate);
+        let record_str = |key: &str| {
+            first
+                .as_ref()
+                .and_then(|value| value.get(key))
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+        };
+        // The child's identity is read from the record and from nowhere else.
+        // The file name happens to embed the same id, but a name is not
+        // evidence: deriving an identity from it would invent one for
+        // provider versions that never recorded it.
+        let agent_id = record_str("agentId");
+        let meta = claude_subagent_meta(&candidate);
+        let meta_str = |key: &str| {
+            meta.as_ref()
+                .and_then(|value| value.get(key))
+                .and_then(Value::as_str)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+        };
+        evidence.push(ClaudeSubagentEvidence {
+            agent_id,
+            agent_type: meta_str("agentType").or_else(|| record_str("attributionAgent")),
+            description: meta_str("description"),
+            model: meta_str("model"),
+            spawn_depth: meta
+                .as_ref()
+                .and_then(|value| value.get("spawnDepth"))
+                .and_then(Value::as_i64),
+            tool_use_id: meta_str("toolUseId"),
+            first_ts_ms: first.as_ref().and_then(|value| {
+                value
+                    .get("timestamp")
+                    .and_then(|ts| ts.as_str().and_then(parse_iso_ms).or_else(|| ts.as_i64()))
+            }),
+            path: candidate,
+        });
+    }
+    Ok(evidence)
+}
+
+fn first_claude_record(path: &Path) -> Option<Value> {
+    let text = fs::read_to_string(path).ok()?;
+    text.lines()
+        .find_map(|line| serde_json::from_str::<Value>(line).ok())
+}
+
+/// The `agent-<agentId>.meta.json` sidecar beside a subagent transcript, when
+/// the provider version writes one.
+fn claude_subagent_meta(transcript: &Path) -> Option<Value> {
+    let path = transcript.with_extension("meta.json");
+    serde_json::from_str(&fs::read_to_string(path).ok()?).ok()
 }
 
 fn ingest_codex(conn: &Connection, options: &HydrateSessionOptions, path: &Path) -> Result<()> {
@@ -517,13 +659,7 @@ fn ingest_codex_children(
         ingest_codex_rollout(conn, &candidate, &meta)?;
         cleanup_codex_subagent_history(conn, &meta.session_id)?;
         cleanup_codex_subagent_registration(conn, &meta.session_id)?;
-        conn.execute(
-            "INSERT INTO session_relationships \
-             (source, parent_session_id, child_session_id, relationship, created_ms) \
-             VALUES ('codex', ?, ?, 'delegated', ?) \
-             ON CONFLICT(source, parent_session_id, child_session_id) DO NOTHING",
-            params![options.session_id, meta.session_id, now_ms()],
-        )?;
+        record_codex_delegation(conn, &options.session_id, &meta, &candidate)?;
     }
     Ok(())
 }
@@ -628,6 +764,20 @@ fn build_result(
             (None, value) | (value, None) => value,
         })
     })?;
+    let mut diagnostics = vec![HydrationDiagnostic {
+        code: "HYDRATION_METRICS".to_string(),
+        message: "targeted provider evidence acquisition completed".to_string(),
+        duration_ms: Some(duration_ms),
+        source_bytes: Some(snapshot.bytes),
+        records_parsed: Some(snapshot.records),
+    }];
+    if options.include_related {
+        diagnostics.extend(unlinked_diagnostics(
+            conn,
+            &options.source,
+            &options.session_id,
+        )?);
+    }
     Ok(HydrateSessionResult {
         contract_version: SESSION_HYDRATION_CONTRACT_VERSION,
         source: options.source.clone(),
@@ -641,13 +791,7 @@ fn build_result(
         },
         evidence,
         related_session_ids,
-        diagnostics: vec![HydrationDiagnostic {
-            code: "HYDRATION_METRICS".to_string(),
-            message: "targeted provider evidence acquisition completed".to_string(),
-            duration_ms: Some(duration_ms),
-            source_bytes: Some(snapshot.bytes),
-            records_parsed: Some(snapshot.records),
-        }],
+        diagnostics,
     })
 }
 
@@ -655,10 +799,46 @@ fn related_ids(conn: &Connection, source: &str, session_id: &str) -> Result<Vec<
     Ok(conn
         .prepare(
             "SELECT child_session_id FROM session_relationships \
-             WHERE source = ? AND parent_session_id = ? ORDER BY child_session_id",
+             WHERE source = ? AND parent_session_id = ? AND child_session_id IS NOT NULL \
+             ORDER BY child_session_id",
         )?
         .query_map(params![source, session_id], |row| row.get::<_, String>(0))?
         .collect::<rusqlite::Result<Vec<_>>>()?)
+}
+
+/// Related evidence this session's provider recorded without naming the child.
+///
+/// Reported as diagnostics rather than as related session ids: there is no id
+/// to hand back, and the caller needs to know the evidence exists and where
+/// its events actually live.
+fn unlinked_diagnostics(
+    conn: &Connection,
+    source: &str,
+    session_id: &str,
+) -> Result<Vec<HydrationDiagnostic>> {
+    Ok(conn
+        .prepare(
+            "SELECT evidence_locator FROM session_relationships \
+             WHERE source = ? AND parent_session_id = ? AND child_session_id IS NULL \
+             ORDER BY relationship_uid",
+        )?
+        .query_map(params![source, session_id], |row| {
+            row.get::<_, Option<String>>(0)
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?
+        .into_iter()
+        .map(|locator| HydrationDiagnostic {
+            code: "RELATIONSHIP_UNLINKED_CHILD".to_string(),
+            message: format!(
+                "{source} related evidence at {} has no stable child identity; \
+                 its events remain attributed to the parent",
+                locator.as_deref().unwrap_or("unknown"),
+            ),
+            duration_ms: None,
+            source_bytes: None,
+            records_parsed: None,
+        })
+        .collect())
 }
 
 fn evidence_counts(
@@ -694,13 +874,6 @@ fn max_event_time(conn: &Connection, source: &str, session_id: &str) -> Result<O
         params![source, session_id],
         |row| row.get(0),
     )?)
-}
-
-fn now_ms() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as i64
 }
 
 #[cfg(test)]
@@ -955,7 +1128,7 @@ mod tests {
         fs::write(
             &child,
             concat!(
-                "{\"timestamp\":\"2026-08-31T10:00:03Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"child\",\"session_id\":\"root\",\"cwd\":\"/work/app\",\"thread_source\":\"subagent\"}}\n",
+                "{\"timestamp\":\"2026-08-31T10:00:03Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"child\",\"session_id\":\"root\",\"parent_thread_id\":\"root\",\"cwd\":\"/work/app\",\"thread_source\":\"subagent\",\"source\":{\"subagent\":{\"other\":\"guardian\"}}}}\n",
                 "{\"timestamp\":\"2026-08-31T10:00:04Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"delegated task\"}}\n",
                 "{\"timestamp\":\"2026-08-31T10:00:05Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"child answer\"}}\n",
             ),
@@ -1000,6 +1173,327 @@ mod tests {
             )
             .unwrap();
         assert_eq!(child_catalog, 0);
+        let relationship: (String, String, String, Option<String>, Option<i64>) = conn
+            .query_row(
+                "SELECT identity_status, evidence_kind, evidence_locator, child_agent_type, spawned_at_ms \
+                 FROM session_relationships WHERE source='codex' AND child_session_id='child'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+            )
+            .unwrap();
+        assert_eq!(relationship.0, "observed");
+        assert_eq!(relationship.1, "codex_session_meta");
+        assert_eq!(relationship.2, child.to_string_lossy());
+        assert_eq!(relationship.3.as_deref(), Some("guardian"));
+        assert!(relationship.4.is_some());
+    }
+
+    #[test]
+    fn codex_child_prompts_are_not_human_history() {
+        let dir = tempfile::tempdir().unwrap();
+        let day = dir.path().join(".codex/sessions/2026/08/31");
+        fs::create_dir_all(&day).unwrap();
+        let root = day.join("rollout-root.jsonl");
+        fs::write(
+            &root,
+            concat!(
+                "{\"timestamp\":\"2026-08-31T10:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"root\",\"cwd\":\"/work/app\"}}\n",
+                "{\"timestamp\":\"2026-08-31T10:00:01Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"root prompt\"}}\n",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            day.join("rollout-child.jsonl"),
+            concat!(
+                "{\"timestamp\":\"2026-08-31T10:00:03Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"child\",\"session_id\":\"root\",\"cwd\":\"/work/app\",\"thread_source\":\"subagent\"}}\n",
+                "{\"timestamp\":\"2026-08-31T10:00:04Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"delegated task\"}}\n",
+            ),
+        )
+        .unwrap();
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "codex", "root", Some(&root));
+        drop(conn);
+
+        hydrate_session_at_with_home(&db, &options("codex", "root"), dir.path()).unwrap();
+        let conn = open_db(&db).unwrap();
+        let counts: (i64, i64, i64) = conn
+            .query_row(
+                "SELECT \
+                   (SELECT COUNT(*) FROM history WHERE source='codex' AND session_id='child'), \
+                   (SELECT COUNT(*) FROM sessions WHERE source='codex' AND session_id='child'), \
+                   (SELECT COUNT(*) FROM history WHERE source='codex' AND session_id='root')",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(counts, (0, 0, 1));
+    }
+
+    /// A parent transcript plus one subagent transcript under
+    /// `<sessionId>/subagents/`, in the layout the provider actually writes.
+    fn claude_parent_with_subagent(
+        home: &Path,
+        agent_records: &str,
+        agent_meta: Option<&str>,
+        stem: &str,
+    ) -> PathBuf {
+        let transcript = home.join(".claude/projects/app/session-1.jsonl");
+        fs::create_dir_all(transcript.parent().unwrap()).unwrap();
+        fs::write(
+            &transcript,
+            concat!(
+                "{\"sessionId\":\"session-1\",\"uuid\":\"u1\",\"cwd\":\"/work/app\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"first prompt\"},\"timestamp\":\"2026-08-31T10:00:00Z\"}\n",
+                "{\"sessionId\":\"session-1\",\"uuid\":\"a1\",\"cwd\":\"/work/app\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"Agent\",\"input\":{\"prompt\":\"plan it\"}}]},\"timestamp\":\"2026-08-31T10:00:01Z\"}\n",
+            ),
+        )
+        .unwrap();
+        let subagents = home.join(".claude/projects/app/session-1/subagents");
+        fs::create_dir_all(&subagents).unwrap();
+        fs::write(subagents.join(format!("{stem}.jsonl")), agent_records).unwrap();
+        if let Some(meta) = agent_meta {
+            fs::write(subagents.join(format!("{stem}.meta.json")), meta).unwrap();
+        }
+        transcript
+    }
+
+    const CLAUDE_AGENT_RECORDS: &str = concat!(
+        "{\"sessionId\":\"session-1\",\"agentId\":\"abc\",\"isSidechain\":true,\"uuid\":\"side-u\",\"cwd\":\"/work/app\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"delegated instruction\"},\"timestamp\":\"2026-08-31T10:00:02Z\"}\n",
+        "{\"sessionId\":\"session-1\",\"agentId\":\"abc\",\"isSidechain\":true,\"uuid\":\"side-a\",\"cwd\":\"/work/app\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":\"child result\"},\"timestamp\":\"2026-08-31T10:00:03Z\"}\n",
+    );
+    const CLAUDE_AGENT_META: &str = "{\"agentType\":\"Plan\",\"description\":\"plan the work\",\"toolUseId\":\"toolu_1\",\"spawnDepth\":1,\"model\":\"opus\"}";
+
+    struct LinkedChild {
+        identity_status: String,
+        agent_type: Option<String>,
+        agent_name: Option<String>,
+        model: Option<String>,
+        spawn_depth: Option<i64>,
+        evidence_ref: Option<String>,
+        has_events: bool,
+    }
+
+    #[test]
+    fn claude_subagent_with_agent_id_is_a_linked_child() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = claude_parent_with_subagent(
+            dir.path(),
+            CLAUDE_AGENT_RECORDS,
+            Some(CLAUDE_AGENT_META),
+            "agent-abc",
+        );
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "claude", "session-1", Some(&transcript));
+        drop(conn);
+
+        let result =
+            hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+        assert_eq!(result.related_session_ids, vec!["abc"]);
+
+        let conn = open_db(&db).unwrap();
+        let row = conn
+            .query_row(
+                "SELECT identity_status, child_agent_type, child_agent_name, child_model, \
+                        spawn_depth, evidence_ref, child_has_events \
+                 FROM session_relationships WHERE source='claude' AND child_session_id='abc'",
+                [],
+                |row| {
+                    Ok(LinkedChild {
+                        identity_status: row.get(0)?,
+                        agent_type: row.get(1)?,
+                        agent_name: row.get(2)?,
+                        model: row.get(3)?,
+                        spawn_depth: row.get(4)?,
+                        evidence_ref: row.get(5)?,
+                        has_events: row.get(6)?,
+                    })
+                },
+            )
+            .unwrap();
+        assert_eq!(row.identity_status, "observed");
+        assert_eq!(row.agent_type.as_deref(), Some("Plan"));
+        assert_eq!(row.agent_name.as_deref(), Some("plan the work"));
+        assert_eq!(row.model.as_deref(), Some("opus"));
+        assert_eq!(row.spawn_depth, Some(1));
+        assert_eq!(row.evidence_ref.as_deref(), Some("toolu_1"));
+        assert!(row.has_events);
+
+        // The child's own output is addressable under the child, its
+        // delegated instruction is nobody's human prompt, and a delegated
+        // thread never becomes a session of its own.
+        let counts: (i64, i64, i64, i64) = conn
+            .query_row(
+                "SELECT \
+                   (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='abc'), \
+                   (SELECT COUNT(*) FROM history WHERE source='claude' AND session_id='abc'), \
+                   (SELECT COUNT(*) FROM sessions WHERE source='claude' AND session_id='abc'), \
+                   (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='session-1' AND event_uid LIKE 'side-%')",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(counts, (1, 0, 0, 0));
+    }
+
+    #[test]
+    fn claude_sidechain_without_agent_id_stays_unlinked() {
+        let dir = tempfile::tempdir().unwrap();
+        let records = concat!(
+            "{\"sessionId\":\"session-1\",\"isSidechain\":true,\"uuid\":\"side-u\",\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"delegated instruction\"},\"timestamp\":\"2026-08-31T10:00:02Z\"}\n",
+            "{\"sessionId\":\"session-1\",\"isSidechain\":true,\"uuid\":\"side-a\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":\"side result\"},\"timestamp\":\"2026-08-31T10:00:03Z\"}\n",
+        );
+        let transcript = claude_parent_with_subagent(dir.path(), records, None, "agent-child");
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "claude", "session-1", Some(&transcript));
+        drop(conn);
+
+        let result =
+            hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+        assert!(result.related_session_ids.is_empty());
+        assert!(result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "RELATIONSHIP_UNLINKED_CHILD"));
+
+        let conn = open_db(&db).unwrap();
+        let row: (String, i64, i64) = conn
+            .query_row(
+                "SELECT identity_status, child_session_id IS NULL, child_has_events \
+                 FROM session_relationships WHERE source='claude' AND parent_session_id='session-1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(row, ("unlinked".to_string(), 1, 0));
+        // The subagent's assistant output stays on the parent, where it is
+        // the only place it can be addressed.
+        let parent_side_events: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_events \
+                 WHERE source='claude' AND session_id='session-1' AND event_uid = 'side-a:0'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(parent_side_events, 1);
+    }
+
+    #[test]
+    fn claude_child_identity_is_never_taken_from_the_filename() {
+        let dir = tempfile::tempdir().unwrap();
+        let records = "{\"sessionId\":\"session-1\",\"isSidechain\":true,\"uuid\":\"side-a\",\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":\"side result\"},\"timestamp\":\"2026-08-31T10:00:03Z\"}\n";
+        let transcript = claude_parent_with_subagent(dir.path(), records, None, "agent-deadbeef");
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "claude", "session-1", Some(&transcript));
+        drop(conn);
+
+        hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+        let conn = open_db(&db).unwrap();
+        let named_after_the_file: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_relationships WHERE child_session_id = 'deadbeef'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(named_after_the_file, 0);
+        let events_under_the_file_stem: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_events WHERE session_id = 'deadbeef'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(events_under_the_file_stem, 0);
+    }
+
+    #[test]
+    fn reparse_moves_parent_attributed_sidechain_events_to_the_child() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = claude_parent_with_subagent(
+            dir.path(),
+            CLAUDE_AGENT_RECORDS,
+            Some(CLAUDE_AGENT_META),
+            "agent-abc",
+        );
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "claude", "session-1", Some(&transcript));
+        // What the previous parser version left behind: the subagent's
+        // assistant output attributed to the parent session.
+        conn.execute(
+            "INSERT INTO session_events \
+             (source, session_id, ts_ms, role, kind, text, event_uid) \
+             VALUES ('claude', 'session-1', 1, 'assistant', 'text', 'child result', 'side-a:0')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+        let conn = open_db(&db).unwrap();
+        let placement: (i64, i64) = conn
+            .query_row(
+                "SELECT \
+                   (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='session-1' AND event_uid='side-a:0'), \
+                   (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='abc' AND event_uid='side-a:0')",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(placement, (0, 1));
+    }
+
+    #[test]
+    fn root_only_hydration_then_related_hydration() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = claude_parent_with_subagent(
+            dir.path(),
+            CLAUDE_AGENT_RECORDS,
+            Some(CLAUDE_AGENT_META),
+            "agent-abc",
+        );
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "claude", "session-1", Some(&transcript));
+        drop(conn);
+
+        let mut request = options("claude", "session-1");
+        request.include_related = false;
+        let root_only = hydrate_session_at_with_home(&db, &request, dir.path()).unwrap();
+        assert!(root_only.related_session_ids.is_empty());
+        let root_prompts = root_only.evidence.prompts;
+        let conn = open_db(&db).unwrap();
+        let untouched: (i64, i64) = conn
+            .query_row(
+                "SELECT \
+                   (SELECT COUNT(*) FROM session_relationships), \
+                   (SELECT COUNT(*) FROM session_events WHERE session_id='abc')",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(untouched, (0, 0));
+        drop(conn);
+
+        request.include_related = true;
+        let related = hydrate_session_at_with_home(&db, &request, dir.path()).unwrap();
+        assert_eq!(related.related_session_ids, vec!["abc"]);
+        assert_eq!(related.evidence.prompts, root_prompts);
+        let conn = open_db(&db).unwrap();
+        let now: (i64, i64) = conn
+            .query_row(
+                "SELECT \
+                   (SELECT COUNT(*) FROM session_relationships), \
+                   (SELECT COUNT(*) FROM session_events WHERE session_id='abc')",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(now, (1, 1));
     }
 
     #[test]

--- a/crates/ai-hist/src/hydrate.rs
+++ b/crates/ai-hist/src/hydrate.rs
@@ -341,6 +341,14 @@ fn source_snapshot(
             stamp.push_str(&file_stamp(&evidence.path)?);
             bytes += evidence.path.metadata()?.len() as i64;
             records += complete_jsonl_records(&evidence.path)?;
+            // The metadata sidecar describes the child — its type, model and
+            // spawn depth, and the tool use that started it — so a sidecar
+            // that arrives or changes on its own is still new evidence.
+            let metadata = claude_subagent_meta_path(&evidence.path);
+            if metadata.is_file() {
+                stamp.push('|');
+                stamp.push_str(&file_stamp(&metadata)?);
+            }
         }
     }
     if options.source == "codex" && options.include_related {
@@ -623,10 +631,17 @@ fn first_claude_record(path: &Path) -> Option<Value> {
         .find_map(|line| serde_json::from_str::<Value>(line).ok())
 }
 
+/// Where the `agent-<agentId>.meta.json` sidecar sits beside a subagent
+/// transcript. The provider version that writes one names it after the
+/// transcript, so the path is derived rather than searched for.
+fn claude_subagent_meta_path(transcript: &Path) -> PathBuf {
+    transcript.with_extension("meta.json")
+}
+
 /// The `agent-<agentId>.meta.json` sidecar beside a subagent transcript, when
 /// the provider version writes one.
 fn claude_subagent_meta(transcript: &Path) -> Option<Value> {
-    let path = transcript.with_extension("meta.json");
+    let path = claude_subagent_meta_path(transcript);
     serde_json::from_str(&fs::read_to_string(path).ok()?).ok()
 }
 
@@ -1461,6 +1476,154 @@ mod tests {
             )
             .unwrap();
         assert_eq!(placement, (0, 1));
+    }
+
+    #[test]
+    fn reparse_moves_parent_attributed_tool_calls_and_file_edits_to_the_child() {
+        let dir = tempfile::tempdir().unwrap();
+        // The child's own tool use: an earlier parser version derived a tool
+        // call and a file edit from it under the parent's identity.
+        let records = concat!(
+            r#"{"sessionId":"session-1","agentId":"abc","isSidechain":true,"uuid":"side-a","cwd":"/work/app","type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_child","name":"Edit","input":{"file_path":"/work/app/lib.rs"}}]},"timestamp":"2026-08-31T10:00:03Z"}"#,
+            "\n",
+        );
+        let transcript = claude_parent_with_subagent(dir.path(), records, None, "agent-abc");
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "claude", "session-1", Some(&transcript));
+        conn.execute(
+            "INSERT INTO session_events \
+             (source, session_id, ts_ms, role, kind, text, event_uid) \
+             VALUES ('claude', 'session-1', 1, 'assistant', 'tool_use', 'Edit /work/app/lib.rs', 'side-a:0')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO tool_calls \
+             (source, session_id, message_id, tool_use_id, name, target, args_json, ts_ms) \
+             VALUES ('claude', 'session-1', 'side-a', 'toolu_child', 'Edit', '/work/app/lib.rs', '{}', 1)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO file_edits \
+             (source, session_id, message_id, tool_use_id, file_path, tool_name, ts_ms) \
+             VALUES ('claude', 'session-1', 'side-a', 'toolu_child', '/work/app/lib.rs', 'Edit', 1)",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+        let conn = open_db(&db).unwrap();
+        // A delegated action belongs to the thread that took it: the parent
+        // must not keep exposing the child's tool call or file edit as its own.
+        let placement: (i64, i64, i64, i64, i64, i64) = conn
+            .query_row(
+                "SELECT \
+                   (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='session-1' AND event_uid='side-a:0'), \
+                   (SELECT COUNT(*) FROM tool_calls WHERE source='claude' AND session_id='session-1' AND tool_use_id='toolu_child'), \
+                   (SELECT COUNT(*) FROM file_edits WHERE source='claude' AND session_id='session-1' AND tool_use_id='toolu_child'), \
+                   (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='abc' AND event_uid='side-a:0'), \
+                   (SELECT COUNT(*) FROM tool_calls WHERE source='claude' AND session_id='abc' AND tool_use_id='toolu_child'), \
+                   (SELECT COUNT(*) FROM file_edits WHERE source='claude' AND session_id='abc' AND tool_use_id='toolu_child')",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(placement, (0, 0, 0, 1, 1, 1));
+    }
+
+    #[test]
+    fn a_child_named_only_by_a_later_record_still_links() {
+        let dir = tempfile::tempdir().unwrap();
+        // A mixed transcript: the provider started naming the child partway
+        // through, so the identity is not on the first record.
+        let records = concat!(
+            r#"{"sessionId":"session-1","isSidechain":true,"uuid":"side-u","type":"user","message":{"role":"user","content":"delegated instruction"},"timestamp":"2026-08-31T10:00:02Z"}"#,
+            "\n",
+            r#"{"sessionId":"session-1","agentId":"abc","isSidechain":true,"uuid":"side-a","type":"assistant","message":{"role":"assistant","content":"child result"},"timestamp":"2026-08-31T10:00:03Z"}"#,
+            "\n",
+        );
+        let transcript = claude_parent_with_subagent(dir.path(), records, None, "agent-abc");
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "claude", "session-1", Some(&transcript));
+        drop(conn);
+
+        let result =
+            hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+        assert_eq!(result.related_session_ids, vec!["abc"]);
+        assert!(!result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "RELATIONSHIP_UNLINKED_CHILD"));
+        let conn = open_db(&db).unwrap();
+        let placement: (i64, i64) = conn
+            .query_row(
+                "SELECT \
+                   (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='abc'), \
+                   (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='session-1' AND event_uid='side-a:0')",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(placement, (1, 0));
+    }
+
+    #[test]
+    fn a_changed_metadata_sidecar_refreshes_the_child_description() {
+        let dir = tempfile::tempdir().unwrap();
+        let transcript = claude_parent_with_subagent(
+            dir.path(),
+            CLAUDE_AGENT_RECORDS,
+            Some(CLAUDE_AGENT_META),
+            "agent-abc",
+        );
+        let db = dir.path().join("history.db");
+        let conn = open_db(&db).unwrap();
+        catalog_row(&conn, "claude", "session-1", Some(&transcript));
+        drop(conn);
+        hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+
+        // The transcript is untouched; only what describes the child changed.
+        fs::write(
+            dir.path()
+                .join(".claude/projects/app/session-1/subagents/agent-abc.meta.json"),
+            "{\"agentType\":\"Explore\",\"description\":\"explore the code\",\"toolUseId\":\"toolu_1\",\"spawnDepth\":2,\"model\":\"haiku\"}",
+        )
+        .unwrap();
+        let refreshed =
+            hydrate_session_at_with_home(&db, &options("claude", "session-1"), dir.path()).unwrap();
+        assert_eq!(refreshed.status, "updated");
+
+        let conn = open_db(&db).unwrap();
+        let row: (Option<String>, Option<String>, Option<String>, Option<i64>) = conn
+            .query_row(
+                "SELECT child_agent_type, child_agent_name, child_model, spawn_depth \
+                 FROM session_relationships WHERE source='claude' AND child_session_id='abc'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            row,
+            (
+                Some("Explore".to_string()),
+                Some("explore the code".to_string()),
+                Some("haiku".to_string()),
+                Some(2),
+            )
+        );
     }
 
     #[test]

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -6392,7 +6392,8 @@ fn sync_claude_session_metadata(
         let key = path.to_string_lossy().to_string();
         let stamp = file_stamp(&path)?;
         if session_state.get(&key).and_then(Value::as_str) == Some(stamp.as_str())
-            && claude_transcript_events_exist(conn, &path)?
+            && (claude_transcript_events_exist(conn, &path)?
+                || claude_sidecar_evidence_exists(conn, &path)?)
         {
             continue;
         }
@@ -6438,6 +6439,35 @@ fn sync_claude_session_metadata(
         sync_note!("  [claude-sessions] scanned {scanned} files, {upserted} sessions updated");
     }
     Ok(())
+}
+
+/// Whether an unchanged subagent sidecar has already been ingested.
+///
+/// A sidecar is deliberately never registered as a session, so the catalog
+/// join [`claude_transcript_events_exist`] makes can never confirm one and
+/// every sidecar would otherwise be re-read and re-ingested on every sync,
+/// however unchanged it is. Its recorded delegation is the equivalent proof,
+/// paired with the events it produced — under the child it named, or under
+/// the parent when it named none — so a wiped or rebuilt database still
+/// re-reads the file.
+fn claude_sidecar_evidence_exists(conn: &Connection, path: &Path) -> Result<bool> {
+    let locator = path.to_string_lossy();
+    let exists: i64 = conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1
+            FROM session_relationships r
+            WHERE r.source = 'claude' AND r.evidence_locator = ?
+              AND EXISTS(
+                SELECT 1 FROM session_events e
+                WHERE e.source = 'claude'
+                  AND e.session_id = COALESCE(r.child_session_id, r.parent_session_id)
+              )
+            LIMIT 1
+        )",
+        [locator.as_ref()],
+        |row| row.get(0),
+    )?;
+    Ok(exists != 0)
 }
 
 fn claude_transcript_events_exist(conn: &Connection, path: &Path) -> Result<bool> {
@@ -6562,13 +6592,17 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
     ingest_claude_transcript_as(conn, path, None)
 }
 
-/// Remove every event a single transcript record produced under one session
-/// id. `message_uuid` is the same identity insertion derives event uids from,
-/// so this reaches the row and all of its per-block siblings — including
+/// Remove everything a single transcript record produced under one session id.
+///
+/// `message_uuid` is the same identity insertion derives event uids from and
+/// stamps on the rows it derives from a record's tool use, so this reaches the
+/// record's events, its tool calls and its file edits together — including
 /// records with no `uuid` of their own, which fall back to the message id or
-/// the file position. The prefix is compared with `substr` rather than `LIKE`
-/// because a provider id may contain `_` or `%`.
-fn delete_claude_events_for_record(
+/// the file position. Leaving the derived rows behind would keep a parent
+/// exposing a delegated thread's actions as its own long after the events
+/// moved to the child. The event prefix is compared with `substr` rather than
+/// `LIKE` because a provider id may contain `_` or `%`.
+fn delete_claude_record_rows(
     conn: &Connection,
     session_id: &str,
     message_uuid: &str,
@@ -6577,6 +6611,14 @@ fn delete_claude_events_for_record(
         "DELETE FROM session_events WHERE source = 'claude' AND session_id = ? \
          AND substr(event_uid, 1, length(?) + 1) = ? || ':'",
         params![session_id, message_uuid, message_uuid],
+    )?;
+    conn.execute(
+        "DELETE FROM tool_calls WHERE source = 'claude' AND session_id = ? AND message_id = ?",
+        params![session_id, message_uuid],
+    )?;
+    conn.execute(
+        "DELETE FROM file_edits WHERE source = 'claude' AND session_id = ? AND message_id = ?",
+        params![session_id, message_uuid],
     )?;
     Ok(())
 }
@@ -6632,14 +6674,14 @@ fn ingest_claude_transcript_as(
             .unwrap_or(&fallback_uid);
         // Heal what an earlier parser version wrote for this record: it
         // attributed every sidechain row to the parent, and stored the rows
-        // this guard now skips. Re-reading the file removes the stale event
-        // under the identity it was written with, so a re-parse moves the
-        // row onto the child instead of duplicating it across both.
+        // this guard now skips. Re-reading the file removes the stale rows
+        // under the identity they were written with, so a re-parse moves them
+        // onto the child instead of duplicating them across both.
         if session_id != record_session_id {
-            delete_claude_events_for_record(conn, record_session_id, message_uuid)?;
+            delete_claude_record_rows(conn, record_session_id, message_uuid)?;
         }
         if skipped_sidechain {
-            delete_claude_events_for_record(conn, session_id, message_uuid)?;
+            delete_claude_record_rows(conn, session_id, message_uuid)?;
             continue;
         }
         let cwd = obj.get("cwd").and_then(Value::as_str);
@@ -9988,6 +10030,56 @@ mod tests {
             )
             .unwrap();
         assert_eq!(child_events, 1);
+    }
+
+    #[test]
+    fn an_unchanged_subagent_sidecar_is_not_re_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_, named, _) = write_claude_parent_with_subagents(dir.path());
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let mut state = Map::new();
+        sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
+
+        // Rewrite the sidecar and record the rewritten file as already seen: a
+        // walk that re-reads every unchanged sidecar, because a sidecar never
+        // has the catalog row the transcript check needs, would ingest this.
+        fs::write(
+            &named,
+            concat!(
+                r#"{"sessionId":"claude-root","agentId":"abc","isSidechain":true,"uuid":"side-b","cwd":"/work/app","type":"assistant","message":{"role":"assistant","content":"later result"},"timestamp":"2026-08-31T11:00:06Z"}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+        let key = named.to_string_lossy().to_string();
+        state
+            .get_mut("claude_sessions_v2")
+            .and_then(Value::as_object_mut)
+            .unwrap()
+            .insert(key, json!(file_stamp(&named).unwrap()));
+
+        sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
+        let rewritten = |conn: &Connection| -> i64 {
+            conn.query_row(
+                "SELECT COUNT(*) FROM session_events \
+                 WHERE source='claude' AND session_id='abc' AND event_uid='side-b:0'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(rewritten(&conn), 0);
+
+        // Once the events it produced are gone the sidecar is evidence of
+        // nothing indexed, so the same unchanged stamp reads it again.
+        conn.execute(
+            "DELETE FROM session_events WHERE source='claude' AND session_id='abc'",
+            [],
+        )
+        .unwrap();
+        sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
+        assert_eq!(rewritten(&conn), 1);
     }
 
     #[test]

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -5267,6 +5267,14 @@ type CodexRolloutWalk = (HashMap<String, String>, HashMap<String, String>, usize
 /// A local-only subagent stays out of the catalog. If the same canonical
 /// session was separately discovered remotely, its retained local events are
 /// also local evidence, so both presences and the canonical row must survive.
+///
+/// Deleting a `sessions` row fires `delete_session_hydration_state`, which
+/// cascades away every relationship the row takes part in — as parent as well
+/// as child. Undoing a subagent's registration is not that session going away,
+/// so the observed delegation evidence, including the thread's own outgoing
+/// edges, is carried across the delete. The trigger itself cannot be narrowed
+/// instead: `CREATE TRIGGER IF NOT EXISTS` never replaces the one an existing
+/// database already has.
 fn cleanup_subagent_registration(conn: &Connection, source: &str, session_id: &str) -> Result<()> {
     conn.execute(
         "DELETE FROM session_presences \
@@ -5277,6 +5285,16 @@ fn cleanup_subagent_registration(conn: &Connection, source: &str, session_id: &s
            )",
         params![source, session_id, source, session_id],
     )?;
+    conn.execute_batch(
+        "CREATE TEMP TABLE IF NOT EXISTS retained_relationships \
+           AS SELECT * FROM session_relationships WHERE 0; \
+         DELETE FROM retained_relationships;",
+    )?;
+    conn.execute(
+        "INSERT INTO retained_relationships SELECT * FROM session_relationships \
+         WHERE source = ? AND (parent_session_id = ? OR child_session_id = ?)",
+        params![source, session_id, session_id],
+    )?;
     conn.execute(
         "DELETE FROM sessions \
          WHERE source = ? AND session_id = ? \
@@ -5285,6 +5303,10 @@ fn cleanup_subagent_registration(conn: &Connection, source: &str, session_id: &s
              WHERE source = ? AND session_id = ?\
            )",
         params![source, session_id, source, session_id],
+    )?;
+    conn.execute_batch(
+        "INSERT OR IGNORE INTO session_relationships SELECT * FROM retained_relationships; \
+         DELETE FROM retained_relationships;",
     )?;
     Ok(())
 }
@@ -5370,6 +5392,17 @@ fn sync_codex_rollouts(
                         branches.remove(session_id);
                         cleanup_codex_subagent_history(conn, session_id)?;
                         cleanup_codex_subagent_registration(conn, session_id)?;
+                        // A database synced before delegation was recorded has
+                        // no topology at all, and its stamps never change
+                        // again. Re-reading one meta line per subagent
+                        // backfills the edge without re-ingesting the rollout.
+                        if !codex_delegation_recorded(conn, session_id)? {
+                            if let Some(meta) = read_codex_session_meta(&rollout)? {
+                                if let Some(parent) = meta.parent_session_id.as_deref() {
+                                    record_codex_delegation(conn, parent, &meta, &rollout)?;
+                                }
+                            }
+                        }
                     }
                 }
                 match recorded_session {
@@ -5533,6 +5566,16 @@ fn record_codex_delegation(
             spawned_at_ms: meta.meta_ts_ms,
         },
     )
+}
+
+fn codex_delegation_recorded(conn: &Connection, child_session_id: &str) -> Result<bool> {
+    let exists: i64 = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM session_relationships \
+         WHERE source = 'codex' AND child_session_id = ? LIMIT 1)",
+        [child_session_id],
+        |row| row.get(0),
+    )?;
+    Ok(exists != 0)
 }
 
 fn session_events_exist(conn: &Connection, source: &str, session_id: &str) -> Result<bool> {
@@ -6356,6 +6399,18 @@ fn sync_claude_session_metadata(
         scanned += 1;
         session_state.insert(key, json!(stamp));
         if let Some(meta) = scan_claude_session_file(&path)? {
+            // A subagent sidecar carries the parent's `sessionId` but is not
+            // that session: registering it would overwrite the parent's
+            // locator with the sidecar path, and ingesting it unattributed
+            // would pull the child's output back onto the parent that
+            // hydration just moved it off.
+            if meta.subagent {
+                ingest_claude_transcript_as(conn, &path, meta.agent_id.as_deref())?;
+                if let Some(agent_id) = meta.agent_id.as_deref() {
+                    cleanup_subagent_registration(conn, "claude", agent_id)?;
+                }
+                continue;
+            }
             upsert_session(
                 conn,
                 &meta.session_id,
@@ -6404,6 +6459,13 @@ struct ClaudeSessionMeta {
     first_ts: i64,
     last_ts: i64,
     last_assistant_text: Option<String>,
+    /// Every identified record is a sidechain row, so this file is a delegated
+    /// sidecar rather than a session of its own — the same rule discovery uses
+    /// to keep sidecars out of the catalog.
+    subagent: bool,
+    /// The child identity the provider recorded, read from the records and
+    /// never from the file name. Absent on versions that do not emit it.
+    agent_id: Option<String>,
 }
 
 fn scan_claude_session_file(path: &Path) -> Result<Option<ClaudeSessionMeta>> {
@@ -6414,10 +6476,30 @@ fn scan_claude_session_file(path: &Path) -> Result<Option<ClaudeSessionMeta>> {
     let mut first_ts = None;
     let mut last_ts = None;
     let mut last_assistant_text = None;
+    let mut identified_records = 0usize;
+    let mut sidechain_records = 0usize;
+    let mut agent_id: Option<String> = None;
     for line in text.lines() {
         let Ok(value) = serde_json::from_str::<Value>(line) else {
             continue;
         };
+        if value
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .is_some_and(|id| !id.is_empty())
+        {
+            identified_records += 1;
+            if value.get("isSidechain").and_then(Value::as_bool) == Some(true) {
+                sidechain_records += 1;
+            }
+        }
+        if agent_id.is_none() {
+            agent_id = value
+                .get("agentId")
+                .and_then(Value::as_str)
+                .filter(|id| !id.is_empty())
+                .map(str::to_string);
+        }
         if session_id.is_none() {
             session_id = value
                 .get("sessionId")
@@ -6467,6 +6549,8 @@ fn scan_claude_session_file(path: &Path) -> Result<Option<ClaudeSessionMeta>> {
         first_ts: first,
         last_ts: last_ts.unwrap_or(first),
         last_assistant_text,
+        subagent: identified_records > 0 && sidechain_records == identified_records,
+        agent_id,
     }))
 }
 
@@ -6475,20 +6559,20 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
 }
 
 /// Remove every event a single transcript record produced under one session
-/// id. The uid prefix is the record's uuid, so this reaches the row and all of
-/// its per-block siblings.
+/// id. `message_uuid` is the same identity insertion derives event uids from,
+/// so this reaches the row and all of its per-block siblings — including
+/// records with no `uuid` of their own, which fall back to the message id or
+/// the file position. The prefix is compared with `substr` rather than `LIKE`
+/// because a provider id may contain `_` or `%`.
 fn delete_claude_events_for_record(
     conn: &Connection,
     session_id: &str,
-    uuid: Option<&str>,
+    message_uuid: &str,
 ) -> Result<()> {
-    let Some(uuid) = uuid else {
-        return Ok(());
-    };
     conn.execute(
         "DELETE FROM session_events WHERE source = 'claude' AND session_id = ? \
-         AND (event_uid = ? || ':0' OR event_uid LIKE ? || ':%')",
-        params![session_id, uuid, uuid],
+         AND substr(event_uid, 1, length(?) + 1) = ? || ':'",
+        params![session_id, message_uuid, message_uuid],
     )?;
     Ok(())
 }
@@ -6531,26 +6615,6 @@ fn ingest_claude_transcript_as(
                 .and_then(Value::as_str)
                 != Some("assistant");
         let uuid = obj.get("uuid").and_then(Value::as_str);
-        // Heal what an earlier parser version wrote for this record: it
-        // attributed every sidechain row to the parent, and stored the rows
-        // this guard now skips. Re-reading the file removes the stale event
-        // under the identity it was written with, so a re-parse moves the
-        // row onto the child instead of duplicating it across both.
-        if session_id != record_session_id {
-            delete_claude_events_for_record(conn, record_session_id, uuid)?;
-        }
-        if skipped_sidechain {
-            delete_claude_events_for_record(conn, session_id, uuid)?;
-            continue;
-        }
-        let cwd = obj.get("cwd").and_then(Value::as_str);
-        let project = cwd;
-        let git_branch = obj.get("gitBranch").and_then(Value::as_str);
-        let ts_ms = obj
-            .get("timestamp")
-            .and_then(|v| v.as_str().and_then(parse_iso_ms).or_else(|| v.as_i64()))
-            .unwrap_or(0);
-        let parent_id = obj.get("parentUuid").and_then(Value::as_str);
         let message = obj.get("message").and_then(Value::as_object);
         let fallback_uid = format!(
             "{}:{}",
@@ -6562,6 +6626,26 @@ fn ingest_claude_transcript_as(
         let message_uuid = uuid
             .or_else(|| message.and_then(|m| m.get("id")).and_then(Value::as_str))
             .unwrap_or(&fallback_uid);
+        // Heal what an earlier parser version wrote for this record: it
+        // attributed every sidechain row to the parent, and stored the rows
+        // this guard now skips. Re-reading the file removes the stale event
+        // under the identity it was written with, so a re-parse moves the
+        // row onto the child instead of duplicating it across both.
+        if session_id != record_session_id {
+            delete_claude_events_for_record(conn, record_session_id, message_uuid)?;
+        }
+        if skipped_sidechain {
+            delete_claude_events_for_record(conn, session_id, message_uuid)?;
+            continue;
+        }
+        let cwd = obj.get("cwd").and_then(Value::as_str);
+        let project = cwd;
+        let git_branch = obj.get("gitBranch").and_then(Value::as_str);
+        let ts_ms = obj
+            .get("timestamp")
+            .and_then(|v| v.as_str().and_then(parse_iso_ms).or_else(|| v.as_i64()))
+            .unwrap_or(0);
+        let parent_id = obj.get("parentUuid").and_then(Value::as_str);
         let message_role = message
             .and_then(|m| m.get("role"))
             .and_then(Value::as_str)
@@ -10383,6 +10467,134 @@ mod tests {
             )
             .unwrap();
         assert_eq!(events, 1);
+    }
+
+    /// State that makes `sync_codex_rollouts` take its stamp-unchanged fast
+    /// path for one already-ingested subagent rollout.
+    fn unchanged_subagent_state(rollout: &std::path::Path, session_id: &str) -> Map<String, Value> {
+        let mut state = Map::new();
+        state.insert(
+            "codex_rollouts_v4".into(),
+            json!({
+                rollout.to_string_lossy().to_string(): {
+                    "stamp": file_stamp(rollout).unwrap(),
+                    "session": session_id,
+                    "subagent": true
+                }
+            }),
+        );
+        state
+    }
+
+    #[test]
+    fn unchanged_subagent_state_backfills_missing_delegation_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        let day = home.join(".codex/sessions/2026/08/01");
+        fs::create_dir_all(&day).unwrap();
+        let rollout = day.join("rollout-unchanged-sub.jsonl");
+        write_codex_subagent_rollout(&rollout, "sess-unchanged-sub");
+
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        // A database synced before delegation was recorded: the events are
+        // already there, so the rollout is never re-read for its own sake.
+        conn.execute(
+            "INSERT INTO session_events \
+             (source, session_id, ts_ms, role, kind, text, event_uid) \
+             VALUES ('codex', 'sess-unchanged-sub', 2, 'assistant', 'text', 'kept event', 'event-1')",
+            [],
+        )
+        .unwrap();
+        let mut state = unchanged_subagent_state(&rollout, "sess-unchanged-sub");
+
+        super::sync_codex_rollouts(&conn, &mut state, home).unwrap();
+        let edge: (String, String, String, i64) = conn
+            .query_row(
+                "SELECT parent_session_id, relationship_uid, evidence_kind, created_ms \
+                 FROM session_relationships \
+                 WHERE source='codex' AND child_session_id='sess-unchanged-sub'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(edge.0, "parent");
+        assert_eq!(edge.1, "child:sess-unchanged-sub");
+        assert_eq!(edge.2, "codex_session_meta");
+
+        // A second pass over the same unchanged state neither duplicates the
+        // row nor re-reads the rollout to rewrite it.
+        super::sync_codex_rollouts(&conn, &mut state, home).unwrap();
+        let (count, created): (i64, i64) = conn
+            .query_row(
+                "SELECT COUNT(*), MIN(created_ms) FROM session_relationships \
+                 WHERE source='codex' AND child_session_id='sess-unchanged-sub'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(created, edge.3);
+    }
+
+    #[test]
+    fn subagent_registration_cleanup_keeps_the_thread_s_own_delegations() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        let day = home.join(".codex/sessions/2026/08/01");
+        fs::create_dir_all(&day).unwrap();
+        let rollout = day.join("rollout-unchanged-sub.jsonl");
+        write_codex_subagent_rollout(&rollout, "sess-unchanged-sub");
+
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        // A stale catalog registration for the subagent, which the fast path
+        // removes — firing the cascade that used to take the topology with it.
+        conn.execute(
+            "INSERT INTO sessions (session_id, source, cwd) \
+             VALUES ('sess-unchanged-sub', 'codex', '/tmp/proj')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_events \
+             (source, session_id, ts_ms, role, kind, text, event_uid) \
+             VALUES ('codex', 'sess-unchanged-sub', 2, 'assistant', 'text', 'kept event', 'event-1')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_relationships \
+             (source, parent_session_id, relationship_uid, child_session_id, relationship, \
+              identity_status, evidence_kind, child_has_events, created_ms, updated_ms) \
+             VALUES ('codex', 'sess-unchanged-sub', 'child:grandchild', 'grandchild', 'delegated', \
+                     'observed', 'codex_session_meta', 1, 1, 1)",
+            [],
+        )
+        .unwrap();
+        let mut state = unchanged_subagent_state(&rollout, "sess-unchanged-sub");
+
+        super::sync_codex_rollouts(&conn, &mut state, home).unwrap();
+        let registrations: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions \
+                 WHERE source='codex' AND session_id='sess-unchanged-sub'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(registrations, 0);
+        let edges: Vec<String> = conn
+            .prepare(
+                "SELECT relationship_uid FROM session_relationships \
+                 WHERE source='codex' AND parent_session_id='sess-unchanged-sub'",
+            )
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(edges, vec!["child:grandchild".to_string()]);
     }
 
     #[test]

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -6390,7 +6390,7 @@ fn sync_claude_session_metadata(
     let mut upserted = 0;
     for path in collect_matching_files(root, "", "jsonl")? {
         let key = path.to_string_lossy().to_string();
-        let stamp = file_stamp(&path)?;
+        let stamp = claude_sync_stamp(&path)?;
         if session_state.get(&key).and_then(Value::as_str) == Some(stamp.as_str())
             && (claude_transcript_events_exist(conn, &path)?
                 || claude_sidecar_evidence_exists(conn, &path)?)
@@ -6439,6 +6439,23 @@ fn sync_claude_session_metadata(
         sync_note!("  [claude-sessions] scanned {scanned} files, {upserted} sessions updated");
     }
     Ok(())
+}
+
+/// What a Claude transcript is skipped on when nothing about it changed.
+///
+/// A subagent sidecar's `agent-<agentId>.meta.json` is the only place the
+/// child's type, name, model and spawn depth are recorded, so metadata that
+/// changes beside an untouched transcript is still new evidence and has to
+/// reach `session_relationships`. Hydration stamps its source snapshot by the
+/// same rule.
+fn claude_sync_stamp(path: &Path) -> Result<String> {
+    let mut stamp = file_stamp(path)?;
+    let metadata = hydrate::claude_subagent_meta_path(path);
+    if metadata.is_file() {
+        stamp.push('|');
+        stamp.push_str(&file_stamp(&metadata)?);
+    }
+    Ok(stamp)
 }
 
 /// Whether an unchanged subagent sidecar has already been ingested.
@@ -8301,8 +8318,8 @@ fn home_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::{
-        checkpoint_sync_state, cleanup_stale_sync_state_temps, cron_schedule, doctor_report,
-        export_history, file_stamp, git_commit_time_ms, git_stdout, import_history,
+        checkpoint_sync_state, claude_sync_stamp, cleanup_stale_sync_state_temps, cron_schedule,
+        doctor_report, export_history, file_stamp, git_commit_time_ms, git_stdout, import_history,
         ingest_claude_transcript, is_sqlite_contention, link_git_commit, load_sync_state,
         parse_trajectory_file, paths_overlap, prepare_sync_and_push_db,
         process_status_with_programs, save_sync_state, search_all, service_command_args,
@@ -10057,7 +10074,7 @@ mod tests {
             .get_mut("claude_sessions_v2")
             .and_then(Value::as_object_mut)
             .unwrap()
-            .insert(key, json!(file_stamp(&named).unwrap()));
+            .insert(key, json!(claude_sync_stamp(&named).unwrap()));
 
         sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
         let rewritten = |conn: &Connection| -> i64 {
@@ -10080,6 +10097,30 @@ mod tests {
         .unwrap();
         sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
         assert_eq!(rewritten(&conn), 1);
+    }
+
+    #[test]
+    fn a_changed_metadata_sidecar_refreshes_delegation_during_a_full_sync() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_, named, _) = write_claude_parent_with_subagents(dir.path());
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let mut state = Map::new();
+        sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
+
+        // The transcript never moves; only what describes the child changes.
+        fs::write(
+            named.with_extension("meta.json"),
+            r#"{"agentType":"Explore","description":"explore the code","toolUseId":"toolu_1","spawnDepth":2,"model":"other-model"}"#,
+        )
+        .unwrap();
+        sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
+
+        let row = delegation_row(&conn, "claude_subagent_meta");
+        assert_eq!(row.agent_type.as_deref(), Some("Explore"));
+        assert_eq!(row.agent_name.as_deref(), Some("explore the code"));
+        assert_eq!(row.model.as_deref(), Some("other-model"));
+        assert_eq!(row.spawn_depth, Some(2));
     }
 
     #[test]
@@ -10114,7 +10155,7 @@ mod tests {
         for path in [&parent, &named, &nameless] {
             claude_sessions.insert(
                 path.to_string_lossy().to_string(),
-                json!(file_stamp(path).unwrap()),
+                json!(claude_sync_stamp(path).unwrap()),
             );
         }
         let mut state = Map::new();

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -30,6 +30,8 @@ mod codex;
 pub mod discover;
 mod hydrate;
 mod learn;
+/// Recording the delegation evidence each provider leaves behind.
+mod relationships;
 /// Remote session connectors (claude.ai/code web sessions, Codex cloud tasks)
 /// and their availability reporting.
 pub mod remote;
@@ -48,6 +50,8 @@ pub use hydrate::{
     HydrationDiagnostic, HydrationEvidence, HydrationIndexedThrough,
     SESSION_HYDRATION_CONTRACT_VERSION,
 };
+pub(crate) use relationships::now_ms;
+pub use relationships::{record_relationship, ObservedRelationship};
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering as AtomicOrdering};
 
@@ -5258,31 +5262,35 @@ fn sync_codex(conn: &Connection, state: &mut Map<String, Value>, home: &Path) ->
 /// (session cwds, session branches, prompts inserted).
 type CodexRolloutWalk = (HashMap<String, String>, HashMap<String, String>, usize);
 
-/// Reconcile the catalog registration for a locally observed Codex subagent.
+/// Reconcile the catalog registration for a locally observed subagent.
 ///
 /// A local-only subagent stays out of the catalog. If the same canonical
 /// session was separately discovered remotely, its retained local events are
 /// also local evidence, so both presences and the canonical row must survive.
-fn cleanup_codex_subagent_registration(conn: &Connection, session_id: &str) -> Result<()> {
+fn cleanup_subagent_registration(conn: &Connection, source: &str, session_id: &str) -> Result<()> {
     conn.execute(
         "DELETE FROM session_presences \
-         WHERE source = 'codex' AND session_id = ? AND location = 'local' \
+         WHERE source = ? AND session_id = ? AND location = 'local' \
            AND NOT EXISTS (\
              SELECT 1 FROM session_presences \
-             WHERE source = 'codex' AND session_id = ? AND location = 'remote'\
+             WHERE source = ? AND session_id = ? AND location = 'remote'\
            )",
-        params![session_id, session_id],
+        params![source, session_id, source, session_id],
     )?;
     conn.execute(
         "DELETE FROM sessions \
-         WHERE source = 'codex' AND session_id = ? \
+         WHERE source = ? AND session_id = ? \
            AND NOT EXISTS (\
              SELECT 1 FROM session_presences \
-             WHERE source = 'codex' AND session_id = ?\
+             WHERE source = ? AND session_id = ?\
            )",
-        params![session_id, session_id],
+        params![source, session_id, source, session_id],
     )?;
     Ok(())
+}
+
+fn cleanup_codex_subagent_registration(conn: &Connection, session_id: &str) -> Result<()> {
+    cleanup_subagent_registration(conn, "codex", session_id)
 }
 
 fn codex_session_has_remote_presence(conn: &Connection, session_id: &str) -> Result<bool> {
@@ -5418,6 +5426,14 @@ fn sync_codex_rollouts(
             };
             inserted += outcome.prompts;
             events += outcome.events;
+            // Topology is recorded by the full sync too, so delegation is
+            // queryable after a plain `sync` and not only after targeted
+            // hydration of the parent.
+            if meta.is_subagent {
+                if let Some(parent) = meta.parent_session_id.as_deref() {
+                    record_codex_delegation(conn, parent, &meta, &rollout)?;
+                }
+            }
             // Subagent threads (guardian/reviewer spawns) keep their events
             // under their own thread id but stay out of the session list.
             if !meta.is_subagent {
@@ -5487,13 +5503,49 @@ fn load_state_string_map(state: &Map<String, Value>, key: &str) -> HashMap<Strin
         .unwrap_or_default()
 }
 
-fn codex_session_events_exist(conn: &Connection, session_id: &str) -> Result<bool> {
+/// Record one Codex subagent rollout as a delegation of its parent thread.
+///
+/// The rollout's own `session_meta` is the evidence: the file locates it, the
+/// thread id is the child's real identity, and the meta line's timestamp is
+/// when the provider recorded the thread starting.
+fn record_codex_delegation(
+    conn: &Connection,
+    parent_session_id: &str,
+    meta: &CodexSessionMeta,
+    rollout: &Path,
+) -> Result<()> {
+    let locator = rollout.to_string_lossy();
+    record_relationship(
+        conn,
+        &ObservedRelationship {
+            source: "codex",
+            parent_session_id,
+            child_session_id: Some(&meta.session_id),
+            relationship: "delegated",
+            child_agent_type: meta.subagent_label.as_deref(),
+            child_agent_name: None,
+            child_model: None,
+            spawn_depth: None,
+            evidence_kind: "codex_session_meta",
+            evidence_locator: Some(&locator),
+            evidence_ref: meta.parent_thread_id.as_deref(),
+            child_has_events: codex_session_events_exist(conn, &meta.session_id)?,
+            spawned_at_ms: meta.meta_ts_ms,
+        },
+    )
+}
+
+fn session_events_exist(conn: &Connection, source: &str, session_id: &str) -> Result<bool> {
     let exists: i64 = conn.query_row(
-        "SELECT EXISTS(SELECT 1 FROM session_events WHERE source = 'codex' AND session_id = ? LIMIT 1)",
-        [session_id],
+        "SELECT EXISTS(SELECT 1 FROM session_events WHERE source = ? AND session_id = ? LIMIT 1)",
+        params![source, session_id],
         |row| row.get(0),
     )?;
     Ok(exists != 0)
+}
+
+fn codex_session_events_exist(conn: &Connection, session_id: &str) -> Result<bool> {
+    session_events_exist(conn, "codex", session_id)
 }
 
 struct CodexSessionMeta {
@@ -5501,7 +5553,17 @@ struct CodexSessionMeta {
     cwd: String,
     git_branch: Option<String>,
     is_subagent: bool,
+    /// The parent this thread was delegated by, from whichever field the
+    /// provider recorded it in.
     parent_session_id: Option<String>,
+    /// `payload.parent_thread_id`, kept as the provider-native reference even
+    /// when `payload.session_id` is what named the parent.
+    parent_thread_id: Option<String>,
+    /// The label under `payload.source.subagent`, when the rollout carries one.
+    subagent_label: Option<String>,
+    /// The `session_meta` line's own timestamp: when the provider recorded
+    /// this thread starting.
+    meta_ts_ms: Option<i64>,
 }
 
 /// Read the `session_meta` line that opens every rollout file.
@@ -5547,29 +5609,53 @@ fn read_codex_session_meta(path: &Path) -> Result<Option<CodexSessionMeta>> {
         .and_then(|g| g.get("branch"))
         .and_then(Value::as_str)
         .map(str::to_string);
+    let subagent = payload
+        .and_then(|p| p.get("source"))
+        .and_then(Value::as_object)
+        .and_then(|s| s.get("subagent"));
     let is_subagent = payload
         .and_then(|p| p.get("thread_source"))
         .and_then(Value::as_str)
         == Some("subagent")
-        || payload
-            .and_then(|p| p.get("source"))
-            .and_then(Value::as_object)
-            .is_some_and(|s| s.contains_key("subagent"));
-    let parent_session_id = is_subagent
-        .then(|| {
-            payload
-                .and_then(|p| p.get("session_id"))
-                .and_then(Value::as_str)
-                .filter(|id| !id.is_empty() && *id != session_id)
-                .map(str::to_string)
-        })
+        || subagent.is_some();
+    let named_parent = |key: &str| {
+        payload
+            .and_then(|p| p.get(key))
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty() && *id != session_id)
+            .map(str::to_string)
+    };
+    let parent_thread_id = is_subagent
+        .then(|| named_parent("parent_thread_id"))
         .flatten();
+    let parent_session_id = is_subagent
+        .then(|| named_parent("session_id").or_else(|| parent_thread_id.clone()))
+        .flatten();
+    // The label is an object in the observed rollouts (`{"other":"guardian"}`);
+    // its value names the agent, and its key is the only thing left when the
+    // value is not a string.
+    let subagent_label = subagent.and_then(|value| match value {
+        Value::String(label) => Some(label.clone()),
+        Value::Object(map) => map
+            .values()
+            .find_map(Value::as_str)
+            .map(str::to_string)
+            .or_else(|| map.keys().next().cloned()),
+        _ => None,
+    });
+    let meta_ts_ms = value
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .and_then(parse_iso_ms);
     Ok(Some(CodexSessionMeta {
         session_id: session_id.to_string(),
         cwd: cwd.to_string(),
         git_branch,
         is_subagent,
         parent_session_id,
+        parent_thread_id,
+        subagent_label,
+        meta_ts_ms,
     }))
 }
 
@@ -6385,6 +6471,37 @@ fn scan_claude_session_file(path: &Path) -> Result<Option<ClaudeSessionMeta>> {
 }
 
 fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
+    ingest_claude_transcript_as(conn, path, None)
+}
+
+/// Remove every event a single transcript record produced under one session
+/// id. The uid prefix is the record's uuid, so this reaches the row and all of
+/// its per-block siblings.
+fn delete_claude_events_for_record(
+    conn: &Connection,
+    session_id: &str,
+    uuid: Option<&str>,
+) -> Result<()> {
+    let Some(uuid) = uuid else {
+        return Ok(());
+    };
+    conn.execute(
+        "DELETE FROM session_events WHERE source = 'claude' AND session_id = ? \
+         AND (event_uid = ? || ':0' OR event_uid LIKE ? || ':%')",
+        params![session_id, uuid, uuid],
+    )?;
+    Ok(())
+}
+
+/// `attributed_session_id` overrides the record's own `sessionId`. Claude
+/// subagent transcripts carry the PARENT's sessionId plus a per-child
+/// `agentId`; when the provider records that agentId we store the child's
+/// events under it so the child is independently addressable.
+fn ingest_claude_transcript_as(
+    conn: &Connection,
+    path: &Path,
+    attributed_session_id: Option<&str>,
+) -> Result<()> {
     let text = fs::read_to_string(path).unwrap_or_default();
     for (line_index, line) in text.lines().enumerate() {
         let Ok(value) = serde_json::from_str::<Value>(line) else {
@@ -6393,10 +6510,11 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
         let Some(obj) = value.as_object() else {
             continue;
         };
-        let session_id = match obj.get("sessionId").and_then(Value::as_str) {
+        let record_session_id = match obj.get("sessionId").and_then(Value::as_str) {
             Some(s) if !s.is_empty() => s,
             _ => continue,
         };
+        let session_id = attributed_session_id.unwrap_or(record_session_id);
         // Subagent sidecar transcripts share the parent's sessionId with
         // isSidechain rows. The subagent's assistant output is real session
         // activity (text and token spend), but its user-role rows are the
@@ -6406,22 +6524,23 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
             .get("isSidechain")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        if sidechain
+        let skipped_sidechain = sidechain
             && obj
                 .get("message")
                 .and_then(|m| m.get("role"))
                 .and_then(Value::as_str)
-                != Some("assistant")
-        {
-            // Heal databases that ingested these rows before this guard:
-            // the uid prefix is this row's uuid, so stale events (and any
-            // per-block siblings) can be removed as the file is re-read.
-            if let Some(uuid) = obj.get("uuid").and_then(Value::as_str) {
-                conn.execute(
-                    "DELETE FROM session_events WHERE source = 'claude' AND session_id = ? AND (event_uid = ? || ':0' OR event_uid LIKE ? || ':%')",
-                    params![session_id, uuid, uuid],
-                )?;
-            }
+                != Some("assistant");
+        let uuid = obj.get("uuid").and_then(Value::as_str);
+        // Heal what an earlier parser version wrote for this record: it
+        // attributed every sidechain row to the parent, and stored the rows
+        // this guard now skips. Re-reading the file removes the stale event
+        // under the identity it was written with, so a re-parse moves the
+        // row onto the child instead of duplicating it across both.
+        if session_id != record_session_id {
+            delete_claude_events_for_record(conn, record_session_id, uuid)?;
+        }
+        if skipped_sidechain {
+            delete_claude_events_for_record(conn, session_id, uuid)?;
             continue;
         }
         let cwd = obj.get("cwd").and_then(Value::as_str);
@@ -6440,9 +6559,7 @@ fn ingest_claude_transcript(conn: &Connection, path: &Path) -> Result<()> {
                 .unwrap_or("session"),
             line_index
         );
-        let message_uuid = obj
-            .get("uuid")
-            .and_then(Value::as_str)
+        let message_uuid = uuid
             .or_else(|| message.and_then(|m| m.get("id")).and_then(Value::as_str))
             .unwrap_or(&fallback_uid);
         let message_role = message

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -6405,10 +6405,14 @@ fn sync_claude_session_metadata(
             // would pull the child's output back onto the parent that
             // hydration just moved it off.
             if meta.subagent {
-                ingest_claude_transcript_as(conn, &path, meta.agent_id.as_deref())?;
-                if let Some(agent_id) = meta.agent_id.as_deref() {
-                    cleanup_subagent_registration(conn, "claude", agent_id)?;
-                }
+                // Topology is recorded by the full sync too, so delegation is
+                // queryable after a plain `sync` and not only after targeted
+                // hydration of the parent. The sidecar's records name that
+                // parent, so this walk reaches the same edge from the child's
+                // side, through the very code hydration uses: a named child
+                // is an observed row, an unnamed one is unlinked evidence.
+                let evidence = hydrate::claude_subagent_evidence(path.clone(), &meta);
+                hydrate::ingest_claude_subagent(conn, &meta.session_id, &evidence)?;
                 continue;
             }
             upsert_session(
@@ -9771,6 +9775,284 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM session_events", [], |row| row.get(0))
             .unwrap();
         assert_eq!(event_count, 4);
+    }
+
+    /// One Claude project tree as the provider writes it: a parent transcript,
+    /// a subagent sidecar the provider named with an in-record `agentId` (with
+    /// its `meta.json` beside it), and a sidechain sidecar from a provider
+    /// version that names no child at all. Returns the three transcripts.
+    fn write_claude_parent_with_subagents(
+        root: &std::path::Path,
+    ) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+        let subagents = root.join("app/claude-root/subagents");
+        fs::create_dir_all(&subagents).unwrap();
+        let parent = root.join("app/claude-root.jsonl");
+        fs::write(
+            &parent,
+            concat!(
+                r#"{"sessionId":"claude-root","uuid":"u1","cwd":"/work/app","type":"user","message":{"role":"user","content":"human prompt"},"timestamp":"2026-08-31T11:00:00Z"}"#, "\n",
+                r#"{"sessionId":"claude-root","uuid":"a1","cwd":"/work/app","type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Agent","input":{"prompt":"plan it"}}]},"timestamp":"2026-08-31T11:00:01Z"}"#, "\n",
+            ),
+        )
+        .unwrap();
+        let named = subagents.join("agent-abc.jsonl");
+        fs::write(
+            &named,
+            concat!(
+                r#"{"sessionId":"claude-root","agentId":"abc","isSidechain":true,"uuid":"side-u","cwd":"/work/app","type":"user","message":{"role":"user","content":"delegated instruction"},"timestamp":"2026-08-31T11:00:02Z"}"#, "\n",
+                r#"{"sessionId":"claude-root","agentId":"abc","isSidechain":true,"uuid":"side-a","cwd":"/work/app","type":"assistant","message":{"role":"assistant","content":"child result"},"timestamp":"2026-08-31T11:00:03Z"}"#, "\n",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            subagents.join("agent-abc.meta.json"),
+            r#"{"agentType":"Plan","description":"plan the work","toolUseId":"toolu_1","spawnDepth":1,"model":"test-model"}"#,
+        )
+        .unwrap();
+        let nameless = subagents.join("agent-nameless.jsonl");
+        fs::write(
+            &nameless,
+            concat!(
+                r#"{"sessionId":"claude-root","isSidechain":true,"uuid":"other-u","cwd":"/work/app","type":"user","message":{"role":"user","content":"second instruction"},"timestamp":"2026-08-31T11:00:04Z"}"#, "\n",
+                r#"{"sessionId":"claude-root","isSidechain":true,"uuid":"other-a","cwd":"/work/app","type":"assistant","message":{"role":"assistant","content":"unnamed result"},"timestamp":"2026-08-31T11:00:05Z"}"#, "\n",
+            ),
+        )
+        .unwrap();
+        (parent, named, nameless)
+    }
+
+    struct DelegationRow {
+        parent: String,
+        child: Option<String>,
+        identity_status: String,
+        agent_type: Option<String>,
+        agent_name: Option<String>,
+        model: Option<String>,
+        spawn_depth: Option<i64>,
+        evidence_kind: String,
+        evidence_locator: Option<String>,
+        evidence_ref: Option<String>,
+        child_has_events: bool,
+        spawned_at_ms: Option<i64>,
+        created_ms: i64,
+    }
+
+    fn delegation_row(conn: &Connection, evidence_kind: &str) -> DelegationRow {
+        conn.query_row(
+            "SELECT parent_session_id, child_session_id, identity_status, child_agent_type, \
+                    child_agent_name, child_model, spawn_depth, evidence_kind, evidence_locator, \
+                    evidence_ref, child_has_events, spawned_at_ms, created_ms \
+             FROM session_relationships WHERE source = 'claude' AND evidence_kind = ?",
+            [evidence_kind],
+            |row| {
+                Ok(DelegationRow {
+                    parent: row.get(0)?,
+                    child: row.get(1)?,
+                    identity_status: row.get(2)?,
+                    agent_type: row.get(3)?,
+                    agent_name: row.get(4)?,
+                    model: row.get(5)?,
+                    spawn_depth: row.get(6)?,
+                    evidence_kind: row.get(7)?,
+                    evidence_locator: row.get(8)?,
+                    evidence_ref: row.get(9)?,
+                    child_has_events: row.get(10)?,
+                    spawned_at_ms: row.get(11)?,
+                    created_ms: row.get(12)?,
+                })
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn plain_claude_sync_records_a_named_subagent_as_an_observed_child() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_, named, _) = write_claude_parent_with_subagents(dir.path());
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let mut state = Map::new();
+
+        // No hydration anywhere: a plain sync is the only thing that has ever
+        // read these files.
+        sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
+
+        let row = delegation_row(&conn, "claude_subagent_meta");
+        assert_eq!(row.parent, "claude-root");
+        assert_eq!(row.child.as_deref(), Some("abc"));
+        assert_eq!(row.identity_status, "observed");
+        assert_eq!(row.agent_type.as_deref(), Some("Plan"));
+        assert_eq!(row.agent_name.as_deref(), Some("plan the work"));
+        assert_eq!(row.model.as_deref(), Some("test-model"));
+        assert_eq!(row.spawn_depth, Some(1));
+        assert_eq!(row.evidence_kind, "claude_subagent_meta");
+        assert_eq!(
+            row.evidence_locator.as_deref(),
+            Some(named.to_string_lossy().as_ref())
+        );
+        assert_eq!(row.evidence_ref.as_deref(), Some("toolu_1"));
+        assert!(row.child_has_events);
+        assert_eq!(
+            row.spawned_at_ms,
+            super::parse_iso_ms("2026-08-31T11:00:02Z")
+        );
+
+        // The child's output is addressable under the child, its delegated
+        // instruction is nobody's human prompt, and a delegated thread never
+        // becomes a session of its own.
+        let counts: (i64, i64, i64, i64) = conn
+            .query_row(
+                "SELECT \
+                   (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='abc'), \
+                   (SELECT COUNT(*) FROM history WHERE source='claude' AND session_id='abc'), \
+                   (SELECT COUNT(*) FROM sessions WHERE source='claude' AND session_id='abc'), \
+                   (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='claude-root' AND event_uid LIKE 'side-%')",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(counts, (1, 0, 0, 0));
+    }
+
+    #[test]
+    fn plain_claude_sync_records_a_nameless_sidechain_as_unlinked_evidence() {
+        let dir = tempfile::tempdir().unwrap();
+        let (_, _, nameless) = write_claude_parent_with_subagents(dir.path());
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let mut state = Map::new();
+
+        sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
+
+        let row = delegation_row(&conn, "claude_sidechain_records");
+        assert_eq!(row.parent, "claude-root");
+        assert_eq!(row.child, None);
+        assert_eq!(row.identity_status, "unlinked");
+        assert!(!row.child_has_events);
+        assert_eq!(
+            row.evidence_locator.as_deref(),
+            Some(nameless.to_string_lossy().as_ref())
+        );
+        assert_eq!(
+            row.spawned_at_ms,
+            super::parse_iso_ms("2026-08-31T11:00:04Z")
+        );
+        // Nothing was invented from the file name, and the unnamed child's
+        // output stays where it can still be addressed: on the parent.
+        let placement: (i64, i64) = conn
+            .query_row(
+                "SELECT \
+                   (SELECT COUNT(*) FROM session_relationships WHERE child_session_id = 'nameless'), \
+                   (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='claude-root' AND event_uid = 'other-a:0')",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(placement, (0, 1));
+    }
+
+    #[test]
+    fn repeated_claude_sync_neither_duplicates_nor_ages_delegation_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        write_claude_parent_with_subagents(dir.path());
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        let mut state = Map::new();
+
+        sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
+        let first = (
+            delegation_row(&conn, "claude_subagent_meta").created_ms,
+            delegation_row(&conn, "claude_sidechain_records").created_ms,
+        );
+
+        // The second walk sees unchanged stamps for every file.
+        sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
+        let rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM session_relationships", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(rows, 2);
+        assert_eq!(
+            (
+                delegation_row(&conn, "claude_subagent_meta").created_ms,
+                delegation_row(&conn, "claude_sidechain_records").created_ms,
+            ),
+            first
+        );
+        let child_events: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='abc'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(child_events, 1);
+    }
+
+    #[test]
+    fn unchanged_claude_stamps_backfill_missing_delegation_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let (parent, named, nameless) = write_claude_parent_with_subagents(dir.path());
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        // A database synced before delegation was recorded: the parent is
+        // registered and indexed, so its stamp fast path skips it entirely,
+        // and no topology exists at all.
+        super::upsert_session(
+            &conn,
+            "claude-root",
+            "claude",
+            Some("/work/app"),
+            None,
+            1,
+            2,
+            None,
+            Some(&parent.to_string_lossy()),
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO session_events \
+             (source, session_id, ts_ms, role, kind, text, event_uid) \
+             VALUES ('claude', 'claude-root', 2, 'assistant', 'text', 'kept event', 'a1:0')",
+            [],
+        )
+        .unwrap();
+        let mut claude_sessions = Map::new();
+        for path in [&parent, &named, &nameless] {
+            claude_sessions.insert(
+                path.to_string_lossy().to_string(),
+                json!(file_stamp(path).unwrap()),
+            );
+        }
+        let mut state = Map::new();
+        state.insert(
+            "claude_sessions_v2".to_string(),
+            Value::Object(claude_sessions),
+        );
+
+        sync_claude_session_metadata(&conn, &mut state, dir.path()).unwrap();
+
+        assert_eq!(
+            delegation_row(&conn, "claude_subagent_meta")
+                .child
+                .as_deref(),
+            Some("abc")
+        );
+        assert_eq!(
+            delegation_row(&conn, "claude_sidechain_records").identity_status,
+            "unlinked"
+        );
+        // The parent itself was never re-read: its stamp skip still holds, so
+        // the walk that backfilled the topology did not re-ingest its prompt.
+        let parent_prompts: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM history WHERE source='claude'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(parent_prompts, 0);
     }
 
     #[test]

--- a/crates/ai-hist/src/relationships.rs
+++ b/crates/ai-hist/src/relationships.rs
@@ -60,6 +60,23 @@ impl ObservedRelationship<'_> {
 /// metadata an earlier one captured.
 pub fn record_relationship(conn: &Connection, observed: &ObservedRelationship<'_>) -> Result<()> {
     let now = now_ms();
+    // An observation that finally names the child supersedes the unlinked row
+    // an earlier provider version left for the same artifact: one file is not
+    // both a linked and an unlinked delegation. Its uid is keyed on the
+    // locator, so without this the stale row would outlive the upgrade.
+    if let (Some(_), Some(locator)) = (observed.child_session_id, observed.evidence_locator) {
+        conn.execute(
+            "DELETE FROM session_relationships \
+             WHERE source = ? AND parent_session_id = ? AND evidence_locator = ? \
+               AND identity_status = ?",
+            params![
+                observed.source,
+                observed.parent_session_id,
+                locator,
+                ai_hist_core::relationships::IDENTITY_UNLINKED,
+            ],
+        )?;
+    }
     conn.execute(
         "INSERT INTO session_relationships \
          (source, parent_session_id, relationship_uid, child_session_id, relationship, \
@@ -203,6 +220,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let conn = open_db(&dir.path().join("history.db")).unwrap();
         record_relationship(&conn, &observed("root", None, "/tmp/agent-a.jsonl")).unwrap();
+        // A second sidecar the provider still does not name must survive the
+        // upgrade of the first one.
+        record_relationship(&conn, &observed("root", None, "/tmp/agent-b.jsonl")).unwrap();
         record_relationship(&conn, &observed("root", Some("abc"), "/tmp/agent-a.jsonl")).unwrap();
         record_relationship(&conn, &observed("root", Some("abc"), "/tmp/agent-a.jsonl")).unwrap();
         let children = session_children(&conn, "claude", "root").unwrap();
@@ -214,5 +234,15 @@ mod tests {
         assert_eq!(observed_child.child_session_id.as_deref(), Some("abc"));
         assert_eq!(observed_child.relationship_uid, "child:abc");
         assert!(observed_child.child_has_events);
+        // The superseded row for the same artifact is retired, not kept
+        // alongside the identity that replaced it.
+        assert_eq!(
+            children
+                .iter()
+                .filter(|child| child.identity_status == "unlinked")
+                .map(|child| child.evidence_locator.clone().unwrap())
+                .collect::<Vec<_>>(),
+            vec!["/tmp/agent-b.jsonl".to_string()]
+        );
     }
 }

--- a/crates/ai-hist/src/relationships.rs
+++ b/crates/ai-hist/src/relationships.rs
@@ -1,0 +1,218 @@
+//! Recording observed delegation evidence.
+//!
+//! One writer for both providers, so a Codex subagent rollout and a Claude
+//! subagent transcript produce rows of the same shape. Nothing here infers a
+//! link: every field comes from something the provider actually recorded, and
+//! a child without a provider-recorded identity is stored as unlinked evidence
+//! rather than given a made-up id.
+
+use anyhow::Result;
+use rusqlite::{params, Connection};
+
+/// What a provider's own records say about one delegation.
+pub struct ObservedRelationship<'a> {
+    pub source: &'a str,
+    pub parent_session_id: &'a str,
+    /// The child's provider-recorded identity, or `None` when this provider
+    /// version records the delegation without giving the child one.
+    pub child_session_id: Option<&'a str>,
+    pub relationship: &'a str,
+    pub child_agent_type: Option<&'a str>,
+    pub child_agent_name: Option<&'a str>,
+    pub child_model: Option<&'a str>,
+    pub spawn_depth: Option<i64>,
+    pub evidence_kind: &'a str,
+    pub evidence_locator: Option<&'a str>,
+    pub evidence_ref: Option<&'a str>,
+    pub child_has_events: bool,
+    pub spawned_at_ms: Option<i64>,
+}
+
+impl ObservedRelationship<'_> {
+    pub fn identity_status(&self) -> &'static str {
+        if self.child_session_id.is_some() {
+            ai_hist_core::relationships::IDENTITY_OBSERVED
+        } else {
+            ai_hist_core::relationships::IDENTITY_UNLINKED
+        }
+    }
+
+    /// The dedupe key, which has to work with and without a child id. Keying
+    /// unlinked evidence on its locator gives every sidecar its own row
+    /// instead of collapsing them all into one.
+    pub fn relationship_uid(&self) -> String {
+        match self.child_session_id {
+            Some(child) => format!("child:{child}"),
+            None => format!(
+                "evidence:{}:{}",
+                self.evidence_kind,
+                self.evidence_locator.unwrap_or("")
+            ),
+        }
+    }
+}
+
+/// Record one observed relationship, refreshing what re-observation can know.
+///
+/// `created_ms` is never updated, so repeated ingestion of the same evidence
+/// is idempotent and keeps its first-observation time. Optional detail is
+/// merged with `COALESCE` so a later, thinner observation cannot erase agent
+/// metadata an earlier one captured.
+pub fn record_relationship(conn: &Connection, observed: &ObservedRelationship<'_>) -> Result<()> {
+    let now = now_ms();
+    conn.execute(
+        "INSERT INTO session_relationships \
+         (source, parent_session_id, relationship_uid, child_session_id, relationship, \
+          identity_status, child_agent_type, child_agent_name, child_model, spawn_depth, \
+          evidence_kind, evidence_locator, evidence_ref, child_has_events, \
+          spawned_at_ms, created_ms, updated_ms) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+         ON CONFLICT(source, parent_session_id, relationship_uid) DO UPDATE SET \
+           child_session_id = excluded.child_session_id, \
+           relationship     = excluded.relationship, \
+           identity_status  = excluded.identity_status, \
+           child_agent_type = COALESCE(excluded.child_agent_type, session_relationships.child_agent_type), \
+           child_agent_name = COALESCE(excluded.child_agent_name, session_relationships.child_agent_name), \
+           child_model      = COALESCE(excluded.child_model,      session_relationships.child_model), \
+           spawn_depth      = COALESCE(excluded.spawn_depth,      session_relationships.spawn_depth), \
+           evidence_kind    = excluded.evidence_kind, \
+           evidence_locator = COALESCE(excluded.evidence_locator, session_relationships.evidence_locator), \
+           evidence_ref     = COALESCE(excluded.evidence_ref,     session_relationships.evidence_ref), \
+           child_has_events = excluded.child_has_events, \
+           spawned_at_ms    = COALESCE(excluded.spawned_at_ms,    session_relationships.spawned_at_ms), \
+           updated_ms       = excluded.updated_ms",
+        params![
+            observed.source,
+            observed.parent_session_id,
+            observed.relationship_uid(),
+            observed.child_session_id,
+            observed.relationship,
+            observed.identity_status(),
+            observed.child_agent_type,
+            observed.child_agent_name,
+            observed.child_model,
+            observed.spawn_depth,
+            observed.evidence_kind,
+            observed.evidence_locator,
+            observed.evidence_ref,
+            observed.child_has_events,
+            observed.spawned_at_ms,
+            now,
+            now,
+        ],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ai_hist_core::{open_db, session_children};
+
+    fn observed<'a>(
+        parent: &'a str,
+        child: Option<&'a str>,
+        locator: &'a str,
+    ) -> ObservedRelationship<'a> {
+        ObservedRelationship {
+            source: "claude",
+            parent_session_id: parent,
+            child_session_id: child,
+            relationship: "delegated",
+            child_agent_type: None,
+            child_agent_name: None,
+            child_model: None,
+            spawn_depth: None,
+            evidence_kind: if child.is_some() {
+                "claude_subagent_meta"
+            } else {
+                "claude_sidechain_records"
+            },
+            evidence_locator: Some(locator),
+            evidence_ref: None,
+            child_has_events: child.is_some(),
+            spawned_at_ms: Some(5),
+        }
+    }
+
+    #[test]
+    fn duplicate_relationship_ingestion_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = open_db(&dir.path().join("history.db")).unwrap();
+        let first = ObservedRelationship {
+            child_agent_type: Some("Plan"),
+            ..observed("root", Some("child"), "/tmp/agent-child.jsonl")
+        };
+        record_relationship(&conn, &first).unwrap();
+        let created: i64 = conn
+            .query_row("SELECT created_ms FROM session_relationships", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        // A later, thinner observation must not erase what the first knew.
+        record_relationship(
+            &conn,
+            &observed("root", Some("child"), "/tmp/agent-child.jsonl"),
+        )
+        .unwrap();
+        let row: (i64, i64, i64, Option<String>) = conn
+            .query_row(
+                "SELECT COUNT(*), MIN(created_ms), MIN(updated_ms), MIN(child_agent_type) \
+                 FROM session_relationships",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(row.0, 1);
+        assert_eq!(row.1, created);
+        assert!(row.2 > created);
+        assert_eq!(row.3.as_deref(), Some("Plan"));
+    }
+
+    #[test]
+    fn unlinked_evidence_rows_do_not_collide() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = open_db(&dir.path().join("history.db")).unwrap();
+        record_relationship(&conn, &observed("root", None, "/tmp/agent-a.jsonl")).unwrap();
+        record_relationship(&conn, &observed("root", None, "/tmp/agent-b.jsonl")).unwrap();
+        let children = session_children(&conn, "claude", "root").unwrap();
+        assert_eq!(children.len(), 2);
+        assert!(children
+            .iter()
+            .all(|child| child.child_session_id.is_none() && child.identity_status == "unlinked"));
+        assert_eq!(
+            children
+                .iter()
+                .map(|child| child.relationship_uid.clone())
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn re_recording_upgrades_unlinked_to_observed_without_duplicating() {
+        let dir = tempfile::tempdir().unwrap();
+        let conn = open_db(&dir.path().join("history.db")).unwrap();
+        record_relationship(&conn, &observed("root", None, "/tmp/agent-a.jsonl")).unwrap();
+        record_relationship(&conn, &observed("root", Some("abc"), "/tmp/agent-a.jsonl")).unwrap();
+        record_relationship(&conn, &observed("root", Some("abc"), "/tmp/agent-a.jsonl")).unwrap();
+        let children = session_children(&conn, "claude", "root").unwrap();
+        assert_eq!(children.len(), 2);
+        let observed_child = children
+            .iter()
+            .find(|child| child.identity_status == "observed")
+            .unwrap();
+        assert_eq!(observed_child.child_session_id.as_deref(), Some("abc"));
+        assert_eq!(observed_child.relationship_uid, "child:abc");
+        assert!(observed_child.child_has_events);
+    }
+}

--- a/crates/ai-hist/tests/session_relationships.rs
+++ b/crates/ai-hist/tests/session_relationships.rs
@@ -1,0 +1,231 @@
+//! End-to-end delegation topology over real provider fixtures.
+//!
+//! One isolated HOME holding a Codex root with two subagent threads and a
+//! grandchild, plus a Claude session with an `agentId`-carrying subagent, is
+//! taken through the acquisition path a host actually uses (sync, discovery,
+//! targeted hydration) and then queried through the public relationship API.
+
+use ai_hist_core::{open_db, session_relationships, session_tree, SessionTreeOptions};
+use ai_hist_engine::{
+    discover_sessions_scoped_at, hydrate_session_at, sync_scoped_at, DiscoverOptions,
+    HydrateSessionOptions, SessionScope,
+};
+use std::fs;
+use std::path::Path;
+
+fn write(path: &Path, contents: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, contents).unwrap();
+}
+
+fn codex_root(home: &Path) {
+    let day = home.join(".codex/sessions/2026/08/31");
+    write(
+        &day.join("rollout-root.jsonl"),
+        concat!(
+            r#"{"timestamp":"2026-08-31T10:00:00Z","type":"session_meta","payload":{"id":"root","cwd":"/work/app"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-08-31T10:00:01Z","type":"event_msg","payload":{"type":"user_message","message":"root prompt"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-08-31T10:00:02Z","type":"event_msg","payload":{"type":"agent_message","message":"root answer"}}"#,
+            "\n",
+        ),
+    );
+    write(
+        &day.join("rollout-child-a.jsonl"),
+        concat!(
+            r#"{"timestamp":"2026-08-31T10:00:03Z","type":"session_meta","payload":{"id":"child-a","session_id":"root","parent_thread_id":"root","cwd":"/work/app","thread_source":"subagent","source":{"subagent":{"other":"guardian"}}}}"#,
+            "\n",
+            r#"{"timestamp":"2026-08-31T10:00:04Z","type":"event_msg","payload":{"type":"user_message","message":"delegated task a"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-08-31T10:00:05Z","type":"event_msg","payload":{"type":"agent_message","message":"child a answer"}}"#,
+            "\n",
+        ),
+    );
+    write(
+        &day.join("rollout-child-b.jsonl"),
+        concat!(
+            r#"{"timestamp":"2026-08-31T10:00:06Z","type":"session_meta","payload":{"id":"child-b","session_id":"root","cwd":"/work/app","thread_source":"subagent"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-08-31T10:00:07Z","type":"event_msg","payload":{"type":"agent_message","message":"child b answer"}}"#,
+            "\n",
+        ),
+    );
+    write(
+        &day.join("rollout-grandchild.jsonl"),
+        concat!(
+            r#"{"timestamp":"2026-08-31T10:00:08Z","type":"session_meta","payload":{"id":"grandchild","session_id":"child-a","cwd":"/work/app","thread_source":"subagent"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-08-31T10:00:09Z","type":"event_msg","payload":{"type":"agent_message","message":"grandchild answer"}}"#,
+            "\n",
+        ),
+    );
+}
+
+fn claude_root(home: &Path) {
+    write(
+        &home.join(".claude/projects/app/claude-root.jsonl"),
+        concat!(
+            r#"{"sessionId":"claude-root","uuid":"u1","cwd":"/work/app","type":"user","message":{"role":"user","content":"human prompt"},"timestamp":"2026-08-31T11:00:00Z"}"#,
+            "\n",
+            r#"{"sessionId":"claude-root","uuid":"a1","cwd":"/work/app","type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Agent","input":{"prompt":"plan it"}}]},"timestamp":"2026-08-31T11:00:01Z"}"#,
+            "\n",
+        ),
+    );
+    let subagents = home.join(".claude/projects/app/claude-root/subagents");
+    write(
+        &subagents.join("agent-abc.jsonl"),
+        concat!(
+            r#"{"sessionId":"claude-root","agentId":"abc","isSidechain":true,"uuid":"side-u","cwd":"/work/app","type":"user","message":{"role":"user","content":"delegated instruction"},"timestamp":"2026-08-31T11:00:02Z"}"#,
+            "\n",
+            r#"{"sessionId":"claude-root","agentId":"abc","isSidechain":true,"uuid":"side-a","cwd":"/work/app","type":"assistant","message":{"role":"assistant","content":"child result"},"timestamp":"2026-08-31T11:00:03Z"}"#,
+            "\n",
+        ),
+    );
+    write(
+        &subagents.join("agent-abc.meta.json"),
+        r#"{"agentType":"Plan","description":"plan the work","toolUseId":"toolu_1","spawnDepth":1,"model":"opus"}"#,
+    );
+}
+
+fn hydrate(db: &Path, source: &str, session_id: &str) {
+    hydrate_session_at(
+        db,
+        &HydrateSessionOptions {
+            source: source.to_string(),
+            session_id: session_id.to_string(),
+            scope: SessionScope::Local,
+            include_related: true,
+        },
+    )
+    .unwrap_or_else(|error| panic!("hydrating {source}/{session_id}: {error:#}"));
+}
+
+/// The only test in this binary: it sets `HOME` for the process, which is
+/// safe exactly because nothing else here runs beside it.
+#[test]
+fn delegation_topology_survives_the_whole_acquisition_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = temp.path();
+    codex_root(home);
+    claude_root(home);
+    std::env::set_var("HOME", home);
+    std::env::set_var("USERPROFILE", home);
+    std::env::set_var("OPENCODE_DB", home.join("missing-opencode.db"));
+    std::env::remove_var("AI_HIST_DB");
+    let db = home.join("history.db");
+
+    // A plain sync records the topology the provider files already describe,
+    // including the edge no single hydration would reach: the grandchild
+    // hangs off a subagent thread, which is never a hydration target.
+    sync_scoped_at(&db, SessionScope::Local).unwrap();
+    discover_sessions_scoped_at(
+        &db,
+        &DiscoverOptions {
+            scope: SessionScope::Local,
+            sources: Vec::new(),
+            limit: None,
+        },
+    )
+    .unwrap();
+    hydrate(&db, "codex", "root");
+    hydrate(&db, "claude", "claude-root");
+
+    let conn = open_db(&db).unwrap();
+
+    let tree = session_tree(&conn, "codex", "root", &SessionTreeOptions::default()).unwrap();
+    assert_eq!(
+        tree.nodes
+            .iter()
+            .map(|node| (node.session_id.as_str(), node.depth))
+            .collect::<Vec<_>>(),
+        vec![
+            ("root", 0),
+            ("child-a", 1),
+            ("grandchild", 2),
+            ("child-b", 1)
+        ]
+    );
+    assert!(tree.nodes.iter().all(|node| node.has_events));
+    assert!(!tree.truncated);
+    assert_eq!(tree.max_depth_reached, 2);
+    assert!(tree.unlinked.is_empty());
+    assert_eq!(tree.capabilities.stable_child_identity, "always");
+    assert_eq!(
+        tree.nodes[1]
+            .relationship
+            .as_ref()
+            .and_then(|edge| edge.child_agent_type.clone()),
+        Some("guardian".to_string())
+    );
+
+    let middle = session_relationships(&conn, "codex", "child-a").unwrap();
+    assert_eq!(middle.as_child.len(), 1);
+    assert_eq!(middle.as_child[0].parent_session_id, "root");
+    assert_eq!(
+        middle
+            .as_parent
+            .iter()
+            .map(|edge| edge.child_session_id.clone().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["grandchild"]
+    );
+
+    let claude = session_relationships(&conn, "claude", "claude-root").unwrap();
+    assert_eq!(claude.capabilities.stable_child_identity, "sometimes");
+    assert_eq!(claude.as_parent.len(), 1);
+    assert_eq!(claude.as_parent[0].child_session_id.as_deref(), Some("abc"));
+    assert_eq!(claude.as_parent[0].identity_status, "observed");
+    assert_eq!(
+        claude.as_parent[0].child_agent_name.as_deref(),
+        Some("plan the work")
+    );
+    assert!(claude.as_parent[0].child_has_events);
+
+    // Delegated threads are evidence, not sessions: only the two roots a
+    // human actually ran are in the catalog.
+    let sessions: Vec<(String, String)> = conn
+        .prepare("SELECT source, session_id FROM sessions ORDER BY source, session_id")
+        .unwrap()
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    assert_eq!(
+        sessions,
+        vec![
+            ("claude".to_string(), "claude-root".to_string()),
+            ("codex".to_string(), "root".to_string()),
+        ]
+    );
+
+    // And a delegated instruction is nobody's prompt.
+    let prompts: Vec<(String, Option<String>)> = conn
+        .prepare("SELECT source, session_id FROM history ORDER BY source, id")
+        .unwrap()
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    assert_eq!(
+        prompts,
+        vec![
+            ("claude".to_string(), Some("claude-root".to_string())),
+            ("codex".to_string(), Some("root".to_string())),
+        ]
+    );
+
+    // The child's own output is addressable under the child, and under the
+    // child only: hydration healed the parent-attributed row the earlier
+    // parser version (and the sync path) wrote.
+    let placement: (i64, i64) = conn
+        .query_row(
+            "SELECT \
+               (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='abc'), \
+               (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='claude-root' AND event_uid LIKE 'side-%')",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(placement, (1, 0));
+}

--- a/crates/ai-hist/tests/session_relationships.rs
+++ b/crates/ai-hist/tests/session_relationships.rs
@@ -228,4 +228,38 @@ fn delegation_topology_survives_the_whole_acquisition_path() {
         )
         .unwrap();
     assert_eq!(placement, (1, 0));
+    drop(conn);
+
+    // A later full sync walks the same provider files again. It must not undo
+    // what hydration established: no re-attribution of the child's output, no
+    // catalog row for a delegated thread, no lost topology.
+    sync_scoped_at(&db, SessionScope::Local).unwrap();
+    let conn = open_db(&db).unwrap();
+    let after: (i64, i64, i64, i64) = conn
+        .query_row(
+            "SELECT \
+               (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='abc'), \
+               (SELECT COUNT(*) FROM session_events WHERE source='claude' AND session_id='claude-root' AND event_uid LIKE 'side-%'), \
+               (SELECT COUNT(*) FROM sessions), \
+               (SELECT COUNT(*) FROM session_relationships)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(after, (1, 0, 2, 4));
+    let raw_path: String = conn
+        .query_row(
+            "SELECT raw_path FROM sessions WHERE source='claude' AND session_id='claude-root'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(raw_path.ends_with("claude-root.jsonl"));
+    assert_eq!(
+        session_tree(&conn, "codex", "root", &SessionTreeOptions::default())
+            .unwrap()
+            .nodes
+            .len(),
+        4
+    );
 }

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -18,6 +18,11 @@ Use these public operations:
   metadata.
 - `search()`, `recent()`, `getSession()`, and `getSessionEventsPage()` for
   indexed history reads.
+- `getSessionRelationships()` / MCP `get_session_relationships` and
+  `getSessionTree()` / MCP `get_session_tree` for delegation topology, plus
+  the SDK-only `getSessionChildrenPage()`, `sessionDescendants()`, and
+  `sessionEventsIncludingDescendants()` for walking large trees. Every event
+  keeps the session id of the session that produced it.
 - `sync()` / MCP `sync` for explicit full local ingestion.
 
 Pass `scope` to collection operations when the default local view is not
@@ -39,7 +44,8 @@ connector. Acquisition result `scope` echoes the request and `locationsRun`
 reports which connector locations executed; use session `locations` for
 observed presences.
 
-The CLI equivalents are `sessions list`, `sessions discover`, `search`,
+The CLI equivalents are `sessions list`, `sessions discover`,
+`sessions hydrate`, `sessions relationships`, `sessions tree`, `search`,
 `recent`, `session`, `events`, `stats`, and `sync`. See
 [Session catalog](session-catalog.md) for discovery and pagination contracts
 and [Architecture](architecture.md) for the process boundary.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,8 @@ Rust owns provider discovery/parsing, schema creation and migration, direct
 SQLite connections, catalog queries, history/event queries, search,
 statistics, and sync. Blocking filesystem and SQLite work is dispatched away
 from Node's event loop. TypeScript validates inputs, validates native contract
-version 4, catalog contract version 2, and hydration contract version 1, normalizes nullable fields, maps
+version 5, catalog contract version 2, hydration contract version 1, and
+session-relationship contract version 1, normalizes nullable fields, maps
 native errors, and supplies pagination helpers.
 
 The CLI and MCP server import only the SDK's public functions. They do not
@@ -67,6 +68,9 @@ row's `locations`.
 | `stats` (`local` / `remote` / `all`) | none | indexed aggregate reads | empty result |
 | `getSession` | none | indexed identity read | empty result |
 | `getSessionEventsPage` | none | bounded keyset page | empty page |
+| `getSessionRelationships` | none | indexed relationship reads | empty result |
+| `getSessionTree` | none | indexed relationship reads, one child query per emitted node | empty result |
+| `getSessionChildrenPage` | none | bounded keyset page | empty page |
 | `sync` (`local`, default) | full explicit scan | migrations + ingestion | creates DB |
 | `sync` (`remote`) | configured remote connectors (error when none) | catalog upserts + presences | creates DB |
 | `sync` (`all`) | full local scan + configured remote connectors | migrations + ingestion | creates DB |
@@ -82,14 +86,58 @@ await hydrateSession({ source: sessions[0].source, sessionId: sessions[0].sessio
 Global sync owns enumeration while targeted hydration resolves one persisted
 catalog presence. Both call the same Rust provider normalization helpers.
 TypeScript never parses a provider source or opens SQLite. Per-session
-checkpoints make unchanged calls constant-work after source resolution, and
-`session_relationships` preserves Codex child identities without flattening
-their events into the selected root.
+checkpoints make unchanged calls constant-work after source resolution.
+
+## Delegation topology
+
+`session_relationships` records one row per observed delegation, keyed by
+`(source, parent_session_id, relationship_uid)`. Each row carries what
+established the link — `evidence_kind`, the provider file in
+`evidence_locator`, and the provider-native reference in `evidence_ref` (a
+Claude `toolUseId`, a Codex `parent_thread_id`) — plus whatever the provider
+recorded about the child: agent type, agent name, model, spawn depth, and the
+provider's own spawn time.
+
+`identity_status` separates two honestly different things. An `observed` row
+names the child: `child_session_id` is the provider's own identity for it, and
+`child_has_events` says whether that child is independently addressable
+through `getSessionEventsPage`. An `unlinked` row means the provider recorded
+a delegation but no stable child identity, so `child_session_id` is null and
+the child's output stays attributed to the parent. A child id is never
+synthesized, never derived from a file name, and never inferred.
+
+What a provider can record is a property of the provider, not of a database,
+so every result reports it:
+
+| Source | Stable child identity | Agent type | Spawn time | Evidence locator |
+|---|---|---|---|---|
+| `codex` | always | yes | yes | yes |
+| `claude` | sometimes (only versions that emit a per-child `agentId`) | yes | yes | yes |
+| `cursor`, `grok`, `opencode`, `relay` | never | no | no | no |
+
+A linked child's events are stored under the child's own session id and are
+never flattened into the parent. The delegated instruction that started a
+child is not a human prompt: it never becomes a `history` row, and a delegated
+thread never becomes a top-level catalog session.
+
+Children are ordered by `(spawned_at_ms, relationship_uid)` with null spawn
+times at the tail; `relationship_uid` is unique per parent, so that is a total
+order shared by `getSessionChildrenPage`, `getSessionTree`, and the SDK's
+`sessionDescendants` walker. Traversal is pre-order over an explicit stack,
+never recursion. A session appears exactly once, at its shallowest reachable
+depth; a repeated session stops expansion and emits a `RELATIONSHIP_CYCLE`
+diagnostic. `maxDepth` (default 32, maximum 64) and `maxNodes` (default 1000,
+maximum 10000) bound the work to one indexed child query per emitted node and
+surface `RELATIONSHIP_TREE_DEPTH_LIMIT` and `RELATIONSHIP_TREE_TRUNCATED`
+diagnostics instead of silently short results. Unlinked rows are reported in
+`unlinked` with a `RELATIONSHIP_UNLINKED_CHILD` diagnostic rather than
+traversed.
 
 Events use `(ts_ms, id)` keyset pagination. Catalog ordering is
 `(last_activity_ms DESC, source ASC, session_id ASC)`, with null timestamps at
-the tail. These total orders prevent duplicate or omitted rows at timestamp
-ties.
+the tail. Relationship ordering is `(spawned_at_ms, relationship_uid)`, also
+with null timestamps at the tail. These total orders prevent duplicate or
+omitted rows at timestamp ties.
 
 ## Native errors
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,7 +143,10 @@ unexpanded, including all parents still pending when the node budget ran out.
 Unlinked rows are reported in `unlinked` with a `RELATIONSHIP_UNLINKED_CHILD`
 diagnostic rather than traversed — at every depth, the boundary included, so a
 node whose only children are unlinked evidence is complete rather than
-truncated.
+truncated. Only a session the tree has not already emitted is charged against
+`maxNodes`, so a diamond is never reported as a budget truncation. The SDK's
+`sessionDescendants` walker applies the same `childCount` and `truncated`
+rules to the nodes it yields.
 
 Events use `(ts_ms, id)` keyset pagination. Catalog ordering is
 `(last_activity_ms DESC, source ASC, session_id ASC)`, with null timestamps at

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,7 +69,7 @@ row's `locations`.
 | `getSession` | none | indexed identity read | empty result |
 | `getSessionEventsPage` | none | bounded keyset page | empty page |
 | `getSessionRelationships` | none | indexed relationship reads | empty result |
-| `getSessionTree` | none | indexed relationship reads, one child query per emitted node | empty result |
+| `getSessionTree` | none | indexed relationship reads, one child query per emitted node | root-only tree |
 | `getSessionChildrenPage` | none | bounded keyset page | empty page |
 | `sync` (`local`, default) | full explicit scan | migrations + ingestion | creates DB |
 | `sync` (`remote`) | configured remote connectors (error when none) | catalog upserts + presences | creates DB |
@@ -124,14 +124,26 @@ Children are ordered by `(spawned_at_ms, relationship_uid)` with null spawn
 times at the tail; `relationship_uid` is unique per parent, so that is a total
 order shared by `getSessionChildrenPage`, `getSessionTree`, and the SDK's
 `sessionDescendants` walker. Traversal is pre-order over an explicit stack,
-never recursion. A session appears exactly once, at its shallowest reachable
-depth; a repeated session stops expansion and emits a `RELATIONSHIP_CYCLE`
-diagnostic. `maxDepth` (default 32, maximum 64) and `maxNodes` (default 1000,
-maximum 10000) bound the work to one indexed child query per emitted node and
-surface `RELATIONSHIP_TREE_DEPTH_LIMIT` and `RELATIONSHIP_TREE_TRUNCATED`
-diagnostics instead of silently short results. Unlinked rows are reported in
-`unlinked` with a `RELATIONSHIP_UNLINKED_CHILD` diagnostic rather than
-traversed.
+never recursion, and `nodes[0]` is always the root — including for a session
+with no recorded delegation and for a database that does not exist yet.
+
+A session appears exactly once, at the position pre-order first reaches it. An
+edge back into the current branch's own ancestry is a cycle: it is not expanded
+again and emits a `RELATIONSHIP_CYCLE` diagnostic. An edge to a session already
+emitted on another branch is a diamond, not a loop; it is simply not expanded a
+second time, and is neither diagnosed nor counted as truncation.
+
+`maxDepth` (default 32, maximum 64) and `maxNodes` (default 1000, maximum
+10000) bound the work to one indexed child query per emitted node and surface
+`RELATIONSHIP_TREE_DEPTH_LIMIT` and `RELATIONSHIP_TREE_TRUNCATED` diagnostics
+instead of silently short results. Tree-level `truncated` means a budget
+stopped the walk short of the recorded evidence, so a cycle or diamond never
+sets it; node-level `truncated` marks every node whose children were left
+unexpanded, including all parents still pending when the node budget ran out.
+Unlinked rows are reported in `unlinked` with a `RELATIONSHIP_UNLINKED_CHILD`
+diagnostic rather than traversed — at every depth, the boundary included, so a
+node whose only children are unlinked evidence is complete rather than
+truncated.
 
 Events use `(ts_ms, id)` keyset pagination. Catalog ordering is
 `(last_activity_ms DESC, source ASC, session_id ASC)`, with null timestamps at

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,7 +1,7 @@
 # Release and platform validation
 
 All public packages use one version: `ai-hist`, `ai-hist-native`, each native
-platform package, and `ai-hist-mcp`. The SDK checks native contract version 3
+platform package, and `ai-hist-mcp`. The SDK checks native contract version 5
 at initialization.
 
 The `Publish RelayHistory npm packages` workflow:

--- a/docs/session-catalog.md
+++ b/docs/session-catalog.md
@@ -41,9 +41,14 @@ ended. File providers validate the saved locator against the expected provider
 root; OpenCode uses session-keyed queries against its live read-only database.
 Relay reports `HYDRATION_UNSUPPORTED` until a full-evidence connector exists.
 
-Codex child rollouts retain provider-native IDs and are linked through
-`session_relationships`; delegated task prompts are not stored as human prompt
-history. Set `includeRelated: false` or use CLI `--no-related` to acquire only
+Codex child rollouts, and Claude subagent transcripts whose records carry a
+per-child `agentId`, retain their provider-native IDs and are linked through
+`session_relationships`: their events are indexed under the child's own
+session id rather than flattened into the parent, and delegated task prompts
+are not stored as human prompt history. Claude evidence from a provider
+version that does not name the child is recorded as an unlinked relationship —
+never as a synthesized identity — and its output stays attributed to the
+parent. Set `includeRelated: false` or use CLI `--no-related` to acquire only
 the selected thread.
 
 | | `ai-hist sessions list` | `ai-hist sessions discover` |
@@ -309,6 +314,22 @@ read.
 | **opencode** | ✓ | ✓ (directory) | – | ✓ | ✓ | ✓ | ✓ | – | – | – | – | – |
 | **relay** | ✓ | – (never) | – | ✓ (synced min ts) | ✓ (synced max ts) | ✓ (earliest synced prompt) | – | – | – | – | – | – |
 
+Delegation is a separate capability, reported on every relationship result as
+`capabilities.stableChildIdentity`:
+
+| Source | Stable child identity | Agent type | Spawn time | Evidence locator |
+|---|---|---|---|---|
+| **codex** | always | ✓ | ✓ | ✓ |
+| **claude** | sometimes | ✓ | ✓ | ✓ |
+| **cursor**, **grok**, **opencode**, **relay** | never | – | – | – |
+
+Claude is `sometimes` because a subagent transcript carries the *parent's*
+`sessionId` on every record; the child's own identity is the per-child
+`agentId`, which only newer provider versions emit. When it is present the
+child is indexed under it; when it is absent the delegation is recorded as
+unlinked evidence and the child id is left null — it is never taken from the
+`agent-<id>.jsonl` file name.
+
 How each adapter works:
 
 - **claude** — `~/.claude/projects/**/*.jsonl`. Head for identity, `cwd`,
@@ -489,6 +510,24 @@ are backfilled with a local presence during migration. Scope queries use this
 table to select sessions and aggregate their `locations`; they do not duplicate
 the session or its events.
 
+`session_relationships` is the delegation table, keyed by
+`(source, parent_session_id, relationship_uid)`. `relationship_uid` is
+`child:<child_session_id>` for an observed child and
+`evidence:<evidence_kind>:<evidence_locator>` for unlinked evidence, which
+makes repeated ingestion idempotent and gives each unlinked sidecar its own
+row. Beside the identity columns (`child_session_id`, nullable, and
+`identity_status`) it stores `relationship`, `child_agent_type`,
+`child_agent_name`, `child_model`, `spawn_depth`, `evidence_kind`,
+`evidence_locator`, `evidence_ref`, `child_has_events`, `spawned_at_ms`,
+`created_ms`, and `updated_ms`; re-ingestion refreshes mutable fields and
+preserves first-observation time. It is read through
+`idx_session_relationships_parent` and `idx_session_relationships_child`.
+Databases written before this shape are rebuilt in place by the
+`session_relationships_v2` marker migration, which copies every existing edge
+forward as an observed `legacy_hydration` row; the marker is required, so an
+unmigrated database is routed through the writable open instead of being read
+as current.
+
 ---
 
 ## Adding a provider
@@ -523,12 +562,22 @@ discoverable".
   result as JSONL when line-oriented records are more convenient. Both run on
   a blocking worker thread and accept `scope` / `sources` / `limit`, with `beforeMs` and
   `after` (the previous page's `nextCursor`) on the listing.
+- **Native (napi), delegation** — `getSessionRelationships(options)` returns one
+  session's edges in both directions plus the provider's capabilities;
+  `getSessionTree(options)` returns the pre-order descendant tree bounded by
+  `maxDepth` / `maxNodes`; `getSessionChildrenPage(options)` returns one keyset
+  page of direct children. All three are cache-only, and a missing database is
+  an empty result rather than an error.
 - **TypeScript SDK** — `listSessionCatalog()` / `discoverSessions()` wrap the
-  same contract for Node consumers; see the SDK's own documentation for the
-  exact signatures.
+  same contract for Node consumers, as do `getSessionRelationships()`,
+  `getSessionTree()`, `getSessionChildrenPage()`, and the `sessionDescendants()`
+  / `sessionEventsIncludingDescendants()` iterators; see the SDK's own
+  documentation for the exact signatures.
 - **MCP** — the stdio server exposes the cache-only listing as a `list_sessions`
   tool, so an agent can enumerate recent sessions without triggering any
-  provider I/O. See the MCP package's documentation for its arguments.
+  provider I/O, and delegation topology as the read-only
+  `get_session_relationships` and `get_session_tree` tools. See the MCP
+  package's documentation for their arguments.
 
 Whatever the surface, `contract_version` means the same thing: check it, and
 fail loudly on a version you do not know.

--- a/docs/session-catalog.md
+++ b/docs/session-catalog.md
@@ -567,7 +567,8 @@ discoverable".
   `getSessionTree(options)` returns the pre-order descendant tree bounded by
   `maxDepth` / `maxNodes`; `getSessionChildrenPage(options)` returns one keyset
   page of direct children. All three are cache-only, and a missing database is
-  an empty result rather than an error.
+  an empty result rather than an error — for the tree, the root-only result a
+  session with no recorded delegation also returns.
 - **TypeScript SDK** — `listSessionCatalog()` / `discoverSessions()` wrap the
   same contract for Node consumers, as do `getSessionRelationships()`,
   `getSessionTree()`, `getSessionChildrenPage()`, and the `sessionDescendants()`

--- a/docs/session-catalog.md
+++ b/docs/session-catalog.md
@@ -48,8 +48,12 @@ session id rather than flattened into the parent, and delegated task prompts
 are not stored as human prompt history. Claude evidence from a provider
 version that does not name the child is recorded as an unlinked relationship —
 never as a synthesized identity — and its output stays attributed to the
-parent. Set `includeRelated: false` or use CLI `--no-related` to acquire only
-the selected thread.
+parent. The hydration stamp covers every file that evidence came from — the
+selected transcript, each subagent transcript, and the
+`agent-<agentId>.meta.json` describing it — so a metadata sidecar that arrives
+or changes on its own still re-hydrates the session. Set
+`includeRelated: false` or use CLI `--no-related` to acquire only the selected
+thread.
 
 | | `ai-hist sessions list` | `ai-hist sessions discover` |
 |---|---|---|

--- a/mcp-package/README.md
+++ b/mcp-package/README.md
@@ -10,9 +10,12 @@ The server imports only `ai-hist` public functions. It never opens SQLite,
 loads the native addon directly, scans provider files, or invokes a CLI.
 
 Tools: `search_history`, `recent_history`, `list_sessions`,
-`discover_sessions`, `hydrate_session`, `get_session`, `get_session_events`, `history_stats`, and
+`discover_sessions`, `hydrate_session`, `get_session`, `get_session_events`,
+`get_session_relationships`, `get_session_tree`, `history_stats`, and
 `sync`. Search, recent history, session listing, discovery, statistics, and sync accept a
 `scope` of `local`, `remote`, or `all`; scope defaults to `local`.
+`get_session`, `get_session_events`, `get_session_relationships`, and
+`get_session_tree` address one session by identity and take no `scope`.
 
 Cached reads support all three scopes. Remote acquisition runs through
 provider connectors (claude.ai/code web sessions, Codex cloud tasks) that are
@@ -23,3 +26,9 @@ sync tools are therefore annotated as open-world writes.
 `hydrate_session` is an idempotent write that fully indexes one previously
 discovered identity and optionally its related provider-native sessions from
 local provider evidence, so it stays annotated as a local, closed-world write.
+
+`get_session_relationships` and `get_session_tree` read the delegation topology
+recorded by hydration and sync: who delegated to whom, what evidence
+established the link, whether the child has a stable identity, and whether its
+events are independently addressable. Tree traversal is cycle-safe,
+deterministically ordered, and bounded by `max_depth` and `max_nodes`.

--- a/plans/007-targeted-session-hydration.md
+++ b/plans/007-targeted-session-hydration.md
@@ -29,6 +29,9 @@
   child task prompts to human prompt history. Claude sidechain evidence remains
   attributed according to the existing parser until the provider exposes a
   stable distinct child identity.
+- The relationship row, its provider evidence, and the public query and
+  traversal APIs are specified in
+  [008 — Session delegation topology](008-session-delegation-topology.md).
 
 ## Concurrency
 

--- a/plans/008-session-delegation-topology.md
+++ b/plans/008-session-delegation-topology.md
@@ -34,8 +34,12 @@
   last. The uid is unique per parent, so that is a total order shared by the
   paged children query and the tree walk.
 - Walk pre-order over an explicit stack. A session is emitted once, at its
-  shallowest reachable depth; a repeat marks its parent truncated and emits a
-  cycle diagnostic instead of looping.
+  shallowest reachable depth. A repeat is a cycle only when the edge points
+  back into the current branch's own ancestry: that marks its parent truncated
+  and emits a cycle diagnostic instead of looping. A repeat that reaches a
+  session already emitted on another branch is a diamond — nothing is missing,
+  so it is simply not expanded again, and nothing is diagnosed, truncated, or
+  charged against the node budget.
 - Bound the work with `max_depth` and `max_nodes`, one indexed child query per
   emitted node, and report depth-limit, truncation, and unlinked-child
   diagnostics rather than returning a silently short tree.

--- a/plans/008-session-delegation-topology.md
+++ b/plans/008-session-delegation-topology.md
@@ -1,0 +1,53 @@
+# Session delegation topology
+
+## Relationship model
+
+- Record one row per observed delegation in `session_relationships`, keyed by
+  `(source, parent_session_id, relationship_uid)`. The uid is
+  `child:<child_session_id>` when the child is named and
+  `evidence:<evidence_kind>:<evidence_locator>` when it is not, so repeated
+  ingestion is idempotent and each unlinked sidecar keeps its own row.
+- Keep `child_session_id` nullable and pair it with `identity_status`
+  (`observed` or `unlinked`). A child identity is never synthesized, inferred,
+  or taken from a file name.
+- Store what the provider actually recorded beside the edge: child agent type,
+  name, model, spawn depth, spawn time, and whether the child's events are
+  independently addressable.
+
+## Provider evidence
+
+- Carry the evidence that established every link: `evidence_kind`, the provider
+  file in `evidence_locator`, and the provider-native reference in
+  `evidence_ref` — a Claude `toolUseId`, a Codex `parent_thread_id`.
+- Codex names every child thread in its rollout metadata, so its children are
+  always observed; both targeted hydration and global sync record them.
+- Claude subagent transcripts carry the parent's `sessionId` plus a per-child
+  `agentId` on newer provider versions. With that id the child's events are
+  indexed under it; without it the delegation is recorded as unlinked evidence
+  and the sidechain output stays attributed to the parent.
+- A delegated instruction is not a human prompt and a delegated thread is not a
+  top-level session: neither becomes a `history` row or a catalog session.
+
+## Traversal
+
+- Order children by `(spawned_at_ms, relationship_uid)` with null spawn times
+  last. The uid is unique per parent, so that is a total order shared by the
+  paged children query and the tree walk.
+- Walk pre-order over an explicit stack. A session is emitted once, at its
+  shallowest reachable depth; a repeat marks its parent truncated and emits a
+  cycle diagnostic instead of looping.
+- Bound the work with `max_depth` and `max_nodes`, one indexed child query per
+  emitted node, and report depth-limit, truncation, and unlinked-child
+  diagnostics rather than returning a silently short tree.
+
+## Public call graph
+
+- Expose `session_relationships`, `session_tree`, and `session_children_page`
+  from Rust through N-API under their own contract version. The TypeScript SDK
+  validates identities, normalizes nullable fields, checks the contract, and
+  adds the `sessionDescendants` and `sessionEventsIncludingDescendants`
+  iterators over the paged primitive. Every yielded event keeps its true owning
+  session id.
+- CLI `sessions relationships` / `sessions tree` and MCP
+  `get_session_relationships` / `get_session_tree` call only the SDK
+  operations, and address a session by identity rather than by scope.

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -19,7 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ai-hist` Node CLI from this package.
 - Advance the required `ai-hist-native` contract to 5. Claude subagent
   transcripts whose records carry an `agentId` are indexed under that child id,
-  so their events move off the parent on the next `hydrateSession`.
+  so their events — and the tool calls and file edits derived from them — move
+  off the parent on the next `hydrateSession`.
 
 ### Added
 

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -17,8 +17,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   either operation.
 - Make session-event pagination the primitive API and ship the public
   `ai-hist` Node CLI from this package.
+- Advance the required `ai-hist-native` contract to 5. Claude subagent
+  transcripts whose records carry an `agentId` are indexed under that child id,
+  so their events move off the parent on the next `hydrateSession`.
 
 ### Added
+
+- Add delegation topology APIs: `getSessionRelationships()`,
+  `getSessionTree()`, and `getSessionChildrenPage()`, plus the
+  `sessionDescendants()` and `sessionEventsIncludingDescendants()` async
+  iterators. Every event `sessionEventsIncludingDescendants()` yields keeps the
+  `sessionId` of the session that produced it; a child's event is never
+  rewritten as the parent's. New exported types: `SessionRelationship`,
+  `RelationshipCapabilities`, `RelationshipDiagnostic`, `SessionRelationships`,
+  `SessionTree`, `SessionTreeNode`, `SessionChildrenPage`,
+  `RelationshipCursor`, `RelationshipType`, `IdentityStatus`,
+  `StableChildIdentity`, `GetSessionRelationshipsOptions`,
+  `GetSessionTreeOptions`, `GetSessionChildrenPageOptions`,
+  `SessionDescendantsOptions`, `DescendantEventsOptions`, and the
+  `SESSION_RELATIONSHIP_CONTRACT_VERSION` constant. Results report
+  `identityStatus` and `capabilities.stableChildIdentity` instead of
+  synthesizing a child identity the provider never recorded.
+- Add the SDK-only `sessions relationships` and `sessions tree` CLI commands
+  and the read-only `get_session_relationships` and `get_session_tree` MCP
+  tools. Both address a session by identity and take no scope.
 
 - Support remote acquisition through the engine's provider connectors:
   `discoverSessions`/`sync` with `scope: 'remote'` (and the remote half of

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -37,7 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SessionDescendantsOptions`, `DescendantEventsOptions`, and the
   `SESSION_RELATIONSHIP_CONTRACT_VERSION` constant. Results report
   `identityStatus` and `capabilities.stableChildIdentity` instead of
-  synthesizing a child identity the provider never recorded.
+  synthesizing a child identity the provider never recorded. `getSessionTree()`
+  always returns the root as `nodes[0]`, including for a session with no
+  recorded delegation and for a database that does not exist yet.
 - Add the SDK-only `sessions relationships` and `sessions tree` CLI commands
   and the read-only `get_session_relationships` and `get_session_tree` MCP
   tools. Both address a session by identity and take no scope.

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -68,6 +68,58 @@ The event primitive is page-based and uses `{ tsMs, id }` as a deterministic
 cursor. The `sessionEvents` async iterator walks pages without accumulating a
 large transcript. `getSessionEvents` is an explicit collecting convenience.
 
+## Delegation topology
+
+Sessions that delegate to subagents form a tree, and it is queryable:
+
+```ts
+import {
+  getSessionRelationships,
+  getSessionTree,
+  sessionEventsIncludingDescendants,
+} from 'ai-hist';
+
+const { asParent, asChild, capabilities } = await getSessionRelationships({
+  source: 'codex',
+  sessionId: rootId,
+});
+const tree = await getSessionTree({ source: 'codex', sessionId: rootId, maxDepth: 8 });
+
+for await (const event of sessionEventsIncludingDescendants({ source: 'codex', sessionId: rootId })) {
+  // event.sessionId is the session that actually produced the event: a
+  // child's event is never rewritten as the parent's.
+  consume(event);
+}
+```
+
+Each `SessionRelationship` reports its `identityStatus`. `observed` means the
+provider named the child, so `childSessionId` is a real session id and
+`childHasEvents` says whether its events are independently addressable through
+`getSessionEventsPage`. `unlinked` means the provider recorded a delegation but
+no stable child identity: `childSessionId` is `null`, the child's output stays
+attributed to the parent, and the row keeps the evidence (`evidenceKind`,
+`evidenceLocator`, `evidenceRef`) that established it. An identity is never
+synthesized.
+
+`capabilities.stableChildIdentity` tells you what to expect from the provider
+before you read a single row: `always` for Codex, `sometimes` for Claude — only
+provider versions that emit a per-child `agentId` name the child — and `never`
+for the remaining sources.
+
+`getSessionTree` returns pre-order `nodes` (the root first), the `unlinked`
+evidence found at any depth, and `diagnostics`. Children are ordered by
+`(spawnedAtMs, relationshipUid)` with null spawn times last, so repeated calls
+against the same database return identical results. Traversal visits each
+session once, at its shallowest depth; a repeat emits a `RELATIONSHIP_CYCLE`
+diagnostic instead of looping. `maxDepth` (default 32, maximum 64) and
+`maxNodes` (default 1000, maximum 10000) bound the work and set `truncated`
+with a `RELATIONSHIP_TREE_DEPTH_LIMIT` or `RELATIONSHIP_TREE_TRUNCATED`
+diagnostic rather than returning a silently short tree.
+
+For large topologies, `getSessionChildrenPage` is the keyset primitive and
+`sessionDescendants` is the async iterator over it, walking descendants
+breadth-first without materializing a tree.
+
 Native loading failures distinguish unsupported platforms, missing optional
 platform packages, addon load failures, SDK/native contract mismatches, and
 database open failures through stable `RelayHistoryError` subclasses. Provider

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -107,14 +107,22 @@ provider versions that emit a per-child `agentId` name the child — and `never`
 for the remaining sources.
 
 `getSessionTree` returns pre-order `nodes` (the root first), the `unlinked`
-evidence found at any depth, and `diagnostics`. Children are ordered by
+evidence found at any depth, and `diagnostics`. `nodes[0]` is always the root,
+so a session with no children — and a database that does not exist yet — comes
+back as a one-node tree rather than an empty one. Children are ordered by
 `(spawnedAtMs, relationshipUid)` with null spawn times last, so repeated calls
-against the same database return identical results. Traversal visits each
-session once, at its shallowest depth; a repeat emits a `RELATIONSHIP_CYCLE`
-diagnostic instead of looping. `maxDepth` (default 32, maximum 64) and
-`maxNodes` (default 1000, maximum 10000) bound the work and set `truncated`
-with a `RELATIONSHIP_TREE_DEPTH_LIMIT` or `RELATIONSHIP_TREE_TRUNCATED`
-diagnostic rather than returning a silently short tree.
+against the same database return identical results.
+
+Traversal visits each session once, at the position pre-order first reaches it.
+An edge back into the current branch's ancestry is a cycle and emits a
+`RELATIONSHIP_CYCLE` diagnostic instead of looping; an edge to a session already
+emitted on another branch is a diamond and is quietly not expanded twice.
+`maxDepth` (default 32, maximum 64) and `maxNodes` (default 1000, maximum
+10000) bound the work and set `truncated` with a
+`RELATIONSHIP_TREE_DEPTH_LIMIT` or `RELATIONSHIP_TREE_TRUNCATED` diagnostic
+rather than returning a silently short tree. Tree-level `truncated` means a
+budget cut the walk short — a cycle or diamond never sets it — while a node's
+own `truncated` marks children it did not expand.
 
 For large topologies, `getSessionChildrenPage` is the keyset primitive and
 `sessionDescendants` is the async iterator over it, walking descendants

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -126,7 +126,10 @@ own `truncated` marks children it did not expand.
 
 For large topologies, `getSessionChildrenPage` is the keyset primitive and
 `sessionDescendants` is the async iterator over it, walking descendants
-breadth-first without materializing a tree.
+breadth-first without materializing a tree. It yields the same nodes
+`getSessionTree` emits, with the same `childCount` (linked children only, at
+the depth boundary included) and the same `truncated` rule, so the two can be
+swapped without changing what a consumer reads.
 
 Native loading failures distinguish unsupported platforms, missing optional
 platform packages, addon load failures, SDK/native contract mismatches, and

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -131,7 +131,8 @@ breadth-first without materializing a tree. It yields the nodes
 children only, at the depth boundary included) and the same `truncated` rule.
 The order differs: the walker is breadth-first, the tree is pre-order, so a
 consumer that depends on either the root node or `getSessionTree`'s ordering
-has to account for that.
+has to account for that. `sessionEventsIncludingDescendants` applies its
+`limit` to each session it reads, not to the iteration as a whole.
 
 Native loading failures distinguish unsupported platforms, missing optional
 platform packages, addon load failures, SDK/native contract mismatches, and

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -126,10 +126,12 @@ own `truncated` marks children it did not expand.
 
 For large topologies, `getSessionChildrenPage` is the keyset primitive and
 `sessionDescendants` is the async iterator over it, walking descendants
-breadth-first without materializing a tree. It yields the same nodes
-`getSessionTree` emits, with the same `childCount` (linked children only, at
-the depth boundary included) and the same `truncated` rule, so the two can be
-swapped without changing what a consumer reads.
+breadth-first without materializing a tree. It yields the nodes
+`getSessionTree` emits minus the root, with the same `childCount` (linked
+children only, at the depth boundary included) and the same `truncated` rule.
+The order differs: the walker is breadth-first, the tree is pre-order, so a
+consumer that depends on either the root node or `getSessionTree`'s ordering
+has to account for that.
 
 Native loading failures distinguish unsupported platforms, missing optional
 platform packages, addon load failures, SDK/native contract mismatches, and

--- a/sdk-ts/src/architecture.test.ts
+++ b/sdk-ts/src/architecture.test.ts
@@ -63,3 +63,16 @@ test('identity-addressed MCP tools are read-only and take no scope', async () =>
     assert.doesNotMatch(registration, /SESSION_SCOPE/, `${tool} addresses a session by identity`);
   }
 });
+
+test('native topology enums are validated rather than cast', async () => {
+  const source = await readFile(join(sourceDir, 'index.ts'), 'utf8');
+  const start = source.indexOf('function relationship(value: UnknownRecord)');
+  assert.notEqual(start, -1, 'the relationship normalizer exists');
+  const body = source.slice(start, source.indexOf('\n}', start));
+  // An out-of-contract value must reach a caller as a contract mismatch, not
+  // as a lie about the shape of the typed API.
+  assert.match(body, /source: catalogSource\(value\.source\)/);
+  assert.match(body, /relationship: relationshipType\(value\.relationship\)/);
+  assert.match(body, /identityStatus: identityStatus\(value\.identityStatus\)/);
+  assert.doesNotMatch(body, /as CatalogSource|as RelationshipType|as IdentityStatus/);
+});

--- a/sdk-ts/src/architecture.test.ts
+++ b/sdk-ts/src/architecture.test.ts
@@ -51,3 +51,15 @@ test('MCP session operations expose scope and acquisition is declared open-world
     assert.match(mcp.slice(start, end === -1 ? undefined : end), /LOCAL_WRITE/, 'hydrate_session indexes local provider evidence, closed-world');
   }
 });
+
+test('identity-addressed MCP tools are read-only and take no scope', async () => {
+  const mcp = await readFile(join(sourceDir, 'mcp-server.ts'), 'utf8');
+  for (const tool of ['get_session', 'get_session_events', 'get_session_relationships', 'get_session_tree']) {
+    const start = mcp.indexOf(`server.tool('${tool}'`);
+    assert.notEqual(start, -1, `${tool} is registered`);
+    const end = mcp.indexOf("server.tool('", start + 13);
+    const registration = mcp.slice(start, end === -1 ? undefined : end);
+    assert.match(registration, /READ/, `${tool} is a read-only tool`);
+    assert.doesNotMatch(registration, /SESSION_SCOPE/, `${tool} addresses a session by identity`);
+  }
+});

--- a/sdk-ts/src/cli-output.test.ts
+++ b/sdk-ts/src/cli-output.test.ts
@@ -196,6 +196,16 @@ test('sessions relationships and sessions tree render topology in both modes', a
     ], { env });
     assert.match(lone.stdout, /^topology-child\n0 descendant\(s\), max depth 0\n$/);
 
+    // A budget that stops the walk is worth saying out loud: the readable
+    // tree prints the same diagnostics the JSON form carries.
+    const bounded = await run(process.execPath, [
+      cli, 'sessions', 'tree', 'codex', 'topology-root', '--max-nodes', '1', '--db', db, '--no-warning',
+    ], { env });
+    assert.match(
+      bounded.stdout,
+      /^topology-root {2}…\n0 descendant\(s\), max depth 0\nRELATIONSHIP_TREE_TRUNCATED: tree exceeded max_nodes=1\ntruncated: node\/depth budget reached\n$/,
+    );
+
     await assert.rejects(
       run(process.execPath, [
         cli, 'sessions', 'tree', 'codex', 'topology-root', '--max-depth', '0', '--db', db, '--no-warning',

--- a/sdk-ts/src/cli-output.test.ts
+++ b/sdk-ts/src/cli-output.test.ts
@@ -119,6 +119,106 @@ test('sessions hydrate uses the SDK contract and is idempotent', async () => {
   }
 });
 
+test('sessions relationships and sessions tree render topology in both modes', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'relayhistory-cli-topology-'));
+  const home = join(root, 'home');
+  const day = join(home, '.codex', 'sessions', '2026', '08', '31');
+  const db = join(root, 'history.db');
+  await mkdir(day, { recursive: true });
+  const rollout = (id: string, at: string, parent?: string) => [
+    JSON.stringify({
+      timestamp: at, type: 'session_meta',
+      payload: parent === undefined
+        ? { id, cwd: '/work/app' }
+        : {
+          id, cwd: '/work/app', session_id: parent, parent_thread_id: parent,
+          thread_source: 'subagent', source: { subagent: { other: 'guardian' } },
+        },
+    }),
+    JSON.stringify({ timestamp: at, type: 'event_msg', payload: { type: 'user_message', message: `${id} prompt` } }),
+    JSON.stringify({ timestamp: at, type: 'event_msg', payload: { type: 'agent_message', message: `${id} answer` } }),
+    '',
+  ].join('\n');
+  await writeFile(join(day, 'rollout-topology-root.jsonl'), rollout('topology-root', '2026-08-31T10:00:00Z'));
+  await writeFile(join(day, 'rollout-topology-child.jsonl'), rollout('topology-child', '2026-08-31T10:00:01Z', 'topology-root'));
+  const env = { ...process.env, HOME: home, USERPROFILE: home };
+  try {
+    await run(process.execPath, [cli, 'sessions', 'discover', '--source', 'codex', '--db', db, '--no-warning'], { env });
+    await run(process.execPath, [cli, 'sessions', 'hydrate', 'codex', 'topology-root', '--db', db, '--no-warning'], { env });
+
+    const relationships = await run(process.execPath, [
+      cli, 'sessions', 'relationships', 'codex', 'topology-root', '--db', db, '--json', '--no-warning',
+    ], { env });
+    const wire = JSON.parse(relationships.stdout) as Record<string, unknown>;
+    assert.equal(wire.contract_version, 1);
+    assert.equal(wire.session_id, 'topology-root');
+    assert.deepEqual(wire.as_child, []);
+    const [edge] = wire.as_parent as Array<Record<string, unknown>>;
+    assert.equal(edge.child_session_id, 'topology-child');
+    assert.equal(edge.identity_status, 'observed');
+    assert.equal(edge.child_has_events, true);
+    assert.equal(edge.relationship_uid, 'child:topology-child');
+    assert.equal((wire.capabilities as Record<string, unknown>).stable_child_identity, 'always');
+
+    const readable = await run(process.execPath, [
+      cli, 'sessions', 'relationships', 'codex', 'topology-root', '--db', db, '--no-warning',
+    ], { env });
+    assert.match(readable.stdout, /codex\/topology-root: 1 child relationship\(s\), 0 parent relationship\(s\)/);
+    assert.match(readable.stdout, /child {2}topology-child {2}delegated {2}guardian/);
+    assert.match(readable.stdout, /identity=observed/);
+    assert.match(readable.stdout, /capability: stable child identity = always/);
+
+    const empty = await run(process.execPath, [
+      cli, 'sessions', 'relationships', 'codex', 'topology-child', '--db', db, '--no-warning',
+    ], { env });
+    assert.match(empty.stdout, /codex\/topology-child: 0 child relationship\(s\), 1 parent relationship\(s\)/);
+    assert.match(empty.stdout, /parent {2}topology-root/);
+
+    const treeJson = await run(process.execPath, [
+      cli, 'sessions', 'tree', 'codex', 'topology-root', '--db', db, '--json', '--no-warning',
+    ], { env });
+    const tree = JSON.parse(treeJson.stdout) as Record<string, unknown>;
+    assert.equal(tree.root_session_id, 'topology-root');
+    assert.equal(tree.truncated, false);
+    assert.deepEqual((tree.nodes as Array<Record<string, unknown>>).map((node) => node.session_id), [
+      'topology-root', 'topology-child',
+    ]);
+
+    const treeHuman = await run(process.execPath, [
+      cli, 'sessions', 'tree', 'codex', 'topology-root', '--max-depth', '4', '--db', db, '--no-warning',
+    ], { env });
+    assert.match(treeHuman.stdout, /^topology-root\n {2}topology-child {2}\[delegated guardian] {2}events=yes\n1 descendant\(s\), max depth 1\n$/);
+
+    await assert.rejects(
+      run(process.execPath, [
+        cli, 'sessions', 'tree', 'codex', 'topology-root', '--max-depth', '0', '--db', db, '--no-warning',
+      ], { env }),
+      (error: unknown) => typeof error === 'object' && error !== null
+        && 'code' in error && error.code === 1
+        && 'stderr' in error && String(error.stderr).includes('INVALID_ARGUMENT'),
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('topology commands require SOURCE and SESSION_ID and reject location scope', async () => {
+  for (const subcommand of ['relationships', 'tree']) {
+    await assert.rejects(
+      run(process.execPath, [cli, 'sessions', subcommand, '--no-warning']),
+      (error: unknown) => isUsageFailure(error, `sessions ${subcommand} requires SOURCE and SESSION_ID`),
+    );
+    await assert.rejects(
+      run(process.execPath, [cli, 'sessions', subcommand, 'codex', 'root', 'extra', '--no-warning']),
+      (error: unknown) => isUsageFailure(error, 'does not accept positional argument'),
+    );
+    await assert.rejects(
+      run(process.execPath, [cli, 'sessions', subcommand, 'codex', 'root', '--remote', '--no-warning']),
+      (error: unknown) => isUsageFailure(error, 'does not accept --local, --remote, or --all'),
+    );
+  }
+});
+
 test('scope flags are boolean, default to local, and are mutually exclusive', async () => {
   const root = await mkdtemp(join(tmpdir(), 'relayhistory-cli-scope-'));
   const db = join(root, 'missing.db');

--- a/sdk-ts/src/cli-output.test.ts
+++ b/sdk-ts/src/cli-output.test.ts
@@ -189,6 +189,13 @@ test('sessions relationships and sessions tree render topology in both modes', a
     ], { env });
     assert.match(treeHuman.stdout, /^topology-root\n {2}topology-child {2}\[delegated guardian] {2}events=yes\n1 descendant\(s\), max depth 1\n$/);
 
+    // A tree always contains its root, so a session with no recorded
+    // delegation renders as itself rather than as nothing at all.
+    const lone = await run(process.execPath, [
+      cli, 'sessions', 'tree', 'codex', 'topology-child', '--db', db, '--no-warning',
+    ], { env });
+    assert.match(lone.stdout, /^topology-child\n0 descendant\(s\), max depth 0\n$/);
+
     await assert.rejects(
       run(process.execPath, [
         cli, 'sessions', 'tree', 'codex', 'topology-root', '--max-depth', '0', '--db', db, '--no-warning',

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -3,8 +3,9 @@
 import { readFile } from 'node:fs/promises';
 
 import {
-  discoverSessions, getSession, getSessionEventsPage, hydrateSession, listSessionCatalogPage,
-  recent, search, stats, sync, type CatalogCursor, type SessionScope,
+  discoverSessions, getSession, getSessionEventsPage, getSessionRelationships, getSessionTree,
+  hydrateSession, listSessionCatalogPage, recent, search, stats, sync,
+  type CatalogCursor, type SessionRelationship, type SessionScope,
 } from './index.js';
 
 type Parsed = { positional: string[]; flags: Map<string, Array<string | true>> };
@@ -14,7 +15,7 @@ type PackageMetadata = { version?: string };
 const BOOLEAN_FLAGS = new Set(['all', 'fts', 'json', 'local', 'no-related', 'no-warning', 'remote', 'version']);
 const VALUE_FLAGS = new Set([
   'after', 'after-ms', 'after-session-id', 'after-source', 'before-ms', 'db', 'limit',
-  'project', 'source', 'tag',
+  'max-depth', 'max-nodes', 'project', 'source', 'tag',
 ]);
 const KNOWN_FLAGS = new Set([...BOOLEAN_FLAGS, ...VALUE_FLAGS]);
 
@@ -190,6 +191,8 @@ function usage(message?: string): never {
   ai-hist sessions list [--local | --remote | --all] [--source SOURCE]... [--limit N] [--before-ms MS] [--after JSON | --after-source SOURCE --after-session-id ID [--after-ms MS]] [--json]
   ai-hist sessions discover [--local | --remote | --all] [--source SOURCE] [--limit N] [--json]
   ai-hist sessions hydrate SOURCE SESSION_ID [--local | --remote | --all] [--no-related] [--db PATH] [--json]
+  ai-hist sessions relationships SOURCE SESSION_ID [--db PATH] [--json]
+  ai-hist sessions tree SOURCE SESSION_ID [--max-depth N] [--max-nodes N] [--db PATH] [--json]
   ai-hist search QUERY... [--local | --remote | --all] [--source SOURCE] [--project PATH] [--limit N] [--json]
   ai-hist recent [N] [--local | --remote | --all] [--source SOURCE] [--project PATH] [--json]
   ai-hist session SESSION_ID [--source SOURCE] [--json]
@@ -250,6 +253,57 @@ function outputHydration(value: Awaited<ReturnType<typeof hydrateSession>>, json
   }
 }
 
+function relationshipLine(direction: 'child' | 'parent', row: SessionRelationship): string {
+  const identity = direction === 'child' ? row.childSessionId ?? '(unlinked)' : row.parentSessionId;
+  return [
+    direction, identity, row.relationship, row.childAgentType ?? '-', row.spawnedAtMs ?? '-',
+    `events=${row.childHasEvents ? 'yes' : 'no'}`, `identity=${row.identityStatus}`,
+    row.evidenceLocator ?? row.evidenceKind,
+  ].join('  ');
+}
+
+function outputRelationships(value: Awaited<ReturnType<typeof getSessionRelationships>>, json: boolean): void {
+  if (json) {
+    output(value, true);
+    return;
+  }
+  const total = value.asParent.length + value.asChild.length;
+  process.stdout.write(total === 0
+    ? `${value.source}/${value.sessionId}: no delegation relationships.\n`
+    : `${value.source}/${value.sessionId}: ${value.asParent.length} child relationship(s), ` +
+      `${value.asChild.length} parent relationship(s)\n`);
+  for (const row of value.asParent) process.stdout.write(`${relationshipLine('child', row)}\n`);
+  for (const row of value.asChild) process.stdout.write(`${relationshipLine('parent', row)}\n`);
+  process.stdout.write(`capability: stable child identity = ${value.capabilities.stableChildIdentity}\n`);
+  for (const diagnostic of value.diagnostics) {
+    process.stdout.write(`${diagnostic.code}: ${diagnostic.message}\n`);
+  }
+}
+
+function outputTree(value: Awaited<ReturnType<typeof getSessionTree>>, json: boolean): void {
+  if (json) {
+    output(value, true);
+    return;
+  }
+  if (value.nodes.length === 0) {
+    process.stdout.write(`${value.source}/${value.rootSessionId}: no indexed delegation tree.\n`);
+  }
+  for (const node of value.nodes) {
+    const edge = node.relationship
+      ? `  [${[node.relationship.relationship, node.relationship.childAgentType].filter(Boolean).join(' ')}]` +
+        `  events=${node.hasEvents ? 'yes' : 'no'}`
+      : '';
+    process.stdout.write(`${'  '.repeat(node.depth)}${node.sessionId}${edge}${node.truncated ? '  …' : ''}\n`);
+  }
+  process.stdout.write(
+    `${Math.max(value.nodes.length - 1, 0)} descendant(s), max depth ${value.maxDepthReached}\n`,
+  );
+  for (const row of value.unlinked) {
+    process.stdout.write(`unlinked evidence: ${row.evidenceKind} ${row.evidenceLocator ?? ''}`.trimEnd() + '\n');
+  }
+  if (value.truncated) process.stdout.write('truncated: node/depth budget reached\n');
+}
+
 async function main(): Promise<void> {
   const rawArgs = process.argv.slice(2);
   const versionArgs = rawArgs.filter((arg) => arg !== '--no-warning');
@@ -298,6 +352,29 @@ async function main(): Promise<void> {
       scope: scopeFlag(args),
       dbPath: textFlag(args, 'db'),
       includeRelated: !args.flags.has('no-related'),
+    }), json);
+    return;
+  }
+  if (command === 'sessions' && subcommand === 'relationships') {
+    validateFlags(args, 'sessions relationships', ['all', 'db', 'json', 'local', 'remote']);
+    const [source, sessionId, ...surplus] = rest;
+    if (!source || !sessionId) usage('sessions relationships requires SOURCE and SESSION_ID');
+    rejectSurplusPositionals(surplus, 'sessions relationships');
+    rejectScopeFlag(args, 'sessions relationships');
+    outputRelationships(await getSessionRelationships({
+      source: source as never, sessionId, dbPath: textFlag(args, 'db'),
+    }), json);
+    return;
+  }
+  if (command === 'sessions' && subcommand === 'tree') {
+    validateFlags(args, 'sessions tree', ['all', 'db', 'json', 'local', 'max-depth', 'max-nodes', 'remote']);
+    const [source, sessionId, ...surplus] = rest;
+    if (!source || !sessionId) usage('sessions tree requires SOURCE and SESSION_ID');
+    rejectSurplusPositionals(surplus, 'sessions tree');
+    rejectScopeFlag(args, 'sessions tree');
+    outputTree(await getSessionTree({
+      source: source as never, sessionId, dbPath: textFlag(args, 'db'),
+      maxDepth: numberFlag(args, 'max-depth'), maxNodes: numberFlag(args, 'max-nodes'),
     }), json);
     return;
   }

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -285,9 +285,6 @@ function outputTree(value: Awaited<ReturnType<typeof getSessionTree>>, json: boo
     output(value, true);
     return;
   }
-  if (value.nodes.length === 0) {
-    process.stdout.write(`${value.source}/${value.rootSessionId}: no indexed delegation tree.\n`);
-  }
   for (const node of value.nodes) {
     const edge = node.relationship
       ? `  [${[node.relationship.relationship, node.relationship.childAgentType].filter(Boolean).join(' ')}]` +

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -298,6 +298,9 @@ function outputTree(value: Awaited<ReturnType<typeof getSessionTree>>, json: boo
   for (const row of value.unlinked) {
     process.stdout.write(`unlinked evidence: ${row.evidenceKind} ${row.evidenceLocator ?? ''}`.trimEnd() + '\n');
   }
+  for (const diagnostic of value.diagnostics) {
+    process.stdout.write(`${diagnostic.code}: ${diagnostic.message}\n`);
+  }
   if (value.truncated) process.stdout.write('truncated: node/depth budget reached\n');
 }
 

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -392,6 +392,7 @@ interface NativeBinding {
 }
 
 const CATALOG_SOURCES: readonly string[] = ['claude', 'codex', 'cursor', 'grok', 'relay', 'opencode'];
+const RELATIONSHIP_TYPES: readonly string[] = ['delegated'];
 const DEFAULT_TREE_MAX_DEPTH = 32;
 const MAX_TREE_MAX_DEPTH = 64;
 
@@ -621,6 +622,22 @@ function assertRelationshipContract(value: number): void {
   }
 }
 
+function catalogSource(value: unknown): CatalogSource {
+  if (typeof value === 'string' && CATALOG_SOURCES.includes(value)) return value as CatalogSource;
+  throw new NativeContractMismatchError(
+    `ai-hist-native returned an invalid catalog source: ${JSON.stringify(value)}. Reinstall matching ai-hist packages.`,
+    'NATIVE_CONTRACT_MISMATCH',
+  );
+}
+
+function relationshipType(value: unknown): RelationshipType {
+  if (typeof value === 'string' && RELATIONSHIP_TYPES.includes(value)) return value as RelationshipType;
+  throw new NativeContractMismatchError(
+    `ai-hist-native returned an invalid relationship type: ${JSON.stringify(value)}. Reinstall matching ai-hist packages.`,
+    'NATIVE_CONTRACT_MISMATCH',
+  );
+}
+
 function identityStatus(value: unknown): IdentityStatus {
   if (value === 'observed' || value === 'unlinked') return value;
   throw new NativeContractMismatchError(
@@ -639,10 +656,10 @@ function stableChildIdentity(value: unknown): StableChildIdentity {
 
 function relationship(value: UnknownRecord): SessionRelationship {
   return {
-    source: String(value.source) as CatalogSource,
+    source: catalogSource(value.source),
     parentSessionId: String(value.parentSessionId),
     childSessionId: nullableString(value.childSessionId),
-    relationship: String(value.relationship) as RelationshipType,
+    relationship: relationshipType(value.relationship),
     identityStatus: identityStatus(value.identityStatus),
     childAgentType: nullableString(value.childAgentType),
     childAgentName: nullableString(value.childAgentName),
@@ -665,7 +682,7 @@ function relationships(value: unknown): SessionRelationship[] {
 function relationshipCapabilities(value: unknown): RelationshipCapabilities {
   const row = (value ?? {}) as UnknownRecord;
   return {
-    source: String(row.source) as CatalogSource,
+    source: catalogSource(row.source),
     stableChildIdentity: stableChildIdentity(row.stableChildIdentity),
     recordsAgentType: row.recordsAgentType === true,
     recordsSpawnTime: row.recordsSpawnTime === true,
@@ -683,7 +700,7 @@ function relationshipDiagnostics(value: unknown): RelationshipDiagnostic[] {
 
 function treeNode(value: UnknownRecord): SessionTreeNode {
   return {
-    source: String(value.source) as CatalogSource,
+    source: catalogSource(value.source),
     sessionId: String(value.sessionId),
     depth: Number(value.depth),
     parentSessionId: nullableString(value.parentSessionId),
@@ -967,6 +984,19 @@ export async function* sessionDescendants(options: SessionDescendantsOptions): A
   const maxDepth = Math.min(Math.max(Math.trunc(options.maxDepth ?? DEFAULT_TREE_MAX_DEPTH), 1), MAX_TREE_MAX_DEPTH);
   const request = { source: options.source, dbPath: options.dbPath };
   const visited = new Set<string>([options.sessionId]);
+  // Each walked session's parent, so a repeated edge can be told apart: back
+  // into this branch's own ancestry it is a cycle, anywhere else it is a
+  // diamond, which leaves nothing unexplored. `getSessionTree` draws the same
+  // line, and the two must not disagree about what `truncated` means.
+  const parentOf = new Map<string, string | null>([[options.sessionId, null]]);
+  const isAncestor = (from: string, candidate: string): boolean => {
+    let current: string | null | undefined = from;
+    while (current !== null && current !== undefined) {
+      if (current === candidate) return true;
+      current = parentOf.get(current) ?? null;
+    }
+    return false;
+  };
   let frontier: SessionTreeNode[] = [{
     source: options.source, sessionId: options.sessionId, depth: 0, parentSessionId: null,
     relationship: null, childCount: 0, hasEvents: false, truncated: false,
@@ -979,24 +1009,25 @@ export async function* sessionDescendants(options: SessionDescendantsOptions): A
       let after: RelationshipCursor | undefined;
       do {
         const page = await getSessionChildrenPage({
-          ...request, sessionId: node.sessionId, limit: expand ? options.pageLimit : 1, after,
+          ...request, sessionId: node.sessionId, limit: options.pageLimit, after,
         });
         children.push(...page.children);
-        after = expand ? page.nextCursor ?? undefined : undefined;
+        after = page.nextCursor ?? undefined;
       } while (after);
+      // Unlinked evidence has no traversable identity, so it is never a child
+      // this walk owes the caller — at the depth boundary included.
       const linked = children.filter((edge): edge is SessionRelationship & { childSessionId: string } =>
         edge.identityStatus === 'observed' && edge.childSessionId !== null);
-      if (expand) {
-        node.childCount = linked.length;
-        node.truncated = linked.some((edge) => visited.has(edge.childSessionId));
-      } else {
-        node.truncated = children.length > 0;
-      }
+      node.childCount = linked.length;
+      node.truncated = expand
+        ? linked.some((edge) => isAncestor(node.sessionId, edge.childSessionId))
+        : linked.length > 0;
       if (node.depth > 0) yield node;
       if (!expand) continue;
       for (const edge of linked) {
         if (visited.has(edge.childSessionId)) continue;
         visited.add(edge.childSessionId);
+        parentOf.set(edge.childSessionId, node.sessionId);
         next.push({
           source: edge.source, sessionId: edge.childSessionId, depth: node.depth + 1,
           parentSessionId: node.sessionId, relationship: edge, childCount: 0,

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -352,6 +352,7 @@ export interface SessionDescendantsOptions extends GetSessionRelationshipsOption
 export interface DescendantEventsOptions {
   source: CatalogSource;
   dbPath?: string;
+  /** Events read per session, not a total for the iteration. */
   limit?: number;
   maxDepth?: number;
   /** Defaults to true. */
@@ -617,7 +618,7 @@ function assertRelationshipContract(value: number): void {
   if (value !== SESSION_RELATIONSHIP_CONTRACT_VERSION) {
     throw new NativeContractMismatchError(
       `ai-hist expects relationship contract ${SESSION_RELATIONSHIP_CONTRACT_VERSION}, but native returned ${value}.`,
-      'RELATIONSHIP_CONTRACT_MISMATCH',
+      'NATIVE_CONTRACT_MISMATCH',
     );
   }
 }

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -9,9 +9,10 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-export const NATIVE_CONTRACT_VERSION = 4;
+export const NATIVE_CONTRACT_VERSION = 5;
 export const SESSION_CATALOG_CONTRACT_VERSION = 2;
 export const SESSION_HYDRATION_CONTRACT_VERSION = 1;
+export const SESSION_RELATIONSHIP_CONTRACT_VERSION = 1;
 
 export type Source = 'claude' | 'codex' | 'cursor' | 'grok' | 'relay' | 'trajectory' | 'opencode';
 export type CatalogSource = Exclude<Source, 'trajectory'>;
@@ -231,6 +232,132 @@ export interface SessionEventsPage {
   nextCursor: EventCursor | null;
 }
 
+export type RelationshipType = 'delegated';
+export type IdentityStatus = 'observed' | 'unlinked';
+export type StableChildIdentity = 'always' | 'sometimes' | 'never';
+
+/**
+ * One observed delegation edge. `childSessionId` is null when the provider
+ * recorded the delegation but no stable child identity, in which case
+ * `identityStatus` is `unlinked` and the child's output stays attributed to
+ * the parent.
+ */
+export interface SessionRelationship {
+  source: CatalogSource;
+  parentSessionId: string;
+  childSessionId: string | null;
+  relationship: RelationshipType;
+  identityStatus: IdentityStatus;
+  childAgentType: string | null;
+  childAgentName: string | null;
+  childModel: string | null;
+  spawnDepth: number | null;
+  evidenceKind: string;
+  evidenceLocator: string | null;
+  evidenceRef: string | null;
+  childHasEvents: boolean;
+  spawnedAtMs: number | null;
+  createdMs: number;
+  relationshipUid: string;
+}
+
+/** What a provider is able to record about its own delegations. */
+export interface RelationshipCapabilities {
+  source: CatalogSource;
+  stableChildIdentity: StableChildIdentity;
+  recordsAgentType: boolean;
+  recordsSpawnTime: boolean;
+  recordsEvidenceLocator: boolean;
+}
+
+export interface RelationshipDiagnostic {
+  code: string;
+  message: string;
+  relationshipUid: string | null;
+}
+
+export interface GetSessionRelationshipsOptions {
+  source: CatalogSource;
+  sessionId: string;
+  dbPath?: string;
+}
+
+export interface SessionRelationships {
+  contractVersion: number;
+  source: CatalogSource;
+  sessionId: string;
+  /** Edges where this session is the delegating parent. */
+  asParent: SessionRelationship[];
+  /** Edges where this session is the delegated child. */
+  asChild: SessionRelationship[];
+  capabilities: RelationshipCapabilities;
+  diagnostics: RelationshipDiagnostic[];
+}
+
+export interface SessionTreeNode {
+  source: CatalogSource;
+  sessionId: string;
+  depth: number;
+  parentSessionId: string | null;
+  /** The edge that reached this node; null for the root. */
+  relationship: SessionRelationship | null;
+  childCount: number;
+  hasEvents: boolean;
+  /** Children exist but were not expanded (depth/node budget, or a cycle). */
+  truncated: boolean;
+}
+
+export interface GetSessionTreeOptions extends GetSessionRelationshipsOptions {
+  /** Default 32, maximum 64. */
+  maxDepth?: number;
+  /** Default 1000, maximum 10000. */
+  maxNodes?: number;
+}
+
+export interface SessionTree {
+  contractVersion: number;
+  source: CatalogSource;
+  rootSessionId: string;
+  /** Pre-order and deterministic; `nodes[0]` is the root when it exists. */
+  nodes: SessionTreeNode[];
+  /** Related evidence at any depth with no stable child identity. */
+  unlinked: SessionRelationship[];
+  capabilities: RelationshipCapabilities;
+  diagnostics: RelationshipDiagnostic[];
+  truncated: boolean;
+  maxDepthReached: number;
+}
+
+export interface RelationshipCursor {
+  spawnedAtMs: number | null;
+  relationshipUid: string;
+}
+
+export interface SessionChildrenPage {
+  children: SessionRelationship[];
+  nextCursor: RelationshipCursor | null;
+}
+
+export interface GetSessionChildrenPageOptions extends GetSessionRelationshipsOptions {
+  /** Default 100, maximum 1000. */
+  limit?: number;
+  after?: RelationshipCursor;
+}
+
+export interface SessionDescendantsOptions extends GetSessionRelationshipsOptions {
+  maxDepth?: number;
+  pageLimit?: number;
+}
+
+export interface DescendantEventsOptions {
+  source: CatalogSource;
+  dbPath?: string;
+  limit?: number;
+  maxDepth?: number;
+  /** Defaults to true. */
+  includeRoot?: boolean;
+}
+
 export interface Stats {
   scope: SessionScope;
   total: number;
@@ -258,8 +385,15 @@ interface NativeBinding {
   listSessionCatalogPage(options?: object): Promise<UnknownRecord>;
   discoverSessions(options?: object): Promise<UnknownRecord>;
   hydrateSession(options: object): Promise<UnknownRecord>;
+  getSessionRelationships(options: object): Promise<UnknownRecord>;
+  getSessionTree(options: object): Promise<UnknownRecord>;
+  getSessionChildrenPage(options: object): Promise<UnknownRecord>;
   sync(options?: object): Promise<UnknownRecord>;
 }
+
+const CATALOG_SOURCES: readonly string[] = ['claude', 'codex', 'cursor', 'grok', 'relay', 'opencode'];
+const DEFAULT_TREE_MAX_DEPTH = 32;
+const MAX_TREE_MAX_DEPTH = 64;
 
 const SUPPORTED_PLATFORMS = new Set([
   'darwin-arm64', 'darwin-x64',
@@ -478,6 +612,111 @@ function sessionEvent(value: UnknownRecord): SessionEvent {
   };
 }
 
+function assertRelationshipContract(value: number): void {
+  if (value !== SESSION_RELATIONSHIP_CONTRACT_VERSION) {
+    throw new NativeContractMismatchError(
+      `ai-hist expects relationship contract ${SESSION_RELATIONSHIP_CONTRACT_VERSION}, but native returned ${value}.`,
+      'RELATIONSHIP_CONTRACT_MISMATCH',
+    );
+  }
+}
+
+function identityStatus(value: unknown): IdentityStatus {
+  if (value === 'observed' || value === 'unlinked') return value;
+  throw new NativeContractMismatchError(
+    `ai-hist-native returned an invalid relationship identity status: ${JSON.stringify(value)}. Reinstall matching ai-hist packages.`,
+    'NATIVE_CONTRACT_MISMATCH',
+  );
+}
+
+function stableChildIdentity(value: unknown): StableChildIdentity {
+  if (value === 'always' || value === 'sometimes' || value === 'never') return value;
+  throw new NativeContractMismatchError(
+    `ai-hist-native returned an invalid stable child identity: ${JSON.stringify(value)}. Reinstall matching ai-hist packages.`,
+    'NATIVE_CONTRACT_MISMATCH',
+  );
+}
+
+function relationship(value: UnknownRecord): SessionRelationship {
+  return {
+    source: String(value.source) as CatalogSource,
+    parentSessionId: String(value.parentSessionId),
+    childSessionId: nullableString(value.childSessionId),
+    relationship: String(value.relationship) as RelationshipType,
+    identityStatus: identityStatus(value.identityStatus),
+    childAgentType: nullableString(value.childAgentType),
+    childAgentName: nullableString(value.childAgentName),
+    childModel: nullableString(value.childModel),
+    spawnDepth: typeof value.spawnDepth === 'number' ? value.spawnDepth : null,
+    evidenceKind: String(value.evidenceKind),
+    evidenceLocator: nullableString(value.evidenceLocator),
+    evidenceRef: nullableString(value.evidenceRef),
+    childHasEvents: value.childHasEvents === true,
+    spawnedAtMs: typeof value.spawnedAtMs === 'number' ? value.spawnedAtMs : null,
+    createdMs: Number(value.createdMs),
+    relationshipUid: String(value.relationshipUid),
+  };
+}
+
+function relationships(value: unknown): SessionRelationship[] {
+  return Array.isArray(value) ? (value as UnknownRecord[]).map(relationship) : [];
+}
+
+function relationshipCapabilities(value: unknown): RelationshipCapabilities {
+  const row = (value ?? {}) as UnknownRecord;
+  return {
+    source: String(row.source) as CatalogSource,
+    stableChildIdentity: stableChildIdentity(row.stableChildIdentity),
+    recordsAgentType: row.recordsAgentType === true,
+    recordsSpawnTime: row.recordsSpawnTime === true,
+    recordsEvidenceLocator: row.recordsEvidenceLocator === true,
+  };
+}
+
+function relationshipDiagnostics(value: unknown): RelationshipDiagnostic[] {
+  return Array.isArray(value) ? (value as UnknownRecord[]).map((item) => ({
+    code: String(item.code),
+    message: String(item.message),
+    relationshipUid: nullableString(item.relationshipUid),
+  })) : [];
+}
+
+function treeNode(value: UnknownRecord): SessionTreeNode {
+  return {
+    source: String(value.source) as CatalogSource,
+    sessionId: String(value.sessionId),
+    depth: Number(value.depth),
+    parentSessionId: nullableString(value.parentSessionId),
+    relationship: value.relationship && typeof value.relationship === 'object'
+      ? relationship(value.relationship as UnknownRecord)
+      : null,
+    childCount: Number(value.childCount),
+    hasEvents: value.hasEvents === true,
+    truncated: value.truncated === true,
+  };
+}
+
+function relationshipCursor(value: unknown): RelationshipCursor | null {
+  if (!value || typeof value !== 'object') return null;
+  const row = value as UnknownRecord;
+  return {
+    spawnedAtMs: typeof row.spawnedAtMs === 'number' ? row.spawnedAtMs : null,
+    relationshipUid: String(row.relationshipUid),
+  };
+}
+
+function validateSessionRef(options: GetSessionRelationshipsOptions, operation: string): void {
+  if (!options || typeof options !== 'object') {
+    throw new InvalidArgumentError(`${operation} options are required`, 'INVALID_ARGUMENT');
+  }
+  if (!CATALOG_SOURCES.includes(options.source)) {
+    throw new InvalidArgumentError(`invalid catalog source: ${String(options.source)}`, 'INVALID_ARGUMENT');
+  }
+  if (typeof options.sessionId !== 'string' || options.sessionId.trim() === '') {
+    throw new InvalidArgumentError('sessionId must not be empty', 'INVALID_ARGUMENT');
+  }
+}
+
 export function defaultDbPath(): string {
   if (process.env.AI_HIST_DB !== undefined) return process.env.AI_HIST_DB;
   if (process.env.XDG_DATA_HOME !== undefined) {
@@ -556,7 +795,7 @@ export async function hydrateSession(options: HydrateSessionOptions): Promise<Hy
   if (!options || typeof options !== 'object') {
     throw new InvalidArgumentError('hydrateSession options are required', 'INVALID_ARGUMENT');
   }
-  if (!['claude', 'codex', 'cursor', 'grok', 'relay', 'opencode'].includes(options.source)) {
+  if (!CATALOG_SOURCES.includes(options.source)) {
     throw new InvalidArgumentError(`invalid catalog source: ${String(options.source)}`, 'INVALID_ARGUMENT');
   }
   if (typeof options.sessionId !== 'string' || options.sessionId.trim() === '') {
@@ -642,6 +881,153 @@ export async function getSessionEvents(sessionId: string, options: Omit<EventsPa
   const events: SessionEvent[] = [];
   for await (const event of sessionEvents(sessionId, options)) events.push(event);
   return events;
+}
+
+/**
+ * Direct delegation relationships for one session, in both directions. A
+ * missing database returns an empty, well-formed result whose `capabilities`
+ * still describe what the provider is able to record.
+ */
+export async function getSessionRelationships(options: GetSessionRelationshipsOptions): Promise<SessionRelationships> {
+  validateSessionRef(options, 'getSessionRelationships');
+  return nativeCall(async (native) => {
+    const value = await native.getSessionRelationships({
+      source: options.source, sessionId: options.sessionId, dbPath: options.dbPath,
+    });
+    const contractVersion = Number(value.contractVersion);
+    assertRelationshipContract(contractVersion);
+    return {
+      contractVersion,
+      source: String(value.source) as CatalogSource,
+      sessionId: String(value.sessionId),
+      asParent: relationships(value.asParent),
+      asChild: relationships(value.asChild),
+      capabilities: relationshipCapabilities(value.capabilities),
+      diagnostics: relationshipDiagnostics(value.diagnostics),
+    };
+  });
+}
+
+/**
+ * The complete descendant delegation tree for one session: pre-order,
+ * cycle-safe, and bounded by `maxDepth` and `maxNodes`. Child events keep
+ * their own session identity and are never flattened into the root.
+ */
+export async function getSessionTree(options: GetSessionTreeOptions): Promise<SessionTree> {
+  validateSessionRef(options, 'getSessionTree');
+  return nativeCall(async (native) => {
+    const value = await native.getSessionTree({
+      source: options.source, sessionId: options.sessionId, dbPath: options.dbPath,
+      maxDepth: options.maxDepth, maxNodes: options.maxNodes,
+    });
+    const contractVersion = Number(value.contractVersion);
+    assertRelationshipContract(contractVersion);
+    return {
+      contractVersion,
+      source: String(value.source) as CatalogSource,
+      rootSessionId: String(value.rootSessionId),
+      nodes: Array.isArray(value.nodes) ? (value.nodes as UnknownRecord[]).map(treeNode) : [],
+      unlinked: relationships(value.unlinked),
+      capabilities: relationshipCapabilities(value.capabilities),
+      diagnostics: relationshipDiagnostics(value.diagnostics),
+      truncated: value.truncated === true,
+      maxDepthReached: Number(value.maxDepthReached),
+    };
+  });
+}
+
+/**
+ * One bounded page of a session's direct children, in the same total order
+ * the tree traversal uses: `(spawnedAtMs, relationshipUid)`, nulls last.
+ */
+export async function getSessionChildrenPage(options: GetSessionChildrenPageOptions): Promise<SessionChildrenPage> {
+  validateSessionRef(options, 'getSessionChildrenPage');
+  return nativeCall(async (native) => {
+    const page = await native.getSessionChildrenPage({
+      source: options.source, sessionId: options.sessionId, dbPath: options.dbPath, limit: options.limit,
+      after: options.after ? {
+        ...options.after,
+        spawnedAtMs: options.after.spawnedAtMs ?? undefined,
+      } : undefined,
+    });
+    return {
+      children: relationships(page.children),
+      nextCursor: relationshipCursor(page.nextCursor),
+    };
+  });
+}
+
+/**
+ * Lazily walks a session's descendants breadth-first over the paged children
+ * primitive, without materializing a large tree. Unlinked evidence has no
+ * traversable identity and is skipped; use `getSessionTree` when you need it.
+ */
+export async function* sessionDescendants(options: SessionDescendantsOptions): AsyncGenerator<SessionTreeNode> {
+  validateSessionRef(options, 'sessionDescendants');
+  const maxDepth = Math.min(Math.max(Math.trunc(options.maxDepth ?? DEFAULT_TREE_MAX_DEPTH), 1), MAX_TREE_MAX_DEPTH);
+  const request = { source: options.source, dbPath: options.dbPath };
+  const visited = new Set<string>([options.sessionId]);
+  let frontier: SessionTreeNode[] = [{
+    source: options.source, sessionId: options.sessionId, depth: 0, parentSessionId: null,
+    relationship: null, childCount: 0, hasEvents: false, truncated: false,
+  }];
+  while (frontier.length > 0) {
+    const next: SessionTreeNode[] = [];
+    for (const node of frontier) {
+      const expand = node.depth < maxDepth;
+      const children: SessionRelationship[] = [];
+      let after: RelationshipCursor | undefined;
+      do {
+        const page = await getSessionChildrenPage({
+          ...request, sessionId: node.sessionId, limit: expand ? options.pageLimit : 1, after,
+        });
+        children.push(...page.children);
+        after = expand ? page.nextCursor ?? undefined : undefined;
+      } while (after);
+      const linked = children.filter((edge): edge is SessionRelationship & { childSessionId: string } =>
+        edge.identityStatus === 'observed' && edge.childSessionId !== null);
+      if (expand) {
+        node.childCount = linked.length;
+        node.truncated = linked.some((edge) => visited.has(edge.childSessionId));
+      } else {
+        node.truncated = children.length > 0;
+      }
+      if (node.depth > 0) yield node;
+      if (!expand) continue;
+      for (const edge of linked) {
+        if (visited.has(edge.childSessionId)) continue;
+        visited.add(edge.childSessionId);
+        next.push({
+          source: edge.source, sessionId: edge.childSessionId, depth: node.depth + 1,
+          parentSessionId: node.sessionId, relationship: edge, childCount: 0,
+          hasEvents: edge.childHasEvents, truncated: false,
+        });
+      }
+    }
+    frontier = next;
+  }
+}
+
+/**
+ * The root session's events followed by each descendant's events, in
+ * descendant traversal order. Every yielded event keeps the `sessionId` of the
+ * session that actually produced it: a child's event is never rewritten as a
+ * parent's.
+ */
+export async function* sessionEventsIncludingDescendants(
+  options: DescendantEventsOptions & { sessionId: string },
+): AsyncGenerator<SessionEvent> {
+  validateSessionRef(options, 'sessionEventsIncludingDescendants');
+  const events = { dbPath: options.dbPath, source: options.source, limit: options.limit };
+  if (options.includeRoot !== false) {
+    yield* sessionEvents(options.sessionId, events);
+  }
+  for await (const node of sessionDescendants({
+    source: options.source, sessionId: options.sessionId, dbPath: options.dbPath, maxDepth: options.maxDepth,
+  })) {
+    if (!node.hasEvents) continue;
+    yield* sessionEvents(node.sessionId, events);
+  }
 }
 
 export async function stats(options: StatsOptions = {}): Promise<Stats> {

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -96,8 +96,8 @@ server.tool('get_session_tree',
   'Complete descendant delegation tree for one session, with cycle protection and deterministic ordering. Child events are not flattened into the parent.', {
   source: CATALOG_SOURCE,
   session_id: z.string().min(1),
-  max_depth: z.number().int().min(1).max(64).optional().default(32),
-  max_nodes: z.number().int().min(1).max(10000).optional().default(1000),
+  max_depth: z.number().int().min(1).max(64).optional(),
+  max_nodes: z.number().int().min(1).max(10000).optional(),
 }, READ, ({ source, session_id, max_depth, max_nodes }) => call(() => getSessionTree({
   source, sessionId: session_id, maxDepth: max_depth, maxNodes: max_nodes,
 })));

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -6,8 +6,8 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 import {
-  discoverSessions, getSession, getSessionEventsPage, hydrateSession, listSessionCatalogPage,
-  recent, search, stats, sync,
+  discoverSessions, getSession, getSessionEventsPage, getSessionRelationships, getSessionTree,
+  hydrateSession, listSessionCatalogPage, recent, search, stats, sync,
 } from './index.js';
 
 const READ = { readOnlyHint: true, idempotentHint: true, openWorldHint: false } as const;
@@ -86,7 +86,23 @@ server.tool('get_session_events', 'Get one bounded page of normalized events.', 
   after: z.object({ tsMs: z.number().int(), id: z.number().int() }).optional(),
 }, READ, ({ session_id, source, limit, after }) => call(() => getSessionEventsPage(session_id, { source, limit, after })));
 
-server.tool('history_stats', 'Statistics for already-indexed RelayHistory data.', {
+server.tool('get_session_relationships',
+  'Direct delegation relationships for one session, in both directions (as parent and as child).', {
+  source: CATALOG_SOURCE,
+  session_id: z.string().min(1),
+}, READ, ({ source, session_id }) => call(() => getSessionRelationships({ source, sessionId: session_id })));
+
+server.tool('get_session_tree',
+  'Complete descendant delegation tree for one session, with cycle protection and deterministic ordering. Child events are not flattened into the parent.', {
+  source: CATALOG_SOURCE,
+  session_id: z.string().min(1),
+  max_depth: z.number().int().min(1).max(64).optional().default(32),
+  max_nodes: z.number().int().min(1).max(10000).optional().default(1000),
+}, READ, ({ source, session_id, max_depth, max_nodes }) => call(() => getSessionTree({
+  source, sessionId: session_id, maxDepth: max_depth, maxNodes: max_nodes,
+})));
+
+server.tool('history_stats','Statistics for already-indexed RelayHistory data.', {
   scope: SESSION_SCOPE.optional().default('local'),
   tag: z.string().optional(),
 }, READ, ({ scope, tag }) => call(() => stats({ scope, tag })));

--- a/sdk-ts/src/native-errors.test.ts
+++ b/sdk-ts/src/native-errors.test.ts
@@ -44,7 +44,7 @@ test('SDK/native contract mismatch is actionable', () => {
     () => validateNativeContract(999),
     (error: unknown) => error instanceof NativeContractMismatchError
       && error.code === 'NATIVE_CONTRACT_MISMATCH'
-      && /requires native contract 4/.test(error.message),
+      && /requires native contract 5/.test(error.message),
   );
   assert.throws(
     () => validateNativeScope('cloud'),

--- a/sdk-ts/src/relationships.test.ts
+++ b/sdk-ts/src/relationships.test.ts
@@ -66,6 +66,29 @@ function childIds(children: SessionRelationship[]): Array<string | null> {
   return children.map((child) => child.childSessionId);
 }
 
+/**
+ * One Claude subagent transcript: its records carry the parent's `sessionId`
+ * and the provider names the child with `agentId`, so the same child can be
+ * reached from more than one parent.
+ */
+async function claudeSubagent(
+  project: string,
+  options: { file: string; parent: string; agent: string; at: string },
+): Promise<void> {
+  const common = { sessionId: options.parent, agentId: options.agent, isSidechain: true, cwd: '/work/app' };
+  await writeFile(join(project, options.file), [
+    JSON.stringify({
+      ...common, uuid: `${options.file}-u`, type: 'user',
+      message: { role: 'user', content: `${options.agent} instruction` }, timestamp: options.at,
+    }),
+    JSON.stringify({
+      ...common, uuid: `${options.file}-a`, type: 'assistant',
+      message: { role: 'assistant', content: `${options.agent} result` }, timestamp: options.at,
+    }),
+    '',
+  ].join('\n'));
+}
+
 test('missing databases answer relationship queries with provider capabilities', async () => {
   const root = await mkdtemp(join(tmpdir(), 'relayhistory-relationships-empty-'));
   const dbPath = join(root, 'missing', 'history.db');
@@ -327,6 +350,45 @@ test('claude evidence without a stable child identity stays unlinked', async () 
     assert.deepEqual(tree.nodes.map((node) => node.sessionId), ['session-1']);
     assert.deepEqual(tree.unlinked, relationships.asParent);
     assert.deepEqual(tree.diagnostics.map((item) => item.code), ['RELATIONSHIP_UNLINKED_CHILD']);
+  });
+});
+
+test('a shared child is emitted once and read the same way by both readers', async () => {
+  await withHome('relayhistory-relationships-diamond-', async (home, dbPath) => {
+    const project = join(home, '.claude', 'projects', 'app');
+    await mkdir(project, { recursive: true });
+    await writeFile(join(project, 'session-root.jsonl'), [
+      JSON.stringify({
+        sessionId: 'root', uuid: 'root-u', cwd: '/work/app', type: 'user',
+        message: { role: 'user', content: 'root prompt' }, timestamp: '2026-08-31T10:00:00Z',
+      }),
+      '',
+    ].join('\n'));
+    // Both children delegate to the same subagent, so the two branches meet
+    // again at `shared`: a diamond, not a cycle.
+    await claudeSubagent(project, { file: 'agent-child-a.jsonl', parent: 'root', agent: 'child-a', at: '2026-08-31T10:00:01Z' });
+    await claudeSubagent(project, { file: 'agent-child-b.jsonl', parent: 'root', agent: 'child-b', at: '2026-08-31T10:00:02Z' });
+    await claudeSubagent(project, { file: 'agent-shared-a.jsonl', parent: 'child-a', agent: 'shared', at: '2026-08-31T10:00:03Z' });
+    await claudeSubagent(project, { file: 'agent-shared-b.jsonl', parent: 'child-b', agent: 'shared', at: '2026-08-31T10:00:04Z' });
+    await sync({ dbPath });
+
+    const tree = await getSessionTree({ source: 'claude', sessionId: 'root', dbPath });
+    assert.deepEqual(tree.nodes.map((node) => node.sessionId), ['root', 'child-a', 'shared', 'child-b']);
+    // Meeting `shared` again leaves nothing unexplored, so neither parent is
+    // marked truncated and no budget was reached.
+    assert.deepEqual(tree.nodes.map((node) => [node.sessionId, node.childCount, node.truncated]), [
+      ['root', 2, false], ['child-a', 1, false], ['shared', 0, false], ['child-b', 1, false],
+    ]);
+    assert.equal(tree.truncated, false);
+    assert.deepEqual(tree.diagnostics, []);
+
+    const walked: SessionTreeNode[] = [];
+    for await (const node of sessionDescendants({ source: 'claude', sessionId: 'root', dbPath })) {
+      walked.push(node);
+    }
+    assert.equal(walked.filter((node) => node.sessionId === 'shared').length, 1);
+    const byId = (nodes: SessionTreeNode[]) => [...nodes].sort((left, right) => left.sessionId.localeCompare(right.sessionId));
+    assert.deepEqual(byId(walked), byId(tree.nodes.slice(1)));
   });
 });
 

--- a/sdk-ts/src/relationships.test.ts
+++ b/sdk-ts/src/relationships.test.ts
@@ -67,8 +67,17 @@ test('missing databases answer relationship queries with provider capabilities',
       },
       diagnostics: [],
     });
+    // A tree always contains its root, so a missing database answers with the
+    // same shape a real childless session has.
     assert.deepEqual(await getSessionTree({ source: 'claude', sessionId: 'root', dbPath }), {
-      contractVersion: 1, source: 'claude', rootSessionId: 'root', nodes: [], unlinked: [],
+      contractVersion: 1,
+      source: 'claude',
+      rootSessionId: 'root',
+      nodes: [{
+        source: 'claude', sessionId: 'root', depth: 0, parentSessionId: null,
+        relationship: null, childCount: 0, hasEvents: false, truncated: false,
+      }],
+      unlinked: [],
       capabilities: {
         source: 'claude', stableChildIdentity: 'sometimes', recordsAgentType: true,
         recordsSpawnTime: true, recordsEvidenceLocator: true,
@@ -186,7 +195,10 @@ test('tree traversal is deterministic, depth-bounded, and cycle-safe', async () 
 
     const cycle = await getSessionTree({ source: 'codex', sessionId: 'loop-a', dbPath });
     assert.deepEqual(cycle.nodes.map((node) => node.sessionId), ['loop-a', 'loop-b']);
-    assert.equal(cycle.truncated, true);
+    // Both sessions are in the tree, so nothing was truncated; only the node
+    // whose child was not expanded again is marked.
+    assert.equal(cycle.truncated, false);
+    assert.equal(cycle.nodes[1].truncated, true);
     assert.deepEqual(cycle.diagnostics.map((item) => item.code), ['RELATIONSHIP_CYCLE']);
 
     // A different source never sees these edges.

--- a/sdk-ts/src/relationships.test.ts
+++ b/sdk-ts/src/relationships.test.ts
@@ -10,6 +10,13 @@ import {
   type SessionRelationship, type SessionTreeNode,
 } from './index.js';
 
+/**
+ * Store locations that a configured environment moves out from under HOME.
+ * A full `sync()` walks every provider, so leaving any of these set would let
+ * the machine running the tests contribute sessions to a fixture database.
+ */
+const STORE_OVERRIDES = ['OPENCODE_DB', 'TRAJECTORY_ROOT', 'RELAYHISTORY_HOME', 'AI_HIST_DB'];
+
 /** Runs one case against a private HOME so provider scans see only its fixtures. */
 async function withHome(
   prefix: string,
@@ -18,14 +25,18 @@ async function withHome(
   const root = await mkdtemp(join(tmpdir(), prefix));
   const home = join(root, 'home');
   await mkdir(home, { recursive: true });
-  const saved = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+  const saved = new Map<string, string | undefined>(
+    ['HOME', 'USERPROFILE', ...STORE_OVERRIDES].map((key) => [key, process.env[key]]),
+  );
   process.env.HOME = home;
   process.env.USERPROFILE = home;
+  for (const key of STORE_OVERRIDES) delete process.env[key];
   try {
     await body(home, join(root, 'history.db'));
   } finally {
-    if (saved.HOME === undefined) delete process.env.HOME; else process.env.HOME = saved.HOME;
-    if (saved.USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = saved.USERPROFILE;
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key]; else process.env[key] = value;
+    }
     await rm(root, { recursive: true, force: true });
   }
 }
@@ -200,6 +211,12 @@ test('tree traversal is deterministic, depth-bounded, and cycle-safe', async () 
     assert.equal(cycle.truncated, false);
     assert.equal(cycle.nodes[1].truncated, true);
     assert.deepEqual(cycle.diagnostics.map((item) => item.code), ['RELATIONSHIP_CYCLE']);
+    // The lazy walker reads the same loop the same way.
+    const walked: SessionTreeNode[] = [];
+    for await (const node of sessionDescendants({ source: 'codex', sessionId: 'loop-a', dbPath })) {
+      walked.push(node);
+    }
+    assert.deepEqual(walked, cycle.nodes.slice(1));
 
     // A different source never sees these edges.
     assert.deepEqual((await getSessionTree({ source: 'claude', sessionId: 'root', dbPath })).nodes.map((node) => node.sessionId), ['root']);
@@ -223,11 +240,19 @@ test('sessionDescendants walks the same descendants as the materialized tree', a
     const byId = (nodes: SessionTreeNode[]) => [...nodes].sort((left, right) => left.sessionId.localeCompare(right.sessionId));
     assert.deepEqual(byId(walked), byId(tree.nodes.slice(1)));
 
-    const bounded: string[] = [];
+    // The walker and the materialized tree must also agree at a depth
+    // boundary: a node there still reports the linked children it did not
+    // expand, and is truncated only because one was left unexplored.
+    const bounded: SessionTreeNode[] = [];
     for await (const node of sessionDescendants({ source: 'codex', sessionId: 'root', dbPath, maxDepth: 1 })) {
-      bounded.push(node.sessionId);
+      bounded.push(node);
     }
-    assert.deepEqual(bounded.sort(), ['child-a', 'child-b']);
+    const shallow = await getSessionTree({ source: 'codex', sessionId: 'root', dbPath, maxDepth: 1 });
+    assert.deepEqual(byId(bounded), byId(shallow.nodes.slice(1)));
+    assert.deepEqual(
+      bounded.map((node) => [node.sessionId, node.childCount, node.truncated]).sort(),
+      [['child-a', 1, true], ['child-b', 0, false]],
+    );
   });
 });
 

--- a/sdk-ts/src/relationships.test.ts
+++ b/sdk-ts/src/relationships.test.ts
@@ -1,0 +1,316 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  InvalidArgumentError,
+  discoverSessions, getSessionChildrenPage, getSessionRelationships, getSessionTree,
+  hydrateSession, sessionDescendants, sessionEventsIncludingDescendants, sync,
+  type SessionRelationship, type SessionTreeNode,
+} from './index.js';
+
+/** Runs one case against a private HOME so provider scans see only its fixtures. */
+async function withHome(
+  prefix: string,
+  body: (home: string, dbPath: string) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  const home = join(root, 'home');
+  await mkdir(home, { recursive: true });
+  const saved = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  try {
+    await body(home, join(root, 'history.db'));
+  } finally {
+    if (saved.HOME === undefined) delete process.env.HOME; else process.env.HOME = saved.HOME;
+    if (saved.USERPROFILE === undefined) delete process.env.USERPROFILE; else process.env.USERPROFILE = saved.USERPROFILE;
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function codexRollout(
+  home: string,
+  id: string,
+  options: { at: string; parent?: string; label?: string },
+): Promise<void> {
+  const day = join(home, '.codex', 'sessions', '2026', '08', '31');
+  await mkdir(day, { recursive: true });
+  const payload = options.parent === undefined
+    ? { id, cwd: '/work/app' }
+    : {
+      id, cwd: '/work/app', session_id: options.parent, parent_thread_id: options.parent,
+      thread_source: 'subagent', source: { subagent: { other: options.label ?? 'guardian' } },
+    };
+  await writeFile(join(day, `rollout-${id}.jsonl`), [
+    JSON.stringify({ timestamp: options.at, type: 'session_meta', payload }),
+    JSON.stringify({ timestamp: options.at, type: 'event_msg', payload: { type: 'user_message', message: `${id} prompt` } }),
+    JSON.stringify({ timestamp: options.at, type: 'event_msg', payload: { type: 'agent_message', message: `${id} answer` } }),
+    '',
+  ].join('\n'));
+}
+
+function childIds(children: SessionRelationship[]): Array<string | null> {
+  return children.map((child) => child.childSessionId);
+}
+
+test('missing databases answer relationship queries with provider capabilities', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'relayhistory-relationships-empty-'));
+  const dbPath = join(root, 'missing', 'history.db');
+  try {
+    assert.deepEqual(await getSessionRelationships({ source: 'codex', sessionId: 'root', dbPath }), {
+      contractVersion: 1, source: 'codex', sessionId: 'root', asParent: [], asChild: [],
+      capabilities: {
+        source: 'codex', stableChildIdentity: 'always', recordsAgentType: true,
+        recordsSpawnTime: true, recordsEvidenceLocator: true,
+      },
+      diagnostics: [],
+    });
+    assert.deepEqual(await getSessionTree({ source: 'claude', sessionId: 'root', dbPath }), {
+      contractVersion: 1, source: 'claude', rootSessionId: 'root', nodes: [], unlinked: [],
+      capabilities: {
+        source: 'claude', stableChildIdentity: 'sometimes', recordsAgentType: true,
+        recordsSpawnTime: true, recordsEvidenceLocator: true,
+      },
+      diagnostics: [], truncated: false, maxDepthReached: 0,
+    });
+    assert.deepEqual(await getSessionChildrenPage({ source: 'cursor', sessionId: 'root', dbPath }), {
+      children: [], nextCursor: null,
+    });
+    const cursor = await getSessionRelationships({ source: 'cursor', sessionId: 'root', dbPath });
+    assert.equal(cursor.capabilities.stableChildIdentity, 'never');
+    assert.equal(cursor.capabilities.recordsEvidenceLocator, false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('relationship queries reject invalid identities before reaching the engine', async () => {
+  const dbPath = join(tmpdir(), 'relayhistory-never-created.db');
+  for (const operation of [
+    () => getSessionRelationships({ source: 'trajectory' as never, sessionId: 'root', dbPath }),
+    () => getSessionTree({ source: 'nope' as never, sessionId: 'root', dbPath }),
+    () => getSessionChildrenPage({ source: 'codex', sessionId: '  ', dbPath }),
+    () => getSessionTree({ source: 'codex', sessionId: '', dbPath }),
+    async () => { for await (const _ of sessionDescendants({ source: 'codex', sessionId: '', dbPath })) break; },
+    async () => {
+      for await (const _ of sessionEventsIncludingDescendants({ source: 'bad' as never, sessionId: 'root', dbPath })) break;
+    },
+  ]) {
+    await assert.rejects(operation(), (error: unknown) => error instanceof InvalidArgumentError
+      && error.code === 'INVALID_ARGUMENT');
+  }
+});
+
+test('codex delegation topology round-trips through discovery and hydration', async () => {
+  await withHome('relayhistory-relationships-codex-', async (home, dbPath) => {
+    await codexRollout(home, 'root', { at: '2026-08-31T10:00:00Z' });
+    await codexRollout(home, 'child-a', { at: '2026-08-31T10:00:03Z', parent: 'root', label: 'guardian' });
+    await codexRollout(home, 'child-b', { at: '2026-08-31T10:00:02Z', parent: 'root', label: 'reviewer' });
+
+    await discoverSessions({ dbPath, sources: ['codex'] });
+    const hydrated = await hydrateSession({ source: 'codex', sessionId: 'root', dbPath });
+    assert.deepEqual([...hydrated.relatedSessionIds].sort(), ['child-a', 'child-b']);
+
+    const relationships = await getSessionRelationships({ source: 'codex', sessionId: 'root', dbPath });
+    assert.equal(relationships.contractVersion, 1);
+    assert.deepEqual(relationships.asChild, []);
+    // Spawn time orders children ahead of the relationship uid tiebreaker.
+    assert.deepEqual(childIds(relationships.asParent), ['child-b', 'child-a']);
+    const [reviewer, guardian] = relationships.asParent;
+    assert.equal(reviewer.identityStatus, 'observed');
+    assert.equal(reviewer.relationship, 'delegated');
+    assert.equal(reviewer.evidenceKind, 'codex_session_meta');
+    assert.equal(reviewer.evidenceRef, 'root');
+    assert.equal(reviewer.childAgentType, 'reviewer');
+    assert.equal(reviewer.childHasEvents, true);
+    assert.equal(reviewer.relationshipUid, 'child:child-b');
+    assert.ok(reviewer.evidenceLocator?.endsWith('rollout-child-b.jsonl'));
+    assert.equal(typeof reviewer.spawnedAtMs, 'number');
+    assert.ok((guardian.spawnedAtMs ?? 0) > (reviewer.spawnedAtMs ?? 0));
+
+    // The same edge is visible from the child, in the other direction.
+    const child = await getSessionRelationships({ source: 'codex', sessionId: 'child-a', dbPath });
+    assert.deepEqual(child.asParent, []);
+    assert.deepEqual(child.asChild, [guardian]);
+
+    const tree = await getSessionTree({ source: 'codex', sessionId: 'root', dbPath });
+    assert.deepEqual(tree.nodes.map((node) => [node.sessionId, node.depth]), [
+      ['root', 0], ['child-b', 1], ['child-a', 1],
+    ]);
+    assert.equal(tree.nodes[0].childCount, 2);
+    assert.equal(tree.nodes[0].relationship, null);
+    assert.equal(tree.nodes[1].parentSessionId, 'root');
+    assert.equal(tree.nodes[1].hasEvents, true);
+    assert.equal(tree.maxDepthReached, 1);
+    assert.equal(tree.truncated, false);
+    assert.deepEqual(tree.unlinked, []);
+    assert.deepEqual(tree.diagnostics, []);
+
+    const first = await getSessionChildrenPage({ source: 'codex', sessionId: 'root', dbPath, limit: 1 });
+    assert.deepEqual(childIds(first.children), ['child-b']);
+    assert.equal(first.nextCursor?.relationshipUid, 'child:child-b');
+    const second = await getSessionChildrenPage({
+      source: 'codex', sessionId: 'root', dbPath, limit: 1, after: first.nextCursor ?? undefined,
+    });
+    assert.deepEqual(childIds(second.children), ['child-a']);
+  });
+});
+
+test('tree traversal is deterministic, depth-bounded, and cycle-safe', async () => {
+  await withHome('relayhistory-relationships-deep-', async (home, dbPath) => {
+    await codexRollout(home, 'root', { at: '2026-08-31T10:00:00Z' });
+    await codexRollout(home, 'child', { at: '2026-08-31T10:00:01Z', parent: 'root' });
+    await codexRollout(home, 'grandchild', { at: '2026-08-31T10:00:02Z', parent: 'child' });
+    // Two threads that name each other are recorded honestly and must not
+    // make traversal loop.
+    await codexRollout(home, 'loop-a', { at: '2026-08-31T10:00:03Z', parent: 'loop-b' });
+    await codexRollout(home, 'loop-b', { at: '2026-08-31T10:00:04Z', parent: 'loop-a' });
+    await sync({ dbPath });
+
+    const tree = await getSessionTree({ source: 'codex', sessionId: 'root', dbPath });
+    assert.deepEqual(tree.nodes.map((node) => node.sessionId), ['root', 'child', 'grandchild']);
+    assert.equal(tree.maxDepthReached, 2);
+    assert.deepEqual(
+      await getSessionTree({ source: 'codex', sessionId: 'root', dbPath }),
+      tree,
+      'repeated traversals of the same database are identical',
+    );
+
+    const shallow = await getSessionTree({ source: 'codex', sessionId: 'root', dbPath, maxDepth: 1 });
+    assert.deepEqual(shallow.nodes.map((node) => node.sessionId), ['root', 'child']);
+    assert.equal(shallow.nodes[1].truncated, true);
+    assert.equal(shallow.truncated, true);
+    assert.deepEqual(shallow.diagnostics.map((item) => item.code), ['RELATIONSHIP_TREE_DEPTH_LIMIT']);
+
+    const cycle = await getSessionTree({ source: 'codex', sessionId: 'loop-a', dbPath });
+    assert.deepEqual(cycle.nodes.map((node) => node.sessionId), ['loop-a', 'loop-b']);
+    assert.equal(cycle.truncated, true);
+    assert.deepEqual(cycle.diagnostics.map((item) => item.code), ['RELATIONSHIP_CYCLE']);
+
+    // A different source never sees these edges.
+    assert.deepEqual((await getSessionTree({ source: 'claude', sessionId: 'root', dbPath })).nodes.map((node) => node.sessionId), ['root']);
+  });
+});
+
+test('sessionDescendants walks the same descendants as the materialized tree', async () => {
+  await withHome('relayhistory-relationships-walk-', async (home, dbPath) => {
+    await codexRollout(home, 'root', { at: '2026-08-31T10:00:00Z' });
+    await codexRollout(home, 'child-a', { at: '2026-08-31T10:00:01Z', parent: 'root' });
+    await codexRollout(home, 'child-b', { at: '2026-08-31T10:00:02Z', parent: 'root' });
+    await codexRollout(home, 'grandchild', { at: '2026-08-31T10:00:03Z', parent: 'child-a' });
+    await sync({ dbPath });
+
+    const walked: SessionTreeNode[] = [];
+    // A page limit of one forces the walker through its cursor path.
+    for await (const node of sessionDescendants({ source: 'codex', sessionId: 'root', dbPath, pageLimit: 1 })) {
+      walked.push(node);
+    }
+    const tree = await getSessionTree({ source: 'codex', sessionId: 'root', dbPath });
+    const byId = (nodes: SessionTreeNode[]) => [...nodes].sort((left, right) => left.sessionId.localeCompare(right.sessionId));
+    assert.deepEqual(byId(walked), byId(tree.nodes.slice(1)));
+
+    const bounded: string[] = [];
+    for await (const node of sessionDescendants({ source: 'codex', sessionId: 'root', dbPath, maxDepth: 1 })) {
+      bounded.push(node.sessionId);
+    }
+    assert.deepEqual(bounded.sort(), ['child-a', 'child-b']);
+  });
+});
+
+test('descendant event iteration preserves each event\'s owning session', async () => {
+  await withHome('relayhistory-relationships-events-', async (home, dbPath) => {
+    await codexRollout(home, 'root', { at: '2026-08-31T10:00:00Z' });
+    await codexRollout(home, 'child', { at: '2026-08-31T10:00:01Z', parent: 'root' });
+    await codexRollout(home, 'grandchild', { at: '2026-08-31T10:00:02Z', parent: 'child' });
+    await sync({ dbPath });
+
+    const owners: string[] = [];
+    for await (const event of sessionEventsIncludingDescendants({ source: 'codex', sessionId: 'root', dbPath })) {
+      assert.equal(event.source, 'codex');
+      owners.push(event.sessionId);
+    }
+    assert.deepEqual([...new Set(owners)], ['root', 'child', 'grandchild']);
+    assert.ok(owners.filter((owner) => owner === 'child').length >= 2);
+
+    const descendantsOnly: string[] = [];
+    for await (const event of sessionEventsIncludingDescendants({
+      source: 'codex', sessionId: 'root', dbPath, includeRoot: false,
+    })) {
+      descendantsOnly.push(event.sessionId);
+    }
+    assert.equal(descendantsOnly.includes('root'), false);
+    assert.deepEqual([...new Set(descendantsOnly)], ['child', 'grandchild']);
+  });
+});
+
+test('claude evidence without a stable child identity stays unlinked', async () => {
+  await withHome('relayhistory-relationships-claude-', async (home, dbPath) => {
+    const project = join(home, '.claude', 'projects', 'app');
+    await mkdir(project, { recursive: true });
+    await writeFile(join(project, 'session-1.jsonl'), [
+      JSON.stringify({
+        sessionId: 'session-1', uuid: 'u1', cwd: '/work/app', type: 'user',
+        message: { role: 'user', content: 'first prompt' }, timestamp: '2026-08-31T10:00:00Z',
+      }),
+      '',
+    ].join('\n'));
+    // This provider version records the sidechain but never names the child.
+    await writeFile(join(project, 'agent-child.jsonl'), [
+      JSON.stringify({
+        sessionId: 'session-1', uuid: 'side-u', isSidechain: true, type: 'user',
+        message: { role: 'user', content: 'delegated instruction' }, timestamp: '2026-08-31T10:00:01Z',
+      }),
+      JSON.stringify({
+        sessionId: 'session-1', uuid: 'side-a', isSidechain: true, type: 'assistant',
+        message: { role: 'assistant', content: 'side result' }, timestamp: '2026-08-31T10:00:02Z',
+      }),
+      '',
+    ].join('\n'));
+
+    await discoverSessions({ dbPath, sources: ['claude'] });
+    const hydrated = await hydrateSession({ source: 'claude', sessionId: 'session-1', dbPath });
+    assert.deepEqual(hydrated.relatedSessionIds, []);
+    assert.ok(hydrated.diagnostics.some((item) => item.code === 'RELATIONSHIP_UNLINKED_CHILD'));
+
+    const relationships = await getSessionRelationships({ source: 'claude', sessionId: 'session-1', dbPath });
+    assert.equal(relationships.capabilities.stableChildIdentity, 'sometimes');
+    assert.equal(relationships.asParent.length, 1);
+    const [evidence] = relationships.asParent;
+    assert.equal(evidence.childSessionId, null);
+    assert.equal(evidence.identityStatus, 'unlinked');
+    assert.equal(evidence.evidenceKind, 'claude_sidechain_records');
+    assert.equal(evidence.childHasEvents, false);
+    // The child id is never taken from the file name.
+    assert.equal(evidence.relationshipUid.startsWith('evidence:'), true);
+    assert.ok(evidence.evidenceLocator?.endsWith('agent-child.jsonl'));
+
+    const tree = await getSessionTree({ source: 'claude', sessionId: 'session-1', dbPath });
+    assert.deepEqual(tree.nodes.map((node) => node.sessionId), ['session-1']);
+    assert.deepEqual(tree.unlinked, relationships.asParent);
+    assert.deepEqual(tree.diagnostics.map((item) => item.code), ['RELATIONSHIP_UNLINKED_CHILD']);
+  });
+});
+
+test('large trees stay bounded by the node budget', async () => {
+  await withHome('relayhistory-relationships-bounded-', async (home, dbPath) => {
+    await codexRollout(home, 'root', { at: '2026-08-31T10:00:00Z' });
+    for (let index = 0; index < 200; index++) {
+      await codexRollout(home, `child-${String(index).padStart(3, '0')}`, {
+        at: '2026-08-31T10:00:01Z', parent: 'root',
+      });
+    }
+    await sync({ dbPath });
+
+    const tree = await getSessionTree({ source: 'codex', sessionId: 'root', dbPath, maxNodes: 50 });
+    assert.equal(tree.nodes.length, 50);
+    assert.equal(tree.truncated, true);
+    assert.deepEqual(tree.diagnostics.map((item) => item.code), ['RELATIONSHIP_TREE_TRUNCATED']);
+    assert.equal(tree.nodes[0].childCount, 200);
+
+    const page = await getSessionChildrenPage({ source: 'codex', sessionId: 'root', dbPath, limit: 100 });
+    assert.equal(page.children.length, 100);
+    assert.equal(page.nextCursor?.relationshipUid, 'child:child-099');
+  });
+});


### PR DESCRIPTION
## Summary

A consumer can now start from a human-started root session, retrieve its delegation tree, and analyze each child agent's evidence separately — without losing provenance and without delegated agent instructions ever appearing as human prompts.

### Relationship model (`session_relationships` v2)

- New row shape with `relationship_uid` primary key, nullable `child_session_id`, `identity_status` (`observed` | `unlinked`), child agent type/name/model, spawn depth, spawn timestamp, evidence kind/locator/ref, and `child_has_events` addressability. A marker-guarded migration (`session_relationships_v2`) rebuilds v1 rows in place, preserving the cascade trigger via `legacy_alter_table`.
- Child identities are never invented: Claude subagent transcripts link only when the records themselves carry a stable `agentId` (never derived from filenames); older sidechain evidence without one is retained as honest `unlinked` rows with a `RELATIONSHIP_UNLINKED_CHILD` diagnostic. A later provider upgrade that names the child retires the superseded unlinked row.
- Per-source `capabilities` report `stableChildIdentity` (`codex: always`, `claude: sometimes`, others `never`).

### Public APIs (Rust core → N-API → TypeScript SDK; CLI/MCP call only the SDK)

- SDK: `getSessionRelationships({source, sessionId})` (both directions), `getSessionTree(...)` (bounded pre-order traversal, cycle protection, deterministic `(spawned_at_ms, relationship_uid)` ordering), `getSessionChildrenPage(...)` (keyset paging for large trees), async generators `sessionDescendants(...)` and `sessionEventsIncludingDescendants(...)` — every yielded event keeps its true `sessionId`; child events are never rewritten as parent events.
- CLI: `ai-hist sessions relationships SOURCE SESSION_ID` and `ai-hist sessions tree SOURCE SESSION_ID [--max-depth N] [--max-nodes N]`, readable and `--json` wire forms.
- MCP: `get_session_relationships`, `get_session_tree` (read-only, identity-addressed).
- Native contract advances 4 → 6: this branch and the 0.12.0 evidence surfaces (#96) each claimed 5 independently, so the merge with main takes the next free number. New session-relationship contract 1; catalog and hydration contracts unchanged.

### Provider coverage and human-prompt semantics

- Codex: full coverage — targeted hydration and plain `sync` both record parent/child rows (including backfill for already-synced rollouts), with `parent_thread_id` fallback, subagent labels, and spawn timestamps as evidence.
- Claude: subagent transcripts with in-record `agentId` are ingested under the child's own id (independently addressable events, with self-healing that moves previously parent-attributed events, tool calls, and file edits); sidechain evidence without a stable identity stays on the parent and is reported through diagnostics and the capability field. Metadata sidecars (`agent-<id>.meta.json`) are stamped by both hydration and full sync, so metadata-only changes refresh the recorded topology.
- Delegated task instructions never enter human prompt history, and child rollouts never appear as top-level human sessions — pinned by tests in both providers.

### Traversal semantics

- Cycle protection via ancestor tracking (diamond-shaped DAGs are not misreported as cycles or charged against the node budget), depth budget (default 32, max 64) and node budget (default 1000, max 10000) with exact `truncated` marking; tree-level `truncated` means budget-only.

## Testing

- Rust: 321 workspace tests green on the merged tree (core relationship queries/traversal, migration, recorder idempotence, hydrate/sync provider paths, end-to-end topology integration), `cargo fmt` and CI's clippy invocation clean.
- TypeScript: 48/48 on the merged tree (SDK round-trips, provenance-preserving descendant iteration, Claude unlinked honesty, diamond topology, bounded traversal, CLI contract, MCP architecture assertions, plus main's evidence-paging suite), `tsc --noEmit` clean.
- An adversarial review pass on the initial implementation surfaced 14 issues (sync/hydrate attribution disagreement, missing-database tree shape, Codex sync backfill, depth-boundary unlinked evidence, cascade-trigger edge loss, and lesser ones); all fixed with regression tests. Subsequent Codex, cubic, and CodeRabbit review findings are likewise fixed with tests or answered on-thread.
- Merged with main's 0.12.0 (tool-calls/file-edits evidence surfaces) preserving both features' behavior; generated files regenerated with the repo tooling.

## Docs

`docs/architecture.md`, `docs/session-catalog.md`, `sdk-ts/README.md`, `docs/agent-integration.md`, `mcp-package/README.md`, both changelogs, and a new `plans/008-session-delegation-topology.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0117uxuPNQ6DB6Zxt2QSyUM5