### PR TITLE
Prevent native contract version drift in release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           npm ci
           npm run build:debug
+          node ../../scripts/verify-native-contract.mjs ./index.js
           git diff --exit-code -- index.d.ts
 
       - name: TypeScript tests

--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -123,12 +123,12 @@ jobs:
       - name: Execute native contract smoke test
         if: matrix.test_native
         shell: bash
-        run: node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==5) process.exit(1)"
+        run: node ../../scripts/verify-native-contract.mjs ./index.js
 
       - name: Execute musl native contract smoke test
         if: matrix.test_musl
         shell: bash
-        run: docker run --rm -v "$PWD:/work" -w /work node:22-alpine node -e "const n=require('./index.js'); if(n.nativeContractVersion()!==5) process.exit(1)"
+        run: docker run --rm -v "$GITHUB_WORKSPACE:/work" -w /work/crates/ai-hist-napi node:22-alpine node ../../scripts/verify-native-contract.mjs ./index.js
 
       - uses: actions/upload-artifact@v4
         with:

--- a/scripts/verify-native-contract.mjs
+++ b/scripts/verify-native-contract.mjs
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function readVersion(relativePath, pattern, label) {
+  const source = readFileSync(resolve(repositoryRoot, relativePath), 'utf8');
+  const match = pattern.exec(source);
+  if (!match) {
+    throw new Error(`Could not read the native contract version from ${label}`);
+  }
+  return Number(match[1]);
+}
+
+const rustVersion = readVersion(
+  'crates/ai-hist-napi/src/lib.rs',
+  /pub const NATIVE_CONTRACT_VERSION:\s*u32\s*=\s*(\d+)\s*;/,
+  'the Rust binding',
+);
+const sdkVersion = readVersion(
+  'sdk-ts/src/index.ts',
+  /export const NATIVE_CONTRACT_VERSION\s*=\s*(\d+)\s*;/,
+  'the TypeScript SDK',
+);
+
+const versions = [
+  ['Rust binding source', rustVersion],
+  ['TypeScript SDK source', sdkVersion],
+];
+
+const addonPath = process.argv[2];
+if (addonPath) {
+  const require = createRequire(import.meta.url);
+  const addon = require(resolve(process.cwd(), addonPath));
+  if (typeof addon.nativeContractVersion !== 'function') {
+    throw new Error(`Built addon at ${addonPath} does not export nativeContractVersion()`);
+  }
+  versions.push(['built native addon', addon.nativeContractVersion()]);
+}
+
+if (new Set(versions.map(([, version]) => version)).size !== 1) {
+  throw new Error(
+    `Native contract versions disagree: ${versions
+      .map(([label, version]) => `${label}=${version}`)
+      .join(', ')}`,
+  );
+}
+
+console.log(`Native contract version ${rustVersion} verified (${versions.map(([label]) => label).join(', ')})`);


### PR DESCRIPTION
## Summary

- replace hard-coded native contract versions in the publish matrix with a shared verifier
- compare the Rust source, TypeScript SDK source, and built addon contract versions
- run the same check in regular CI so drift is caught before release
- emit all observed versions when a mismatch occurs

## Why

Publish run 33585442293 built contract version 7 successfully, then failed because its smoke test still expected version 5.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/publish-napi.yml`
- `node scripts/verify-native-contract.mjs`
- verifier against the locally built native addon
- `node --test scripts/*.test.mjs`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

