### PR TITLE
fix: resolve Codex subagent parent IDs

### DIFF
--- a/crates/ai-hist/src/hydrate.rs
+++ b/crates/ai-hist/src/hydrate.rs
@@ -1315,7 +1315,9 @@ fn ingest_codex_children(
         ingest_codex_rollout(conn, &candidate, &meta)?;
         cleanup_codex_subagent_history(conn, &meta.session_id)?;
         cleanup_codex_subagent_registration(conn, &meta.session_id)?;
-        record_codex_delegation(conn, &options.session_id, &meta, &candidate)?;
+        if let Some(parent_session_id) = meta.parent_session_id.as_deref() {
+            record_codex_delegation(conn, parent_session_id, &meta, &candidate)?;
+        }
     }
     Ok(())
 }
@@ -1324,18 +1326,49 @@ fn codex_children(root_path: &Path, parent_session_id: &str) -> Result<Vec<PathB
     let Some(directory) = root_path.parent() else {
         return Ok(Vec::new());
     };
-    Ok(collect_matching_files(directory, "rollout-", "jsonl")?
-        .into_iter()
-        .filter(|candidate| candidate != root_path)
-        .filter(|candidate| {
-            read_codex_session_meta(candidate)
-                .ok()
-                .flatten()
-                .is_some_and(|meta| {
-                    meta.is_subagent && meta.parent_session_id.as_deref() == Some(parent_session_id)
-                })
-        })
-        .collect())
+    let mut children_by_parent: HashMap<String, Vec<(String, PathBuf)>> = HashMap::new();
+    for candidate in collect_matching_files(directory, "rollout-", "jsonl")? {
+        if candidate == root_path {
+            continue;
+        }
+        let Some(meta) = read_codex_session_meta(&candidate)? else {
+            continue;
+        };
+        if !meta.is_subagent {
+            continue;
+        }
+        let Some(parent) = meta.parent_session_id.as_deref() else {
+            continue;
+        };
+        children_by_parent
+            .entry(parent.to_string())
+            .or_default()
+            .push((meta.session_id, candidate));
+    }
+
+    let mut descendants = Vec::new();
+    let mut pending = vec![parent_session_id.to_string()];
+    let mut visited_sessions = HashSet::from([parent_session_id.to_string()]);
+    let mut visited_paths = HashSet::new();
+    while let Some(parent) = pending.pop() {
+        let Some(children) = children_by_parent.remove(&parent) else {
+            continue;
+        };
+        for (child_session_id, path) in children {
+            if child_session_id == parent_session_id {
+                continue;
+            }
+            if !visited_paths.insert(path.clone()) {
+                continue;
+            }
+            descendants.push(path);
+            if visited_sessions.insert(child_session_id.clone()) {
+                pending.push(child_session_id);
+            }
+        }
+    }
+    descendants.sort();
+    Ok(descendants)
 }
 
 fn ingest_cursor(
@@ -1455,9 +1488,17 @@ fn build_result(
 fn related_ids(conn: &Connection, source: &str, session_id: &str) -> Result<Vec<String>> {
     Ok(conn
         .prepare(
-            "SELECT child_session_id FROM session_relationships \
-             WHERE source = ? AND parent_session_id = ? AND child_session_id IS NOT NULL \
-             ORDER BY child_session_id",
+            "WITH RECURSIVE descendants(child_session_id) AS ( \
+               SELECT child_session_id FROM session_relationships \
+               WHERE source = ?1 AND parent_session_id = ?2 \
+                 AND child_session_id IS NOT NULL AND child_session_id != ?2 \
+               UNION \
+               SELECT relationship.child_session_id FROM session_relationships relationship \
+               JOIN descendants ON relationship.parent_session_id = descendants.child_session_id \
+               WHERE relationship.source = ?1 AND relationship.child_session_id IS NOT NULL \
+                 AND relationship.child_session_id != ?2 \
+             ) \
+             SELECT child_session_id FROM descendants ORDER BY child_session_id",
         )?
         .query_map(params![source, session_id], |row| row.get::<_, String>(0))?
         .collect::<rusqlite::Result<Vec<_>>>()?)
@@ -1857,12 +1898,42 @@ mod tests {
         fs::create_dir_all(&day).unwrap();
         let root = day.join("rollout-root.jsonl");
         let child = day.join("rollout-child.jsonl");
+        let child_parent_thread = day.join("rollout-child-parent-thread.jsonl");
+        let child_thread_spawn = day.join("rollout-child-thread-spawn.jsonl");
+        let grandchild = day.join("rollout-grandchild.jsonl");
         fs::write(
             &root,
             concat!(
                 "{\"timestamp\":\"2026-08-31T10:00:00Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"root\",\"cwd\":\"/work/app\"}}\n",
                 "{\"timestamp\":\"2026-08-31T10:00:01Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"root prompt\"}}\n",
                 "{\"timestamp\":\"2026-08-31T10:00:02Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"root answer\"}}\n",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            &grandchild,
+            concat!(
+                "{\"timestamp\":\"2026-08-31T10:00:12Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"grandchild\",\"cwd\":\"/work/app\",\"source\":{\"subagent\":{\"thread_spawn\":{\"parent_thread_id\":\"child-thread-spawn\",\"depth\":2}}}}}\n",
+                "{\"timestamp\":\"2026-08-31T10:00:13Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"nested task\"}}\n",
+                "{\"timestamp\":\"2026-08-31T10:00:14Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"nested answer\"}}\n",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            &child_parent_thread,
+            concat!(
+                "{\"timestamp\":\"2026-08-31T10:00:06Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"child-parent-thread\",\"parent_thread_id\":\"root\",\"cwd\":\"/work/app\",\"source\":{\"subagent\":{\"other\":\"guardian\"}}}}\n",
+                "{\"timestamp\":\"2026-08-31T10:00:07Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"guardian task\"}}\n",
+                "{\"timestamp\":\"2026-08-31T10:00:08Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"guardian answer\"}}\n",
+            ),
+        )
+        .unwrap();
+        fs::write(
+            &child_thread_spawn,
+            concat!(
+                "{\"timestamp\":\"2026-08-31T10:00:09Z\",\"type\":\"session_meta\",\"payload\":{\"id\":\"child-thread-spawn\",\"cwd\":\"/work/app\",\"source\":{\"subagent\":{\"thread_spawn\":{\"parent_thread_id\":\"root\",\"depth\":1}}}}}\n",
+                "{\"timestamp\":\"2026-08-31T10:00:10Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"user_message\",\"message\":\"spawned task\"}}\n",
+                "{\"timestamp\":\"2026-08-31T10:00:11Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"spawned answer\"}}\n",
             ),
         )
         .unwrap();
@@ -1888,19 +1959,27 @@ mod tests {
         request.include_related = true;
         let with_child = hydrate_session_at_with_home(&db, &request, dir.path()).unwrap();
         assert_eq!(with_child.status, "updated");
-        assert_eq!(with_child.related_session_ids, vec!["child"]);
+        assert_eq!(
+            with_child.related_session_ids,
+            vec![
+                "child",
+                "child-parent-thread",
+                "child-thread-spawn",
+                "grandchild"
+            ]
+        );
         let conn = open_db(&db).unwrap();
         let child_events: i64 = conn
             .query_row(
-                "SELECT COUNT(*) FROM session_events WHERE source='codex' AND session_id='child'",
+                "SELECT COUNT(*) FROM session_events WHERE source='codex' AND session_id != 'root'",
                 [],
                 |row| row.get(0),
             )
             .unwrap();
-        assert!(child_events >= 2);
+        assert!(child_events >= 8);
         let child_prompts: i64 = conn
             .query_row(
-                "SELECT COUNT(*) FROM history WHERE source='codex' AND session_id='child'",
+                "SELECT COUNT(*) FROM history WHERE source='codex' AND session_id != 'root'",
                 [],
                 |row| row.get(0),
             )
@@ -1908,7 +1987,7 @@ mod tests {
         assert_eq!(child_prompts, 0);
         let child_catalog: i64 = conn
             .query_row(
-                "SELECT COUNT(*) FROM sessions WHERE source='codex' AND session_id='child'",
+                "SELECT COUNT(*) FROM sessions WHERE source='codex' AND session_id != 'root'",
                 [],
                 |row| row.get(0),
             )
@@ -1927,6 +2006,15 @@ mod tests {
         assert_eq!(relationship.2, child.to_string_lossy());
         assert_eq!(relationship.3.as_deref(), Some("guardian"));
         assert!(relationship.4.is_some());
+        let grandchild_parent: String = conn
+            .query_row(
+                "SELECT parent_session_id FROM session_relationships \
+                 WHERE source='codex' AND child_session_id='grandchild'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(grandchild_parent, "child-thread-spawn");
     }
 
     #[test]

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -5603,8 +5603,8 @@ struct CodexSessionMeta {
     /// The parent this thread was delegated by, from whichever field the
     /// provider recorded it in.
     parent_session_id: Option<String>,
-    /// `payload.parent_thread_id`, kept as the provider-native reference even
-    /// when `payload.session_id` is what named the parent.
+    /// The provider-native parent-thread reference, whether top-level or in a
+    /// structured thread-spawn source, kept separately from legacy `session_id`.
     parent_thread_id: Option<String>,
     /// The label under `payload.source.subagent`, when the rollout carries one.
     subagent_label: Option<String>,
@@ -5613,13 +5613,56 @@ struct CodexSessionMeta {
     meta_ts_ms: Option<i64>,
 }
 
+/// Resolve the parent identity from every Codex session-meta shape observed in
+/// local rollouts. Newer producers use the explicit top-level field, spawned
+/// agents can retain it inside their structured source, and older producers
+/// used `session_id` for the parent conversation.
+fn codex_parent_thread_id(
+    payload: Option<&serde_json::Map<String, Value>>,
+    session_id: &str,
+) -> Option<String> {
+    let valid_parent = |value: Option<&Value>| {
+        value
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty() && *id != session_id)
+            .map(str::to_string)
+    };
+
+    valid_parent(payload.and_then(|p| p.get("parent_thread_id"))).or_else(|| {
+        valid_parent(
+            payload
+                .and_then(|p| p.get("source"))
+                .and_then(Value::as_object)
+                .and_then(|source| source.get("subagent"))
+                .and_then(Value::as_object)
+                .and_then(|subagent| subagent.get("thread_spawn"))
+                .and_then(Value::as_object)
+                .and_then(|spawn| spawn.get("parent_thread_id")),
+        )
+    })
+}
+
+fn codex_parent_session_id(
+    payload: Option<&serde_json::Map<String, Value>>,
+    session_id: &str,
+) -> Option<String> {
+    codex_parent_thread_id(payload, session_id).or_else(|| {
+        payload
+            .and_then(|p| p.get("session_id"))
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty() && *id != session_id)
+            .map(str::to_string)
+    })
+}
+
 /// Read the `session_meta` line that opens every rollout file.
 ///
-/// Sessions key on `payload.id` — the per-thread id. Newer rollouts also
-/// carry `payload.session_id`, but that names the *parent* conversation for
-/// subagent threads; keying on it would collapse every subagent into its
-/// parent. Subagent threads are detected instead (`thread_source`, or the
-/// object form of `payload.source`) and excluded from session registration.
+/// Sessions key on `payload.id` — the per-thread id. Subagent rollouts can
+/// carry their parent in `parent_thread_id`, a structured thread-spawn source,
+/// or the legacy `session_id`; keying on any of those would collapse every
+/// subagent into its parent. Subagent threads are detected instead
+/// (`thread_source`, or the object form of `payload.source`) and excluded from
+/// session registration.
 fn read_codex_session_meta(path: &Path) -> Result<Option<CodexSessionMeta>> {
     let first = fs::read_to_string(path)
         .ok()
@@ -5665,18 +5708,11 @@ fn read_codex_session_meta(path: &Path) -> Result<Option<CodexSessionMeta>> {
         .and_then(Value::as_str)
         == Some("subagent")
         || subagent.is_some();
-    let named_parent = |key: &str| {
-        payload
-            .and_then(|p| p.get(key))
-            .and_then(Value::as_str)
-            .filter(|id| !id.is_empty() && *id != session_id)
-            .map(str::to_string)
-    };
     let parent_thread_id = is_subagent
-        .then(|| named_parent("parent_thread_id"))
+        .then(|| codex_parent_thread_id(payload, session_id))
         .flatten();
     let parent_session_id = is_subagent
-        .then(|| named_parent("session_id").or_else(|| parent_thread_id.clone()))
+        .then(|| codex_parent_session_id(payload, session_id))
         .flatten();
     // The label is an object in the observed rollouts (`{"other":"guardian"}`);
     // its value names the agent, and its key is the only thing left when the
@@ -10518,6 +10554,75 @@ mod tests {
 
     fn codex_meta(path: &std::path::Path) -> super::CodexSessionMeta {
         super::read_codex_session_meta(path).unwrap().unwrap()
+    }
+
+    #[test]
+    fn codex_parent_resolution_supports_current_structured_and_legacy_metadata() {
+        let cases = [
+            (
+                json!({
+                    "id": "child",
+                    "parent_thread_id": "top-level-parent",
+                    "session_id": "legacy-parent",
+                    "source": {"subagent": {"thread_spawn": {
+                        "parent_thread_id": "nested-parent",
+                        "depth": 1
+                    }}}
+                }),
+                Some("top-level-parent"),
+            ),
+            (
+                json!({
+                    "id": "child",
+                    "source": {"subagent": {"thread_spawn": {
+                        "parent_thread_id": "nested-parent",
+                        "depth": 1
+                    }}}
+                }),
+                Some("nested-parent"),
+            ),
+            (
+                json!({"id": "child", "session_id": "legacy-parent"}),
+                Some("legacy-parent"),
+            ),
+            (
+                json!({
+                    "id": "child",
+                    "parent_thread_id": "child",
+                    "session_id": "",
+                    "source": {"subagent": {"thread_spawn": {
+                        "parent_thread_id": "child",
+                        "depth": 1
+                    }}}
+                }),
+                None,
+            ),
+        ];
+
+        for (payload, expected) in cases {
+            assert_eq!(
+                super::codex_parent_session_id(payload.as_object(), "child").as_deref(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn codex_marker_only_guardian_remains_an_unlinked_subagent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout-guardian.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                r#"{"timestamp":"2026-08-31T10:00:00.000Z","type":"session_meta","payload":{"id":"guardian","cwd":"/tmp/proj","source":{"subagent":{"other":"guardian"}}}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let meta = codex_meta(&path);
+        assert!(meta.is_subagent);
+        assert_eq!(meta.parent_session_id, None);
     }
 
     fn response_user(ts: &str, text: &str) -> String {


### PR DESCRIPTION
## Summary

- resolve Codex subagent parents from top-level `parent_thread_id`
- resolve structured thread-spawn parents from `source.subagent.thread_spawn.parent_thread_id`
- retain legacy `session_id` parent resolution as a fallback
- traverse the complete descendant graph during related hydration while preserving each immediate parent edge
- keep marker-only guardians unlinked rather than promoting them to root sessions

## Why

Codex has emitted parent identities in several session-meta shapes. Relayhistory did not read the structured thread-spawn parent, so those children remained detached even though the relationship was present in the rollout. Once immediate parents are resolved, related hydration must also follow depth-2+ spawns so grandchildren are not omitted.

This change does not promote subagents into the root catalog or add their delegated prompts to human prompt history.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ai-hist-engine`
  - 252 unit tests passed
  - 19 discovery tests passed
  - 1 relationship topology test passed
  - 3 resilience tests passed
  - 2 declared benchmarks ignored
- focused hydration regression covers legacy, top-level, nested thread-spawn, and depth-2 descendant metadata