### PR TITLE
feat(capture): project_id on every event, filesTouched/session_outcome/updated_ms in the outbox (P0 of neighborhood-memory)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@ Notable changes to the native `ai-hist` CLI are documented here.
 ## [Unreleased]
 
 - Populate `projectId` on every cloud-sync envelope (repo slug from
-  `history.project` or the session cwd's git remote; the explicit string
-  `unknown` when neither is known). Emit `filesTouched` from
-  `session_file_edits` / `session_file_edits_page`, `session_outcome`
-  envelopes from `session_commit_links`, and re-push revised trajectories
-  through an `updated_ms` watermark on the sync cursor.
+  `history.project` or the session cwd's git remote, including relative
+  forms such as `./repo`; the explicit string `unknown` when neither is
+  known). Emit `filesTouched` from `session_file_edits` /
+  `session_file_edits_page`, `session_outcome` envelopes from
+  `session_commit_links` (`shippedAt` from evidence `commit_time_ms`;
+  event ids include source and match method), and re-push revised
+  trajectories through a `(updated_ms, rowid)` keyset. An upgraded client
+  re-upserts previously synced history once (`capture_version` on the
+  cursor). Sessions whose `file_edits` grow after the last prompt
+  envelope republish `filesTouched`.
 
 - Add targeted remote hydration for Claude Code web sessions through the
   provider's bounded teleport-evidence interface, and partial Codex cloud task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Notable changes to the native `ai-hist` CLI are documented here.
 
 ## [Unreleased]
 
+- Populate `projectId` on every cloud-sync envelope (repo slug from
+  `history.project` or the session cwd's git remote; the explicit string
+  `unknown` when neither is known). Emit `filesTouched` from
+  `session_file_edits` / `session_file_edits_page`, `session_outcome`
+  envelopes from `session_commit_links`, and re-push revised trajectories
+  through an `updated_ms` watermark on the sync cursor.
+
 - Add targeted remote hydration for Claude Code web sessions through the
   provider's bounded teleport-evidence interface, and partial Codex cloud task
   hydration through `codex cloud diff`. Hydration contract v2 reports honest

--- a/crates/ai-hist-core/src/convergence.rs
+++ b/crates/ai-hist-core/src/convergence.rs
@@ -116,6 +116,117 @@ pub struct ConvergenceEnvelope {
     /// (confidence) are not shadow-stored here.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record: Option<Value>,
+    /// Structural file-overlap signal (WS-1 optional). Populated from `file_edits`.
+    #[serde(rename = "filesTouched", skip_serializing_if = "Vec::is_empty")]
+    pub files_touched: Vec<String>,
+    /// `kind=session_outcome` fields — the cloud ingest path already accepts these.
+    #[serde(rename = "commitSha", skip_serializing_if = "Option::is_none")]
+    pub commit_sha: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(rename = "matchMethod", skip_serializing_if = "Option::is_none")]
+    pub match_method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub numstat: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files: Option<Value>,
+    #[serde(rename = "shippedAt", skip_serializing_if = "Option::is_none")]
+    pub shipped_at: Option<String>,
+}
+
+/// Explicit project id when nothing resolvable is known. Never omitted (`None`) on
+/// the wire — the cloud Pair filter drops NULL/empty `projectId` once capture lands.
+pub const UNKNOWN_PROJECT: &str = "unknown";
+
+/// Canonical project id for the cloud `project_aliases` table: a repo slug
+/// (`owner/repo` or a short name), never a filesystem path.
+///
+/// `project` (from `history.project` / `trajectories.project_id`) wins; `git_remote`
+/// is the session-cwd fallback. Empty / unparseable → [`UNKNOWN_PROJECT`].
+pub fn resolve_project_id(project: Option<&str>, git_remote: Option<&str>) -> String {
+    if let Some(project) = nonempty(project) {
+        return normalize_project_id(project);
+    }
+    if let Some(remote) = nonempty(git_remote) {
+        return normalize_project_id(remote);
+    }
+    UNKNOWN_PROJECT.to_string()
+}
+
+fn nonempty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|s| !s.is_empty())
+}
+
+fn normalize_project_id(raw: &str) -> String {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return UNKNOWN_PROJECT.to_string();
+    }
+    if let Some(slug) = slug_from_git_remote(raw) {
+        return slug;
+    }
+    if is_filesystem_path(raw) {
+        let slug = last_path_component(raw);
+        return if slug.is_empty() {
+            UNKNOWN_PROJECT.to_string()
+        } else {
+            slug
+        };
+    }
+    raw.trim_end_matches('/').to_string()
+}
+
+fn is_filesystem_path(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    s.starts_with('/')
+        || s.starts_with('~')
+        || s.starts_with("\\\\")
+        || (bytes.len() >= 3
+            && bytes[0].is_ascii_alphabetic()
+            && bytes[1] == b':'
+            && (bytes[2] == b'\\' || bytes[2] == b'/'))
+}
+
+fn last_path_component(s: &str) -> String {
+    s.replace('\\', "/")
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .unwrap_or("")
+        .to_string()
+}
+
+/// `git@host:owner/repo.git` / `https://host/owner/repo.git` → `owner/repo`.
+fn slug_from_git_remote(raw: &str) -> Option<String> {
+    let s = raw.trim();
+    let path = if let Some(rest) = s.strip_prefix("git@") {
+        rest.split_once(':')?.1.to_string()
+    } else if s.contains("://") {
+        let after_scheme = s.split_once("://")?.1;
+        let host_and_path = after_scheme
+            .rsplit_once('@')
+            .map(|(_, host)| host)
+            .unwrap_or(after_scheme);
+        let (_, path) = host_and_path.split_once('/')?;
+        path.to_string()
+    } else if s.contains('@') && s.contains(':') && !s.contains("://") {
+        s.split_once(':')?.1.to_string()
+    } else {
+        return None;
+    };
+    let mut path = path;
+    if let Some(cut) = path.find(['?', '#']) {
+        path.truncate(cut);
+    }
+    let path = path.trim_start_matches('/').trim_end_matches('/');
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    if path.is_empty() {
+        None
+    } else {
+        Some(path.to_string())
+    }
 }
 
 /// Canonical retrospective `kind`s (ratified WS-1 ADR). The eventId prefix equals the
@@ -128,8 +239,18 @@ const KIND_FINDING: &str = "finding";
 /// Map a `HistoryEntry` prompt row into a `prompt` convergence event.
 ///
 /// eventId is deterministic from `(timestamp_ms, prompt_hash)` so re-syncs are idempotent
-/// even when the row carries no session id.
+/// even when the row carries no session id. `projectId` is always a slug (or
+/// [`UNKNOWN_PROJECT`]), never `None`.
 pub fn map_history_entry(entry: &HistoryEntry) -> ConvergenceEnvelope {
+    map_history_entry_with(entry, None, Vec::new())
+}
+
+/// Like [`map_history_entry`], with a git-remote fallback and `filesTouched`.
+pub fn map_history_entry_with(
+    entry: &HistoryEntry,
+    git_remote: Option<&str>,
+    files_touched: Vec<String>,
+) -> ConvergenceEnvelope {
     let session_id = entry
         .session_id
         .clone()
@@ -152,12 +273,118 @@ pub fn map_history_entry(entry: &HistoryEntry) -> ConvergenceEnvelope {
         confidence: None,
         tags: Vec::new(),
         actor_name: None,
-        project_id: None,
+        project_id: Some(resolve_project_id(entry.project.as_deref(), git_remote)),
         task_title: None,
         task_description: None,
         task_status: None,
         task_ref: None,
         record: None,
+        files_touched: normalize_files_touched(files_touched),
+        commit_sha: None,
+        repo: None,
+        branch: None,
+        match_method: None,
+        numstat: None,
+        files: None,
+        shipped_at: None,
+    }
+}
+
+/// A `session_commit_links` row, mapped to a `kind=session_outcome` envelope.
+pub struct SessionCommitLink<'a> {
+    pub source: &'a str,
+    pub session_id: &'a str,
+    pub repo: Option<&'a str>,
+    pub branch: Option<&'a str>,
+    pub commit_sha: &'a str,
+    pub match_method: &'a str,
+    pub confidence: f64,
+    pub files_json: Option<&'a str>,
+    pub numstat_json: Option<&'a str>,
+    pub created_at_ms: i64,
+}
+
+/// One envelope per linked commit. Shape matches cloud `OutcomeEnvelope`
+/// (`commitSha`, `matchMethod`, `numstat`, `files`) plus WS-1 `projectId` /
+/// `filesTouched`.
+pub fn map_session_outcome(
+    link: &SessionCommitLink<'_>,
+    project_id: &str,
+    files_touched: Vec<String>,
+) -> ConvergenceEnvelope {
+    let sha = link.commit_sha.trim();
+    let method = link.match_method.trim();
+    ConvergenceEnvelope {
+        v: 1,
+        kind: "session_outcome".to_string(),
+        source: link.source.to_string(),
+        lens: Some("history".to_string()),
+        session_id: link.session_id.to_string(),
+        event_id: format!("session_outcome:{}:{sha}", link.session_id),
+        ts: epoch_ms_to_iso(link.created_at_ms),
+        event_type: "session_outcome".to_string(),
+        content: format!("session linked to commit {sha} via {method}"),
+        significance: None,
+        confidence: Some(link.confidence),
+        tags: Vec::new(),
+        actor_name: None,
+        project_id: Some(resolve_project_id(Some(project_id), None)),
+        task_title: None,
+        task_description: None,
+        task_status: None,
+        task_ref: None,
+        record: None,
+        files_touched: normalize_files_touched(files_touched),
+        commit_sha: Some(sha.to_string()),
+        repo: nonempty(link.repo).map(normalize_home_path),
+        branch: nonempty(link.branch).map(str::to_string),
+        match_method: Some(method.to_string()),
+        numstat: wrap_numstat(link.numstat_json),
+        files: parse_files_json(link.files_json),
+        shipped_at: Some(epoch_ms_to_iso(link.created_at_ms)),
+    }
+}
+
+fn normalize_files_touched(files: Vec<String>) -> Vec<String> {
+    let mut out = Vec::new();
+    for file in files {
+        let normalized = normalize_home_path(file.trim());
+        if !normalized.is_empty() && !out.iter().any(|existing| existing == &normalized) {
+            out.push(normalized);
+        }
+    }
+    out
+}
+
+fn wrap_numstat(raw: Option<&str>) -> Option<Value> {
+    let parsed: Value = serde_json::from_str(nonempty(raw)?).ok()?;
+    match parsed {
+        Value::Array(_) => Some(json!({ "files": parsed })),
+        Value::Object(_) => Some(parsed),
+        _ => None,
+    }
+}
+
+fn parse_files_json(raw: Option<&str>) -> Option<Value> {
+    let parsed: Value = serde_json::from_str(nonempty(raw)?).ok()?;
+    match parsed {
+        Value::Array(items) => Some(Value::Array(
+            items.into_iter().map(normalize_file_value).collect(),
+        )),
+        _ => None,
+    }
+}
+
+fn normalize_file_value(value: Value) -> Value {
+    match value {
+        Value::String(path) => Value::String(normalize_home_path(&path)),
+        Value::Object(mut map) => {
+            if let Some(Value::String(path)) = map.get("path").cloned() {
+                map.insert("path".into(), json!(normalize_home_path(&path)));
+            }
+            Value::Object(map)
+        }
+        other => other,
     }
 }
 
@@ -226,7 +453,7 @@ pub fn map_trajectory(row: &TrajectoryRow<'_>) -> Vec<ConvergenceEnvelope> {
     let task_title = owned(row.task_title);
     let task_description = owned(row.task_description);
     let task_status = owned(row.status);
-    let project_id = owned(row.project_id);
+    let project_id = Some(resolve_project_id(row.project_id, None));
     // taskRef: bounded cross-lens correlation seed (None until ai-hist persists task.source).
     let task_ref_json = row
         .task_ref
@@ -277,6 +504,14 @@ pub fn map_trajectory(row: &TrajectoryRow<'_>) -> Vec<ConvergenceEnvelope> {
                 task_status: task_status.clone(),
                 task_ref: task_ref_json.clone(),
                 record: decision_record(d), // chosen/alternatives only
+                files_touched: Vec::new(),
+                commit_sha: None,
+                repo: None,
+                branch: None,
+                match_method: None,
+                numstat: None,
+                files: None,
+                shipped_at: None,
             });
         }
     }
@@ -311,6 +546,14 @@ pub fn map_trajectory(row: &TrajectoryRow<'_>) -> Vec<ConvergenceEnvelope> {
                     task_status: task_status.clone(),
                     task_ref: task_ref_json.clone(),
                     record: None,
+                    files_touched: Vec::new(),
+                    commit_sha: None,
+                    repo: None,
+                    branch: None,
+                    match_method: None,
+                    numstat: None,
+                    files: None,
+                    shipped_at: None,
                 });
             };
 
