### PR TITLE
feat(cli): replay cloud sessions for offline reading

### DIFF
--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -1137,6 +1137,74 @@ fn map_http_err(e: ureq::Error) -> anyhow::Error {
     }
 }
 
+/// Fetch every page in the server's ascending `(ts, eventId)` order.
+pub fn replay_events(
+    auth: &StoredAuth,
+    session_id: &str,
+    limit: Option<usize>,
+    max_content: Option<usize>,
+) -> Result<Vec<serde_json::Value>> {
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct EventPage {
+        // Keep the event payload intact so --json preserves fields added by the server.
+        events: Vec<serde_json::Value>,
+        next_cursor: Option<String>,
+    }
+
+    require_secure_transport(&auth.base_url)?;
+    let url = format!(
+        "{}/v1/sessions/{}/events",
+        normalized_stage(&auth.base_url)?,
+        encode_path_segment(session_id)
+    );
+    let mut events = Vec::new();
+    let mut cursor: Option<String> = None;
+    let mut seen_cursors = HashSet::new();
+    loop {
+        let response = send_with_auth_refresh(
+            auth,
+            |current| {
+                let mut request = ureq::get(&url)
+                    .set("Authorization", &format!("Bearer {}", current.access_token))
+                    .query("order", "asc");
+                if let Some(value) = limit {
+                    request = request.query("limit", &value.to_string());
+                }
+                if let Some(value) = max_content {
+                    request = request.query("maxContent", &value.to_string());
+                }
+                if let Some(value) = &cursor {
+                    request = request.query("cursor", value);
+                }
+                request.call().map_err(Box::new)
+            },
+            |error| match error {
+                ureq::Error::Status(401, _) => anyhow::anyhow!(
+                    "HTTP 401: relayhistory session is expired or invalid; run `ai-hist login` for the selected --base-url"
+                ),
+                other => map_http_err(other),
+            },
+        )
+        .context("replay query failed (authentication failures require `ai-hist login` for the selected --base-url)")?;
+        let page: EventPage = response.into_json().context("parsing replay events page")?;
+        events.extend(page.events);
+        match page.next_cursor {
+            None => return Ok(events),
+            Some(next) => {
+                // Preserve the opaque cursor, including its event-id tiebreak. A short
+                // page is not exhaustion, and a repeated cursor must fail instead of
+                // looping forever or saving duplicated events as a complete transcript.
+                anyhow::ensure!(
+                    !next.is_empty() && seen_cursors.insert(next.clone()),
+                    "replay returned an empty or repeated nextCursor; transcript is incomplete"
+                );
+                cursor = Some(next);
+            }
+        }
+    }
+}
+
 // ----- WS-6 Pair: in-session warning check (client of POST /v1/pair/check) -----
 
 /// Minimal current-session context sent to `/v1/pair/check`. **Never** file contents or

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -35,6 +35,7 @@ mod relationships;
 /// Remote session connectors (claude.ai/code web sessions, Codex cloud tasks)
 /// and their availability reporting.
 pub mod remote;
