### PR TITLE
feat(sdk): export runtime source registry

### DIFF
--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Export immutable `SOURCES` and `CATALOG_SOURCES` runtime tuples alongside
+  `isSource()` and `isCatalogSource()` guards, so consumers can validate source
+  input without duplicating the SDK's provider registry.
 - Surface bounded OpenCode provider-query and inspected-record counters through the typed SDK,
   CLI JSON, and MCP discovery result.
 - Expose hydration contract v2 with `capability`, shallow/partial outcomes,

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Export immutable `SOURCES` and `CATALOG_SOURCES` runtime tuples alongside
+- Export immutable `SOURCES` and derived `CATALOG_SOURCES` runtime registries alongside
   `isSource()` and `isCatalogSource()` guards, so consumers can validate source
   input without duplicating the SDK's provider registry.
 - Surface bounded OpenCode provider-query and inspected-record counters through the typed SDK,

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -57,11 +57,12 @@ or `shallow_only` when no richer evidence is exposed. Partial results retain
 `discoveryState: 'shallow'`. `sync` is full ingestion.
 Missing databases return empty read results; they do not trigger provider I/O.
 
-`SOURCES` and `CATALOG_SOURCES` are immutable runtime tuples corresponding to
+`SOURCES` and `CATALOG_SOURCES` are immutable runtime registries corresponding to
 the exported `Source` and `CatalogSource` types. Use `isSource(value)` or
 `isCatalogSource(value)` to validate untyped input without maintaining a copied
