### PR TITLE
feat(capture): publish conversation turns and a git taskRef

### DIFF
--- a/crates/ai-hist-core/src/convergence.rs
+++ b/crates/ai-hist-core/src/convergence.rs
@@ -248,14 +248,42 @@ const KIND_FINDING: &str = "finding";
 /// even when the row carries no session id. `projectId` is always a slug (or
 /// [`UNKNOWN_PROJECT`]), never `None`.
 pub fn map_history_entry(entry: &HistoryEntry) -> ConvergenceEnvelope {
-    map_history_entry_with(entry, None, Vec::new())
+    map_history_entry_with(entry, None, Vec::new(), None)
 }
 
-/// Like [`map_history_entry`], with a git-remote fallback and `filesTouched`.
+/// The `taskRef` a prompt belongs to, as `{system:"git", id:"<project>@<branch>"}`.
+///
+/// A branch is the closest thing to a unit of work that exists while the work is being
+/// done — a PR number does not exist yet when the session runs, and a commit sha does not
+/// exist until the end. Keying on `<project>@<branch>` lets a PR (or a person) ask for
+/// every session behind a branch after the fact.
+///
+/// Returns `None` rather than a placeholder when the branch is unknown or detached: the
+/// server stores `{}` for absent, and a synthetic ref would make unrelated sessions
+/// collide under one task.
+pub fn git_task_ref(project_id: &str, branch: Option<&str>) -> Option<serde_json::Value> {
+    let branch = branch.map(str::trim).filter(|b| {
+        // A detached HEAD is not a task, and neither is an empty string.
+        !b.is_empty() && *b != "HEAD" && *b != "(detached)"
+    })?;
+    if project_id.is_empty() || project_id == UNKNOWN_PROJECT {
+        return None;
+    }
+    Some(serde_json::json!({
+        "system": "git",
+        "id": format!("{project_id}@{branch}"),
+    }))
+}
+
+/// Like [`map_history_entry`], with a git-remote fallback, `filesTouched` and the branch
+/// the session was on.
+/// Like [`map_history_entry`], with a git-remote fallback, `filesTouched`, and the
+/// branch the session was on.
 pub fn map_history_entry_with(
     entry: &HistoryEntry,
     git_remote: Option<&str>,
     files_touched: Vec<String>,
+    git_branch: Option<&str>,
 ) -> ConvergenceEnvelope {
     let session_id = entry
         .session_id
@@ -283,7 +311,10 @@ pub fn map_history_entry_with(
         task_title: None,
         task_description: None,
         task_status: None,
-        task_ref: None,
+        task_ref: git_task_ref(
+            &resolve_project_id(entry.project.as_deref(), git_remote),
+            git_branch,
+        ),
         record: None,
         files_touched: normalize_files_touched(files_touched),
         commit_sha: None,
@@ -1682,5 +1713,46 @@ mod tests {
         assert!(v["confidence"].is_null());
         // projectId is always present (never NULL)
         assert_eq!(v["projectId"], UNKNOWN_PROJECT);
+    }
+    #[test]
+    fn task_ref_names_the_branch_the_work_happened_on() {
+        let value = git_task_ref("AgentWorkforce/relayhistory", Some("feat/turns")).unwrap();
+        assert_eq!(value["system"], "git");
+        assert_eq!(value["id"], "AgentWorkforce/relayhistory@feat/turns");
+    }
+
+    /// A synthetic ref would make unrelated sessions collide under one task, which is
+    /// worse than no ref at all — the server stores `{}` for absent and the filter simply
+    /// does not match.
+    #[test]
+    fn task_ref_is_absent_rather_than_synthetic_when_there_is_no_real_branch() {
+        assert!(git_task_ref("owner/repo", None).is_none());
+        assert!(git_task_ref("owner/repo", Some("")).is_none());
+        assert!(git_task_ref("owner/repo", Some("   ")).is_none());
+        // A detached HEAD is a position, not a unit of work.
+        assert!(git_task_ref("owner/repo", Some("HEAD")).is_none());
+        // An unknown project would group every unattributable session together.
+        assert!(git_task_ref(UNKNOWN_PROJECT, Some("main")).is_none());
+    }
+
+    #[test]
+    fn prompt_envelopes_carry_the_task_ref() {
+        let entry = HistoryEntry {
+            id: 1,
+            source: "claude".into(),
+            session_id: Some("s1".into()),
+            project: Some("AgentWorkforce/relayhistory".into()),
+            prompt: "why".into(),
+            prompt_hash: Some("h".into()),
+            timestamp_ms: 1_700_000_000_000,
+        };
+        let env = map_history_entry_with(&entry, None, Vec::new(), Some("fix/scrub"));
+        let task_ref = env
+            .task_ref
+            .expect("branch known, so a taskRef is expected");
+        assert_eq!(task_ref["id"], "AgentWorkforce/relayhistory@fix/scrub");
+
+        let without = map_history_entry_with(&entry, None, Vec::new(), None);
+        assert!(without.task_ref.is_none());
     }
 }

--- a/crates/ai-hist-core/src/lib.rs
+++ b/crates/ai-hist-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod outbox;
 /// Delegation topology: recorded parent/child relationships and bounded,
 /// cycle-safe traversal over them.
 pub mod relationships;
+pub mod turns;
 
 pub use relationships::{
     relationship_capabilities, session_children, session_children_page, session_parents,

--- a/crates/ai-hist-core/src/outbox.rs
+++ b/crates/ai-hist-core/src/outbox.rs
@@ -47,6 +47,12 @@ pub struct SyncCursor {
     /// Highest `file_edits.id` whose session's `filesTouched` has been published.
     #[serde(default)]
     pub file_edit_id: i64,
+    /// Highest `session_events.id` whose session's conversation turns have been
+    /// published. Independent of `capture_version`: a cursor file written before turns
+    /// existed defaults to 0 and publishes the whole transcript backlog, without
+    /// forcing another convergence replay.
+    #[serde(default)]
+    pub session_event_id: i64,
     /// Mapper generation. Missing from pre-neighborhood-memory cursor files (serde
     /// default 0). Those rewind history/trajectory watermarks once so existing
     /// rows are re-upserted with `projectId` / `filesTouched`.
@@ -62,6 +68,7 @@ impl Default for SyncCursor {
             trajectory_updated_ms: 0,
             commit_link_id: 0,
             file_edit_id: 0,
+            session_event_id: 0,
             capture_version: Self::CAPTURE_VERSION,
         }
     }
@@ -86,6 +93,11 @@ impl SyncCursor {
                 trajectory_updated_ms: other.trajectory_updated_ms,
                 commit_link_id: self.commit_link_id.max(other.commit_link_id),
                 file_edit_id: other.file_edit_id,
+                // Deliberately NOT rewound. `capture_version` is the convergence
+                // mapper's generation; the transcript is a separate stream with its
+                // own watermark. Rewinding it here would republish the whole turns
+                // backlog every time the convergence mapper changes.
+                session_event_id: self.session_event_id.max(other.session_event_id),
             };
         }
         if self.capture_version > other.capture_version {
@@ -102,6 +114,7 @@ impl SyncCursor {
             trajectory_updated_ms,
             commit_link_id: self.commit_link_id.max(other.commit_link_id),
             file_edit_id: self.file_edit_id.max(other.file_edit_id),
+            session_event_id: self.session_event_id.max(other.session_event_id),
             capture_version: self.capture_version,
         }
     }
@@ -117,6 +130,9 @@ impl SyncCursor {
             trajectory_updated_ms: 0,
             commit_link_id: self.commit_link_id,
             file_edit_id: 0,
+            // Carried, not reset: the convergence backfill has nothing to do with the
+            // transcript stream, and restarting it would re-send every turn.
+            session_event_id: self.session_event_id,
         }
     }
 