+mod replay;
 
 pub use discover::{
     discover_sessions, discover_sessions_collect, discover_sessions_with_env,
@@ -630,6 +631,25 @@ enum Command {
         #[arg(long, default_value = "local-dev")]
         label: String,
     },
+    /// Fetch a cloud session transcript for offline reading (never imports into SQLite).
+    Replay {
+        session_id: String,
+        /// Select the cloud stage. Defaults to RELAYHISTORY_BASE_URL/AI_HIST_BASE_URL, then prod.
+        #[arg(long)]
+        base_url: Option<String>,
+        /// Events per request (server default 200, maximum 1000). All pages are fetched.
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Cap content per event on the server; truncated events are marked explicitly.
+        #[arg(long)]
+        max_content: Option<usize>,
+        /// Emit the raw event array as JSON.
+        #[arg(long)]
+        json: bool,
+        /// Save the transcript to a file instead of stdout.
+        #[arg(long)]
+        out: Option<PathBuf>,
+    },
     /// Push new local history + trajectory events to relayhistory-cloud.
     Push {
         /// Select the cloud stage. Required when this machine has sessions for multiple stages.
@@ -929,6 +949,25 @@ pub fn run() -> Result<()> {
     // Pre-dispatch them so the common connection setup below cannot initialize the schema or
     // wait on SQLite before contention is detected.
     match &cli.command {
+        // The common read-only path can create or migrate SQLite. A cloud replay must
+        // also work on a fresh machine without creating a local history store.
+        Command::Replay {
+            session_id,
+            base_url,
+            limit,
+            max_content,
+            json,
+            out,
+        } => {
+            return replay::run(
+                session_id,
+                base_url.as_deref(),
+                *limit,
+                *max_content,
+                *json,
+                out.as_deref(),
+            );
+        }
         Command::Sync {
             scope,
             install_service,
@@ -968,6 +1007,7 @@ pub fn run() -> Result<()> {
     };
 
     match cli.command {
+        Command::Replay { .. } => unreachable!("replay is dispatched before opening SQLite"),
         Command::Search {
             scope,
             query,

--- a/crates/ai-hist/src/replay.rs
+++ b/crates/ai-hist/src/replay.rs
@@ -1,0 +1,74 @@
+use crate::cloud;
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::io::{self, Write};
+use std::path::Path;
+
+pub fn run(
+    session_id: &str,
+    base_url: Option<&str>,
+    limit: Option<usize>,
+    max_content: Option<usize>,
+    json: bool,
+    out: Option<&Path>,
+) -> Result<()> {
+    let base_url = base_url
+        .map(String::from)
+        .unwrap_or_else(cloud::default_base_url);
+    let auth = cloud::load_auth(Some(&base_url))?.context(
+        "not authenticated for the selected stage — run `ai-hist login` or `ai-hist admin-mint` first",
+    )?;
+    let events = cloud::replay_events(&auth, session_id, limit, max_content)?;
+    let body = if json {
+        format!("{}\n", serde_json::to_string(&events)?)
+    } else {
+        render(session_id, &events)
+    };
+    // Finish fetching before touching the destination: an expired token on page two
+    // must not overwrite an existing offline transcript with only page one.
+    if let Some(path) = out {
+        std::fs::write(path, body)
+            .with_context(|| format!("writing replay to {}", path.display()))?;
+    } else {
+        io::stdout().lock().write_all(body.as_bytes())?;
+    }
+    Ok(())
+}
+
+fn render(session_id: &str, events: &[Value]) -> String {
+    let mut output = format!(
+        "Session {session_id} — {} event(s), oldest first\n",
+        events.len()
+    );
+    if events.is_empty() {
+        output.push_str("No events found.\n");
+    }
+    for event in events {
+        let text = |field: &str| event[field].as_str().unwrap_or("");
+        output.push_str(&format!(
+            "\n[{}] {} / {} ({})\n",
+            text("ts"),
+            text("source"),
+            text("kind"),
+            text("eventId")
+        ));
+        for (field, label) in [
+            ("actorName", "Actor"),
+            ("actorRole", "Role"),
+            ("toolName", "Tool"),
+            ("taskTitle", "Task"),
+        ] {
+            if let Some(value) = event[field].as_str().filter(|value| !value.is_empty()) {
+                output.push_str(&format!("{label}: {value}\n"));
+            }
+        }
+        // The flag is authoritative even if content is empty or lacks the server's
+        // inline suffix; a cut transcript must never look like the session ended here.
+        if event["contentTruncated"].as_bool() == Some(true) {
+            output.push_str("[CONTENT TRUNCATED by server maxContent; this event is incomplete]\n");
+        }
+        output.push_str(event["content"].as_str().unwrap_or("(no content)"));
+        output.push('\n');
+    }
+    output
+}

--- a/crates/ai-hist/src/replay.rs
+++ b/crates/ai-hist/src/replay.rs
@@ -2,6 +2,7 @@ use crate::cloud;
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::io::{self, Write};
+use tempfile::NamedTempFile;
 use std::path::Path;
 
 pub fn run(
@@ -20,18 +21,47 @@ pub fn run(
     )?;
     let events = cloud::replay_events(&auth, session_id, limit, max_content)?;
     let body = if json {
-        format!("{}\n", serde_json::to_string(&events)?)
+        // Serialize once and push the newline, rather than `format!`-ing the serialized
+        // string into a second one. A long session's transcript is the largest thing this
+        // command holds; duplicating it wholesale to append a byte is a needless spike.
+        let mut body = serde_json::to_string(&events)?;
+        body.push('\n');
+        body
     } else {
         render(session_id, &events)
     };
     // Finish fetching before touching the destination: an expired token on page two
     // must not overwrite an existing offline transcript with only page one.
     if let Some(path) = out {
-        std::fs::write(path, body)
+        write_atomically(path, body.as_bytes())
             .with_context(|| format!("writing replay to {}", path.display()))?;
     } else {
         io::stdout().lock().write_all(body.as_bytes())?;
     }
+    Ok(())
+}
+
+/// Write via a temporary file in the destination's own directory, then rename over it.
+///
+/// The same reason the fetch completes before the write: an existing transcript must not
+/// be destroyed by a replay that does not finish. `fs::write` truncates first, so a full
+/// disk or an interrupted process leaves a half-written file where a complete one was.
+/// `rename` within a directory is atomic, so the destination only ever holds the old
+/// complete transcript or the new one.
+///
+/// The temp file is a sibling, not in the system temp dir, because `rename` across
+/// filesystems fails — and the destination is frequently on a different mount than /tmp.
+fn write_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
+    let dir = path.parent().filter(|p| !p.as_os_str().is_empty());
+    let mut temp = match dir {
+        Some(dir) => NamedTempFile::new_in(dir)?,
+        None => NamedTempFile::new_in(".")?,
+    };
+    temp.write_all(bytes)?;
+    // Flush to disk before the rename: a rename that lands before the data does would
+    // leave an empty file after a crash, which is exactly the loss this guards against.
+    temp.as_file().sync_all()?;
+    temp.persist(path).map_err(|e| e.error)?;
     Ok(())
 }
 

--- a/crates/ai-hist/src/replay.rs
+++ b/crates/ai-hist/src/replay.rs
@@ -1,7 +1,6 @@
 use crate::cloud;
 use anyhow::{Context, Result};
 use serde_json::Value;
-use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
 use tempfile::NamedTempFile;
@@ -56,20 +55,22 @@ pub fn run(
 fn write_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
     let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
     let dir = parent.unwrap_or_else(|| Path::new("."));
-    let tmp = NamedTempFile::new_in(dir)?;
+    let mut tmp = NamedTempFile::new_in(dir)
+        .with_context(|| format!("creating temporary transcript in {}", dir.display()))?;
+    // Write through the handle `NamedTempFile` already holds. Converting to a path first
+    // and reopening by name would close a securely-created file and then re-resolve that
+    // name, which on a shared or writable directory is a symlink race: an attacker
+    // swapping a link in between would have us truncate and overwrite an arbitrary file.
+    tmp.write_all(bytes)?;
+    // Flush before replacing: a replacement that lands before the data would leave an
+    // empty file after a crash, which is exactly the loss this guards against.
+    tmp.as_file().sync_all()?;
     let tmp_path = tmp.into_temp_path();
-    {
-        let mut file = fs::File::create(&tmp_path)
-            .with_context(|| format!("creating temporary transcript at {}", tmp_path.display()))?;
-        file.write_all(bytes)?;
-        // Flush before replacing: a replacement that lands before the data would leave an
-        // empty file after a crash, which is exactly the loss this guards against.
-        file.sync_all()?;
-    }
     atomicwrites::replace_atomic(&tmp_path, path)
         .with_context(|| format!("atomically replacing {}", path.display()))?;
-    // Keep the guard from deleting a path it no longer owns after a successful replace.
-    std::mem::forget(tmp_path);
+    // The replace consumed the temporary; keep the guard from trying to unlink a path it
+    // no longer owns.
+    tmp_path.keep()?;
     Ok(())
 }
 

--- a/crates/ai-hist/src/replay.rs
+++ b/crates/ai-hist/src/replay.rs
@@ -2,8 +2,8 @@ use crate::cloud;
 use anyhow::{Context, Result};
 use serde_json::Value;
 use std::io::{self, Write};
-use tempfile::NamedTempFile;
 use std::path::Path;
+use tempfile::NamedTempFile;
 
 pub fn run(
     session_id: &str,

--- a/crates/ai-hist/src/replay.rs
+++ b/crates/ai-hist/src/replay.rs
@@ -1,6 +1,7 @@
 use crate::cloud;
 use anyhow::{Context, Result};
 use serde_json::Value;
+use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
 use tempfile::NamedTempFile;
@@ -41,27 +42,34 @@ pub fn run(
     Ok(())
 }
 
-/// Write via a temporary file in the destination's own directory, then rename over it.
+/// Write via a temporary file in the destination's own directory, then atomically replace.
 ///
-/// The same reason the fetch completes before the write: an existing transcript must not
-/// be destroyed by a replay that does not finish. `fs::write` truncates first, so a full
-/// disk or an interrupted process leaves a half-written file where a complete one was.
-/// `rename` within a directory is atomic, so the destination only ever holds the old
-/// complete transcript or the new one.
+/// Same reason the fetch completes before the write: an existing transcript must not be
+/// destroyed by a replay that does not finish. `fs::write` truncates first, so a full disk
+/// or an interrupted process leaves a half-written file where a complete one was.
 ///
-/// The temp file is a sibling, not in the system temp dir, because `rename` across
-/// filesystems fails — and the destination is frequently on a different mount than /tmp.
+/// Uses `atomicwrites::replace_atomic` rather than a plain rename, matching
+/// `cloud.rs`'s state writer. `std::fs::rename` replaces an existing file on Unix but NOT
+/// on Windows, so persisting over an existing transcript would fail there — every repeat
+/// replay to the same path, which is the normal case. The temp file is a sibling because
+/// replacement across filesystems fails and the destination is often on another mount.
 fn write_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
-    let dir = path.parent().filter(|p| !p.as_os_str().is_empty());
-    let mut temp = match dir {
-        Some(dir) => NamedTempFile::new_in(dir)?,
-        None => NamedTempFile::new_in(".")?,
-    };
-    temp.write_all(bytes)?;
-    // Flush to disk before the rename: a rename that lands before the data does would
-    // leave an empty file after a crash, which is exactly the loss this guards against.
-    temp.as_file().sync_all()?;
-    temp.persist(path).map_err(|e| e.error)?;
+    let parent = path.parent().filter(|p| !p.as_os_str().is_empty());
+    let dir = parent.unwrap_or_else(|| Path::new("."));
+    let tmp = NamedTempFile::new_in(dir)?;
+    let tmp_path = tmp.into_temp_path();
+    {
+        let mut file = fs::File::create(&tmp_path)
+            .with_context(|| format!("creating temporary transcript at {}", tmp_path.display()))?;
+        file.write_all(bytes)?;
+        // Flush before replacing: a replacement that lands before the data would leave an
+        // empty file after a crash, which is exactly the loss this guards against.
+        file.sync_all()?;
+    }
+    atomicwrites::replace_atomic(&tmp_path, path)
+        .with_context(|| format!("atomically replacing {}", path.display()))?;
+    // Keep the guard from deleting a path it no longer owns after a successful replace.
+    std::mem::forget(tmp_path);
     Ok(())
 }
 

--- a/crates/ai-hist/tests/replay.rs
+++ b/crates/ai-hist/tests/replay.rs
@@ -1,0 +1,279 @@
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn server(pages: Vec<(u16, Value)>) -> (String, thread::JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    listener.set_nonblocking(true).unwrap();
+    let handle = thread::spawn(move || {
+        let mut requests = Vec::new();
+        for (status, page) in pages {
+            let start = Instant::now();
+            let mut stream = loop {
+                match listener.accept() {
+                    Ok((stream, _)) => break stream,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        assert!(start.elapsed() < Duration::from_secs(10), "missing request");
+                        thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("{error}"),
+                }
+            };
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut request = String::new();
+            loop {
+                let mut line = String::new();
+                let count = reader.read_line(&mut line).unwrap();
+                request.push_str(&line);
+                if count == 0 || line == "\r\n" {
+                    break;
+                }
+            }
+            let body = page.to_string();
+            write!(stream, "HTTP/1.1 {status} Test\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).unwrap();
+            requests.push(request);
+        }
+        requests
+    });
+    (base, handle)
+}
+
+fn save_auth(home: &Path, base: &str, legacy: bool) {
+    let path = if legacy {
+        home.join("auth.json")
+    } else {
+        let stages = home.join("stages");
+        std::fs::create_dir_all(&stages).unwrap();
+        stages.join(format!("{}.auth.json", ai_hist_core::prompt_hash(base)))
+    };
+    std::fs::write(
+        path,
+        json!({
+            "base_url": base, "access_token": "rth_at_test", "refresh_token": null
+        })
+        .to_string(),
+    )
+    .unwrap();
+}
+
+fn replay(home: &Path, base: &str, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_ai-hist"))
+        .env("RELAYHISTORY_HOME", home)
+        .env("RELAYHISTORY_BASE_URL", base)
+        .env_remove("AI_HIST_BASE_URL")
+        .arg("--db")
+        .arg(home.join("must-not-create.db"))
+        .arg("replay")
+        .args(args)
+        .output()
+        .unwrap()
+}
+
+fn event(id: &str, ts: &str, content: Value, truncated: bool) -> Value {
+    json!({"eventId": id, "ts": ts, "source": "claude", "kind": "prompt",
+        "actorName": "Alice", "actorRole": "user", "content": content,
+        "contentTruncated": truncated, "futureField": {"preserved": true}})
+}
+
+fn success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn replay_pages_past_a_short_page_and_preserves_raw_events_and_cursor_ties() {
+    let home = tempfile::tempdir().unwrap();
+    let ts = "2026-09-06T12:00:00.000Z";
+    let first = event("a", ts, json!("first"), false);
+    let second = event("b", ts, json!("second"), true);
+    let third = event("c", "2026-09-06T12:00:01.000Z", json!("third"), false);
+    let cursor = format!("{ts}|a+&?");
+    let (base, server) = server(vec![
+        (
+            200,
+            json!({"events": [first.clone()], "nextCursor": cursor}),
+        ),
+        (
+            200,
+            json!({"events": [second.clone()], "nextCursor": format!("{ts}|b")}),
+        ),
+        (200, json!({"events": [third.clone()], "nextCursor": null})),
+    ]);
+    save_auth(home.path(), &base, false);
+    let output = replay(
+        home.path(),
+        &base,
+        &[
+            "session/with?reserved",
+            "--json",
+            "--limit",
+            "7",
+            "--max-content",
+            "12",
+        ],
+    );
+    success(&output);
+    assert_eq!(
+        serde_json::from_slice::<Value>(&output.stdout).unwrap(),
+        json!([first, second, third])
+    );
+    let requests = server.join().unwrap();
+    for request in &requests {
+        assert!(
+            request.starts_with("GET /v1/sessions/session%2Fwith%3Freserved/events?"),
+            "{request}"
+        );
+        assert!(request.contains("Authorization: Bearer rth_at_test"));
+        assert!(request.contains("order=asc"));
+        assert!(request.contains("limit=7"));
+        assert!(request.contains("maxContent=12"));
+    }
+    let target = requests[1].split_whitespace().nth(1).unwrap();
+    let url = url::Url::parse(&format!("{base}{target}")).unwrap();
+    assert_eq!(
+        url.query_pairs()
+            .find(|(key, _)| key == "cursor")
+            .unwrap()
+            .1,
+        cursor
+    );
+    assert!(!home.path().join("must-not-create.db").exists());
+}
+
+#[test]
+fn replay_renders_chronology_and_marks_truncation_even_without_content() {
+    let home = tempfile::tempdir().unwrap();
+    let (base, server) = server(vec![(
+        200,
+        json!({"events": [
+        event("first", "2026-09-06T12:00:00Z", json!("hello\nworld"), false),
+        event("second", "2026-09-06T12:01:00Z", Value::Null, true)
+    ], "nextCursor": null}),
+    )]);
+    save_auth(home.path(), &base, false);
+    let path = home.path().join("offline.txt");
+    let output = replay(
+        home.path(),
+        &base,
+        &["session", "--out", path.to_str().unwrap()],
+    );
+    success(&output);
+    server.join().unwrap();
+    assert!(output.stdout.is_empty());
+    let text = std::fs::read_to_string(path).unwrap();
+    assert!(text.find("(first)").unwrap() < text.find("(second)").unwrap());
+    assert!(text.contains("hello\nworld"));
+    assert!(text.contains("Actor: Alice"));
+    assert!(text.contains("CONTENT TRUNCATED by server maxContent; this event is incomplete"));
+}
+
+#[test]
+fn replay_unknown_session_is_an_empty_array_and_json_can_be_saved() {
+    let home = tempfile::tempdir().unwrap();
+    let (base, server) = server(vec![(200, json!({"events": [], "nextCursor": null}))]);
+    save_auth(home.path(), &base, true);
+    let path = home.path().join("offline.json");
+    let output = replay(
+        home.path(),
+        &base,
+        &["unknown", "--json", "--out", path.to_str().unwrap()],
+    );
+    success(&output);
+    server.join().unwrap();
+    assert!(output.stdout.is_empty());
+    assert_eq!(std::fs::read_to_string(path).unwrap(), "[]\n");
+    assert!(!home.path().join("must-not-create.db").exists());
+}
+
+#[test]
+fn replay_without_selected_stage_auth_explains_login_without_opening_sqlite() {
+    let home = tempfile::tempdir().unwrap();
+    save_auth(home.path(), "http://127.0.0.1:2", false);
+    save_auth(home.path(), "http://127.0.0.1:2", true);
+    let output = replay(home.path(), "http://127.0.0.1:1", &["session"]);
+    assert!(!output.status.success());
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        error.contains("not authenticated for the selected stage"),
+        "{error}"
+    );
+    assert!(error.contains("ai-hist login"));
+    assert!(!error.contains("panicked"));
+    assert!(!home.path().join("must-not-create.db").exists());
+}
+
+#[test]
+fn replay_expired_token_on_later_page_leaves_existing_transcript_intact() {
+    let home = tempfile::tempdir().unwrap();
+    let (base, server) = server(vec![
+        (
+            200,
+            json!({"events": [event("first", "2026-09-06T12:00:00Z", json!("first"), false)], "nextCursor": "2026-09-06T12:00:00Z|first"}),
+        ),
+        (401, json!({"error": "expired token"})),
+    ]);
+    save_auth(home.path(), &base, false);
+    let path = home.path().join("offline.txt");
+    std::fs::write(&path, "previous transcript").unwrap();
+    let output = replay(
+        home.path(),
+        &base,
+        &["session", "--out", path.to_str().unwrap()],
+    );
+    server.join().unwrap();
+    assert!(!output.status.success());
+    let error = String::from_utf8_lossy(&output.stderr);
+    assert!(error.contains("HTTP 401"), "{error}");
+    assert!(error.contains("expired or invalid"));
+    assert!(error.contains("ai-hist login"));
+    assert!(!error.contains("panicked"));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        std::fs::read_to_string(path).unwrap(),
+        "previous transcript"
+    );
+}
+
+#[test]
+fn replay_rejects_repeated_cursors_instead_of_saving_an_incomplete_transcript() {
+    let home = tempfile::tempdir().unwrap();
+    let page = json!({"events": [], "nextCursor": "2026-09-06T12:00:00Z|same"});
+    let (base, server) = server(vec![(200, page.clone()), (200, page)]);
+    save_auth(home.path(), &base, false);
+    let output = replay(home.path(), &base, &["session", "--json"]);
+    server.join().unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("repeated nextCursor"));
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
+fn replay_explicit_base_url_overrides_default_and_does_not_open_an_invalid_db() {
+    let home = tempfile::tempdir().unwrap();
+    std::fs::write(home.path().join("must-not-create.db"), "not sqlite").unwrap();
+    let (base, server) = server(vec![(200, json!({"events": [], "nextCursor": null}))]);
+    save_auth(home.path(), &base, false);
+    let output = replay(
+        home.path(),
+        "http://127.0.0.1:1",
+        &["unknown", "--base-url", &base],
+    );
+    success(&output);
+    server.join().unwrap();
+    assert!(String::from_utf8_lossy(&output.stdout).contains("No events found."));
+    assert_eq!(
+        std::fs::read_to_string(home.path().join("must-not-create.db")).unwrap(),
+        "not sqlite"
+    );
+}

--- a/crates/ai-hist/tests/replay.rs
+++ b/crates/ai-hist/tests/replay.rs
@@ -24,6 +24,11 @@ fn server(pages: Vec<(u16, Value)>) -> (String, thread::JoinHandle<Vec<String>>)
                     Err(error) => panic!("{error}"),
                 }
             };
+            // The listener is non-blocking so `accept` can poll, and on macOS/BSD the
+            // accepted stream INHERITS O_NONBLOCK. `set_read_timeout` does not clear it,
+            // so `read_line` below returned WouldBlock the instant the client had not yet
+            // written — an intermittent panic that looks like a product bug and is not one.
+            stream.set_nonblocking(false).unwrap();
             stream
                 .set_read_timeout(Some(Duration::from_secs(5)))
                 .unwrap();
@@ -176,6 +181,19 @@ fn replay_renders_chronology_and_marks_truncation_even_without_content() {
     assert!(text.contains("hello\nworld"));
     assert!(text.contains("Actor: Alice"));
     assert!(text.contains("CONTENT TRUNCATED by server maxContent; this event is incomplete"));
+    // The notice must be tied to the flag, not printed for every event: asserting only the
+    // positive case would pass a regression that marks a complete transcript as truncated,
+    // which is the same lie in the opposite direction.
+    assert_eq!(
+        text.matches("CONTENT TRUNCATED").count(),
+        1,
+        "only the flagged event may carry the truncation notice"
+    );
+    let first = &text[text.find("(first)").unwrap()..text.find("(second)").unwrap()];
+    assert!(
+        !first.contains("CONTENT TRUNCATED"),
+        "an event with contentTruncated=false must not be marked truncated"
+    );
 }
 
 #[test]

--- a/crates/ai-hist/tests/replay.rs
+++ b/crates/ai-hist/tests/replay.rs
@@ -197,6 +197,49 @@ fn replay_renders_chronology_and_marks_truncation_even_without_content() {
 }
 
 #[test]
+fn replay_over_an_existing_transcript_replaces_it() {
+    // The overwrite path had no coverage: the only test writing a file first exercised the
+    // FAILURE case (expired token leaves it intact). A successful repeat replay to the same
+    // path is the normal way this command is used, and it is the case that breaks when the
+    // replacement primitive cannot overwrite — `rename` does not, on Windows.
+    let home = tempfile::tempdir().unwrap();
+    let (base, server) = server(vec![(
+        200,
+        json!({"events": [event("only", "2026-09-06T12:00:00Z", json!("fresh"), false)], "nextCursor": null}),
+    )]);
+    save_auth(home.path(), &base, false);
+    let path = home.path().join("offline.txt");
+    std::fs::write(&path, "stale transcript from an earlier replay").unwrap();
+    let output = replay(
+        home.path(),
+        &base,
+        &["session", "--out", path.to_str().unwrap()],
+    );
+    success(&output);
+    server.join().unwrap();
+    let text = std::fs::read_to_string(&path).unwrap();
+    assert!(text.contains("fresh"), "{text}");
+    assert!(
+        !text.contains("stale transcript"),
+        "the previous transcript must be replaced, not appended to: {text}"
+    );
+    // The sibling temp file must not survive a successful replace. Match tempfile's own
+    // ".tmp" prefix rather than "anything unexpected" — the auth fixture legitimately
+    // creates a `stages` directory here, and excluding dotfiles wholesale would have
+    // hidden exactly the leftovers this is looking for.
+    let leftovers: Vec<_> = std::fs::read_dir(home.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with(".tmp"))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "atomic write left temporary files behind: {leftovers:?}"
+    );
+}
+
+#[test]
 fn replay_unknown_session_is_an_empty_array_and_json_can_be_saved() {
     let home = tempfile::tempdir().unwrap();
     let (base, server) = server(vec![(200, json!({"events": [], "nextCursor": null}))]);


### PR DESCRIPTION
Adds `ai-hist replay <sessionId>` to the Rust CLI so a cloud session can be saved and read offline. It fetches every cursor page from `GET /v1/sessions/:sessionId/events` with `order=asc`, preserves the server's `(ts, eventId)` order, and renders event content with timestamps and actor context. `contentTruncated: true` produces an explicit incomplete-content notice, including when content is absent.

Supports `--json` (raw event array), `--out <path>`, `--limit` (server page size; all pages still fetched), `--max-content`, and `--base-url`. Reuses stage-scoped auth, HTTPS validation, and the existing token refresh flow. Replay dispatches before SQLite setup and never imports events. Fetch failures leave an existing output file intact; repeated cursors fail clearly.

Seven CLI integration tests cover three-page pagination, shared timestamps and cursor encoding, passthroughs, raw-field preservation, text/JSON files, truncation, missing/expired auth, empty unknown sessions, stage selection/legacy fallback, and no SQLite access.

Validation: `cargo build`, `cargo test`, `cargo fmt --all -- --check`, and `cargo clippy --workspace --all-targets -- -A clippy::too_many_arguments -D warnings` passed with exit code 0. Exact `cargo test` summaries:

```text
test result: ok. 115 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.73s
test result: ok. 257 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 16.54s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.34s
test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.06s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.21s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 91.71s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Scope notes: `CLAUDE.md` is absent from this repository's `main`; the described guidance exists in `AgentWorkforce/relayhistory-cloud/CLAUDE.md`, which was read alongside the recall route and API docs. The README identifies the Rust binary as an internal development harness; this PR implements the requested Rust command and does not change the npm/TypeScript CLI. `outbox.rs` and `convergence.rs` are untouched.