@@ -417,6 +660,14 @@ fn compacted_event(
         task_status: task_status.map(str::to_string),
         task_ref: task_ref.cloned(),
         record,
+        files_touched: Vec::new(),
+        commit_sha: None,
+        repo: None,
+        branch: None,
+        match_method: None,
+        numstat: None,
+        files: None,
+        shipped_at: None,
     })
 }
 
@@ -1173,6 +1424,102 @@ mod tests {
         assert_eq!(env.event_id, "prompt:1782036000000:abc123");
         assert_eq!(env.ts, "2026-06-21T10:00:00.000Z");
         assert_eq!(env.content, "fix the auth bug");
+        assert_eq!(env.project_id.as_deref(), Some("p"));
+        assert!(env.project_id.is_some());
+    }
+
+    #[test]
+    fn project_id_mapping_path_git_remote_and_unknown() {
+        // path project → last component, never a filesystem path on the wire
+        assert_eq!(
+            resolve_project_id(Some("/Users/khaliqgant/Projects/relayhistory"), None),
+            "relayhistory"
+        );
+        assert_eq!(
+            resolve_project_id(Some(r"C:\Users\alice\Projects\my-app"), None),
+            "my-app"
+        );
+        // git-remote project → owner/repo slug
+        assert_eq!(
+            resolve_project_id(None, Some("git@github.com:AgentWorkforce/relayhistory.git")),
+            "AgentWorkforce/relayhistory"
+        );
+        assert_eq!(
+            resolve_project_id(
+                None,
+                Some("https://github.com/AgentWorkforce/relayhistory.git")
+            ),
+            "AgentWorkforce/relayhistory"
+        );
+        // unknown → explicit "unknown", never NULL
+        assert_eq!(resolve_project_id(None, None), UNKNOWN_PROJECT);
+        assert_eq!(resolve_project_id(Some("  "), Some("")), UNKNOWN_PROJECT);
+        let unknown = map_history_entry(&HistoryEntry {
+            id: 1,
+            source: "claude".into(),
+            session_id: Some("s".into()),
+            project: None,
+            prompt: "hi".into(),
+            prompt_hash: Some("h".into()),
+            timestamp_ms: 0,
+        });
+        assert_eq!(unknown.kind, "prompt");
+        assert_eq!(unknown.project_id.as_deref(), Some(UNKNOWN_PROJECT));
+        let v = serde_json::to_value(&unknown).unwrap();
+        assert_eq!(v["projectId"], UNKNOWN_PROJECT);
+        assert!(!v["projectId"].is_null());
+        // history.project wins over git remote
+        assert_eq!(
+            resolve_project_id(
+                Some("/tmp/other-app"),
+                Some("git@github.com:AgentWorkforce/relayhistory.git")
+            ),
+            "other-app"
+        );
+    }
+
+    #[test]
+    fn session_outcome_envelope_shape() {
+        let env = map_session_outcome(
+            &SessionCommitLink {
+                source: "claude",
+                session_id: "s1",
+                repo: Some("/Users/khaliqgant/Projects/relayhistory"),
+                branch: Some("feat/x"),
+                commit_sha: "abc123def",
+                match_method: "cwd+branch",
+                confidence: 0.91,
+                files_json: Some(r#"["src/lib.rs","src/main.rs"]"#),
+                numstat_json: Some(r#"[{"path":"src/lib.rs","additions":3,"deletions":1}]"#),
+                created_at_ms: 1_782_036_000_000,
+            },
+            "relayhistory",
+            vec!["/Users/khaliqgant/Projects/relayhistory/src/lib.rs".into()],
+        );
+        assert_eq!(env.kind, "session_outcome");
+        assert_eq!(env.source, "claude");
+        assert_eq!(env.session_id, "s1");
+        assert_eq!(env.event_id, "session_outcome:s1:abc123def");
+        assert_eq!(env.project_id.as_deref(), Some("relayhistory"));
+        assert_eq!(env.commit_sha.as_deref(), Some("abc123def"));
+        assert_eq!(env.match_method.as_deref(), Some("cwd+branch"));
+        assert_eq!(env.confidence, Some(0.91));
+        assert_eq!(
+            env.files_touched,
+            vec!["/Users/~/Projects/relayhistory/src/lib.rs"]
+        );
+        let v = serde_json::to_value(&env).unwrap();
+        assert_eq!(v["kind"], "session_outcome");
+        assert_eq!(v["commitSha"], "abc123def");
+        assert_eq!(v["matchMethod"], "cwd+branch");
+        assert_eq!(v["projectId"], "relayhistory");
+        assert_eq!(
+            v["filesTouched"][0],
+            "/Users/~/Projects/relayhistory/src/lib.rs"
+        );
+        assert_eq!(v["files"][0], "src/lib.rs");
+        assert_eq!(v["numstat"]["files"][0]["path"], "src/lib.rs");
+        assert_eq!(v["repo"], "/Users/~/Projects/relayhistory");
     }
 
     #[test]
@@ -1230,5 +1577,7 @@ mod tests {
         // confidence emitted as null (not skipped)
         assert!(v.get("confidence").is_some());
         assert!(v["confidence"].is_null());
+        // projectId is always present (never NULL)
+        assert_eq!(v["projectId"], UNKNOWN_PROJECT);
     }
 }

--- a/crates/ai-hist-core/src/convergence.rs
+++ b/crates/ai-hist-core/src/convergence.rs
@@ -169,7 +169,7 @@ fn normalize_project_id(raw: &str) -> String {
     }
     if is_filesystem_path(raw) {
         let slug = last_path_component(raw);
-        return if slug.is_empty() {
+        return if slug.is_empty() || slug == "." || slug == ".." {
             UNKNOWN_PROJECT.to_string()
         } else {
             slug
@@ -182,6 +182,12 @@ fn is_filesystem_path(s: &str) -> bool {
     let bytes = s.as_bytes();
     s.starts_with('/')
         || s.starts_with('~')
+        || s == "."
+        || s == ".."
+        || s.starts_with("./")
+        || s.starts_with("../")
+        || s.starts_with(".\\")
+        || s.starts_with("..\\")
         || s.starts_with("\\\\")
         || (bytes.len() >= 3
             && bytes[0].is_ascii_alphabetic()
@@ -1439,6 +1445,16 @@ mod tests {
             resolve_project_id(Some(r"C:\Users\alice\Projects\my-app"), None),
             "my-app"
         );
+        // relative path forms → last component, never a path on the wire
+        assert_eq!(resolve_project_id(Some("./repo"), None), "repo");
+        assert_eq!(
+            resolve_project_id(Some("../relayhistory"), None),
+            "relayhistory"
+        );
+        assert_eq!(resolve_project_id(Some("./foo/bar"), None), "bar");
+        assert_eq!(resolve_project_id(Some(r".\repo"), None), "repo");
+        assert_eq!(resolve_project_id(Some("."), None), UNKNOWN_PROJECT);
+        assert_eq!(resolve_project_id(Some(".."), None), UNKNOWN_PROJECT);
         // git-remote project → owner/repo slug
         assert_eq!(
             resolve_project_id(None, Some("git@github.com:AgentWorkforce/relayhistory.git")),

--- a/crates/ai-hist-core/src/convergence.rs
+++ b/crates/ai-hist-core/src/convergence.rs
@@ -307,6 +307,7 @@ pub struct SessionCommitLink<'a> {
     pub confidence: f64,
     pub files_json: Option<&'a str>,
     pub numstat_json: Option<&'a str>,
+    pub evidence_json: Option<&'a str>,
     pub created_at_ms: i64,
 }
 
@@ -320,13 +321,18 @@ pub fn map_session_outcome(
 ) -> ConvergenceEnvelope {
     let sha = link.commit_sha.trim();
     let method = link.match_method.trim();
+    let source = link.source.trim();
+    let shipped_ms = commit_time_ms(link.evidence_json).unwrap_or(link.created_at_ms);
     ConvergenceEnvelope {
         v: 1,
         kind: "session_outcome".to_string(),
-        source: link.source.to_string(),
+        source: source.to_string(),
         lens: Some("history".to_string()),
         session_id: link.session_id.to_string(),
-        event_id: format!("session_outcome:{}:{sha}", link.session_id),
+        event_id: format!(
+            "session_outcome:{source}:{}:{sha}:{method}",
+            link.session_id
+        ),
         ts: epoch_ms_to_iso(link.created_at_ms),
         event_type: "session_outcome".to_string(),
         content: format!("session linked to commit {sha} via {method}"),
@@ -347,8 +353,17 @@ pub fn map_session_outcome(
         match_method: Some(method.to_string()),
         numstat: wrap_numstat(link.numstat_json),
         files: parse_files_json(link.files_json),
-        shipped_at: Some(epoch_ms_to_iso(link.created_at_ms)),
+        shipped_at: Some(epoch_ms_to_iso(shipped_ms)),
     }
+}
+
+/// Commit time from `session_commit_links.evidence_json`, when the hook stored it.
+fn commit_time_ms(evidence_json: Option<&str>) -> Option<i64> {
+    let parsed: Value = serde_json::from_str(nonempty(evidence_json)?).ok()?;
+    parsed
+        .get("commit_time_ms")
+        .and_then(Value::as_i64)
+        .filter(|ms| *ms > 0)
 }
 
 fn normalize_files_touched(files: Vec<String>) -> Vec<String> {
@@ -1507,6 +1522,7 @@ mod tests {
                 confidence: 0.91,
                 files_json: Some(r#"["src/lib.rs","src/main.rs"]"#),
                 numstat_json: Some(r#"[{"path":"src/lib.rs","additions":3,"deletions":1}]"#),
+                evidence_json: None,
                 created_at_ms: 1_782_036_000_000,
             },
             "relayhistory",
@@ -1515,7 +1531,10 @@ mod tests {
         assert_eq!(env.kind, "session_outcome");
         assert_eq!(env.source, "claude");
         assert_eq!(env.session_id, "s1");
-        assert_eq!(env.event_id, "session_outcome:s1:abc123def");
+        assert_eq!(
+            env.event_id,
+            "session_outcome:claude:s1:abc123def:cwd+branch"
+        );
         assert_eq!(env.project_id.as_deref(), Some("relayhistory"));
         assert_eq!(env.commit_sha.as_deref(), Some("abc123def"));
         assert_eq!(env.match_method.as_deref(), Some("cwd+branch"));
@@ -1536,6 +1555,74 @@ mod tests {
         assert_eq!(v["files"][0], "src/lib.rs");
         assert_eq!(v["numstat"]["files"][0]["path"], "src/lib.rs");
         assert_eq!(v["repo"], "/Users/~/Projects/relayhistory");
+        assert_eq!(v["shippedAt"], "2026-06-21T10:00:00.000Z");
+    }
+
+    #[test]
+    fn session_outcome_shipped_at_uses_commit_time_not_link_time() {
+        let env = map_session_outcome(
+            &SessionCommitLink {
+                source: "claude",
+                session_id: "s1",
+                repo: Some("/tmp/repo"),
+                branch: Some("main"),
+                commit_sha: "abc123def",
+                match_method: "cwd",
+                confidence: 0.9,
+                files_json: None,
+                numstat_json: None,
+                evidence_json: Some(r#"{"commit_time_ms":1000}"#),
+                created_at_ms: 1_782_036_000_000,
+            },
+            "repo",
+            Vec::new(),
+        );
+        assert_eq!(env.shipped_at.as_deref(), Some("1970-01-01T00:00:01.000Z"));
+        assert_eq!(env.ts, "2026-06-21T10:00:00.000Z");
+        let v = serde_json::to_value(&env).unwrap();
+        assert_eq!(v["shippedAt"], "1970-01-01T00:00:01.000Z");
+        assert_ne!(v["shippedAt"], v["ts"]);
+    }
+
+    #[test]
+    fn session_outcome_event_id_includes_source_and_match_method() {
+        let a = map_session_outcome(
+            &SessionCommitLink {
+                source: "claude",
+                session_id: "s1",
+                repo: None,
+                branch: None,
+                commit_sha: "abc123def",
+                match_method: "cwd",
+                confidence: 0.5,
+                files_json: None,
+                numstat_json: None,
+                evidence_json: None,
+                created_at_ms: 1,
+            },
+            "repo",
+            Vec::new(),
+        );
+        let b = map_session_outcome(
+            &SessionCommitLink {
+                source: "claude",
+                session_id: "s1",
+                repo: None,
+                branch: None,
+                commit_sha: "abc123def",
+                match_method: "cwd+branch",
+                confidence: 0.9,
+                files_json: None,
+                numstat_json: None,
+                evidence_json: None,
+                created_at_ms: 2,
+            },
+            "repo",
+            Vec::new(),
+        );
+        assert_eq!(a.event_id, "session_outcome:claude:s1:abc123def:cwd");
+        assert_eq!(b.event_id, "session_outcome:claude:s1:abc123def:cwd+branch");
+        assert_ne!(a.event_id, b.event_id);
     }
 
     #[test]

--- a/crates/ai-hist-core/src/outbox.rs
+++ b/crates/ai-hist-core/src/outbox.rs
@@ -15,7 +15,10 @@ use crate::convergence::{
     map_history_entry_with, map_session_outcome, map_trajectory, normalize_home_path,
     resolve_project_id, ConvergenceEnvelope, SessionCommitLink, TrajectoryRow, UNKNOWN_PROJECT,
 };
-use crate::HistoryEntry;
+use crate::{
+    session_file_edits, session_file_edits_page, HistoryEntry, SessionEvidenceCursor,
+    SessionFileEdit,
+};
 use anyhow::Result;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
@@ -40,6 +43,19 @@ pub struct SyncCursor {
     /// Highest `session_commit_links.id` included in a synced batch.
     #[serde(default)]
     pub commit_link_id: i64,
+}
+
+impl SyncCursor {
+    /// Advance each watermark independently so a stale writer cannot rewind one
+    /// by publishing an older value of another.
+    pub fn merge_max(&self, other: &Self) -> Self {
+        Self {
+            history_id: self.history_id.max(other.history_id),
+            trajectory_rowid: self.trajectory_rowid.max(other.trajectory_rowid),
+            trajectory_updated_ms: self.trajectory_updated_ms.max(other.trajectory_updated_ms),
+            commit_link_id: self.commit_link_id.max(other.commit_link_id),
+        }
+    }
 }
 
 /// The next outbox batch: the envelopes to POST and the cursor they advance to.
@@ -371,30 +387,39 @@ fn session_files(
     if let Some(hit) = cache.get(&key) {
         return Ok(hit.clone());
     }
-    let files = if let Some(source) = source {
-        let mut stmt = conn.prepare(
-            "SELECT file_path FROM file_edits WHERE source = ?1 AND session_id = ?2 ORDER BY id ASC",
-        )?;
-        let rows: rusqlite::Result<Vec<String>> = stmt
-            .query_map(rusqlite::params![source, session_id], |r| r.get(0))?
-            .collect();
-        rows?
-    } else {
-        let mut stmt =
-            conn.prepare("SELECT file_path FROM file_edits WHERE session_id = ?1 ORDER BY id ASC")?;
-        let rows: rusqlite::Result<Vec<String>> =
-            stmt.query_map([session_id], |r| r.get(0))?.collect();
-        rows?
+    let edits = match source {
+        Some(source) => collect_session_file_edits(conn, source, session_id)?,
+        None => session_file_edits(conn, session_id, None)?,
     };
     let mut deduped = Vec::new();
-    for file in files {
-        let trimmed = file.trim();
+    for edit in edits {
+        let trimmed = edit.file_path.trim();
         if !trimmed.is_empty() && !deduped.iter().any(|existing| existing == trimmed) {
             deduped.push(trimmed.to_string());
         }
     }
     cache.insert(key, deduped.clone());
     Ok(deduped)
+}
+
+/// Page through [`session_file_edits_page`] until the session is exhausted.
+fn collect_session_file_edits(
+    conn: &Connection,
+    source: &str,
+    session_id: &str,
+) -> Result<Vec<SessionFileEdit>> {
+    let mut all = Vec::new();
+    let mut after: Option<SessionEvidenceCursor> = None;
+    loop {
+        let page = session_file_edits_page(conn, source, session_id, 1_000, after.as_ref())?;
+        let next = page.next_cursor;
+        all.extend(page.file_edits);
+        match next {
+            Some(cursor) => after = Some(cursor),
+            None => break,
+        }
+    }
+    Ok(all)
 }
 
 fn trajectory_files(

--- a/crates/ai-hist-core/src/outbox.rs
+++ b/crates/ai-hist-core/src/outbox.rs
@@ -197,7 +197,7 @@ pub fn build_outbox_batch(
     {
         let mut stmt = conn.prepare(
             "SELECT id, source, session_id, repo, branch, commit_sha, match_method, confidence, \
-             files_json, numstat_json, created_at_ms \
+             files_json, numstat_json, evidence_json, created_at_ms \
              FROM session_commit_links WHERE id > ?1 ORDER BY id ASC LIMIT ?2",
         )?;
         let rows = stmt.query_map([cursor.commit_link_id, limit], |r| {
@@ -212,7 +212,8 @@ pub fn build_outbox_batch(
                 confidence: r.get(7)?,
                 files_json: r.get(8)?,
                 numstat_json: r.get(9)?,
-                created_at_ms: r.get(10)?,
+                evidence_json: r.get(10)?,
+                created_at_ms: r.get(11)?,
             })
         })?;
         for row in rows {
@@ -243,6 +244,7 @@ pub fn build_outbox_batch(
                     confidence: link.confidence,
                     files_json: link.files_json.as_deref(),
                     numstat_json: link.numstat_json.as_deref(),
+                    evidence_json: link.evidence_json.as_deref(),
                     created_at_ms: link.created_at_ms,
                 },
                 &project_id,
@@ -284,6 +286,7 @@ struct CommitLinkOwned {
     confidence: f64,
     files_json: Option<String>,
     numstat_json: Option<String>,
+    evidence_json: Option<String>,
     created_at_ms: i64,
 }
 
@@ -531,18 +534,29 @@ mod tests {
     }
 
     fn add_commit_link(conn: &Connection, session: &str, sha: &str, method: &str) {
+        add_commit_link_evidence(conn, session, sha, method, None);
+    }
+
+    fn add_commit_link_evidence(
+        conn: &Connection,
+        session: &str,
+        sha: &str,
+        method: &str,
+        evidence_json: Option<&str>,
+    ) {
         conn.execute(
             "INSERT INTO session_commit_links \
              (source, session_id, repo, branch, commit_sha, match_method, confidence, \
-              files_json, numstat_json, created_at_ms) \
+              files_json, numstat_json, evidence_json, created_at_ms) \
              VALUES ('claude', ?, '/Users/khaliqgant/Projects/relayhistory', 'main', ?, ?, 0.9, \
-                     ?, ?, 1_782_036_000_000)",
+                     ?, ?, ?, 1_782_036_000_000)",
             rusqlite::params![
                 session,
                 sha,
                 method,
                 r#"["src/lib.rs"]"#,
                 r#"[{"path":"src/lib.rs","additions":2,"deletions":0}]"#,
+                evidence_json,
             ],
         )
         .unwrap();
@@ -874,5 +888,65 @@ mod tests {
 
         let empty = build_outbox_batch(&conn, &batch.cursor, 100, &none).unwrap();
         assert!(!empty.records.iter().any(|r| r.kind == "session_outcome"));
+    }
+
+    #[test]
+    fn session_outcome_shipped_at_comes_from_evidence_commit_time() {
+        let conn = mem();
+        add_history_project(
+            &conn,
+            "s-ship",
+            Some("/Users/me/Projects/relayhistory"),
+            "land it",
+            1,
+        );
+        add_commit_link_evidence(
+            &conn,
+            "s-ship",
+            "deadbeef",
+            "cwd",
+            Some(r#"{"commit_time_ms":1000}"#),
+        );
+        let none = HashSet::new();
+        let batch = build_outbox_batch(&conn, &SyncCursor::default(), 100, &none).unwrap();
+        let outcome = batch
+            .records
+            .iter()
+            .find(|r| r.kind == "session_outcome")
+            .unwrap();
+        assert_eq!(
+            outcome.shipped_at.as_deref(),
+            Some("1970-01-01T00:00:01.000Z")
+        );
+        assert_eq!(outcome.ts, "2026-06-21T10:00:00.000Z");
+    }
+
+    #[test]
+    fn session_outcome_event_ids_differ_when_match_method_differs() {
+        let conn = mem();
+        add_history_project(
+            &conn,
+            "s-dup",
+            Some("/Users/me/Projects/relayhistory"),
+            "same commit two ways",
+            1,
+        );
+        add_commit_link(&conn, "s-dup", "abc123def", "cwd");
+        add_commit_link(&conn, "s-dup", "abc123def", "cwd+branch");
+        let none = HashSet::new();
+        let batch = build_outbox_batch(&conn, &SyncCursor::default(), 100, &none).unwrap();
+        let ids: Vec<_> = batch
+            .records
+            .iter()
+            .filter(|r| r.kind == "session_outcome")
+            .map(|r| r.event_id.as_str())
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "session_outcome:claude:s-dup:abc123def:cwd",
+                "session_outcome:claude:s-dup:abc123def:cwd+branch",
+            ]
+        );
     }
 }

--- a/crates/ai-hist-core/src/outbox.rs
+++ b/crates/ai-hist-core/src/outbox.rs
@@ -7,9 +7,9 @@
 //! does sync rusqlite reads, so it is fully unit-testable without a server.
 //!
 //! Cursor model (mirrors burn's `archive_state` watermark): monotonic `history.id`,
-//! `trajectories.rowid` plus a `trajectories.updated_ms` watermark so rows revised after
-//! first sync re-push (the server upsert is already safe), and `session_commit_links.id`
-//! for `session_outcome` envelopes.
+//! a trajectories keyset `(updated_ms, rowid)` so rows revised after first sync re-push
+//! without skipping equal-timestamp boundaries (the server upsert is already safe),
+//! and `session_commit_links.id` for `session_outcome` envelopes.
 
 use crate::convergence::{
     map_history_entry_with, map_session_outcome, map_trajectory, normalize_home_path,
@@ -33,11 +33,11 @@ pub struct SyncCursor {
     /// Highest `history.id` included in a synced batch.
     #[serde(default)]
     pub history_id: i64,
-    /// Highest `trajectories.rowid` included in a synced batch.
+    /// `trajectories.rowid` of the last row emitted in keyset order.
     #[serde(default)]
     pub trajectory_rowid: i64,
-    /// Highest `trajectories.updated_ms` included in a synced batch. Catches rows that
-    /// were revised after their rowid first crossed the cursor.
+    /// `trajectories.updated_ms` of the last row emitted in keyset order. Together
+    /// with `trajectory_rowid` this is a total continuation key, not an independent max.
     #[serde(default)]
     pub trajectory_updated_ms: i64,
     /// Highest `session_commit_links.id` included in a synced batch.
@@ -46,15 +46,28 @@ pub struct SyncCursor {
 }
 
 impl SyncCursor {
-    /// Advance each watermark independently so a stale writer cannot rewind one
-    /// by publishing an older value of another.
+    /// Advance watermarks so a stale writer cannot rewind one. History and
+    /// commit-link ids are independent maxima. Trajectories use a single keyset
+    /// position `(updated_ms, rowid)` — taking those two fields independently
+    /// skips equal-timestamp rows when `LIMIT` splits a batch.
     pub fn merge_max(&self, other: &Self) -> Self {
+        let (trajectory_updated_ms, trajectory_rowid) = if other.trajectory_key_after(self) {
+            (other.trajectory_updated_ms, other.trajectory_rowid)
+        } else {
+            (self.trajectory_updated_ms, self.trajectory_rowid)
+        };
         Self {
             history_id: self.history_id.max(other.history_id),
-            trajectory_rowid: self.trajectory_rowid.max(other.trajectory_rowid),
-            trajectory_updated_ms: self.trajectory_updated_ms.max(other.trajectory_updated_ms),
+            trajectory_rowid,
+            trajectory_updated_ms,
             commit_link_id: self.commit_link_id.max(other.commit_link_id),
         }
+    }
+
+    fn trajectory_key_after(&self, other: &Self) -> bool {
+        self.trajectory_updated_ms > other.trajectory_updated_ms
+            || (self.trajectory_updated_ms == other.trajectory_updated_ms
+                && self.trajectory_rowid > other.trajectory_rowid)
     }
 }
 
@@ -129,18 +142,17 @@ pub fn build_outbox_batch(
         }
     }
 
-    // --- trajectories (decisions/retro) — rowid + updated_ms watermarks ---
-    let updated_watermark = trajectory_updated_watermark(conn, cursor)?;
-    next.trajectory_updated_ms = next.trajectory_updated_ms.max(updated_watermark);
+    // --- trajectories (decisions/retro) — keyset on (updated_ms, rowid) ---
     {
         let mut stmt = conn.prepare(
             "SELECT rowid, id, persona_id, project_id, task_title, task_description, status, \
              decisions_json, retrospective_json, timestamp_ms, updated_ms, path \
-             FROM trajectories WHERE rowid > ?1 OR updated_ms > ?2 \
+             FROM trajectories \
+             WHERE updated_ms > ?1 OR (updated_ms = ?1 AND rowid > ?2) \
              ORDER BY updated_ms ASC, rowid ASC LIMIT ?3",
         )?;
         let raw = stmt.query_map(
-            rusqlite::params![cursor.trajectory_rowid, updated_watermark, limit],
+            rusqlite::params![cursor.trajectory_updated_ms, cursor.trajectory_rowid, limit],
             |r| {
                 Ok(TrajRowOwned {
                     rowid: r.get(0)?,
@@ -161,8 +173,8 @@ pub fn build_outbox_batch(
         for row in raw {
             let t = row?;
             if incognito.contains(&t.id) {
-                next.trajectory_rowid = next.trajectory_rowid.max(t.rowid);
-                next.trajectory_updated_ms = next.trajectory_updated_ms.max(t.updated_ms);
+                next.trajectory_rowid = t.rowid;
+                next.trajectory_updated_ms = t.updated_ms;
                 continue;
             }
             let mut mapped = map_trajectory(&TrajectoryRow {
@@ -187,8 +199,8 @@ pub fn build_outbox_batch(
             for env in &mut mapped {
                 env.files_touched = files.clone();
             }
-            next.trajectory_rowid = next.trajectory_rowid.max(t.rowid);
-            next.trajectory_updated_ms = next.trajectory_updated_ms.max(t.updated_ms);
+            next.trajectory_rowid = t.rowid;
+            next.trajectory_updated_ms = t.updated_ms;
             records.extend(mapped);
         }
     }
@@ -288,19 +300,6 @@ struct CommitLinkOwned {
     numstat_json: Option<String>,
     evidence_json: Option<String>,
     created_at_ms: i64,
-}
-
-/// Old cursors (pre-watermark) have `trajectory_updated_ms = 0`. Seed from already-synced
-/// rows so the first push after upgrade does not replay every trajectory.
-fn trajectory_updated_watermark(conn: &Connection, cursor: &SyncCursor) -> Result<i64> {
-    if cursor.trajectory_updated_ms > 0 || cursor.trajectory_rowid <= 0 {
-        return Ok(cursor.trajectory_updated_ms);
-    }
-    Ok(conn.query_row(
-        "SELECT COALESCE(MAX(updated_ms), 0) FROM trajectories WHERE rowid <= ?1",
-        [cursor.trajectory_rowid],
-        |r| r.get(0),
-    )?)
 }
 
 fn git_remote_for_entry(
@@ -502,11 +501,24 @@ mod tests {
         updated_ms: i64,
         path: Option<&str>,
     ) {
+        add_trajectory_rowid(conn, None, id, decisions, retro, updated_ms, path);
+    }
+
+    fn add_trajectory_rowid(
+        conn: &Connection,
+        rowid: Option<i64>,
+        id: &str,
+        decisions: &str,
+        retro: &str,
+        updated_ms: i64,
+        path: Option<&str>,
+    ) {
         conn.execute(
-            "INSERT INTO trajectories (id, version, persona_id, project_id, task_title, \
+            "INSERT INTO trajectories (rowid, id, version, persona_id, project_id, task_title, \
              task_description, status, decisions_json, retrospective_json, search_text, path, \
-             updated_ms, timestamp_ms) VALUES (?,1,?,?,?,?,?,?,?,?,?,?,?)",
+             updated_ms, timestamp_ms) VALUES (?, ?,1,?,?,?,?,?,?,?,?,?,?,?)",
             rusqlite::params![
+                rowid,
                 id,
                 "planner",
                 "proj",
@@ -888,6 +900,103 @@ mod tests {
 
         let empty = build_outbox_batch(&conn, &batch.cursor, 100, &none).unwrap();
         assert!(!empty.records.iter().any(|r| r.kind == "session_outcome"));
+    }
+
+    #[test]
+    fn equal_timestamp_keyset_does_not_skip_rows() {
+        // Reviewer example: (rowid, updated_ms) = (3,1), (1,2), (2,2) with LIMIT 2.
+        // Independent max(rowid)/max(updated_ms) advances to (3, 2) and permanently
+        // drops (2, 2). Keyset continuation from the last emitted pair does not.
+        let conn = mem();
+        add_trajectory_rowid(
+            &conn,
+            Some(3),
+            "t3",
+            "[]",
+            r#"{"summary":"rowid-3"}"#,
+            1,
+            None,
+        );
+        add_trajectory_rowid(
+            &conn,
+            Some(1),
+            "t1",
+            "[]",
+            r#"{"summary":"rowid-1"}"#,
+            2,
+            None,
+        );
+        add_trajectory_rowid(
+            &conn,
+            Some(2),
+            "t2",
+            "[]",
+            r#"{"summary":"rowid-2"}"#,
+            2,
+            None,
+        );
+        let none = HashSet::new();
+        let first = build_outbox_batch(&conn, &SyncCursor::default(), 2, &none).unwrap();
+        let first_ids: Vec<_> = first
+            .records
+            .iter()
+            .filter(|r| r.kind == "reflection")
+            .map(|r| r.session_id.as_str())
+            .collect();
+        assert_eq!(first_ids, vec!["t3", "t1"]);
+        assert_eq!(first.cursor.trajectory_updated_ms, 2);
+        assert_eq!(first.cursor.trajectory_rowid, 1);
+
+        let second = build_outbox_batch(&conn, &first.cursor, 2, &none).unwrap();
+        let second_ids: Vec<_> = second
+            .records
+            .iter()
+            .filter(|r| r.kind == "reflection")
+            .map(|r| r.session_id.as_str())
+            .collect();
+        assert_eq!(
+            second_ids,
+            vec!["t2"],
+            "equal-timestamp row after LIMIT split must appear in the next batch"
+        );
+        assert_eq!(second.cursor.trajectory_updated_ms, 2);
+        assert_eq!(second.cursor.trajectory_rowid, 2);
+    }
+
+    #[test]
+    fn legacy_zero_updated_ms_watermark_replays_amended_trajectory() {
+        // Old client pushed rowid 1 with no updated_ms field (deserializes as 0).
+        // The row was then amended. Seeding from MAX(updated_ms) would set the
+        // watermark to 50 and permanently exclude it; keep the stored 0.
+        let conn = mem();
+        add_trajectory_at(
+            &conn,
+            "traj-1",
+            "[]",
+            r#"{"summary":"amended after old push"}"#,
+            50,
+            None,
+        );
+        let old = SyncCursor {
+            history_id: 0,
+            trajectory_rowid: 1,
+            trajectory_updated_ms: 0,
+            commit_link_id: 0,
+        };
+        let none = HashSet::new();
+        let batch = build_outbox_batch(&conn, &old, 100, &none).unwrap();
+        assert!(
+            batch
+                .records
+                .iter()
+                .any(|r| r.content.contains("amended after old push")),
+            "amended trajectory must replay from a zero updated_ms watermark: {:?}",
+            batch
+                .records
+                .iter()
+                .map(|r| r.content.as_str())
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/ai-hist-core/src/outbox.rs
+++ b/crates/ai-hist-core/src/outbox.rs
@@ -9,7 +9,8 @@
 //! Cursor model (mirrors burn's `archive_state` watermark): monotonic `history.id`,
 //! a trajectories keyset `(updated_ms, rowid)` so rows revised after first sync re-push
 //! without skipping equal-timestamp boundaries (the server upsert is already safe),
-//! and `session_commit_links.id` for `session_outcome` envelopes.
+//! `session_commit_links.id` for `session_outcome` envelopes, and `file_edits.id` so a
+//! session whose edits grow after its last prompt envelope republishes `filesTouched`.
 
 use crate::convergence::{
     map_history_entry_with, map_session_outcome, map_trajectory, normalize_home_path,
@@ -43,6 +44,9 @@ pub struct SyncCursor {
     /// Highest `session_commit_links.id` included in a synced batch.
     #[serde(default)]
     pub commit_link_id: i64,
+    /// Highest `file_edits.id` whose session's `filesTouched` has been published.
+    #[serde(default)]
+    pub file_edit_id: i64,
     /// Mapper generation. Missing from pre-neighborhood-memory cursor files (serde
     /// default 0). Those rewind history/trajectory watermarks once so existing
     /// rows are re-upserted with `projectId` / `filesTouched`.
@@ -57,6 +61,7 @@ impl Default for SyncCursor {
             trajectory_rowid: 0,
             trajectory_updated_ms: 0,
             commit_link_id: 0,
+            file_edit_id: 0,
             capture_version: Self::CAPTURE_VERSION,
         }
     }
@@ -80,6 +85,7 @@ impl SyncCursor {
                 trajectory_rowid: other.trajectory_rowid,
                 trajectory_updated_ms: other.trajectory_updated_ms,
                 commit_link_id: self.commit_link_id.max(other.commit_link_id),
+                file_edit_id: other.file_edit_id,
             };
         }
         if self.capture_version > other.capture_version {
@@ -95,6 +101,7 @@ impl SyncCursor {
             trajectory_rowid,
             trajectory_updated_ms,
             commit_link_id: self.commit_link_id.max(other.commit_link_id),
+            file_edit_id: self.file_edit_id.max(other.file_edit_id),
             capture_version: self.capture_version,
         }
     }
@@ -109,6 +116,7 @@ impl SyncCursor {
             trajectory_rowid: 0,
             trajectory_updated_ms: 0,
             commit_link_id: self.commit_link_id,
+            file_edit_id: 0,
         }
     }
 
@@ -150,6 +158,7 @@ pub fn build_outbox_batch(
     let mut next = cursor.clone();
     let mut remotes: HashMap<String, Option<String>> = HashMap::new();
     let mut file_cache: HashMap<(String, String), Vec<String>> = HashMap::new();
+    let mut published_sessions: HashSet<(String, String)> = HashSet::new();
 
     // --- history (prompts) — append-only, watermark on id ---
     {
@@ -187,6 +196,9 @@ pub fn build_outbox_batch(
                 Some(sid) => session_files(conn, &mut file_cache, Some(&entry.source), sid)?,
                 None => Vec::new(),
             };
+            if let Some(sid) = &entry.session_id {
+                published_sessions.insert((entry.source.clone(), sid.clone()));
+            }
             records.push(map_history_entry_with(&entry, git_remote.as_deref(), files));
         }
     }
@@ -314,6 +326,49 @@ pub fn build_outbox_batch(
         }
     }
 
+    // --- file_edits that grew after the last prompt envelope for a session ---
+    {
+        struct FileEditWatermark {
+            source: String,
+            session_id: String,
+            max_id: i64,
+        }
+        let mut stmt = conn.prepare(
+            "SELECT source, session_id, MAX(id) AS max_id \
+             FROM file_edits WHERE id > ?1 \
+             GROUP BY source, session_id \
+             ORDER BY max_id ASC LIMIT ?2",
+        )?;
+        let rows = stmt.query_map([cursor.file_edit_id, limit], |r| {
+            Ok(FileEditWatermark {
+                source: r.get(0)?,
+                session_id: r.get(1)?,
+                max_id: r.get(2)?,
+            })
+        })?;
+        for row in rows {
+            let hit = row?;
+            if records.len() >= MAX_RECORDS {
+                break;
+            }
+            next.file_edit_id = next.file_edit_id.max(hit.max_id);
+            if incognito.contains(&hit.session_id) {
+                continue;
+            }
+            if published_sessions.contains(&(hit.source.clone(), hit.session_id.clone())) {
+                continue;
+            }
+            let Some(entry) = latest_history_for_session(conn, &hit.source, &hit.session_id)?
+            else {
+                continue;
+            };
+            let git_remote = git_remote_for_entry(conn, &entry, &mut remotes);
+            let files = session_files(conn, &mut file_cache, Some(&entry.source), &hit.session_id)?;
+            records.push(map_history_entry_with(&entry, git_remote.as_deref(), files));
+            published_sessions.insert((hit.source, hit.session_id));
+        }
+    }
+
     Ok(OutboxBatch {
         records,
         cursor: next,
@@ -349,6 +404,29 @@ struct CommitLinkOwned {
     numstat_json: Option<String>,
     evidence_json: Option<String>,
     created_at_ms: i64,
+}
+
+fn latest_history_for_session(
+    conn: &Connection,
+    source: &str,
+    session_id: &str,
+) -> Result<Option<HistoryEntry>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, source, session_id, project, prompt, prompt_hash, timestamp_ms \
+         FROM history WHERE source = ?1 AND session_id = ?2 ORDER BY id DESC LIMIT 1",
+    )?;
+    let mut rows = stmt.query_map(rusqlite::params![source, session_id], |r| {
+        Ok(HistoryEntry {
+            id: r.get(0)?,
+            source: r.get(1)?,
+            session_id: r.get(2)?,
+            project: r.get(3)?,
+            prompt: r.get(4)?,
+            prompt_hash: r.get(5)?,
+            timestamp_ms: r.get(6)?,
+        })
+    })?;
+    Ok(rows.next().transpose()?)
 }
 
 fn git_remote_for_entry(
@@ -737,6 +815,7 @@ mod tests {
             serde_json::from_str(r#"{"history_id":7,"trajectory_rowid":3}"#).unwrap();
         assert_eq!(old.trajectory_updated_ms, 0);
         assert_eq!(old.commit_link_id, 0);
+        assert_eq!(old.file_edit_id, 0);
         assert_eq!(old.capture_version, 0);
     }
 
@@ -1094,6 +1173,67 @@ mod tests {
                 .map(|r| r.content.as_str())
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn file_edits_after_last_prompt_republish_files_touched() {
+        let conn = mem();
+        add_history_project(
+            &conn,
+            "s-late",
+            Some("/Users/me/Projects/relayhistory"),
+            "start the session",
+            1,
+        );
+        let none = HashSet::new();
+        let first = build_outbox_batch(&conn, &SyncCursor::default(), 100, &none).unwrap();
+        let prompt = first.records.iter().find(|r| r.kind == "prompt").unwrap();
+        assert!(prompt.files_touched.is_empty());
+
+        add_file_edit(
+            &conn,
+            "s-late",
+            "/Users/me/Projects/relayhistory/src/outbox.rs",
+            "Edit",
+        );
+        let second = build_outbox_batch(&conn, &first.cursor, 100, &none).unwrap();
+        let replayed: Vec<_> = second
+            .records
+            .iter()
+            .filter(|r| r.kind == "prompt")
+            .collect();
+        assert_eq!(replayed.len(), 1);
+        assert_eq!(replayed[0].content, "start the session");
+        assert!(replayed[0]
+            .files_touched
+            .iter()
+            .any(|f| f.ends_with("src/outbox.rs")));
+        assert!(second.cursor.file_edit_id > first.cursor.file_edit_id);
+
+        let third = build_outbox_batch(&conn, &second.cursor, 100, &none).unwrap();
+        assert!(!third.records.iter().any(|r| r.kind == "prompt"));
+    }
+
+    #[test]
+    fn new_prompt_with_new_file_edits_does_not_double_emit() {
+        let conn = mem();
+        add_history(&conn, "s1", "first", 1);
+        let none = HashSet::new();
+        let first = build_outbox_batch(&conn, &SyncCursor::default(), 100, &none).unwrap();
+        add_file_edit(&conn, "s1", "src/a.rs", "Edit");
+        add_history(&conn, "s1", "second", 2);
+        let second = build_outbox_batch(&conn, &first.cursor, 100, &none).unwrap();
+        let prompts: Vec<_> = second
+            .records
+            .iter()
+            .filter(|r| r.kind == "prompt")
+            .collect();
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(prompts[0].content, "second");
+        assert!(prompts[0]
+            .files_touched
+            .iter()
+            .any(|f| f.ends_with("src/a.rs")));
     }
 
     #[test]

--- a/crates/ai-hist-core/src/outbox.rs
+++ b/crates/ai-hist-core/src/outbox.rs
@@ -28,7 +28,7 @@ use std::path::Path;
 /// Resume watermarks for incremental cloud sync (the local cursor store). Persisted by the
 /// binding layer (single cursor store) and advanced to the server-confirmed values after a
 /// successful `/v1/ingest`.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SyncCursor {
     /// Highest `history.id` included in a synced batch.
     #[serde(default)]
@@ -43,14 +43,48 @@ pub struct SyncCursor {
     /// Highest `session_commit_links.id` included in a synced batch.
     #[serde(default)]
     pub commit_link_id: i64,
+    /// Mapper generation. Missing from pre-neighborhood-memory cursor files (serde
+    /// default 0). Those rewind history/trajectory watermarks once so existing
+    /// rows are re-upserted with `projectId` / `filesTouched`.
+    #[serde(default)]
+    pub capture_version: i64,
+}
+
+impl Default for SyncCursor {
+    fn default() -> Self {
+        Self {
+            history_id: 0,
+            trajectory_rowid: 0,
+            trajectory_updated_ms: 0,
+            commit_link_id: 0,
+            capture_version: Self::CAPTURE_VERSION,
+        }
+    }
 }
 
 impl SyncCursor {
+    /// Neighborhood-memory capture mapper. Bump when an upgraded client must
+    /// re-upsert already-synced rows with newly populated fields.
+    pub const CAPTURE_VERSION: i64 = 1;
+
     /// Advance watermarks so a stale writer cannot rewind one. History and
     /// commit-link ids are independent maxima. Trajectories use a single keyset
     /// position `(updated_ms, rowid)` — taking those two fields independently
-    /// skips equal-timestamp rows when `LIMIT` splits a batch.
+    /// skips equal-timestamp rows when `LIMIT` splits a batch. A higher
+    /// `capture_version` may rewind history/trajectory positions to backfill.
     pub fn merge_max(&self, other: &Self) -> Self {
+        if other.capture_version > self.capture_version {
+            return Self {
+                capture_version: other.capture_version,
+                history_id: other.history_id,
+                trajectory_rowid: other.trajectory_rowid,
+                trajectory_updated_ms: other.trajectory_updated_ms,
+                commit_link_id: self.commit_link_id.max(other.commit_link_id),
+            };
+        }
+        if self.capture_version > other.capture_version {
+            return self.clone();
+        }
         let (trajectory_updated_ms, trajectory_rowid) = if other.trajectory_key_after(self) {
             (other.trajectory_updated_ms, other.trajectory_rowid)
         } else {
@@ -61,6 +95,20 @@ impl SyncCursor {
             trajectory_rowid,
             trajectory_updated_ms,
             commit_link_id: self.commit_link_id.max(other.commit_link_id),
+            capture_version: self.capture_version,
+        }
+    }
+
+    fn migrated(&self) -> Self {
+        if self.capture_version >= Self::CAPTURE_VERSION {
+            return self.clone();
+        }
+        Self {
+            capture_version: Self::CAPTURE_VERSION,
+            history_id: 0,
+            trajectory_rowid: 0,
+            trajectory_updated_ms: 0,
+            commit_link_id: self.commit_link_id,
         }
     }
 
@@ -97,6 +145,7 @@ pub fn build_outbox_batch(
     // reflections), so the batch must be bounded on EMITTED records, not rows scanned, or a
     // handful of roll-ups blows past the cap and the push 400s.
     const MAX_RECORDS: usize = 900;
+    let cursor = cursor.migrated();
     let mut records = Vec::new();
     let mut next = cursor.clone();
     let mut remotes: HashMap<String, Option<String>> = HashMap::new();
@@ -680,6 +729,7 @@ mod tests {
             trajectory_rowid: 3,
             trajectory_updated_ms: 99,
             commit_link_id: 4,
+            ..Default::default()
         };
         let s = serde_json::to_string(&c).unwrap();
         assert_eq!(serde_json::from_str::<SyncCursor>(&s).unwrap(), c);
@@ -687,6 +737,7 @@ mod tests {
             serde_json::from_str(r#"{"history_id":7,"trajectory_rowid":3}"#).unwrap();
         assert_eq!(old.trajectory_updated_ms, 0);
         assert_eq!(old.commit_link_id, 0);
+        assert_eq!(old.capture_version, 0);
     }
 
     #[test]
@@ -903,6 +954,53 @@ mod tests {
     }
 
     #[test]
+    fn upgraded_cursor_replays_previously_synced_prompts() {
+        let conn = mem();
+        add_history_project(
+            &conn,
+            "s-old",
+            Some("/Users/me/Projects/relayhistory"),
+            "already pushed without projectId",
+            1,
+        );
+        let old: SyncCursor =
+            serde_json::from_str(r#"{"history_id":1,"trajectory_rowid":0}"#).unwrap();
+        assert_eq!(old.capture_version, 0);
+        assert_eq!(old.history_id, 1);
+        let none = HashSet::new();
+        let batch = build_outbox_batch(&conn, &old, 100, &none).unwrap();
+        let prompt = batch
+            .records
+            .iter()
+            .find(|r| r.kind == "prompt")
+            .expect("historical prompt must be re-upserted once");
+        assert_eq!(prompt.content, "already pushed without projectId");
+        assert_eq!(prompt.project_id.as_deref(), Some("relayhistory"));
+        assert_eq!(batch.cursor.capture_version, SyncCursor::CAPTURE_VERSION);
+        assert_eq!(batch.cursor.history_id, 1);
+
+        let empty = build_outbox_batch(&conn, &batch.cursor, 100, &none).unwrap();
+        assert!(!empty.records.iter().any(|r| r.kind == "prompt"));
+    }
+
+    #[test]
+    fn capture_version_upgrade_rewinds_history_in_merge_max() {
+        let old = SyncCursor {
+            history_id: 99,
+            capture_version: 0,
+            ..Default::default()
+        };
+        let upgraded = old.migrated();
+        assert_eq!(upgraded.history_id, 0);
+        assert_eq!(upgraded.capture_version, SyncCursor::CAPTURE_VERSION);
+        let merged = old.merge_max(&upgraded);
+        assert_eq!(merged.history_id, 0);
+        assert_eq!(merged.capture_version, SyncCursor::CAPTURE_VERSION);
+        let stale = upgraded.merge_max(&old);
+        assert_eq!(stale, upgraded);
+    }
+
+    #[test]
     fn equal_timestamp_keyset_does_not_skip_rows() {
         // Reviewer example: (rowid, updated_ms) = (3,1), (1,2), (2,2) with LIMIT 2.
         // Independent max(rowid)/max(updated_ms) advances to (3, 2) and permanently
@@ -978,10 +1076,9 @@ mod tests {
             None,
         );
         let old = SyncCursor {
-            history_id: 0,
             trajectory_rowid: 1,
             trajectory_updated_ms: 0,
-            commit_link_id: 0,
+            ..Default::default()
         };
         let none = HashSet::new();
         let batch = build_outbox_batch(&conn, &old, 100, &none).unwrap();

--- a/crates/ai-hist-core/src/outbox.rs
+++ b/crates/ai-hist-core/src/outbox.rs
@@ -6,17 +6,21 @@
 //! binding layer (the `ai-hist` binary) per the no-async-in-core rule — this module only
 //! does sync rusqlite reads, so it is fully unit-testable without a server.
 //!
-//! Cursor model (mirrors burn's `archive_state` watermark): monotonic `history.id` and
-//! `trajectories.rowid`. NOTE (v1 limitation): trajectory rows that are *updated* after
-//! first sync are not re-pushed by rowid alone — the server upsert makes a re-push safe,
-//! but catching updates would need an `updated_ms` watermark (deferred).
+//! Cursor model (mirrors burn's `archive_state` watermark): monotonic `history.id`,
+//! `trajectories.rowid` plus a `trajectories.updated_ms` watermark so rows revised after
+//! first sync re-push (the server upsert is already safe), and `session_commit_links.id`
+//! for `session_outcome` envelopes.
 
-use crate::convergence::{map_history_entry, map_trajectory, ConvergenceEnvelope, TrajectoryRow};
+use crate::convergence::{
+    map_history_entry_with, map_session_outcome, map_trajectory, normalize_home_path,
+    resolve_project_id, ConvergenceEnvelope, SessionCommitLink, TrajectoryRow, UNKNOWN_PROJECT,
+};
 use crate::HistoryEntry;
 use anyhow::Result;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 /// Resume watermarks for incremental cloud sync (the local cursor store). Persisted by the
 /// binding layer (single cursor store) and advanced to the server-confirmed values after a
@@ -29,6 +33,13 @@ pub struct SyncCursor {
     /// Highest `trajectories.rowid` included in a synced batch.
     #[serde(default)]
     pub trajectory_rowid: i64,
+    /// Highest `trajectories.updated_ms` included in a synced batch. Catches rows that
+    /// were revised after their rowid first crossed the cursor.
+    #[serde(default)]
+    pub trajectory_updated_ms: i64,
+    /// Highest `session_commit_links.id` included in a synced batch.
+    #[serde(default)]
+    pub commit_link_id: i64,
 }
 
 /// The next outbox batch: the envelopes to POST and the cursor they advance to.
@@ -59,6 +70,8 @@ pub fn build_outbox_batch(
     const MAX_RECORDS: usize = 900;
     let mut records = Vec::new();
     let mut next = cursor.clone();
+    let mut remotes: HashMap<String, Option<String>> = HashMap::new();
+    let mut file_cache: HashMap<(String, String), Vec<String>> = HashMap::new();
 
     // --- history (prompts) — append-only, watermark on id ---
     {
@@ -91,38 +104,52 @@ pub fn build_outbox_batch(
                     continue;
                 }
             }
-            records.push(map_history_entry(&entry));
+            let git_remote = git_remote_for_entry(conn, &entry, &mut remotes);
+            let files = match &entry.session_id {
+                Some(sid) => session_files(conn, &mut file_cache, Some(&entry.source), sid)?,
+                None => Vec::new(),
+            };
+            records.push(map_history_entry_with(&entry, git_remote.as_deref(), files));
         }
     }
 
-    // --- trajectories (decisions/retro) — watermark on rowid ---
+    // --- trajectories (decisions/retro) — rowid + updated_ms watermarks ---
+    let updated_watermark = trajectory_updated_watermark(conn, cursor)?;
+    next.trajectory_updated_ms = next.trajectory_updated_ms.max(updated_watermark);
     {
         let mut stmt = conn.prepare(
             "SELECT rowid, id, persona_id, project_id, task_title, task_description, status, \
-             decisions_json, retrospective_json, timestamp_ms \
-             FROM trajectories WHERE rowid > ?1 ORDER BY rowid ASC LIMIT ?2",
+             decisions_json, retrospective_json, timestamp_ms, updated_ms, path \
+             FROM trajectories WHERE rowid > ?1 OR updated_ms > ?2 \
+             ORDER BY updated_ms ASC, rowid ASC LIMIT ?3",
         )?;
-        let raw = stmt.query_map([cursor.trajectory_rowid, limit], |r| {
-            Ok(TrajRowOwned {
-                rowid: r.get(0)?,
-                id: r.get(1)?,
-                persona_id: r.get(2)?,
-                project_id: r.get(3)?,
-                task_title: r.get(4)?,
-                task_description: r.get(5)?,
-                status: r.get(6)?,
-                decisions_json: r.get(7)?,
-                retrospective_json: r.get(8)?,
-                timestamp_ms: r.get(9)?,
-            })
-        })?;
+        let raw = stmt.query_map(
+            rusqlite::params![cursor.trajectory_rowid, updated_watermark, limit],
+            |r| {
+                Ok(TrajRowOwned {
+                    rowid: r.get(0)?,
+                    id: r.get(1)?,
+                    persona_id: r.get(2)?,
+                    project_id: r.get(3)?,
+                    task_title: r.get(4)?,
+                    task_description: r.get(5)?,
+                    status: r.get(6)?,
+                    decisions_json: r.get(7)?,
+                    retrospective_json: r.get(8)?,
+                    timestamp_ms: r.get(9)?,
+                    updated_ms: r.get(10)?,
+                    path: r.get(11)?,
+                })
+            },
+        )?;
         for row in raw {
             let t = row?;
             if incognito.contains(&t.id) {
                 next.trajectory_rowid = next.trajectory_rowid.max(t.rowid);
+                next.trajectory_updated_ms = next.trajectory_updated_ms.max(t.updated_ms);
                 continue;
             }
-            let mapped = map_trajectory(&TrajectoryRow {
+            let mut mapped = map_trajectory(&TrajectoryRow {
                 id: &t.id,
                 persona_id: t.persona_id.as_deref(),
                 project_id: t.project_id.as_deref(),
@@ -140,8 +167,71 @@ pub fn build_outbox_batch(
             if !records.is_empty() && records.len() + mapped.len() > MAX_RECORDS {
                 break;
             }
+            let files = trajectory_files(conn, &mut file_cache, &t.id, t.path.as_deref())?;
+            for env in &mut mapped {
+                env.files_touched = files.clone();
+            }
             next.trajectory_rowid = next.trajectory_rowid.max(t.rowid);
+            next.trajectory_updated_ms = next.trajectory_updated_ms.max(t.updated_ms);
             records.extend(mapped);
+        }
+    }
+
+    // --- session_commit_links → kind=session_outcome (one envelope per link row) ---
+    {
+        let mut stmt = conn.prepare(
+            "SELECT id, source, session_id, repo, branch, commit_sha, match_method, confidence, \
+             files_json, numstat_json, created_at_ms \
+             FROM session_commit_links WHERE id > ?1 ORDER BY id ASC LIMIT ?2",
+        )?;
+        let rows = stmt.query_map([cursor.commit_link_id, limit], |r| {
+            Ok(CommitLinkOwned {
+                id: r.get(0)?,
+                source: r.get(1)?,
+                session_id: r.get(2)?,
+                repo: r.get(3)?,
+                branch: r.get(4)?,
+                commit_sha: r.get(5)?,
+                match_method: r.get(6)?,
+                confidence: r.get(7)?,
+                files_json: r.get(8)?,
+                numstat_json: r.get(9)?,
+                created_at_ms: r.get(10)?,
+            })
+        })?;
+        for row in rows {
+            let link = row?;
+            if records.len() >= MAX_RECORDS {
+                break;
+            }
+            next.commit_link_id = next.commit_link_id.max(link.id);
+            if incognito.contains(&link.session_id) {
+                continue;
+            }
+            let files = session_files(conn, &mut file_cache, Some(&link.source), &link.session_id)?;
+            let project_id = session_project_id(
+                conn,
+                &link.source,
+                &link.session_id,
+                link.repo.as_deref(),
+                &mut remotes,
+            );
+            records.push(map_session_outcome(
+                &SessionCommitLink {
+                    source: &link.source,
+                    session_id: &link.session_id,
+                    repo: link.repo.as_deref(),
+                    branch: link.branch.as_deref(),
+                    commit_sha: &link.commit_sha,
+                    match_method: &link.match_method,
+                    confidence: link.confidence,
+                    files_json: link.files_json.as_deref(),
+                    numstat_json: link.numstat_json.as_deref(),
+                    created_at_ms: link.created_at_ms,
+                },
+                &project_id,
+                files,
+            ));
         }
     }
 
@@ -163,6 +253,176 @@ struct TrajRowOwned {
     decisions_json: String,
     retrospective_json: String,
     timestamp_ms: i64,
+    updated_ms: i64,
+    path: Option<String>,
+}
+
+struct CommitLinkOwned {
+    id: i64,
+    source: String,
+    session_id: String,
+    repo: Option<String>,
+    branch: Option<String>,
+    commit_sha: String,
+    match_method: String,
+    confidence: f64,
+    files_json: Option<String>,
+    numstat_json: Option<String>,
+    created_at_ms: i64,
+}
+
+/// Old cursors (pre-watermark) have `trajectory_updated_ms = 0`. Seed from already-synced
+/// rows so the first push after upgrade does not replay every trajectory.
+fn trajectory_updated_watermark(conn: &Connection, cursor: &SyncCursor) -> Result<i64> {
+    if cursor.trajectory_updated_ms > 0 || cursor.trajectory_rowid <= 0 {
+        return Ok(cursor.trajectory_updated_ms);
+    }
+    Ok(conn.query_row(
+        "SELECT COALESCE(MAX(updated_ms), 0) FROM trajectories WHERE rowid <= ?1",
+        [cursor.trajectory_rowid],
+        |r| r.get(0),
+    )?)
+}
+
+fn git_remote_for_entry(
+    conn: &Connection,
+    entry: &HistoryEntry,
+    remotes: &mut HashMap<String, Option<String>>,
+) -> Option<String> {
+    if entry
+        .project
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|s| !s.is_empty())
+    {
+        return None;
+    }
+    let sid = entry.session_id.as_deref()?;
+    let cwd = session_cwd(conn, &entry.source, sid)?;
+    remotes
+        .entry(cwd.clone())
+        .or_insert_with(|| git_origin_url(&cwd))
+        .clone()
+}
+
+fn session_cwd(conn: &Connection, source: &str, session_id: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT cwd FROM sessions WHERE source = ?1 AND session_id = ?2",
+        rusqlite::params![source, session_id],
+        |r| r.get::<_, Option<String>>(0),
+    )
+    .ok()
+    .flatten()
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())
+}
+
+fn git_origin_url(cwd: &str) -> Option<String> {
+    if !Path::new(cwd).is_dir() {
+        return None;
+    }
+    let out = std::process::Command::new("git")
+        .args(["-C", cwd, "remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!url.is_empty()).then_some(url)
+}
+
+fn session_project_id(
+    conn: &Connection,
+    source: &str,
+    session_id: &str,
+    repo: Option<&str>,
+    remotes: &mut HashMap<String, Option<String>>,
+) -> String {
+    let project: Option<String> = conn
+        .query_row(
+            "SELECT project FROM history WHERE source = ?1 AND session_id = ?2 \
+             AND project IS NOT NULL AND trim(project) != '' LIMIT 1",
+            rusqlite::params![source, session_id],
+            |r| r.get(0),
+        )
+        .ok();
+    let remote = session_cwd(conn, source, session_id).and_then(|cwd| {
+        remotes
+            .entry(cwd.clone())
+            .or_insert_with(|| git_origin_url(&cwd))
+            .clone()
+    });
+    let resolved = resolve_project_id(project.as_deref(), remote.as_deref());
+    if resolved != UNKNOWN_PROJECT {
+        resolved
+    } else {
+        resolve_project_id(repo, None)
+    }
+}
+
+fn session_files(
+    conn: &Connection,
+    cache: &mut HashMap<(String, String), Vec<String>>,
+    source: Option<&str>,
+    session_id: &str,
+) -> Result<Vec<String>> {
+    let key = (source.unwrap_or("*").to_string(), session_id.to_string());
+    if let Some(hit) = cache.get(&key) {
+        return Ok(hit.clone());
+    }
+    let files = if let Some(source) = source {
+        let mut stmt = conn.prepare(
+            "SELECT file_path FROM file_edits WHERE source = ?1 AND session_id = ?2 ORDER BY id ASC",
+        )?;
+        let rows: rusqlite::Result<Vec<String>> = stmt
+            .query_map(rusqlite::params![source, session_id], |r| r.get(0))?
+            .collect();
+        rows?
+    } else {
+        let mut stmt =
+            conn.prepare("SELECT file_path FROM file_edits WHERE session_id = ?1 ORDER BY id ASC")?;
+        let rows: rusqlite::Result<Vec<String>> =
+            stmt.query_map([session_id], |r| r.get(0))?.collect();
+        rows?
+    };
+    let mut deduped = Vec::new();
+    for file in files {
+        let trimmed = file.trim();
+        if !trimmed.is_empty() && !deduped.iter().any(|existing| existing == trimmed) {
+            deduped.push(trimmed.to_string());
+        }
+    }
+    cache.insert(key, deduped.clone());
+    Ok(deduped)
+}
+
+fn trajectory_files(
+    conn: &Connection,
+    cache: &mut HashMap<(String, String), Vec<String>>,
+    trajectory_id: &str,
+    path: Option<&str>,
+) -> Result<Vec<String>> {
+    let mut files = session_files(conn, cache, None, trajectory_id)?;
+    if let Some(origin) = path.and_then(learn_origin_session) {
+        for file in session_files(conn, cache, None, origin)? {
+            if !files.iter().any(|existing| existing == &file) {
+                files.push(file);
+            }
+        }
+    }
+    Ok(files
+        .into_iter()
+        .map(|f| normalize_home_path(f.trim()))
+        .filter(|f| !f.is_empty())
+        .collect())
+}
+
+fn learn_origin_session(path: &str) -> Option<&str> {
+    let rest = path.strip_prefix("learn://")?;
+    rest.split_once('/')
+        .map(|(_, session)| session)
+        .filter(|s| !s.is_empty())
 }
 
 #[cfg(test)]
@@ -177,13 +437,23 @@ mod tests {
     }
 
     fn add_history(conn: &Connection, session: &str, prompt: &str, ts: i64) {
+        add_history_project(conn, session, None, prompt, ts);
+    }
+
+    fn add_history_project(
+        conn: &Connection,
+        session: &str,
+        project: Option<&str>,
+        prompt: &str,
+        ts: i64,
+    ) {
         insert_history(
             conn,
             &HistoryEntry {
                 id: 0,
                 source: "claude".into(),
                 session_id: Some(session.into()),
-                project: None,
+                project: project.map(str::to_string),
                 prompt: prompt.into(),
                 prompt_hash: Some(crate::prompt_hash(prompt)),
                 timestamp_ms: ts,
@@ -193,10 +463,21 @@ mod tests {
     }
 
     fn add_trajectory(conn: &Connection, id: &str, decisions: &str, retro: &str) {
+        add_trajectory_at(conn, id, decisions, retro, 1, None);
+    }
+
+    fn add_trajectory_at(
+        conn: &Connection,
+        id: &str,
+        decisions: &str,
+        retro: &str,
+        updated_ms: i64,
+        path: Option<&str>,
+    ) {
         conn.execute(
             "INSERT INTO trajectories (id, version, persona_id, project_id, task_title, \
              task_description, status, decisions_json, retrospective_json, search_text, path, \
-             updated_ms, timestamp_ms) VALUES (?,1,?,?,?,?,?,?,?,?,NULL,?,?)",
+             updated_ms, timestamp_ms) VALUES (?,1,?,?,?,?,?,?,?,?,?,?,?)",
             rusqlite::params![
                 id,
                 "planner",
@@ -207,11 +488,56 @@ mod tests {
                 decisions,
                 retro,
                 "search",
-                1,
+                path,
+                updated_ms,
                 1_782_036_000_000i64
             ],
         )
         .unwrap();
+    }
+
+    fn add_file_edit(conn: &Connection, session: &str, path: &str, tool: &str) {
+        conn.execute(
+            "INSERT INTO file_edits (source, session_id, tool_use_id, file_path, tool_name) \
+             VALUES ('claude', ?, ?, ?, ?)",
+            rusqlite::params![session, format!("tool_{path}"), path, tool],
+        )
+        .unwrap();
+    }
+
+    fn add_commit_link(conn: &Connection, session: &str, sha: &str, method: &str) {
+        conn.execute(
+            "INSERT INTO session_commit_links \
+             (source, session_id, repo, branch, commit_sha, match_method, confidence, \
+              files_json, numstat_json, created_at_ms) \
+             VALUES ('claude', ?, '/Users/khaliqgant/Projects/relayhistory', 'main', ?, ?, 0.9, \
+                     ?, ?, 1_782_036_000_000)",
+            rusqlite::params![
+                session,
+                sha,
+                method,
+                r#"["src/lib.rs"]"#,
+                r#"[{"path":"src/lib.rs","additions":2,"deletions":0}]"#,
+            ],
+        )
+        .unwrap();
+    }
+
+    fn init_git_repo(origin: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let status = std::process::Command::new("git")
+            .args(["init"])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(status.status.success(), "git init failed");
+        let add = std::process::Command::new("git")
+            .args(["remote", "add", "origin", origin])
+            .current_dir(dir.path())
+            .output()
+            .unwrap();
+        assert!(add.status.success(), "git remote add failed");
+        dir
     }
 
     #[test]
@@ -301,8 +627,227 @@ mod tests {
         let c = SyncCursor {
             history_id: 7,
             trajectory_rowid: 3,
+            trajectory_updated_ms: 99,
+            commit_link_id: 4,
         };
         let s = serde_json::to_string(&c).unwrap();
         assert_eq!(serde_json::from_str::<SyncCursor>(&s).unwrap(), c);
+        let old: SyncCursor =
+            serde_json::from_str(r#"{"history_id":7,"trajectory_rowid":3}"#).unwrap();
+        assert_eq!(old.trajectory_updated_ms, 0);
+        assert_eq!(old.commit_link_id, 0);
+    }
+
+    #[test]
+    fn outbox_batch_project_id_is_never_null() {
+        let conn = mem();
+        add_history_project(
+            &conn,
+            "s-path",
+            Some("/Users/khaliqgant/Projects/relayhistory"),
+            "path project prompt",
+            1,
+        );
+        add_history(&conn, "s-unknown", "no project", 2);
+        add_trajectory(
+            &conn,
+            "traj-1",
+            r#"[{"chosen":"Formik"}]"#,
+            r#"{"summary":"shipped"}"#,
+        );
+        add_commit_link(&conn, "s-path", "abc111", "cwd");
+        let none = HashSet::new();
+        let batch = build_outbox_batch(&conn, &SyncCursor::default(), 100, &none).unwrap();
+        assert!(!batch.records.is_empty());
+        assert!(batch.records.iter().all(|r| r.project_id.is_some()));
+        assert!(batch
+            .records
+            .iter()
+            .all(|r| r.project_id.as_deref() != Some("")));
+        let path_prompt = batch
+            .records
+            .iter()
+            .find(|r| r.kind == "prompt" && r.session_id == "s-path")
+            .unwrap();
+        assert_eq!(path_prompt.project_id.as_deref(), Some("relayhistory"));
+        let unknown_prompt = batch
+            .records
+            .iter()
+            .find(|r| r.kind == "prompt" && r.session_id == "s-unknown")
+            .unwrap();
+        assert_eq!(unknown_prompt.project_id.as_deref(), Some(UNKNOWN_PROJECT));
+        assert!(batch.records.iter().any(|r| r.kind == "session_outcome"));
+    }
+
+    #[test]
+    fn git_remote_of_session_cwd_becomes_repo_slug() {
+        let repo = init_git_repo("git@github.com:AgentWorkforce/relayhistory.git");
+        let conn = mem();
+        conn.execute(
+            "INSERT INTO sessions (session_id, source, cwd, parser_version) VALUES (?, 'claude', ?, 1)",
+            rusqlite::params!["s-git", repo.path().display().to_string()],
+        )
+        .unwrap();
+        add_history(&conn, "s-git", "work in the cloned repo", 1);
+        let none = HashSet::new();
+        let batch = build_outbox_batch(&conn, &SyncCursor::default(), 100, &none).unwrap();
+        assert_eq!(batch.records.len(), 1);
+        assert_eq!(batch.records[0].kind, "prompt");
+        assert_eq!(
+            batch.records[0].project_id.as_deref(),
+            Some("AgentWorkforce/relayhistory")
+        );
+        let v = serde_json::to_value(&batch.records[0]).unwrap();
+        assert_eq!(v["projectId"], "AgentWorkforce/relayhistory");
+        assert!(!v["projectId"].is_null());
+    }
+
+    #[test]
+    fn files_touched_on_session_and_trajectory_envelopes() {
+        let conn = mem();
+        add_history_project(
+            &conn,
+            "s1",
+            Some("/Users/me/Projects/relayhistory"),
+            "edit the mapper",
+            1,
+        );
+        add_file_edit(
+            &conn,
+            "s1",
+            "/Users/me/Projects/relayhistory/src/outbox.rs",
+            "Edit",
+        );
+        add_file_edit(
+            &conn,
+            "s1",
+            "crates/ai-hist-core/src/convergence.rs",
+            "Write",
+        );
+        add_trajectory_at(
+            &conn,
+            "learn_abc",
+            r#"[{"chosen":"slug the project"}]"#,
+            r#"{"summary":"shipped"}"#,
+            5,
+            Some("learn://claude/s1"),
+        );
+        let none = HashSet::new();
+        let batch = build_outbox_batch(&conn, &SyncCursor::default(), 100, &none).unwrap();
+        let prompts: Vec<_> = batch
+            .records
+            .iter()
+            .filter(|r| r.kind == "prompt")
+            .collect();
+        assert_eq!(prompts.len(), 1);
+        assert!(prompts[0]
+            .files_touched
+            .iter()
+            .any(|f| f.ends_with("src/outbox.rs")));
+        assert!(prompts[0]
+            .files_touched
+            .iter()
+            .any(|f| f.ends_with("crates/ai-hist-core/src/convergence.rs")));
+        let traj: Vec<_> = batch
+            .records
+            .iter()
+            .filter(|r| r.lens.as_deref() == Some("trajectories"))
+            .collect();
+        assert!(!traj.is_empty());
+        assert!(traj
+            .iter()
+            .all(|r| r.files_touched == prompts[0].files_touched));
+        let v = serde_json::to_value(prompts[0]).unwrap();
+        assert!(v["filesTouched"].as_array().unwrap().len() >= 2);
+    }
+
+    #[test]
+    fn revised_trajectory_is_re_pushed_via_updated_ms_watermark() {
+        let conn = mem();
+        add_trajectory(
+            &conn,
+            "traj-1",
+            r#"[{"chosen":"Formik"}]"#,
+            r#"{"summary":"first draft"}"#,
+        );
+        let none = HashSet::new();
+        let first = build_outbox_batch(&conn, &SyncCursor::default(), 100, &none).unwrap();
+        assert!(first
+            .records
+            .iter()
+            .any(|r| r.content.contains("first draft")));
+        assert!(first.cursor.trajectory_rowid >= 1);
+        assert!(first.cursor.trajectory_updated_ms >= 1);
+
+        let empty = build_outbox_batch(&conn, &first.cursor, 100, &none).unwrap();
+        assert!(empty
+            .records
+            .iter()
+            .all(|r| r.lens.as_deref() != Some("trajectories")));
+
+        conn.execute(
+            "UPDATE trajectories SET retrospective_json = ?, updated_ms = ? WHERE id = ?",
+            rusqlite::params![r#"{"summary":"amended after the run"}"#, 50i64, "traj-1"],
+        )
+        .unwrap();
+        let second = build_outbox_batch(&conn, &first.cursor, 100, &none).unwrap();
+        assert!(
+            second
+                .records
+                .iter()
+                .any(|r| r.kind == "reflection" && r.content.contains("amended after the run")),
+            "revised trajectory must appear in the next batch: {:?}",
+            second
+                .records
+                .iter()
+                .map(|r| (r.kind.as_str(), r.content.as_str()))
+                .collect::<Vec<_>>()
+        );
+        assert!(second.cursor.trajectory_updated_ms >= 50);
+    }
+
+    #[test]
+    fn n_linked_commits_yield_n_session_outcome_envelopes() {
+        let conn = mem();
+        add_history_project(
+            &conn,
+            "s-n",
+            Some("/Users/me/Projects/relayhistory"),
+            "land the fix",
+            1,
+        );
+        for i in 1..=3 {
+            add_commit_link(&conn, "s-n", &format!("sha{i:03}"), "cwd+branch");
+        }
+        let none = HashSet::new();
+        let batch = build_outbox_batch(&conn, &SyncCursor::default(), 100, &none).unwrap();
+        let outcomes: Vec<_> = batch
+            .records
+            .iter()
+            .filter(|r| r.kind == "session_outcome")
+            .collect();
+        assert_eq!(outcomes.len(), 3);
+        let shas: Vec<_> = outcomes
+            .iter()
+            .map(|r| r.commit_sha.clone().unwrap())
+            .collect();
+        assert_eq!(shas, vec!["sha001", "sha002", "sha003"]);
+        assert!(outcomes
+            .iter()
+            .all(|r| r.match_method.as_deref() == Some("cwd+branch")));
+        assert!(outcomes
+            .iter()
+            .all(|r| r.project_id.as_deref() == Some("relayhistory")));
+        assert!(outcomes.iter().all(|r| r.confidence == Some(0.9)));
+        let v = serde_json::to_value(outcomes[0]).unwrap();
+        assert_eq!(v["kind"], "session_outcome");
+        assert_eq!(v["commitSha"], "sha001");
+        assert_eq!(v["matchMethod"], "cwd+branch");
+        assert_eq!(v["numstat"]["files"][0]["path"], "src/lib.rs");
+        assert_eq!(v["files"][0], "src/lib.rs");
+        assert_eq!(batch.cursor.commit_link_id, 3);
+
+        let empty = build_outbox_batch(&conn, &batch.cursor, 100, &none).unwrap();
+        assert!(!empty.records.iter().any(|r| r.kind == "session_outcome"));
     }
 }

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -448,16 +448,18 @@ pub fn batch_id(machine: &str, from: &SyncCursor, to: &SyncCursor, count: usize)
     format!(
         "b_{}",
         ai_hist_core::prompt_hash(&format!(
-            "{machine}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{count}",
+            "{machine}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{count}",
             from.history_id,
             from.trajectory_rowid,
             from.trajectory_updated_ms,
             from.commit_link_id,
+            from.file_edit_id,
             from.capture_version,
             to.history_id,
             to.trajectory_rowid,
             to.trajectory_updated_ms,
             to.commit_link_id,
+            to.file_edit_id,
             to.capture_version
         ))
     )
@@ -591,6 +593,7 @@ fn push_once(
             "trajectory_rowid": batch.cursor.trajectory_rowid,
             "trajectory_updated_ms": batch.cursor.trajectory_updated_ms,
             "commit_link_id": batch.cursor.commit_link_id,
+            "file_edit_id": batch.cursor.file_edit_id,
             "capture_version": batch.cursor.capture_version,
         })),
         records: batch.records,

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -1809,7 +1809,8 @@ mod tests {
                 },
             )
             .unwrap();
-            // Even a later stale writer cannot rewind either watermark.
+            // Even a later stale writer cannot rewind history/commit ids, or the
+            // trajectory keyset position (updated_ms, rowid) as a single pair.
             save_cursor(
                 base_url,
                 &SyncCursor {
@@ -1824,7 +1825,7 @@ mod tests {
                 load_cursor(base_url).unwrap(),
                 SyncCursor {
                     history_id: 100,
-                    trajectory_rowid: 100,
+                    trajectory_rowid: 1,
                     trajectory_updated_ms: 50,
                     commit_link_id: 20,
                 }
@@ -1858,7 +1859,7 @@ mod tests {
                 load_cursor(base_url).unwrap(),
                 SyncCursor {
                     history_id: 125,
-                    trajectory_rowid: 125,
+                    trajectory_rowid: 1,
                     trajectory_updated_ms: 50,
                     commit_link_id: 20,
                 }

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -352,10 +352,7 @@ pub fn load_cursor(base_url: &str) -> Result<SyncCursor> {
 pub fn save_cursor(base_url: &str, cursor: &SyncCursor) -> Result<()> {
     let _cursor_lock = acquire_cursor_lock(base_url)?;
     let current = load_cursor(base_url)?;
-    let merged = SyncCursor {
-        history_id: current.history_id.max(cursor.history_id),
-        trajectory_rowid: current.trajectory_rowid.max(cursor.trajectory_rowid),
-    };
+    let merged = current.merge_max(cursor);
     write_private(
         &cursor_path(base_url)?,
         &serde_json::to_string_pretty(&merged)?,
@@ -1807,6 +1804,8 @@ mod tests {
                 &SyncCursor {
                     history_id: 100,
                     trajectory_rowid: 1,
+                    trajectory_updated_ms: 50,
+                    commit_link_id: 2,
                 },
             )
             .unwrap();
@@ -1816,6 +1815,8 @@ mod tests {
                 &SyncCursor {
                     history_id: 1,
                     trajectory_rowid: 100,
+                    trajectory_updated_ms: 5,
+                    commit_link_id: 20,
                 },
             )
             .unwrap();
@@ -1824,6 +1825,8 @@ mod tests {
                 SyncCursor {
                     history_id: 100,
                     trajectory_rowid: 100,
+                    trajectory_updated_ms: 50,
+                    commit_link_id: 20,
                 }
             );
 
@@ -1835,11 +1838,13 @@ mod tests {
                             SyncCursor {
                                 history_id: 100 + revision,
                                 trajectory_rowid: 1,
+                                ..Default::default()
                             }
                         } else {
                             SyncCursor {
                                 history_id: 1,
                                 trajectory_rowid: 100 + revision,
+                                ..Default::default()
                             }
                         };
                         save_cursor("http://localhost:8787", &cursor).unwrap();
@@ -1854,6 +1859,8 @@ mod tests {
                 SyncCursor {
                     history_id: 125,
                     trajectory_rowid: 125,
+                    trajectory_updated_ms: 50,
+                    commit_link_id: 20,
                 }
             );
         });
@@ -2310,6 +2317,7 @@ mod tests {
             let cursor = SyncCursor {
                 history_id: 17,
                 trajectory_rowid: 3,
+                ..Default::default()
             };
             save_cursor(&auth.base_url, &cursor).unwrap();
 
@@ -2357,6 +2365,7 @@ mod tests {
             let legacy_cursor = SyncCursor {
                 history_id: 900,
                 trajectory_rowid: 42,
+                ..Default::default()
             };
             write_private(
                 &legacy_cursor_path(),
@@ -2397,10 +2406,12 @@ mod tests {
             let prod_cursor = SyncCursor {
                 history_id: 101,
                 trajectory_rowid: 7,
+                ..Default::default()
             };
             let dev_cursor = SyncCursor {
                 history_id: 9,
                 trajectory_rowid: 2,
+                ..Default::default()
             };
 
             save_auth(&prod).unwrap();

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -451,8 +451,15 @@ pub fn batch_id(machine: &str, from: &SyncCursor, to: &SyncCursor, count: usize)
     format!(
         "b_{}",
         ai_hist_core::prompt_hash(&format!(
-            "{machine}:{}:{}:{}:{}:{count}",
-            from.history_id, from.trajectory_rowid, to.history_id, to.trajectory_rowid
+            "{machine}:{}:{}:{}:{}:{}:{}:{}:{}:{count}",
+            from.history_id,
+            from.trajectory_rowid,
+            from.trajectory_updated_ms,
+            from.commit_link_id,
+            to.history_id,
+            to.trajectory_rowid,
+            to.trajectory_updated_ms,
+            to.commit_link_id
         ))
     )
 }
@@ -583,6 +590,8 @@ fn push_once(
         cursors: Some(serde_json::json!({
             "history_id": batch.cursor.history_id,
             "trajectory_rowid": batch.cursor.trajectory_rowid,
+            "trajectory_updated_ms": batch.cursor.trajectory_updated_ms,
+            "commit_link_id": batch.cursor.commit_link_id,
         })),
         records: batch.records,
     };
@@ -2025,6 +2034,7 @@ mod tests {
         let to = SyncCursor {
             history_id: 5,
             trajectory_rowid: 2,
+            ..Default::default()
         };
         assert_eq!(batch_id("m1", &from, &to, 7), batch_id("m1", &from, &to, 7));
         assert_ne!(batch_id("m1", &from, &to, 7), batch_id("m1", &from, &to, 8));
@@ -2046,6 +2056,7 @@ mod tests {
             let c = SyncCursor {
                 history_id: 9,
                 trajectory_rowid: 4,
+                ..Default::default()
             };
             save_cursor(&auth.base_url, &c).unwrap();
             assert_eq!(load_cursor(&auth.base_url).unwrap(), c);

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -448,15 +448,17 @@ pub fn batch_id(machine: &str, from: &SyncCursor, to: &SyncCursor, count: usize)
     format!(
         "b_{}",
         ai_hist_core::prompt_hash(&format!(
-            "{machine}:{}:{}:{}:{}:{}:{}:{}:{}:{count}",
+            "{machine}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{count}",
             from.history_id,
             from.trajectory_rowid,
             from.trajectory_updated_ms,
             from.commit_link_id,
+            from.capture_version,
             to.history_id,
             to.trajectory_rowid,
             to.trajectory_updated_ms,
-            to.commit_link_id
+            to.commit_link_id,
+            to.capture_version
         ))
     )
 }
@@ -589,6 +591,7 @@ fn push_once(
             "trajectory_rowid": batch.cursor.trajectory_rowid,
             "trajectory_updated_ms": batch.cursor.trajectory_updated_ms,
             "commit_link_id": batch.cursor.commit_link_id,
+            "capture_version": batch.cursor.capture_version,
         })),
         records: batch.records,
     };
@@ -1806,6 +1809,7 @@ mod tests {
                     trajectory_rowid: 1,
                     trajectory_updated_ms: 50,
                     commit_link_id: 2,
+                    ..Default::default()
                 },
             )
             .unwrap();
@@ -1818,6 +1822,7 @@ mod tests {
                     trajectory_rowid: 100,
                     trajectory_updated_ms: 5,
                     commit_link_id: 20,
+                    ..Default::default()
                 },
             )
             .unwrap();
@@ -1828,6 +1833,7 @@ mod tests {
                     trajectory_rowid: 1,
                     trajectory_updated_ms: 50,
                     commit_link_id: 20,
+                    ..Default::default()
                 }
             );
 
@@ -1862,6 +1868,7 @@ mod tests {
                     trajectory_rowid: 1,
                     trajectory_updated_ms: 50,
                     commit_link_id: 20,
+                    ..Default::default()
                 }
             );
         });


### PR DESCRIPTION
Implements **section 2, P0-1 and P0-2** of [`docs/specs/2026-09-02-neighborhood-memory-capture.md`](docs/specs/2026-09-02-neighborhood-memory-capture.md). Spec lives in PR #102 and is **not** in this branch.

Rebased `--onto origin/main` from `1ffacdc`, so this PR is implementation-only against current main (`b29f214`, 0.14.0).

Reconciled against Will's main work:

- **#94** remote session hydration (`hydrate.rs`, `remote.rs`, a much larger `cloud.rs`): the 15-line outbox-cursor / `batch_id` / ingest `cursors` change is re-applied on top of that hydration/remote code. `save_cursor` now `merge_max`s the new `trajectory_updated_ms` and `commit_link_id` watermarks instead of constructing a two-field `SyncCursor`. Remaining `SyncCursor { ... }` literals use `..Default::default()`.
- **#96** tool-call and file-edit paging: `filesTouched` is emitted through `session_file_edits` / `session_file_edits_page`, not a copy of the `file_edits` SQL.
- **#97** session relationships, **#98** Codex parent resolution, **#100** runtime source registry: no overlapping capture path; left as on main.
- **#101** native-contract version check: `scripts/verify-native-contract.mjs` and `sdk-ts` tests pass. Native contract stays at **7**; no version bump.

Nothing from spec section 3 or later. WS-1 envelope schema is unchanged: these populate existing optional fields (`projectId`, `filesTouched`) or add optional `session_outcome` fields the cloud ingest path already accepts.

### P0-1 `project_id` on every history event

- Populate from `history.project`, falling back to the git remote of the session cwd.
- Normalize to a repo slug (`owner/repo` or last path component), never a filesystem path (including relative forms such as `./repo`).
- Unknown → explicit string `unknown`, never `None`.
- Emitted on `kind=prompt` rows.

### P0-2 Outbox signals

- `filesTouched` on session and trajectory envelopes, from `session_file_edits` / `session_file_edits_page`.
- `session_outcome` envelopes from `session_commit_links` (commit sha, `matchMethod`, `confidence`, numstat; `shippedAt` from evidence `commit_time_ms`).
- Trajectories re-push via a `(updated_ms, rowid)` keyset so revised rows and equal-timestamp boundaries are total.
- `capture_version` on the cursor re-upserts previously synced history once on upgrade.
- `file_edit_id` watermark republishes `filesTouched` when edits grow after the last prompt.

### Review feedback

Seven distinct findings (eight review comments; shippedAt was raised twice):

1. Replay previously synced prompts — **fixed** (`f684075`)
2. Legacy cursor migration loses amended trajectories — **fixed** (`788e7dc`)
3. Equal-timestamp boundary skip — **fixed** (`788e7dc`)
4. File edits after the last prompt never republish — **fixed** (`8014681`)
5. `shippedAt` from commit time — **fixed** (`c77a8f3`)
6. Relative project path leaks — **fixed** (`da71c10`)
7. `session_outcome` event id collision — **fixed** (`c77a8f3`)

### CI-equivalent (local)

```
$ cargo fmt --all -- --check
(clean)
```

```
$ cargo clippy --workspace --all-targets -- -A clippy::too_many_arguments -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.79s
```

```
$ cargo test --workspace
test result: ok. 94 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.76s
test result: ok. 252 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.65s
test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.42s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 65.71s
```

```
$ cargo test -p ai-hist-engine write_private_replaces_existing_state
test cloud::tests::write_private_replaces_existing_state ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 251 filtered out; finished in 0.03s
```

🤖 Generated with Grok via agent-relay, overseen by Claude


## Review feedback

All seven distinct findings (eight comments) from `chatgpt-codex-connector[bot]` and `cubic-dev-ai[bot]` are addressed, each with a reply on its thread:

1. P1 replay previously synced prompts — **fixed** (`f684075`): `SyncCursor.capture_version` rewinds `history_id` and the trajectory keyset once on upgrade so historical rows re-upsert with `projectId` / `filesTouched`.
2. P1 legacy cursor loses amended trajectories — **fixed** (`788e7dc`): no seeding from `MAX(updated_ms)`; a legacy cursor keeps 0 and the keyset replays.
3. P1 equal-timestamp boundary skip — **fixed** (`788e7dc`): total keyset `(updated_ms, rowid)`; test uses the reviewer's `(3,1),(1,2),(2,2)` / limit 2 example.
4. P2 file edits after the last prompt never republish — **fixed** (`8014681`): `file_edit_id` watermark; the latest prompt re-upserts with current `filesTouched`.
5. P2 `shippedAt` from commit time — **fixed** (`c77a8f3`): `commit_time_ms` from the link evidence, `created_at_ms` only as fallback.
6. P2 relative project path leaks — **fixed** (`da71c10`): `./repo`, `../x`, `.`, `..` and Windows forms slug to the last component or `unknown`.
7. P2 event id collision across `match_method` — **fixed** (`c77a8f3`): id includes source and match method.

CHANGELOG updated (`de4c1a9`).

## Verification after review feedback (overseer, on `de4c1a9`)

```
cargo test --workspace
test result: ok. 94 passed; 0 failed   (ai-hist-core; was 84 before feedback)
test result: ok. 252 passed; 0 failed
test result: ok. 19 passed; 0 failed
test result: ok. 1 passed; 0 failed
test result: ok. 3 passed; 0 failed
cargo clippy --workspace --all-targets -- -A clippy::too_many_arguments -D warnings
Finished `dev` profile
cargo fmt --all -- --check
(clean)
```
CI: `verify`, `node-22-sdk`, `windows-state-replacement` pass on `de4c1a9`.