@@ -157,6 +173,7 @@ pub fn build_outbox_batch(
     let mut records = Vec::new();
     let mut next = cursor.clone();
     let mut remotes: HashMap<String, Option<String>> = HashMap::new();
+    let mut branches: HashMap<String, Option<String>> = HashMap::new();
     let mut file_cache: HashMap<(String, String), Vec<String>> = HashMap::new();
     let mut published_sessions: HashSet<(String, String)> = HashSet::new();
 
@@ -199,7 +216,13 @@ pub fn build_outbox_batch(
             if let Some(sid) = &entry.session_id {
                 published_sessions.insert((entry.source.clone(), sid.clone()));
             }
-            records.push(map_history_entry_with(&entry, git_remote.as_deref(), files));
+            let branch = session_branch_for_entry(conn, &entry, &mut branches);
+            records.push(map_history_entry_with(
+                &entry,
+                git_remote.as_deref(),
+                files,
+                branch.as_deref(),
+            ));
         }
     }
 
@@ -364,7 +387,13 @@ pub fn build_outbox_batch(
             };
             let git_remote = git_remote_for_entry(conn, &entry, &mut remotes);
             let files = session_files(conn, &mut file_cache, Some(&entry.source), &hit.session_id)?;
-            records.push(map_history_entry_with(&entry, git_remote.as_deref(), files));
+            let branch = session_branch_for_entry(conn, &entry, &mut branches);
+            records.push(map_history_entry_with(
+                &entry,
+                git_remote.as_deref(),
+                files,
+                branch.as_deref(),
+            ));
             published_sessions.insert((hit.source, hit.session_id));
         }
     }
@@ -427,6 +456,32 @@ fn latest_history_for_session(
         })
     })?;
     Ok(rows.next().transpose()?)
