### PR TITLE
fix(project-id): prefer the git remote over the harness cwd

### DIFF
--- a/crates/ai-hist-core/src/convergence.rs
+++ b/crates/ai-hist-core/src/convergence.rs
@@ -143,14 +143,48 @@ pub const UNKNOWN_PROJECT: &str = "unknown";
 /// Canonical project id for the cloud `project_aliases` table: a repo slug
 /// (`owner/repo` or a short name), never a filesystem path.
 ///
-/// `project` (from `history.project` / `trajectories.project_id`) wins; `git_remote`
-/// is the session-cwd fallback. Empty / unparseable → [`UNKNOWN_PROJECT`].
+/// Precedence, in order:
+///
+/// 1. an EXPLICIT `project` that is not a filesystem path — a deliberate label
+///    (`trajectories.project_id`) always wins, because a human chose it
+/// 2. the session's `git_remote`, which yields `owner/repo`
+/// 3. the `project` path's last component
+/// 4. [`UNKNOWN_PROJECT`]
+///
+/// A path used to win outright, and that is what fragmented the store. In practice
+/// `project` is the harness's cwd, so the remote was resolved on every call and then
+/// discarded, and `normalize_project_id` reduced the path to its last segment. Every
+/// worktree and every subdirectory of one repo therefore became its own project:
+/// `relayfile`, `relayfile-6e8d1a5c`, `relayfile-fork`, `relayfile-dev-collab` — and
+/// an agent working in `cloud/packages/web` filed its work under `web`. On
+/// 2026-09-04 the production store held 45,394 distinct ids for a few dozen repos,
+/// 142 of them for `cloud` alone, while only 128 events out of 274,264 carried the
+/// `owner/repo` form that `GET /v1/sessions?project=` is queried with.
+///
+/// The remote is the one identifier that is stable across worktrees, checkouts and
+/// subdirectories, so it now outranks a path. It does NOT outrank an explicit label:
+/// overriding a deliberately chosen project id with the repo it happens to live in
+/// would lose information rather than canonicalise it.
 pub fn resolve_project_id(project: Option<&str>, git_remote: Option<&str>) -> String {
-    if let Some(project) = nonempty(project) {
-        return normalize_project_id(project);
+    let project = nonempty(project);
+
+    // An explicit, non-path label is a deliberate choice — keep it.
+    if let Some(project) = project {
+        if !is_filesystem_path(project) {
+            return normalize_project_id(project);
+        }
     }
+
+    // Otherwise prefer the remote, which is stable across worktrees and subdirectories.
     if let Some(remote) = nonempty(git_remote) {
-        return normalize_project_id(remote);
+        let resolved = normalize_project_id(remote);
+        if resolved != UNKNOWN_PROJECT {
+            return resolved;
+        }
+    }
+
+    if let Some(project) = project {
+        return normalize_project_id(project);
     }
     UNKNOWN_PROJECT.to_string()
 }
@@ -1530,10 +1564,23 @@ mod tests {
         let v = serde_json::to_value(&unknown).unwrap();
         assert_eq!(v["projectId"], UNKNOWN_PROJECT);
         assert!(!v["projectId"].is_null());
-        // history.project wins over git remote
+        // The git remote wins over a cwd PATH. This inverted a previous assertion
+        // ("history.project wins over git remote"), deliberately: a path is the
+        // harness's working directory, so preferring it made every worktree and
+        // subdirectory its own project and left the store with 45,394 distinct ids
+        // for a few dozen repos.
         assert_eq!(
             resolve_project_id(
                 Some("/tmp/other-app"),
+                Some("git@github.com:AgentWorkforce/relayhistory.git")
+            ),
+            "AgentWorkforce/relayhistory"
+        );
+        // An explicit, non-path label still wins — that half of the old contract
+        // survives, because a chosen id carries intent a repo name does not.
+        assert_eq!(
+            resolve_project_id(
+                Some("other-app"),
                 Some("git@github.com:AgentWorkforce/relayhistory.git")
             ),
             "other-app"
@@ -1754,5 +1801,93 @@ mod tests {
 
         let without = map_history_entry_with(&entry, None, Vec::new(), None);
         assert!(without.task_ref.is_none());
+    }
+
+    /// The production store held 45,394 distinct project ids for a few dozen repos
+    /// because the harness cwd outranked the git remote and was then reduced to its
+    /// last path segment. These pin the precedence that fixes it.
+    mod project_id_precedence {
+        use super::super::{resolve_project_id, UNKNOWN_PROJECT};
+
+        const REMOTE: &str = "git@github.com:AgentWorkforce/relayfile.git";
+
+        #[test]
+        fn a_worktree_path_resolves_to_the_repo_not_the_directory() {
+            // The bug: `relayfile-live-review-vhs`, `relayfile-6e8d1a5c` and
+            // `relayfile-fork` were three different projects to every consumer.
+            for cwd in [
+                "/Users/k/Projects/AgentWorkforce/relayfile",
+                "/Users/k/Projects/AgentWorkforce/relayfile-6e8d1a5c",
+                "/Users/k/Projects/AgentWorkforce/relayfile-live-review-vhs",
+                "/Users/k/Projects/AgentWorkforce/relayfile-fork",
+            ] {
+                assert_eq!(
+                    resolve_project_id(Some(cwd), Some(REMOTE)),
+                    "AgentWorkforce/relayfile",
+                    "worktree {cwd} must resolve to the repo"
+                );
+            }
+        }
+
+        #[test]
+        fn a_subdirectory_resolves_to_the_repo_not_the_subdirectory() {
+            // An agent working in cloud/packages/web filed its work under `web`,
+            // which is why `web` and `sdk` appear as top-level projects.
+            assert_eq!(
+                resolve_project_id(
+                    Some("/Users/k/Projects/AgentWorkforce/cloud/packages/web"),
+                    Some("git@github.com:AgentWorkforce/cloud.git"),
+                ),
+                "AgentWorkforce/cloud"
+            );
+        }
+
+        #[test]
+        fn an_explicit_label_still_wins_over_the_remote() {
+            // A deliberately chosen project id carries intent the repo name does not.
+            // Overriding it would lose information rather than canonicalise it.
+            assert_eq!(
+                resolve_project_id(Some("relayfile-demo-readiness-0901"), Some(REMOTE)),
+                "relayfile-demo-readiness-0901"
+            );
+        }
+
+        #[test]
+        fn a_path_falls_back_to_its_last_component_when_there_is_no_remote() {
+            // Not every checkout has an origin. Previous behaviour is preserved.
+            assert_eq!(
+                resolve_project_id(Some("/Users/k/Projects/AgentWorkforce/relayfile"), None),
+                "relayfile"
+            );
+        }
+
+        #[test]
+        fn an_unparseable_remote_does_not_swallow_the_path() {
+            // A remote that yields nothing must not turn a usable path into `unknown`.
+            assert_eq!(
+                resolve_project_id(
+                    Some("/Users/k/Projects/AgentWorkforce/relayfile"),
+                    Some("   ")
+                ),
+                "relayfile"
+            );
+        }
+
+        #[test]
+        fn nothing_resolvable_is_still_unknown() {
+            assert_eq!(resolve_project_id(None, None), UNKNOWN_PROJECT);
+        }
+
+        #[test]
+        fn https_and_ssh_remotes_agree() {
+            // The same checkout must not change identity with the clone URL used.
+            assert_eq!(
+                resolve_project_id(
+                    Some("/tmp/wt"),
+                    Some("https://github.com/AgentWorkforce/relayfile.git")
+                ),
+                resolve_project_id(Some("/tmp/wt"), Some(REMOTE)),
+            );
+        }
     }
 }

--- a/crates/ai-hist-core/src/convergence.rs
+++ b/crates/ai-hist-core/src/convergence.rs
@@ -176,10 +176,15 @@ pub fn resolve_project_id(project: Option<&str>, git_remote: Option<&str>) -> St
     }
 
     // Otherwise prefer the remote, which is stable across worktrees and subdirectories.
+    //
+    // `slug_from_git_remote`, NOT `normalize_project_id`: only a value that actually
+    // parses as a repository remote may outrank a usable path. `normalize_project_id`
+    // accepts any non-path string, so a malformed remote (`not-a-git-remote`, or a local
+    // origin like `../repo.git`) would be taken as the project id and would discard a
+    // perfectly good cwd — trading one noncanonical id for another.
     if let Some(remote) = nonempty(git_remote) {
-        let resolved = normalize_project_id(remote);
-        if resolved != UNKNOWN_PROJECT {
-            return resolved;
+        if let Some(slug) = slug_from_git_remote(remote) {
+            return slug;
         }
     }
 
@@ -212,7 +217,7 @@ fn normalize_project_id(raw: &str) -> String {
     raw.trim_end_matches('/').to_string()
 }
 
-fn is_filesystem_path(s: &str) -> bool {
+pub(crate) fn is_filesystem_path(s: &str) -> bool {
     let bytes = s.as_bytes();
     s.starts_with('/')
         || s.starts_with('~')
@@ -1863,14 +1868,23 @@ mod tests {
 
         #[test]
         fn an_unparseable_remote_does_not_swallow_the_path() {
-            // A remote that yields nothing must not turn a usable path into `unknown`.
-            assert_eq!(
-                resolve_project_id(
-                    Some("/Users/k/Projects/AgentWorkforce/relayfile"),
-                    Some("   ")
-                ),
-                "relayfile"
-            );
+            // NON-EMPTY malformed remotes. The earlier version of this test passed
+            // whitespace, which `nonempty` strips before the remote branch is reached —
+            // it asserted nothing about the behaviour it named.
+            //
+            // `normalize_project_id` accepts any non-path string, so without requiring a
+            // parsed slug each of these would become the project id and discard a
+            // perfectly usable path — trading one noncanonical id for another.
+            for bogus in ["not-a-git-remote", "../repo.git", "origin", "   "] {
+                assert_eq!(
+                    resolve_project_id(
+                        Some("/Users/k/Projects/AgentWorkforce/relayfile"),
+                        Some(bogus)
+                    ),
+                    "relayfile",
+                    "remote {bogus:?} does not parse as a repo slug and must not win"
+                );
+            }
         }
 
         #[test]

--- a/crates/ai-hist-core/src/outbox.rs
+++ b/crates/ai-hist-core/src/outbox.rs
@@ -489,11 +489,16 @@ fn git_remote_for_entry(
     entry: &HistoryEntry,
     remotes: &mut HashMap<String, Option<String>>,
 ) -> Option<String> {
+    // Only an EXPLICIT, non-path project makes the remote unnecessary. When the entry
+    // carries its cwd — the common case, and the one the fragmentation comes from —
+    // the remote is exactly what we need, so returning None here made
+    // `resolve_project_id`'s remote preference unreachable on the publishing path and
+    // the cwd basename went out unchanged.
     if entry
         .project
         .as_deref()
         .map(str::trim)
-        .is_some_and(|s| !s.is_empty())
+        .is_some_and(|s| !s.is_empty() && !crate::convergence::is_filesystem_path(s))
     {
         return None;
     }
@@ -669,6 +674,93 @@ mod tests {
             },
         )
         .unwrap();
+    }
+
+    /// A path-valued `project` must NOT suppress the remote lookup.
+    ///
+    /// This is the test whose absence let the first version of the fix ship inert.
+    /// `resolve_project_id` learned to prefer the remote, but `git_remote_for_entry`
+    /// returned `None` for ANY non-empty `project` — and `project` is the cwd in the
+    /// common case, so the publishing path never had a remote to prefer and kept
+    /// emitting the cwd basename. Unit tests on `resolve_project_id` all passed.
+    #[test]
+    fn a_path_valued_project_still_fetches_the_git_remote() {
+        let repo = tempfile::tempdir().unwrap();
+        let cwd = repo.path().to_str().unwrap().to_string();
+        for args in [
+            vec!["init", "--quiet"],
+            vec![
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:AgentWorkforce/relayfile.git",
+            ],
+        ] {
+            let ok = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&cwd)
+                .args(&args)
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false);
+            if !ok {
+                return; // no usable git in this environment; nothing to assert
+            }
+        }
+
+        let conn = mem();
+        conn.execute(
+            "INSERT INTO sessions (session_id, source, cwd, parser_version) VALUES ('s-path','claude',?1,1)",
+            rusqlite::params![cwd],
+        )
+        .unwrap();
+
+        let mut remotes = HashMap::new();
+        let entry = HistoryEntry {
+            id: 1,
+            source: "claude".into(),
+            session_id: Some("s-path".into()),
+            // The cwd, exactly as the harness records it.
+            project: Some(cwd.clone()),
+            prompt: "hi".into(),
+            prompt_hash: Some("h".into()),
+            timestamp_ms: 0,
+        };
+
+        let remote = git_remote_for_entry(&conn, &entry, &mut remotes);
+        assert!(
+            remote.is_some(),
+            "a path-valued project must still resolve the remote, or the cwd basename goes out unchanged"
+        );
+        assert_eq!(
+            crate::convergence::resolve_project_id(entry.project.as_deref(), remote.as_deref()),
+            "AgentWorkforce/relayfile"
+        );
+    }
+
+    /// The other half: an explicit label is a deliberate choice, so the remote lookup
+    /// stays skipped and the label survives.
+    #[test]
+    fn an_explicit_label_skips_the_remote_lookup() {
+        let conn = mem();
+        conn.execute(
+            "INSERT INTO sessions (session_id, source, cwd, parser_version) VALUES ('s-label','claude','/tmp/whatever',1)",
+            [],
+        )
+        .unwrap();
+
+        let mut remotes = HashMap::new();
+        let entry = HistoryEntry {
+            id: 1,
+            source: "claude".into(),
+            session_id: Some("s-label".into()),
+            project: Some("relayfile-demo-readiness-0901".into()),
+            prompt: "hi".into(),
+            prompt_hash: Some("h".into()),
+            timestamp_ms: 0,
+        };
+
+        assert!(git_remote_for_entry(&conn, &entry, &mut remotes).is_none());
     }
 
     fn add_trajectory(conn: &Connection, id: &str, decisions: &str, retro: &str) {


### PR DESCRIPTION
## The problem, measured

Production `convergence_events`, 2026-09-04:

| shape | events | distinct ids |
| --- | --- | --- |
| bare single segment | 256,688 | **45,394** |
| null | 85,559 | — |
| sentinel `unknown` | 15,527 | 1 |
| absolute filesystem path | 1,921 | 62 |
| **`owner/repo` (queryable)** | **128** | 5 |

**45,394 distinct project ids for a few dozen repos.** `cloud` alone accounts for 142. Only **128 of 274,264** events carry the `owner/repo` form that `GET /v1/sessions?project=` is queried with — so `?project=AgentWorkforce/relayfile-cloud` matches essentially nothing, and repo-intel's digest has to compensate with alias tables and substring sweeps.

## Root cause

`session_project_id` (`outbox.rs:535`) resolves the git remote on every call and then discards it:

```rust
let remote = session_cwd(...).and_then(|cwd| ... git_origin_url(&cwd) ...);
let resolved = resolve_project_id(project.as_deref(), remote.as_deref());
```

`resolve_project_id` preferred `project` — in practice the harness's **working directory** — and `normalize_project_id` reduces a path to its last segment. So one repo scatters:

```
relayfile, relayfile-6e8d1a5c, relayfile-fork, relayfile-dev-collab
relayfile-cloud, relayfile-cloud-d636f931
```

and an agent working in `cloud/packages/web` files under `web` — which is why `web`, `sdk`, and even `Projects` appear as top-level project ids.

`slug_from_git_remote` already produces exactly the right `owner/repo`. It was simply ordered second.

## The change

New precedence:

1. an explicit `project` that is **not** a filesystem path — a deliberate label
2. the git remote
3. the path's last component
4. `unknown`

An explicit label still outranks the remote: overriding a deliberately chosen id with the repo it happens to sit in would lose information rather than canonicalise it, so `relayfile-demo-readiness-0901` is preserved.

Two guards keep this from regressing: a remote that resolves to nothing must not turn a usable path into `unknown`, and a path with no remote still falls back to its last component exactly as before.

## A deliberately inverted assertion

`project_id_mapping_path_git_remote_and_unknown` pinned *"history.project wins over git remote"*. That is the old contract and the thing being fixed. It now asserts the new behaviour, **and** the half that survives (an explicit label winning) is pinned alongside it so the distinction cannot be lost silently.

## Tests

7 new cases: worktree paths collapse to the repo · a subdirectory resolves to the repo, not the subdirectory · an explicit label still wins · path-only fallback preserved · an unparseable remote does not swallow the path · nothing resolvable is still `unknown` · https and ssh remotes agree.

Verified the two central tests **fail** against the old precedence rather than passing vacuously. Full workspace suite green (390 tests), `cargo clippy -D warnings` clean, `cargo fmt --check` clean.

## Scope

Forward-looking only — existing rows keep their ids. The backfill of the 274k historical rows is a separate, separately-approved step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1KdhQH9QodhnsxSMo6ax7

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