-provider list. `trajectory` is a history source but not a discoverable session
-catalog source, so it appears only in `SOURCES`.
+provider list. `CATALOG_SOURCES` is derived from `SOURCES`; `trajectory` is a
+history source but not a discoverable session catalog source, so it appears
+only in `SOURCES`.
 
 Session discovery, listing, search, recent history, statistics, and sync accept
 `scope: 'local' | 'remote' | 'all'`. Scope defaults to `local`, preserving

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -10,6 +10,7 @@ npm install ai-hist
 
 ```ts
 import {
+  CATALOG_SOURCES,
   discoverSessions,
   hydrateSession,
   listSessionCatalogPage,
@@ -25,6 +26,9 @@ import {
   stats,
   sync,
 } from 'ai-hist';
+
+// Runtime validation stays in step with the sources supported by this build.
+for (const source of CATALOG_SOURCES) console.log(source);
 
 await discoverSessions({ scope: 'all', limit: 100 });
 const page = await listSessionCatalogPage({ scope: 'all', limit: 20 });
@@ -52,6 +56,12 @@ Codex cloud tasks return `partial` when their supported unified diff is indexed
 or `shallow_only` when no richer evidence is exposed. Partial results retain
 `discoveryState: 'shallow'`. `sync` is full ingestion.
 Missing databases return empty read results; they do not trigger provider I/O.
+
+`SOURCES` and `CATALOG_SOURCES` are immutable runtime tuples corresponding to
+the exported `Source` and `CatalogSource` types. Use `isSource(value)` or
+`isCatalogSource(value)` to validate untyped input without maintaining a copied
+provider list. `trajectory` is a history source but not a discoverable session
+catalog source, so it appears only in `SOURCES`.
 
 Session discovery, listing, search, recent history, statistics, and sync accept
 `scope: 'local' | 'remote' | 'all'`. Scope defaults to `local`, preserving

--- a/sdk-ts/src/helpers.test.ts
+++ b/sdk-ts/src/helpers.test.ts
@@ -11,9 +11,9 @@ import {
   resumeCommand,
 } from './index.js';
 
-test('exports immutable runtime source registries and matching type guards', () => {
+test('exports immutable, aligned runtime source registries and matching type guards', () => {
   assert.deepEqual(SOURCES, ['claude', 'codex', 'cursor', 'grok', 'relay', 'trajectory', 'opencode']);
-  assert.deepEqual(CATALOG_SOURCES, ['claude', 'codex', 'cursor', 'grok', 'relay', 'opencode']);
+  assert.deepEqual(CATALOG_SOURCES, SOURCES.filter((source) => source !== 'trajectory'));
   assert.equal(Object.isFrozen(SOURCES), true);
   assert.equal(Object.isFrozen(CATALOG_SOURCES), true);
 

--- a/sdk-ts/src/helpers.test.ts
+++ b/sdk-ts/src/helpers.test.ts
@@ -2,7 +2,29 @@ import assert from 'node:assert/strict';
 import { join } from 'node:path';
 import test from 'node:test';
 
-import { defaultDbPath, resumeCommand } from './index.js';
+import {
+  CATALOG_SOURCES,
+  SOURCES,
+  defaultDbPath,
+  isCatalogSource,
+  isSource,
+  resumeCommand,
+} from './index.js';
+
+test('exports immutable runtime source registries and matching type guards', () => {
+  assert.deepEqual(SOURCES, ['claude', 'codex', 'cursor', 'grok', 'relay', 'trajectory', 'opencode']);
+  assert.deepEqual(CATALOG_SOURCES, ['claude', 'codex', 'cursor', 'grok', 'relay', 'opencode']);
+  assert.equal(Object.isFrozen(SOURCES), true);
+  assert.equal(Object.isFrozen(CATALOG_SOURCES), true);
+
+  for (const source of SOURCES) assert.equal(isSource(source), true);
+  for (const source of CATALOG_SOURCES) assert.equal(isCatalogSource(source), true);
+  assert.equal(isCatalogSource('trajectory'), false);
+  for (const value of ['unknown', '', null, undefined, 1, {}]) {
+    assert.equal(isSource(value), false);
+    assert.equal(isCatalogSource(value), false);
+  }
+});
 
 test('defaultDbPath follows native environment precedence', () => {
   const previousDb = process.env.AI_HIST_DB;

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -32,14 +32,9 @@ export const SOURCES = Object.freeze([
 
 export type Source = (typeof SOURCES)[number];
 export type CatalogSource = Exclude<Source, 'trajectory'>;
-export const CATALOG_SOURCES = Object.freeze([
-  'claude',
-  'codex',
-  'cursor',
-  'grok',
-  'relay',
-  'opencode',
-] as const satisfies readonly CatalogSource[]);
+export const CATALOG_SOURCES: readonly CatalogSource[] = Object.freeze(
+  SOURCES.filter((source): source is CatalogSource => source !== 'trajectory'),
+);
 
 const SOURCE_SET: ReadonlySet<string> = new Set(SOURCES);
 const CATALOG_SOURCE_SET: ReadonlySet<string> = new Set(CATALOG_SOURCES);

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -20,11 +20,40 @@ export const SESSION_EVIDENCE_CONTRACT_VERSION = 1;
  * so the runtime checks below and the compile-time type cannot drift apart,
  * and it is the same list the MCP server's `SOURCE` enum publishes.
  */
-const SOURCES = ['claude', 'codex', 'cursor', 'grok', 'relay', 'trajectory', 'opencode'] as const;
-const CATALOG_SOURCES: readonly string[] = SOURCES.filter((source) => source !== 'trajectory');
+export const SOURCES = Object.freeze([
+  'claude',
+  'codex',
+  'cursor',
+  'grok',
+  'relay',
+  'trajectory',
+  'opencode',
+] as const);
 
 export type Source = (typeof SOURCES)[number];
 export type CatalogSource = Exclude<Source, 'trajectory'>;
+export const CATALOG_SOURCES = Object.freeze([
+  'claude',
+  'codex',
+  'cursor',
+  'grok',
+  'relay',
+  'opencode',
+] as const satisfies readonly CatalogSource[]);
+
+const SOURCE_SET: ReadonlySet<string> = new Set(SOURCES);
+const CATALOG_SOURCE_SET: ReadonlySet<string> = new Set(CATALOG_SOURCES);
+
+/** Return whether an unknown value is a source recognized by this SDK build. */
+export function isSource(value: unknown): value is Source {
+  return typeof value === 'string' && SOURCE_SET.has(value);
+}
+
+/** Return whether an unknown value can identify a session catalog entry. */
+export function isCatalogSource(value: unknown): value is CatalogSource {
+  return typeof value === 'string' && CATALOG_SOURCE_SET.has(value);
+}
+
 export type SessionScope = 'local' | 'remote' | 'all';
 export type SessionLocation = Exclude<SessionScope, 'all'>;
 
@@ -803,7 +832,7 @@ function assertEvidenceContract(value: number): void {
 }
 
 function catalogSource(value: unknown): CatalogSource {
-  if (typeof value === 'string' && CATALOG_SOURCES.includes(value)) return value as CatalogSource;
+  if (isCatalogSource(value)) return value;
   throw new NativeContractMismatchError(
     `ai-hist-native returned an invalid catalog source: ${JSON.stringify(value)}. Reinstall matching ai-hist packages.`,
     'NATIVE_CONTRACT_MISMATCH',


### PR DESCRIPTION
## Summary

- export immutable `SOURCES` and derived `CATALOG_SOURCES` runtime registries from `ai-hist`
- add `isSource()` and `isCatalogSource()` guards for validating untyped input
- reuse the public catalog guard at the native normalization boundary
- document and test the runtime/type-level contract

## Why

Consumers currently receive the `Source` and `CatalogSource` TypeScript unions but cannot inspect or validate those sets at runtime without copying RelayHistory's provider list. A copied list can drift as provider support changes.

`SOURCES` is the canonical frozen tuple from which the `Source` union is derived. `CATALOG_SOURCES` is frozen and derived directly from `SOURCES`, so a future non-trajectory provider cannot be added to the master registry without appearing in the catalog registry. The public guards give HTTP, CLI, and configuration boundaries a canonical validator for the installed SDK build. `trajectory` remains a general history source but is intentionally excluded from the discoverable session catalog registry.

## Compatibility

This is an additive TypeScript SDK change. It does not alter the native or session-catalog contracts.

## Verification

- `npm run typecheck` in `sdk-ts`
- `npm test` in `sdk-ts` — 50 tests passed
- generated declarations include both readonly registries and both type predicates
- `git diff --check`