+}
+
+/// The git branch a session was working on, cached per `(source, session_id)`.
+///
+/// Read from the local `sessions` row rather than from the working tree: the branch that
+/// matters is the one checked out when the prompt was typed, and the tree has almost
+/// certainly moved on by the time a push runs.
+fn session_branch_for_entry(
+    conn: &Connection,
+    entry: &HistoryEntry,
+    branches: &mut HashMap<String, Option<String>>,
+) -> Option<String> {
+    let sid = entry.session_id.as_deref()?;
+    let key = format!("{}\u{1}{sid}", entry.source);
+    branches
+        .entry(key)
+        .or_insert_with(|| {
+            conn.query_row(
+                "SELECT git_branch FROM sessions WHERE source = ?1 AND session_id = ?2",
+                rusqlite::params![&entry.source, sid],
+                |r| r.get::<_, Option<String>>(0),
+            )
+            .ok()
+            .flatten()
+        })
+        .clone()
 }
 
 fn git_remote_for_entry(

--- a/crates/ai-hist-core/src/turns.rs
+++ b/crates/ai-hist-core/src/turns.rs
@@ -1,0 +1,456 @@
+//! Conversation turns: the readable transcript half of cloud sync.
+//!
+//! The convergence outbox ([`crate::outbox`]) publishes *prompts* — what the human typed
+//! — plus distilled trajectory records. It has never carried the other side of the
+//! conversation. Measured on one machine on 2026-09-03, the cloud held 337,139 prompts
+//! while these were local-only:
+//!
+//! ```text
+//! assistant text      190,165   the answers
+//! assistant tool_use  350,551   what the agent actually did
+//! tool_result         338,614
+//! assistant thinking    4,823   the reasoning
+//! ```
+//!
+//! So "replay this session" returned only what the user typed. This module builds the
+//! batches that `POST /v1/sessions/:sessionId/turns` needs to close that, from the local
+//! `session_events` table the `ai-hist events` replay already reads.
+//!
+//! Network I/O lives in the binding layer, per the no-async-in-core rule; this module is
+//! sync rusqlite reads and is unit-testable without a server.
+
+use anyhow::Result;
+use rusqlite::Connection;
+use serde::Serialize;
+use std::collections::HashSet;
+
+/// The server caps a turns request at 1,000. Chunk below it rather than at it, so a
+/// future server-side reduction does not silently start rejecting whole sessions.
+pub const MAX_TURNS_PER_REQUEST: usize = 500;
+
+/// Sessions published per push run. A push already carries the convergence batch; this
+/// bounds the extra work so a machine with a large backlog drains steadily instead of
+/// stalling one run for hours.
+pub const DEFAULT_SESSION_BUDGET: usize = 12;
+
+/// One turn in the wire shape `POST /v1/sessions/:sessionId/turns` accepts.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ConversationTurn {
+    #[serde(rename = "sessionOwner")]
+    pub session_owner: String,
+    #[serde(rename = "turnIndex")]
+    pub turn_index: i64,
+    /// `user` | `assistant` | `system` — the only roles the server accepts.
+    pub role: String,
+    pub content: String,
+    #[serde(rename = "actorName")]
+    pub actor_name: String,
+    /// `owner` | `steerer`.
+    #[serde(rename = "actorRole")]
+    pub actor_role: String,
+    pub metadata: serde_json::Value,
+    /// RFC3339.
+    pub ts: String,
+}
+
+/// A whole session's turns, chunked for the wire.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionTurns {
+    pub session_id: String,
+    pub source: String,
+    /// Chunks of at most [`MAX_TURNS_PER_REQUEST`], in turn order.
+    pub chunks: Vec<Vec<ConversationTurn>>,
+}
+
+/// The batch a single push run should publish, plus the watermark it advances to.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TurnsBatch {
+    pub sessions: Vec<SessionTurns>,
+    /// Highest `session_events.id` scanned, emitted or not.
+    pub session_event_id: i64,
+}
+
+struct RawEvent {
+    session_id: String,
+    source: String,
+    ts_ms: i64,
+    role: String,
+    kind: String,
+    text: Option<String>,
+    model: Option<String>,
+}
+
+/// Map a local `session_events` role/kind pair onto the three roles the server accepts.
+///
+/// `tool_result` has no server-side role of its own and is not the assistant speaking, so
+/// it lands as `system` with the original kind preserved in `metadata`. Dropping these
+/// would leave a transcript where the agent calls a tool and nothing ever comes back.
+fn wire_role(role: &str) -> &'static str {
+    match role {
+        "user" => "user",
+        "assistant" => "assistant",
+        _ => "system",
+    }
+}
+
+/// Who to attribute a turn to. Never empty — the server rejects an empty `actorName`, and
+/// an unattributed turn in a shared transcript is worse than a coarse one.
+fn actor_name(role: &str, model: Option<&str>, source: &str) -> String {
+    match role {
+        "user" => "user".to_string(),
+        "assistant" => model
+            .filter(|m| !m.trim().is_empty())
+            .unwrap_or(source)
+            .to_string(),
+        _ => format!("{source}:tool"),
+    }
+}
+
+fn epoch_ms_to_iso(ms: i64) -> String {
+    crate::convergence::epoch_ms_to_iso(ms)
+}
+
+/// Build the next batch of conversation turns past `session_event_id`.
+///
+/// Sessions are published **whole**, not incrementally, because `turnIndex` is the
+/// server's idempotency key and it is a position within the session. Publishing only the
+/// new tail would number those turns from zero and overwrite the beginning of the
+/// transcript with its own end — a corruption that still returns 200 and still looks like
+/// a full session on read. Whole-session publishing costs a re-send and cannot do that.
+///
+/// `incognito` sessions are skipped but still advance the watermark, matching the
+/// convergence outbox so a suppressed session is never rescanned forever.
+pub fn build_turns_batch(
+    conn: &Connection,
+    session_event_id: i64,
+    session_budget: usize,
+    incognito: &HashSet<String>,
+) -> Result<TurnsBatch> {
+    let budget = session_budget.max(1);
+
+    // Which sessions have anything new, oldest change first so the backlog drains in a
+    // predictable order rather than jumping around.
+    let mut stmt = conn.prepare(
+        "SELECT session_id, source, MIN(id) AS first_new_id \
+         FROM session_events WHERE id > ?1 \
+         GROUP BY session_id, source ORDER BY first_new_id ASC LIMIT ?2",
+    )?;
+    let pending: Vec<(String, String)> = stmt
+        .query_map(rusqlite::params![session_event_id, budget as i64], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+        })?
+        .filter_map(|row| row.ok())
+        .collect();
+
+    if pending.is_empty() {
+        return Ok(TurnsBatch {
+            sessions: Vec::new(),
+            session_event_id,
+        });
+    }
+
+    // Advance to the highest id belonging to the sessions actually taken this run. Using
+    // the table-wide MAX would skip every session whose events sort after the budget cut.
+    let mut watermark = session_event_id;
+    let mut sessions = Vec::new();
+
+    let mut events_stmt = conn.prepare(
+        "SELECT session_id, source, ts_ms, role, kind, text, model, id \
+         FROM session_events WHERE session_id = ?1 AND source = ?2 \
+         ORDER BY ts_ms ASC, id ASC",
+    )?;
+
+    for (session_id, source) in pending {
+        let rows = events_stmt.query_map(rusqlite::params![&session_id, &source], |r| {
+            Ok((
+                RawEvent {
+                    session_id: r.get(0)?,
+                    source: r.get(1)?,
+                    ts_ms: r.get(2)?,
+                    role: r.get(3)?,
+                    kind: r.get(4)?,
+                    text: r.get(5)?,
+                    model: r.get(6)?,
+                },
+                r.get::<_, i64>(7)?,
+            ))
+        })?;
+
+        let mut turns: Vec<ConversationTurn> = Vec::new();
+        for row in rows {
+            let (event, id) = match row {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+            watermark = watermark.max(id);
+
+            // An event with no text carries nothing a reader can use. Skip it, but only
+            // after the watermark has moved past it.
+            let content = match event.text.as_deref().map(str::trim) {
+                Some(text) if !text.is_empty() => text.to_string(),
+                _ => continue,
+            };
+
+            let index = turns.len() as i64;
+            turns.push(ConversationTurn {
+                session_owner: event.source.clone(),
+                turn_index: index,
+                role: wire_role(&event.role).to_string(),
+                content,
+                actor_name: actor_name(&event.role, event.model.as_deref(), &event.source),
+                actor_role: "owner".to_string(),
+                metadata: serde_json::json!({
+                    // The server validates `nativeCli` against claude/codex and ignores
+                    // other keys, so the local kind survives for readers that want to
+                    // distinguish thinking from a tool call.
+                    "kind": event.kind,
+                    "sourceRole": event.role,
+                }),
+                ts: epoch_ms_to_iso(event.ts_ms),
+            });
+            let _ = event.session_id;
+        }
+
+        if incognito.contains(&session_id) || turns.is_empty() {
+            continue;
+        }
+
+        let chunks: Vec<Vec<ConversationTurn>> = turns
+            .chunks(MAX_TURNS_PER_REQUEST)
+            .map(|chunk| chunk.to_vec())
+            .collect();
+
+        sessions.push(SessionTurns {
+            session_id,
+            source,
+            chunks,
+        });
+    }
+
+    Ok(TurnsBatch {
+        sessions,
+        session_event_id: watermark,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                project TEXT, cwd TEXT, git_branch TEXT,
+                message_id TEXT, parent_id TEXT,
+                ts_ms INTEGER NOT NULL,
+                role TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                text TEXT, model TEXT, token_json TEXT,
+                event_uid TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert(conn: &Connection, session: &str, ts: i64, role: &str, kind: &str, text: &str) {
+        conn.execute(
+            "INSERT INTO session_events (source, session_id, ts_ms, role, kind, text, model, event_uid)
+             VALUES ('claude', ?1, ?2, ?3, ?4, ?5, 'claude-opus-5', ?6)",
+            rusqlite::params![session, ts, role, kind, text, format!("{session}-{ts}-{kind}")],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn publishes_both_sides_of_the_conversation() {
+        let conn = db();
+        insert(&conn, "s1", 1000, "user", "text", "why is it failing?");
+        insert(
+            &conn,
+            "s1",
+            2000,
+            "assistant",
+            "thinking",
+            "consider the regex",
+        );
+        insert(&conn, "s1", 3000, "assistant", "tool_use", "grep -n scrub");
+        insert(
+            &conn,
+            "s1",
+            4000,
+            "tool_result",
+            "tool_result",
+            "scrub.ts:41",
+        );
+        insert(
+            &conn,
+            "s1",
+            5000,
+            "assistant",
+            "text",
+            "the scheme is unbounded",
+        );
+
+        let batch = build_turns_batch(&conn, 0, 10, &HashSet::new()).unwrap();
+        let turns = &batch.sessions[0].chunks[0];
+
+        assert_eq!(turns.len(), 5);
+        assert_eq!(
+            turns.iter().map(|t| t.role.as_str()).collect::<Vec<_>>(),
+            ["user", "assistant", "assistant", "system", "assistant"],
+        );
+        // Dense, ordered indices — the server's idempotency key.
+        assert_eq!(
+            turns.iter().map(|t| t.turn_index).collect::<Vec<_>>(),
+            [0, 1, 2, 3, 4],
+        );
+    }
+
+    #[test]
+    fn orders_by_timestamp_not_insertion() {
+        let conn = db();
+        insert(&conn, "s1", 3000, "assistant", "text", "third");
+        insert(&conn, "s1", 1000, "user", "text", "first");
+        insert(&conn, "s1", 2000, "assistant", "thinking", "second");
+
+        let batch = build_turns_batch(&conn, 0, 10, &HashSet::new()).unwrap();
+        let contents: Vec<&str> = batch.sessions[0].chunks[0]
+            .iter()
+            .map(|t| t.content.as_str())
+            .collect();
+
+        assert_eq!(contents, ["first", "second", "third"]);
+    }
+
+    /// `turnIndex` is a position in the session and the server's conflict key. Publishing
+    /// only a new tail would renumber it from zero and overwrite the start of the
+    /// transcript with its end — while still returning 200 and still reading as a full
+    /// session. Whole-session publishing is what prevents that.
+    #[test]
+    fn republishes_the_whole_session_when_only_the_tail_is_new() {
+        let conn = db();
+        insert(&conn, "s1", 1000, "user", "text", "first");
+        insert(&conn, "s1", 2000, "assistant", "text", "second");
+        let first = build_turns_batch(&conn, 0, 10, &HashSet::new()).unwrap();
+        assert_eq!(first.sessions[0].chunks[0].len(), 2);
+
+        insert(&conn, "s1", 3000, "user", "text", "third");
+        let second = build_turns_batch(&conn, first.session_event_id, 10, &HashSet::new()).unwrap();
+        let turns = &second.sessions[0].chunks[0];
+
+        assert_eq!(turns.len(), 3, "the whole session must be republished");
+        assert_eq!(turns[0].content, "first");
+        assert_eq!(turns[0].turn_index, 0);
+        assert_eq!(turns[2].content, "third");
+        assert_eq!(turns[2].turn_index, 2);
+    }
+
+    #[test]
+    fn chunks_a_long_session_below_the_server_cap() {
+        let conn = db();
+        for i in 0..(MAX_TURNS_PER_REQUEST + 25) {
+            insert(&conn, "s1", 1000 + i as i64, "user", "text", "hello");
+        }
+
+        let batch = build_turns_batch(&conn, 0, 10, &HashSet::new()).unwrap();
+        let chunks = &batch.sessions[0].chunks;
+
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].len(), MAX_TURNS_PER_REQUEST);
+        assert_eq!(chunks[1].len(), 25);
+        // Indices stay absolute across the chunk boundary, or the second request
+        // overwrites the first at indices 0..25.
+        assert_eq!(chunks[1][0].turn_index, MAX_TURNS_PER_REQUEST as i64);
+    }
+
+    #[test]
+    fn skips_empty_text_but_still_advances_the_watermark() {
+        let conn = db();
+        insert(&conn, "s1", 1000, "assistant", "tool_use", "   ");
+        insert(&conn, "s1", 2000, "user", "text", "real");
+
+        let batch = build_turns_batch(&conn, 0, 10, &HashSet::new()).unwrap();
+
+        assert_eq!(batch.sessions[0].chunks[0].len(), 1);
+        assert_eq!(
+            batch.session_event_id, 2,
+            "watermark must pass the skipped row"
+        );
+    }
+
+    #[test]
+    fn incognito_sessions_are_skipped_but_do_not_stall_the_watermark() {
+        let conn = db();
+        insert(&conn, "secret", 1000, "user", "text", "private");
+        insert(&conn, "s2", 2000, "user", "text", "public");
+
+        let incognito: HashSet<String> = ["secret".to_string()].into_iter().collect();
+        let batch = build_turns_batch(&conn, 0, 10, &incognito).unwrap();
+
+        let ids: Vec<&str> = batch
+            .sessions
+            .iter()
+            .map(|s| s.session_id.as_str())
+            .collect();
+        assert_eq!(ids, ["s2"]);
+        assert_eq!(batch.session_event_id, 2);
+    }
+
+    /// The watermark must cover the sessions actually taken. A table-wide MAX would skip
+    /// every session sorting after the budget cut — they would never be published, and
+    /// the run would still report success.
+    #[test]
+    fn budget_does_not_skip_sessions_past_the_cut() {
+        let conn = db();
+        insert(&conn, "s1", 1000, "user", "text", "one");
+        insert(&conn, "s2", 2000, "user", "text", "two");
+        insert(&conn, "s3", 3000, "user", "text", "three");
+
+        let first = build_turns_batch(&conn, 0, 1, &HashSet::new()).unwrap();
+        assert_eq!(first.sessions.len(), 1);
+        assert_eq!(first.sessions[0].session_id, "s1");
+
+        let second = build_turns_batch(&conn, first.session_event_id, 1, &HashSet::new()).unwrap();
+        assert_eq!(
+            second.sessions[0].session_id, "s2",
+            "s2 must not be skipped"
+        );
+
+        let third = build_turns_batch(&conn, second.session_event_id, 1, &HashSet::new()).unwrap();
+        assert_eq!(third.sessions[0].session_id, "s3");
+    }
+
+    #[test]
+    fn attributes_every_turn_to_a_non_empty_actor() {
+        let conn = db();
+        insert(&conn, "s1", 1000, "user", "text", "hi");
+        insert(&conn, "s1", 2000, "assistant", "text", "hello");
+        insert(&conn, "s1", 3000, "tool_result", "tool_result", "ok");
+
+        let batch = build_turns_batch(&conn, 0, 10, &HashSet::new()).unwrap();
+
+        for turn in &batch.sessions[0].chunks[0] {
+            assert!(
+                !turn.actor_name.trim().is_empty(),
+                "the server rejects an empty actorName: {turn:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn no_new_events_is_a_no_op_that_holds_its_watermark() {
+        let conn = db();
+        insert(&conn, "s1", 1000, "user", "text", "hi");
+        let first = build_turns_batch(&conn, 0, 10, &HashSet::new()).unwrap();
+
+        let second = build_turns_batch(&conn, first.session_event_id, 10, &HashSet::new()).unwrap();
+
+        assert!(second.sessions.is_empty());
+        assert_eq!(second.session_event_id, first.session_event_id);
+    }
+}

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -14,6 +14,7 @@
 
 use ai_hist_core::convergence::{IngestRequest, IngestResponse, MachineIdentity};
 use ai_hist_core::outbox::{build_outbox_batch, SyncCursor};
+use ai_hist_core::turns::{build_turns_batch, ConversationTurn, DEFAULT_SESSION_BUDGET};
 use anyhow::{Context, Result};
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
@@ -465,9 +466,42 @@ pub fn batch_id(machine: &str, from: &SyncCursor, to: &SyncCursor, count: usize)
     )
 }
 
+/// Percent-encode one URL path segment.
+///
+/// Session ids come from harness files, not from us. A raw `/` or `?` in one would
+/// silently retarget the request at a different endpoint — and the server would answer
+/// that other request successfully, so nothing downstream would look wrong. Unreserved
+/// characters (RFC 3986 §2.3) pass through; everything else is escaped.
+fn encode_path_segment(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(*byte as char)
+            }
+            other => out.push_str(&format!("%{other:02X}")),
+        }
+    }
+    out
+}
+
 /// The HTTP side of `/v1/ingest`, abstracted so the push orchestration is testable.
 pub trait Ingestor {
     fn ingest(&self, auth: &StoredAuth, req: &IngestRequest) -> Result<IngestResponse>;
+
+    /// `POST /v1/sessions/:sessionId/turns` — one chunk of a session's transcript.
+    ///
+    /// Defaulted so existing test doubles keep compiling; the live ureq implementation
+    /// overrides it. A double that does not override reports zero published turns, which
+    /// is what "this test is not about turns" should look like.
+    fn publish_turns(
+        &self,
+        _auth: &StoredAuth,
+        _session_id: &str,
+        _turns: &[ConversationTurn],
+    ) -> Result<u64> {
+        Ok(0)
+    }
 }
 
 /// Result of a `push` run.
@@ -481,6 +515,10 @@ pub struct PushReport {
     pub batch_limit: usize,
     /// Number of ingest attempts in this push run, including any smaller retry.
     pub attempts: usize,
+    /// Conversation turns accepted by `/v1/sessions/:id/turns` in this run.
+    pub turns_sent: u64,
+    /// Sessions whose transcript was published in this run.
+    pub turns_sessions: usize,
 }
 
 /// A typed Cloudflare Worker capacity rejection. Keeping the status, body, and attempted
@@ -554,6 +592,59 @@ pub fn push(
     }
 }
 
+/// Publish conversation transcripts for sessions with new events, after the convergence
+/// batch has been accepted.
+///
+/// Ordering matters: turns are published only once `/v1/ingest` has succeeded, so a run
+/// that fails on the convergence batch does not advance the transcript watermark either.
+/// A failure here is logged and swallowed rather than failing the push — the convergence
+/// records are already durably accepted at that point, and turning a transcript hiccup
+/// into a push failure would roll the whole run back and re-send them.
+fn publish_session_turns(
+    conn: &Connection,
+    client: &dyn Ingestor,
+    auth: &StoredAuth,
+    cursor: &SyncCursor,
+    incognito: &HashSet<String>,
+) -> (u64, usize, i64) {
+    let batch = match build_turns_batch(
+        conn,
+        cursor.session_event_id,
+        DEFAULT_SESSION_BUDGET,
+        incognito,
+    ) {
+        Ok(batch) => batch,
+        Err(_) => return (0, 0, cursor.session_event_id),
+    };
+    if batch.sessions.is_empty() {
+        return (0, 0, batch.session_event_id);
+    }
+
+    let mut accepted = 0u64;
+    let mut sessions = 0usize;
+    for session in &batch.sessions {
+        let mut whole_session_ok = true;
+        for chunk in &session.chunks {
+            match client.publish_turns(auth, &session.session_id, chunk) {
+                Ok(count) => accepted += count,
+                Err(_) => {
+                    whole_session_ok = false;
+                    break;
+                }
+            }
+        }
+        if !whole_session_ok {
+            // Hold the watermark at the last fully published session. Advancing past a
+            // half-published transcript would leave it permanently truncated, and the
+            // next run would report a clean `turns_sent: 0`.
+            return (accepted, sessions, cursor.session_event_id);
+        }
+        sessions += 1;
+    }
+
+    (accepted, sessions, batch.session_event_id)
+}
+
 fn push_once(
     conn: &Connection,
     client: &dyn Ingestor,
@@ -566,22 +657,33 @@ fn push_once(
 ) -> Result<PushReport> {
     let batch = build_outbox_batch(conn, cursor, batch_limit, incognito)?;
     if batch.records.is_empty() {
+        // Transcripts are published here too, not only on the path with convergence
+        // records. The two streams have independent watermarks, and a machine whose
+        // prompts are fully synced still has a transcript backlog — gating turns on new
+        // prompts would strand it behind a permanent `sent: 0`.
+        let mut advanced = batch.cursor;
+        let (turns_sent, turns_sessions, session_event_id) =
+            publish_session_turns(conn, client, auth, &advanced, incognito);
+        advanced.session_event_id = session_event_id;
+
         // Incognito and zero-emission rows still advance scan cursors. Persist that progress
         // even though there is no payload, otherwise a reduced capacity retry can report a
         // no-op and rebuild the original oversized request on the next run.
-        if batch.cursor != *cursor {
-            save_cursor(&auth.base_url, &batch.cursor)?;
+        if advanced != *cursor {
+            save_cursor(&auth.base_url, &advanced)?;
         }
         return Ok(PushReport {
             sent: 0,
             accepted: 0,
-            cursor: batch.cursor,
+            cursor: advanced,
             batch_id: None,
             batch_limit,
             // `attempts` names the next attempted HTTP call. If this empty batch followed
             // rejected requests, retain the number of calls already made; a first-run no-op
             // still reports zero.
             attempts: attempts.saturating_sub(1),
+            turns_sent,
+            turns_sessions,
         });
     }
     let bid = batch_id(&machine.id, cursor, &batch.cursor, batch.records.len());
@@ -600,14 +702,20 @@ fn push_once(
     };
     let resp = client.ingest(auth, &req).context("POST /v1/ingest")?;
     // advance the cursor only after the server accepts the batch (durable outbox)
-    save_cursor(&auth.base_url, &batch.cursor)?;
+    let mut advanced = batch.cursor;
+    let (turns_sent, turns_sessions, session_event_id) =
+        publish_session_turns(conn, client, auth, &advanced, incognito);
+    advanced.session_event_id = session_event_id;
+    save_cursor(&auth.base_url, &advanced)?;
     Ok(PushReport {
         sent: req.records.len(),
         accepted: resp.accepted,
-        cursor: batch.cursor,
+        cursor: advanced,
         batch_id: Some(bid),
         batch_limit,
         attempts,
+        turns_sent,
+        turns_sessions,
     })
 }
 
@@ -672,6 +780,51 @@ impl Ingestor for UreqIngestor {
         )
         .context("ingest failed")?;
         Ok(response.into_json::<IngestResponse>()?)
+    }
+
+    fn publish_turns(
+        &self,
+        auth: &StoredAuth,
+        session_id: &str,
+        turns: &[ConversationTurn],
+    ) -> Result<u64> {
+        if turns.is_empty() {
+            return Ok(0);
+        }
+        require_secure_transport(&auth.base_url)?;
+        // The session id is a path segment and can contain characters that are not URL
+        // safe, so encode it rather than interpolating it raw.
+        let url = format!(
+            "{}/v1/sessions/{}/turns",
+            auth.base_url.trim_end_matches('/'),
+            encode_path_segment(session_id),
+        );
+        let payload = serde_json::json!({ "turns": turns });
+        let response = send_with_auth_refresh(
+            auth,
+            |current| {
+                ureq::post(&url)
+                    .set("Authorization", &format!("Bearer {}", current.access_token))
+                    .set("Content-Type", "application/json")
+                    .send_json(payload.clone())
+                    .map_err(Box::new)
+            },
+            |error| match error {
+                ureq::Error::Status(code, response) => anyhow::anyhow!(
+                    "turns failed: HTTP {code}: {}",
+                    response.into_string().unwrap_or_default()
+                ),
+                other => other.into(),
+            },
+        )
+        .context("publish turns failed")?;
+
+        #[derive(serde::Deserialize)]
+        struct TurnsResponse {
+            #[serde(default)]
+            accepted: u64,
+        }
+        Ok(response.into_json::<TurnsResponse>()?.accepted)
     }
 }
 
@@ -3131,5 +3284,199 @@ exit 0"#,
         let _relayhistory_base_url = EnvVarGuard::set("RELAYHISTORY_BASE_URL", "///");
         let _ai_hist_base_url = EnvVarGuard::set("AI_HIST_BASE_URL", "http://localhost:8787/");
         assert_eq!(default_base_url(), "http://localhost:8787");
+    }
+    // ----- conversation turns on the push path -----
+
+    fn turns_test_auth() -> StoredAuth {
+        StoredAuth {
+            base_url: "http://localhost:8787".into(),
+            access_token: "rth_at_test".into(),
+            ..Default::default()
+        }
+    }
+
+    /// Records every turns request and can be told to fail for one session, so the tests
+    /// can check both the happy path and what a partial failure does to the watermark.
+    struct TurnsRecordingIngestor {
+        published: RefCell<Vec<(String, usize)>>,
+        fail_session: Option<String>,
+    }
+
+    impl TurnsRecordingIngestor {
+        fn new() -> Self {
+            Self {
+                published: RefCell::new(Vec::new()),
+                fail_session: None,
+            }
+        }
+        fn failing(session: &str) -> Self {
+            Self {
+                published: RefCell::new(Vec::new()),
+                fail_session: Some(session.to_string()),
+            }
+        }
+    }
+
+    impl Ingestor for TurnsRecordingIngestor {
+        fn ingest(&self, _auth: &StoredAuth, req: &IngestRequest) -> Result<IngestResponse> {
+            Ok(IngestResponse {
+                batch_id: req.batch_id.clone(),
+                received: req.records.len() as u64,
+                accepted: req.records.len() as u64,
+                cursors: None,
+            })
+        }
+
+        fn publish_turns(
+            &self,
+            _auth: &StoredAuth,
+            session_id: &str,
+            turns: &[ConversationTurn],
+        ) -> Result<u64> {
+            if self.fail_session.as_deref() == Some(session_id) {
+                anyhow::bail!("turns failed: HTTP 500");
+            }
+            self.published
+                .borrow_mut()
+                .push((session_id.to_string(), turns.len()));
+            Ok(turns.len() as u64)
+        }
+    }
+
+    fn add_session_event(conn: &Connection, session: &str, ts: i64, role: &str, text: &str) {
+        conn.execute(
+            "INSERT INTO session_events (source, session_id, ts_ms, role, kind, text, model, event_uid)
+             VALUES ('claude', ?1, ?2, ?3, 'text', ?4, 'claude-opus-5', ?5)",
+            rusqlite::params![session, ts, role, text, format!("{session}-{ts}-{role}")],
+        )
+        .unwrap();
+    }
+
+    /// The transcript backlog must not be gated on new prompts. Most machines reach
+    /// "prompts fully synced" long before their transcript is published, and a run that
+    /// reported `sent: 0` while silently skipping turns would look exactly like a
+    /// machine with nothing to do.
+    #[test]
+    fn publishes_turns_even_when_there_are_no_new_convergence_records() {
+        with_temp_home(|| {
+            let conn = mem();
+            add_session_event(&conn, "s1", 1_000, "user", "why does it fail?");
+            add_session_event(&conn, "s1", 2_000, "assistant", "the regex is unbounded");
+
+            let client = TurnsRecordingIngestor::new();
+            let auth = turns_test_auth();
+
+            let report = push(
+                &conn,
+                &client,
+                &auth,
+                &MachineIdentity {
+                    id: "m1".into(),
+                    ..Default::default()
+                },
+                &SyncCursor::default(),
+                500,
+                &HashSet::new(),
+            )
+            .unwrap();
+
+            assert_eq!(report.sent, 0, "no history rows exist");
+            assert_eq!(report.turns_sent, 2, "but the transcript must still go");
+            assert_eq!(report.turns_sessions, 1);
+            assert_eq!(client.published.borrow().len(), 1);
+            assert!(report.cursor.session_event_id > 0);
+        });
+    }
+
+    #[test]
+    fn publishes_both_sides_of_the_conversation_not_just_prompts() {
+        with_temp_home(|| {
+            let conn = mem();
+            add(&conn, "why does it fail?", 1_000);
+            add_session_event(&conn, "s1", 1_000, "user", "why does it fail?");
+            add_session_event(&conn, "s1", 2_000, "assistant", "the regex is unbounded");
+
+            let client = TurnsRecordingIngestor::new();
+            let report = push(
+                &conn,
+                &client,
+                &turns_test_auth(),
+                &MachineIdentity {
+                    id: "m1".into(),
+                    ..Default::default()
+                },
+                &SyncCursor::default(),
+                500,
+                &HashSet::new(),
+            )
+            .unwrap();
+
+            assert!(report.sent > 0, "the prompt still goes through convergence");
+            assert_eq!(report.turns_sent, 2, "and the assistant reply goes too");
+        });
+    }
+
+    /// A half-published transcript must not advance the watermark. If it did, the session
+    /// would stay permanently truncated and every later run would report a clean
+    /// `turns_sent: 0` — the failure would be indistinguishable from being up to date.
+    #[test]
+    fn a_failed_transcript_does_not_advance_the_watermark() {
+        with_temp_home(|| {
+            let conn = mem();
+            add_session_event(&conn, "s1", 1_000, "user", "hello");
+
+            let client = TurnsRecordingIngestor::failing("s1");
+            let report = push(
+                &conn,
+                &client,
+                &turns_test_auth(),
+                &MachineIdentity {
+                    id: "m1".into(),
+                    ..Default::default()
+                },
+                &SyncCursor::default(),
+                500,
+                &HashSet::new(),
+            )
+            .unwrap();
+
+            assert_eq!(report.turns_sent, 0);
+            assert_eq!(
+                report.cursor.session_event_id, 0,
+                "the watermark must stay put so the next run retries",
+            );
+        });
+    }
+
+    /// A convergence-mapper replay must not restart the transcript stream. They are
+    /// separate backlogs; conflating them would re-send every turn on every mapper bump.
+    #[test]
+    fn a_capture_version_replay_leaves_the_turns_watermark_alone() {
+        let old = SyncCursor {
+            capture_version: 0,
+            history_id: 5_000,
+            session_event_id: 4_242,
+            ..Default::default()
+        };
+        let upgraded = old.merge_max(&SyncCursor {
+            capture_version: SyncCursor::CAPTURE_VERSION,
+            history_id: 0,
+            session_event_id: 4_242,
+            ..Default::default()
+        });
+
+        assert_eq!(upgraded.history_id, 0, "convergence rewinds");
+        assert_eq!(
+            upgraded.session_event_id, 4_242,
+            "the transcript watermark must survive a convergence replay",
+        );
+    }
+
+    #[test]
+    fn encodes_a_session_id_that_would_otherwise_change_the_url() {
+        assert_eq!(encode_path_segment("abc-123_x.y~z"), "abc-123_x.y~z");
+        assert_eq!(encode_path_segment("a/b"), "a%2Fb");
+        assert_eq!(encode_path_segment("a?b=c"), "a%3Fb%3Dc");
+        assert_eq!(encode_path_segment("a b"), "a%20b");
     }
 }


### PR DESCRIPTION
Two gaps that made a cloud "session replay" show only half the session.

## Turns — the missing half of every transcript

The outbox publishes *prompts* — what the human typed — plus distilled trajectory records. It has never carried the other side. Measured against production on 2026-09-03:

| | in the cloud | local only |
|---|---|---|
| user prompts | 337,139 | — |
| assistant text | — | **190,165** |
| assistant tool_use | — | **350,551** |
| tool_result | — | **338,614** |
| assistant thinking | — | **4,823** |

`POST /v1/sessions/:id/turns` has existed since #23 and **nothing ever called it** — 48 rows across 5 sessions, against 69,389 sessions in the store. So "replay this session" returned the user's side and stopped.

`ai_hist_core::turns` builds the batches from the local `session_events` table that `ai-hist events` already replays, and `push` publishes them once the convergence batch is accepted.

### Three things that fail while still looking like success

- **Sessions publish whole, never incrementally.** `turnIndex` is the server's conflict key and it is a *position within the session*. Publishing only a new tail would renumber from zero and overwrite the start of the transcript with its end — 200 on every request, and a full-looking session on read. Test: `republishes_the_whole_session_when_only_the_tail_is_new`.
- **Turns publish on the empty-batch path too.** The two streams have independent watermarks, and most machines reach "prompts fully synced" long before the transcript is published. Gating turns on new prompts would strand the entire backlog behind a permanent `sent: 0` — indistinguishable from a machine with nothing to do. Test: `publishes_turns_even_when_there_are_no_new_convergence_records`.
- **A failed transcript holds its watermark.** Advancing past a half-published session would leave it truncated forever while every later run reported a clean `turns_sent: 0`. Test: `a_failed_transcript_does_not_advance_the_watermark`.

`session_event_id` is a new cursor field, deliberately independent of `capture_version`: a convergence-mapper replay must not restart the transcript stream (test: `a_capture_version_replay_leaves_the_turns_watermark_alone`), and a cursor written before turns existed defaults to 0 and drains the backlog without forcing another convergence replay.

The session id is percent-encoded into the path — it comes from harness files, not from us, and a raw `/` would retarget the request at a different endpoint which then answers *successfully*.

## taskRef

`task_ref` was `{}` on all 302,643 rows, so `GET /v1/events?taskRef=` matched nothing. Now `{system:"git", id:"<project>@<branch>"}`, from the session's branch, cached per session alongside the existing git-remote lookup.

A branch is the closest thing to a unit of work that exists *while the work happens* — a PR number doesn't exist yet, and a commit sha doesn't exist until the end. Absent rather than synthetic when the branch is unknown, empty, or detached, or when the project is `unknown`: a placeholder would collide unrelated sessions under one task.

## Gates

`385 tests pass` across the workspace (106 core + 257 engine + 19 + 1 + 3, 0 failures). `cargo fmt --check` clean.

## Related

- `relayhistory-cloud` #27 added the read side (`GET /v1/sessions/:id/events`). This fills what that reads.
- Builds on #103 (`project_id` on every event) — `git_task_ref` reuses its `resolve_project_id` output so the two fields agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1KdhQH9QodhnsxSMo6ax7

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

