### PR TITLE
[garden] Add cloud remote connector to ai-hist

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,27 @@ not separate catalogs: every result comes from the same session ledger. Reads
 only filter that cached ledger. Remote discovery and remote sync run through
 provider connectors: `claude-web` lists your claude.ai/code web sessions using
 the OAuth sign-in the Claude Code CLI stored, and `codex-cloud` lists Codex
-cloud tasks through `codex cloud list --json`. A connector is configured when
-the provider's own CLI is signed in on this machine — see
+cloud tasks through `codex cloud list --json`. The `cloud` connector lists
+teammate sessions from RelayHistory using the stored `rth_at_` session from
+`ai-hist login`, with at least 60 seconds of recorded validity remaining. See
 [docs/remote-connectors.md](docs/remote-connectors.md). With no connector
 configured, remote-only acquisition returns an unsupported-operation error; it
 never silently falls back to local work. `--all` runs the local adapters plus
 every configured connector, and an acquisition summary reports the requested
 `scope` alongside the `locations_run` that actually executed. Each catalog
 row's `locations` array reports where that session was actually observed.
+
+| Remote connector | Source | Stored sign-in |
+|---|---|---|
+| `claude-web` | `claude` | Claude Code OAuth |
+| `codex-cloud` | `codex` | Codex CLI |
+| `cloud` | Upstream provider source; org-wide teammate sessions | RelayHistory `rth_at_` session under `RELAYHISTORY_HOME` (default `~/.agentworkforce/relayhistory`) |
+
+Cloud discovery records `cloud://<orgId>/<sessionId>` on the remote presence.
+An existing local natural key gains a remote presence, so `--all` returns it
+once. Cloud recall shares push's stage selection, credential refresh, and
+HTTPS-or-loopback guard. Discovery populates the cached session catalog;
+automatic cloud event ingestion is separate.
 
 No Rust toolchain, C/C++ compiler, standalone CLI, curl installer, or runtime
 binary download is used.

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -1182,6 +1182,14 @@ pub fn recall_auth() -> Result<StoredAuth> {
         .as_millis() as i64;
     anyhow::ensure!(expiry.is_some_and(|expiry| expiry >= now.saturating_add(60_000)),
         "stored relayhistory access-token expiry is missing, invalid, or less than 60s away (run `ai-hist login`)");
+    // Recall rollups omit tenancy; the locally cached org is needed only for
+    // provenance markers, never sent to the service as an authorization selector.
+    anyhow::ensure!(
+        auth.org_id
+            .as_deref()
+            .is_some_and(|id| !id.trim().is_empty()),
+        "stored cloud session has no orgId for provenance (run `ai-hist login`)"
+    );
     Ok(auth)
 }
 

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -20,7 +20,7 @@ use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use url::Url;
@@ -33,6 +33,10 @@ pub struct StoredAuth {
     /// Base URL of the relayhistory-cloud service, e.g. `http://localhost:8787`.
     pub base_url: String,
     pub access_token: String,
+    /// Server-issued expiry (RFC 3339). Legacy sessions without this remain
+    /// usable by push, but cannot advertise recall availability until login/refresh.
+    #[serde(default, alias = "accessTokenExpiresAt")]
+    pub access_token_expires_at: Option<String>,
     #[serde(default)]
     pub refresh_token: Option<String>,
     /// Local cache only — never authoritative; the server owns tenancy from the token.
@@ -924,6 +928,10 @@ fn refresh_auth(auth: &StoredAuth) -> Result<StoredAuth> {
     Ok(StoredAuth {
         base_url: auth.base_url.clone(),
         access_token: field(&payload, "accessToken")?,
+        access_token_expires_at: payload
+            .get("accessTokenExpiresAt")
+            .and_then(|v| v.as_str())
+            .map(String::from),
         refresh_token: Some(field(&payload, "refreshToken")?),
         org_id: auth.org_id.clone(),
         workspace_id: auth.workspace_id.clone(),
@@ -954,6 +962,10 @@ pub fn admin_mint(
     Ok(StoredAuth {
         base_url: base_url.trim_end_matches('/').to_string(),
         access_token: field(&v, "accessToken")?,
+        access_token_expires_at: v
+            .get("accessTokenExpiresAt")
+            .and_then(|v| v.as_str())
+            .map(String::from),
         refresh_token: v
             .get("refreshToken")
             .and_then(|x| x.as_str())
@@ -984,6 +996,10 @@ pub fn login(
     Ok(StoredAuth {
         base_url: base_url.trim_end_matches('/').to_string(),
         access_token: field(&v, "accessToken")?,
+        access_token_expires_at: v
+            .get("accessTokenExpiresAt")
+            .and_then(|v| v.as_str())
+            .map(String::from),
         refresh_token: v
             .get("refreshToken")
             .and_then(|x| x.as_str())
@@ -1135,6 +1151,104 @@ fn map_http_err(e: ureq::Error) -> anyhow::Error {
         }
         other => other.into(),
     }
+}
+
+/// Resolve recall credentials using the same stage selection and storage as push.
+/// This is read-only: status probes must never refresh, log in, or fail hard.
+pub fn recall_auth() -> Result<StoredAuth> {
+    let explicit_stage = ["RELAYHISTORY_BASE_URL", "AI_HIST_BASE_URL"]
+        .iter()
+        .any(|key| {
+            std::env::var(key)
+                .ok()
+                .and_then(|v| normalize_base_url(&v))
+                .is_some()
+        });
+    let base = explicit_stage.then(default_base_url);
+    let auth = load_auth(base.as_deref())?
+        .context("no stored relayhistory session (run `ai-hist login`)")?;
+    require_secure_transport(&auth.base_url)?;
+    anyhow::ensure!(
+        auth.access_token.starts_with("rth_at_"),
+        "stored relayhistory session has no rth_at_ access token (run `ai-hist login`)"
+    );
+    let expiry = auth
+        .access_token_expires_at
+        .as_deref()
+        .and_then(crate::parse_iso_ms);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+    anyhow::ensure!(expiry.is_some_and(|expiry| expiry >= now.saturating_add(60_000)),
+        "stored relayhistory access-token expiry is missing, invalid, or less than 60s away (run `ai-hist login`)");
+    Ok(auth)
+}
+
+/// Org-scoped recall endpoints. The service derives tenancy from the bearer;
+/// the client never supplies an org/workspace selector.
+pub enum RecallResource<'a> {
+    Sessions,
+    Events,
+    SessionEvents(&'a str),
+}
+
+/// Fetch one bounded recall page with the existing auth refresh and transport guard.
+/// Callers own pagination; opaque cursors are encoded by ureq, never concatenated.
+pub fn recall_page(
+    auth: &StoredAuth,
+    resource: RecallResource<'_>,
+    query: &[(&str, &str)],
+) -> Result<serde_json::Value> {
+    require_secure_transport(&auth.base_url)?;
+    anyhow::ensure!(
+        !query
+            .iter()
+            .any(|(key, _)| matches!(*key, "org_id" | "orgId" | "workspace_id" | "workspaceId")),
+        "recall tenancy comes from the token, not query parameters"
+    );
+    let path = match resource {
+        RecallResource::Sessions => "/v1/sessions".to_string(),
+        RecallResource::Events => "/v1/events".to_string(),
+        RecallResource::SessionEvents(id) => {
+            format!("/v1/sessions/{}/events", encode_path_segment(id))
+        }
+    };
+    let url = format!("{}{}", normalized_stage(&auth.base_url)?, path);
+    let agent = ureq::AgentBuilder::new().redirects(0).build();
+    let response = send_with_auth_refresh(
+        auth,
+        |current| {
+            let mut request = agent
+                .get(&url)
+                .timeout(std::time::Duration::from_secs(30))
+                .set("Authorization", &format!("Bearer {}", current.access_token));
+            for (key, value) in query {
+                request = request.query(key, value);
+            }
+            request.call().map_err(Box::new)
+        },
+        |error| match error {
+            ureq::Error::Status(code, _) => anyhow::anyhow!("recall request failed: HTTP {code}"),
+            other => other.into(),
+        },
+    )?;
+    anyhow::ensure!(
+        response.status() == 200,
+        "recall request failed: HTTP {}",
+        response.status()
+    );
+    const MAX_BYTES: usize = 16 * 1024 * 1024;
+    let mut bytes = Vec::new();
+    response
+        .into_reader()
+        .take((MAX_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    anyhow::ensure!(
+        bytes.len() <= MAX_BYTES,
+        "recall page exceeded the 16 MiB response-size limit"
+    );
+    serde_json::from_slice(&bytes).context("recall returned malformed JSON")
 }
 
 /// Fetch every page in the server's ascending `(ts, eventId)` order.
@@ -1691,7 +1805,7 @@ fn humanize_secs(secs: u64) -> String {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use ai_hist_core::{init_db, insert_history, HistoryEntry};
     use std::cell::RefCell;
@@ -1805,7 +1919,7 @@ mod tests {
 
     // RELAYHISTORY_HOME is process-global; serialize env-home tests so cargo's parallel
     // runner can't clobber it across tests.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     struct EnvVarGuard {
         key: &'static str,
@@ -1848,6 +1962,8 @@ mod tests {
     ) -> (String, std::collections::HashMap<String, String>, String) {
         use std::io::{BufRead, BufReader, Read};
 
+        // Accepted sockets inherit nonblocking mode on macOS.
+        stream.set_nonblocking(false).unwrap();
         stream
             .set_read_timeout(Some(std::time::Duration::from_secs(5)))
             .unwrap();
@@ -2286,6 +2402,7 @@ mod tests {
             let auth = StoredAuth {
                 base_url: "http://localhost:8787".into(),
                 access_token: "rth_at_x".into(),
+                access_token_expires_at: None,
                 refresh_token: Some("rth_rt_y".into()),
                 org_id: Some("org-a".into()),
                 workspace_id: None,
@@ -2312,6 +2429,7 @@ mod tests {
                         save_auth(&StoredAuth {
                             base_url: "http://localhost:8787".into(),
                             access_token: format!("rth_at_{writer}_{revision}"),
+                            access_token_expires_at: None,
                             refresh_token: Some(format!("rth_rt_{writer}_{revision}")),
                             ..Default::default()
                         })
@@ -2412,6 +2530,7 @@ mod tests {
             let auth = StoredAuth {
                 base_url: format!("http://{addr}"),
                 access_token: "rth_at_expired".into(),
+                access_token_expires_at: None,
                 refresh_token: Some("rth_rt_old".into()),
                 org_id: Some("org-a".into()),
                 workspace_id: Some("ws-a".into()),
@@ -2512,6 +2631,7 @@ mod tests {
             let auth = StoredAuth {
                 base_url: format!("http://{addr}"),
                 access_token: "rth_at_expired".into(),
+                access_token_expires_at: None,
                 refresh_token: Some("rth_rt_old".into()),
                 ..Default::default()
             };

--- a/crates/ai-hist/src/discover.rs
+++ b/crates/ai-hist/src/discover.rs
@@ -1790,7 +1790,14 @@ pub struct SessionCatalogPage {
 /// Built in one place so the query-plan test asserts the plan of the statement
 /// that actually runs.
 fn catalog_list_query(options: &CatalogListOptions) -> (String, Vec<Box<dyn rusqlite::ToSql>>) {
-    let mut sql = format!("SELECT {SESSION_COLUMNS} FROM sessions WHERE source <> 'trajectory'");
+    let mut sql = format!("SELECT {SESSION_COLUMNS} FROM sessions WHERE ");
+    if options.scope == SessionScope::Local {
+        sql.push_str("source <> 'trajectory'");
+    } else {
+        // Local trajectories are derived artifacts; remotely recalled trajectory
+        // sessions are provider evidence and must survive cached remote/all reads.
+        sql.push_str("(source <> 'trajectory' OR EXISTS (SELECT 1 FROM session_presences p WHERE p.source = sessions.source AND p.session_id = sessions.session_id AND p.location = 'remote'))");
+    }
     let mut args: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
     match options.scope {
         SessionScope::Local => sql.push_str(
@@ -2246,7 +2253,7 @@ fn select_providers(
     for source in &options.sources {
         if let Some(exempt) = DISCOVERY_EXEMPTIONS
             .iter()
-            .find(|entry| entry.source == source)
+            .find(|entry| entry.source == source && options.scope == SessionScope::Local)
         {
             anyhow::bail!(
                 "source '{}' is exempt from session discovery: {}",

--- a/crates/ai-hist/src/discover.rs
+++ b/crates/ai-hist/src/discover.rs
@@ -1857,9 +1857,9 @@ fn catalog_list_query(options: &CatalogListOptions) -> (String, Vec<Box<dyn rusq
 /// List the session catalog straight out of the database.
 ///
 /// Pure SQL over `sessions`: no filesystem access, no provider I/O, and no
-/// scan of `history` / `session_events` / `tool_calls`. `trajectory` rows are
-/// excluded defensively — trajectories are derived records, not sessions, and
-/// must never appear in a session list even if something wrote one.
+/// scan of `history` / `session_events` / `tool_calls`. Locally derived
+/// `trajectory` records are excluded. Remote/all scopes can include trajectory
+/// sessions with an explicitly observed remote presence from cloud recall.
 ///
 /// Rows come back in the catalog's total order:
 /// `(last_activity_ms DESC, source ASC, session_id ASC)`, with rows of unknown
@@ -2039,7 +2039,13 @@ static UPSERT_SESSION_SQL: LazyLock<String> = LazyLock::new(|| {
              WHEN sessions.last_activity_ms IS NULL THEN excluded.last_activity_ms \
              ELSE MAX(sessions.last_activity_ms, excluded.last_activity_ms) END, \
          last_assistant_text = COALESCE(excluded.last_assistant_text, sessions.last_assistant_text), \
-         raw_path = COALESCE(excluded.raw_path, sessions.raw_path), \
+         raw_path = CASE WHEN ?17 = 'remote' AND EXISTS ( \
+             SELECT 1 FROM session_presences p WHERE p.source = sessions.source \
+             AND p.session_id = sessions.session_id AND p.location = 'local') \
+             THEN COALESCE((SELECT p.raw_locator FROM session_presences p \
+                 WHERE p.source = sessions.source AND p.session_id = sessions.session_id \
+                 AND p.location = 'local'), sessions.raw_path, excluded.raw_path) \
+             ELSE COALESCE(excluded.raw_path, sessions.raw_path) END, \
          first_prompt = COALESCE(excluded.first_prompt, sessions.first_prompt), \
          models_json = COALESCE(excluded.models_json, sessions.models_json), \
          originator = COALESCE(excluded.originator, sessions.originator), \
@@ -2124,6 +2130,12 @@ fn upsert_shallow_session_in_transaction(
             session.initial_commit,
             json_array_or_none(&session.workspace_roots),
             session.source_stamp,
+            // Remote provenance belongs on its presence; a local transcript
+            // remains the canonical raw path used by local readers and sync.
+            match location {
+                SessionLocation::Local => "local",
+                SessionLocation::Remote => "remote",
+            },
         ],
         row_to_session,
     )?;

--- a/crates/ai-hist/src/discover.rs
+++ b/crates/ai-hist/src/discover.rs
@@ -2100,6 +2100,38 @@ fn upsert_shallow_session_in_transaction(
     session: &ShallowSession,
     location: SessionLocation,
 ) -> Result<ShallowSession> {
+    if location == SessionLocation::Remote {
+        // Cache-only local reads classify a preexisting presence-less row as
+        // legacy local. Preserve that classification before adding the first
+        // remote presence, including the gap between a local full-session write
+        // and its separate presence write.
+        let legacy_local = conn
+            .prepare_cached(
+                "SELECT raw_path, source_stamp, discovery_state FROM sessions s \
+             WHERE source = ? AND session_id = ? AND NOT EXISTS ( \
+                 SELECT 1 FROM session_presences p WHERE p.source = s.source \
+                 AND p.session_id = s.session_id)",
+            )?
+            .query_row(params![session.source, session.session_id], |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                ))
+            })
+            .optional()?;
+        if let Some((raw_path, stamp, state)) = legacy_local {
+            upsert_session_presence(
+                conn,
+                &session.source,
+                &session.session_id,
+                SessionLocation::Local,
+                raw_path.as_deref(),
+                stamp.as_deref(),
+                state.as_deref(),
+            )?;
+        }
+    }
     // The presence lands first: the sessions upsert's RETURNING clause
     // computes `locations` from `session_presences`, so this run's own
     // presence must already be visible when the merged row is read back.

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -11868,6 +11868,8 @@ mod tests {
     fn read_request_line(stream: &mut std::net::TcpStream) -> String {
         use std::io::{BufRead, BufReader};
 
+        // Accepted sockets inherit nonblocking mode on macOS.
+        stream.set_nonblocking(false).unwrap();
         stream
             .set_read_timeout(Some(Duration::from_secs(5)))
             .unwrap();

--- a/crates/ai-hist/src/remote.rs
+++ b/crates/ai-hist/src/remote.rs
@@ -1213,7 +1213,7 @@ impl ShallowSessionProvider for CloudProvider {
         let mut rows = BTreeMap::new();
         let mut cursor: Option<String> = None;
         let mut seen_cursors = std::collections::HashSet::new();
-        for page_index in 0..MAX_LIST_PAGES {
+        for _ in 0..MAX_LIST_PAGES {
             let page_limit = self
                 .limit
                 .map(|limit| limit.saturating_sub(candidates.len()).clamp(1, 100))
@@ -1257,10 +1257,9 @@ impl ShallowSessionProvider for CloudProvider {
                 seen_cursors.insert(cursor.clone().unwrap()),
                 "cloud recall returned a repeated nextCursor"
             );
-            anyhow::ensure!(
-                page_index + 1 < MAX_LIST_PAGES,
-                "cloud recall exceeded the 100-page limit; narrow the request"
-            );
+            // Catalog discovery is bounded sampling, not transcript hydration.
+            // Reaching the page cap keeps the fetched rows, like the other
+            // connectors; a malformed/repeated cursor still fails above.
         }
         *self.fetched.lock().expect("remote connector row cache") = rows;
         Ok(candidates)

--- a/crates/ai-hist/src/remote.rs
+++ b/crates/ai-hist/src/remote.rs
@@ -1,4 +1,4 @@
-//! Remote session connectors: claude.ai/code web sessions and Codex cloud tasks.
+//! Remote session connectors: provider surfaces and org-wide RelayHistory recall.
 //!
 //! A remote connector enumerates the sessions a provider keeps on its own
 //! service — Claude Code sessions running on claude.ai/code, Codex cloud
@@ -10,8 +10,8 @@
 //!
 //! # Capability boundary
 //!
-//! A connector is **configured** when the provider's own CLI has been signed
-//! in on this machine — RelayHistory never runs an auth flow of its own:
+//! Provider connectors use their CLI’s sign-in; cloud uses the RelayHistory
+//! session already created by `ai-hist login`. Discovery never starts a login flow:
 //!
 //! * `claude-web` — `~/.claude/.credentials.json` holds the claude.ai OAuth
 //!   token the Claude Code CLI stored at sign-in (override the path with
@@ -19,6 +19,8 @@
 //!   elsewhere, e.g. macOS keychain users who export a token file).
 //! * `codex-cloud` — `~/.codex/auth.json` exists (written by `codex login`),
 //!   and the `codex` CLI is invoked for the actual listing.
+//! * `cloud` — a stored RelayHistory session resolved by [`crate::cloud`],
+//!   with an `rth_at_` access token valid for at least another 60 seconds.
 //!
 //! Requesting `--remote` acquisition with no connector configured fails
 //! loudly, exactly as before connectors existed; `--all` runs whatever is
@@ -30,8 +32,9 @@
 //! invented to fill the gap. The provider's session/task *title* is stored as
 //! `first_prompt` — for both providers the title is derived from the opening
 //! prompt, and it is the only human-readable identifier the listing offers.
-//! Remote rows stay `discovery_state = "shallow"`; full remote transcript
-//! ingestion is a separate capability that has not shipped.
+//! Cloud uses the recall summary or task title and preserves the upstream source.
+//! Discovery rows stay `discovery_state = "shallow"`; transcript hydration is
+//! provider-specific and is not performed by cloud discovery.
 //!
 //! # Contract stability
 //!
@@ -59,10 +62,24 @@ use crate::discover::{
     excerpt, Candidate, DiscoveryEnv, ScanEnv, ShallowSession, ShallowSessionProvider,
 };
 
+/// Org-scoped recall resources, implemented in the shared cloud transport.
+pub use crate::cloud::RecallResource as CloudRecallResource;
+
+/// Read one recall page using the configured RelayHistory session. All token
+/// loading, stage selection, refresh, URL encoding and guards remain in cloud.rs.
+pub fn cloud_recall_page(
+    resource: CloudRecallResource<'_>,
+    query: &[(&str, &str)],
+) -> Result<Value> {
+    crate::cloud::recall_page(&crate::cloud::recall_auth()?, resource, query)
+}
+
 /// Connector name for the claude.ai/code web-session lister.
 pub const CLAUDE_WEB_CONNECTOR: &str = "claude-web";
 /// Connector name for the Codex cloud task lister.
 pub const CODEX_CLOUD_CONNECTOR: &str = "codex-cloud";
+/// Connector name for org-wide RelayHistory recall. This is not a source.
+pub const CLOUD_CONNECTOR: &str = "cloud";
 
 /// Most listing pages one enumeration may fetch, whatever the caller asked.
 const MAX_LIST_PAGES: usize = 100;
@@ -94,9 +111,9 @@ pub(crate) enum RemoteSessionEvidence {
 /// cannot.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RemoteConnectorStatus {
-    /// Connector name (`claude-web`, `codex-cloud`).
+    /// Connector name (`claude-web`, `codex-cloud`, `cloud`).
     pub connector: &'static str,
-    /// The `SOURCE_CHOICES` source its sessions land under.
+    /// The upstream source, or `"*"` for a cross-source connector.
     pub source: &'static str,
     /// `true` when the provider CLI's stored sign-in was found.
     pub configured: bool,
@@ -121,6 +138,7 @@ fn codex_auth_path(home: &Path) -> PathBuf {
 pub fn remote_connector_statuses_at(home: &Path) -> Vec<RemoteConnectorStatus> {
     let claude_path = claude_credentials_path(home);
     let codex_path = codex_auth_path(home);
+    let cloud_auth = crate::cloud::recall_auth();
     vec![
         RemoteConnectorStatus {
             connector: CLAUDE_WEB_CONNECTOR,
@@ -148,6 +166,19 @@ pub fn remote_connector_statuses_at(home: &Path) -> Vec<RemoteConnectorStatus> {
                 )
             },
         },
+        RemoteConnectorStatus {
+            connector: CLOUD_CONNECTOR,
+            source: "*",
+            configured: cloud_auth.is_ok(),
+            detail: match cloud_auth {
+                Ok(auth) => format!(
+                    "RelayHistory session at {} ({})",
+                    crate::cloud::config_dir().display(),
+                    auth.base_url
+                ),
+                Err(error) => format!("{}: {error:#}", crate::cloud::config_dir().display()),
+            },
+        },
     ]
 }
 
@@ -167,7 +198,7 @@ pub(crate) fn unconfigured_message(operation: &str, statuses: &[RemoteConnectorS
         .collect::<Vec<_>>()
         .join("; ");
     format!(
-        "remote session {operation} is not available: no remote provider connectors are configured ({reasons})"
+        "no remote provider connectors are configured: remote session {operation} is not available ({reasons})"
     )
 }
 
@@ -212,7 +243,11 @@ pub fn ensure_remote_connectors_configured_for_at(
     }
     let statuses: Vec<RemoteConnectorStatus> = remote_connector_statuses_at(home)
         .into_iter()
-        .filter(|status| sources.is_empty() || sources.iter().any(|s| s == status.source))
+        .filter(|status| {
+            status.connector == CLOUD_CONNECTOR
+                || sources.is_empty()
+                || sources.iter().any(|s| s == status.source)
+        })
         .collect();
     anyhow::ensure!(
         !statuses.is_empty(),
@@ -250,6 +285,13 @@ pub(crate) fn configured_remote_providers(
             Box::new(ExecCodexCli),
             limit,
         )));
+    }
+    if let Ok(auth) = crate::cloud::recall_auth() {
+        // One adapter per upstream source preserves the engine's source filters,
+        // diagnostics and global recency ordering without inventing a cloud source.
+        for source in SOURCE_CHOICES {
+            providers.push(Box::new(CloudProvider::new(auth.clone(), source, limit)));
+        }
     }
     providers
 }
@@ -1052,6 +1094,173 @@ impl ShallowSessionProvider for CodexCloudProvider {
             if done {
                 break;
             }
+        }
+        *self.fetched.lock().expect("remote connector row cache") = rows;
+        Ok(candidates)
+    }
+
+    fn read_shallow(
+        &self,
+        _scan: &ScanEnv<'_>,
+        _catalog: Option<&Connection>,
+        candidate: &Candidate,
+    ) -> Result<Option<ShallowSession>> {
+        Ok(take_fetched(&self.fetched, &candidate.locator))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// cloud — org-wide recall, preserving the upstream provider's natural key
+// ---------------------------------------------------------------------------
+
+pub(crate) struct CloudProvider {
+    auth: crate::cloud::StoredAuth,
+    source: &'static str,
+    limit: Option<usize>,
+    fetched: FetchedRows,
+}
+
+impl CloudProvider {
+    fn new(auth: crate::cloud::StoredAuth, source: &'static str, limit: Option<usize>) -> Self {
+        Self {
+            auth,
+            source,
+            limit,
+            fetched: FetchedRows::default(),
+        }
+    }
+}
+
+fn map_cloud_session(value: &Value, org_id: &str) -> Result<(Candidate, ShallowSession)> {
+    let source = string_field(value, "source").context("cloud session omitted source")?;
+    let source = *SOURCE_CHOICES
+        .iter()
+        .find(|known| **known == source)
+        .with_context(|| format!("cloud returned unsupported source '{source}'"))?;
+    let id = string_field(value, "sessionId").context("cloud session omitted sessionId")?;
+    let locator = format!("cloud://{}/{}", urlencode(org_id), urlencode(&id));
+    let first_activity_ms = string_field(value, "firstTs")
+        .as_deref()
+        .and_then(crate::parse_iso_ms);
+    let last_activity_ms = string_field(value, "lastTs")
+        .as_deref()
+        .and_then(crate::parse_iso_ms);
+    // Include the full rollup, org and stage-independent locator: title/count changes
+    // invalidate the cache even when lastTs did not move.
+    let stamp = format!(
+        "cloud:{}:{:x}",
+        locator,
+        Sha256::digest(serde_json::to_vec(value)?)
+    );
+    let session = ShallowSession {
+        source: source.into(),
+        session_id: id.clone(),
+        first_prompt: string_field(value, "summary")
+            .or_else(|| string_field(value, "taskTitle"))
+            .map(|s| excerpt(&s)),
+        first_activity_ms,
+        last_activity_ms,
+        models: value
+            .get("models")
+            .and_then(Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default(),
+        raw_path: Some(locator.clone()),
+        discovery_state: "shallow".into(),
+        ..Default::default()
+    };
+    Ok((
+        Candidate {
+            source,
+            locator,
+            session_id: Some(id),
+            recency_hint_ms: last_activity_ms,
+            stamp,
+        },
+        session,
+    ))
+}
+
+impl ShallowSessionProvider for CloudProvider {
+    fn source(&self) -> &'static str {
+        self.source
+    }
+    fn location(&self) -> SessionLocation {
+        SessionLocation::Remote
+    }
+
+    fn enumerate(
+        &self,
+        _env: &DiscoveryEnv<'_>,
+        _requested_limit: Option<usize>,
+    ) -> Result<Vec<Candidate>> {
+        if self.limit == Some(0) {
+            return Ok(Vec::new());
+        }
+        let org_id = self
+            .auth
+            .org_id
+            .as_deref()
+            .filter(|id| !id.trim().is_empty())
+            .context("stored cloud session has no orgId for provenance (run `ai-hist login`)")?;
+        let mut candidates = Vec::new();
+        let mut rows = BTreeMap::new();
+        let mut cursor: Option<String> = None;
+        let mut seen_cursors = std::collections::HashSet::new();
+        for page_index in 0..MAX_LIST_PAGES {
+            let page_limit = self
+                .limit
+                .map(|limit| limit.saturating_sub(candidates.len()).clamp(1, 100))
+                .unwrap_or(100)
+                .to_string();
+            let mut query = vec![("source", self.source), ("limit", page_limit.as_str())];
+            if let Some(cursor) = cursor.as_deref() {
+                query.push(("cursor", cursor));
+            }
+            let payload = crate::cloud::recall_page(
+                &self.auth,
+                crate::cloud::RecallResource::Sessions,
+                &query,
+            )?;
+            let page = payload
+                .get("sessions")
+                .and_then(Value::as_array)
+                .context("cloud recall response has no sessions array")?;
+            for value in page {
+                let (candidate, session) = map_cloud_session(value, org_id)?;
+                anyhow::ensure!(
+                    candidate.source == self.source,
+                    "cloud recall returned a session outside the requested source"
+                );
+                if rows.insert(candidate.locator.clone(), session).is_none() {
+                    candidates.push(candidate);
+                }
+                if self.limit.is_some_and(|limit| candidates.len() >= limit) {
+                    break;
+                }
+            }
+            cursor = match payload.get("nextCursor") {
+                None | Some(Value::Null) => None,
+                Some(Value::String(value)) if !value.is_empty() => Some(value.clone()),
+                _ => anyhow::bail!("cloud recall returned an invalid nextCursor"),
+            };
+            if cursor.is_none() || self.limit.is_some_and(|limit| candidates.len() >= limit) {
+                break;
+            }
+            anyhow::ensure!(
+                seen_cursors.insert(cursor.clone().unwrap()),
+                "cloud recall returned a repeated nextCursor"
+            );
+            anyhow::ensure!(
+                page_index + 1 < MAX_LIST_PAGES,
+                "cloud recall exceeded the 100-page limit; narrow the request"
+            );
         }
         *self.fetched.lock().expect("remote connector row cache") = rows;
         Ok(candidates)

--- a/crates/ai-hist/src/remote/tests.rs
+++ b/crates/ai-hist/src/remote/tests.rs
@@ -39,33 +39,47 @@ fn write_claude_credentials(home: &Path, expires_at_ms: i64) -> PathBuf {
 
 const FAR_FUTURE_MS: i64 = 4_102_444_800_000; // 2100-01-01
 
-/// Serializes the availability tests and clears the ambient
-/// `RELAYHISTORY_CLAUDE_CREDENTIALS` override for their duration, restoring
-/// whatever value the process had once the guard drops.
-static CREDENTIALS_OVERRIDE_LOCK: Mutex<()> = Mutex::new(());
-
+/// Share cloud.rs's lock because both modules change RELAYHISTORY_HOME.
 struct ClearedCredentialsOverride {
-    previous: Option<std::ffi::OsString>,
+    previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
+    _home: tempfile::TempDir,
     _serialized: std::sync::MutexGuard<'static, ()>,
 }
 
 fn without_credentials_override() -> ClearedCredentialsOverride {
-    let guard = CREDENTIALS_OVERRIDE_LOCK
+    let guard = crate::cloud::tests::ENV_LOCK
         .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let previous = std::env::var_os("RELAYHISTORY_CLAUDE_CREDENTIALS");
-    std::env::remove_var("RELAYHISTORY_CLAUDE_CREDENTIALS");
+        .unwrap_or_else(|p| p.into_inner());
+    let home = tempfile::tempdir().unwrap();
+    let keys = [
+        "RELAYHISTORY_CLAUDE_CREDENTIALS",
+        "RELAYHISTORY_HOME",
+        "RELAYHISTORY_BASE_URL",
+        "AI_HIST_BASE_URL",
+    ];
+    let previous = keys
+        .into_iter()
+        .map(|key| {
+            let value = std::env::var_os(key);
+            std::env::remove_var(key);
+            (key, value)
+        })
+        .collect();
+    std::env::set_var("RELAYHISTORY_HOME", home.path());
     ClearedCredentialsOverride {
         previous,
+        _home: home,
         _serialized: guard,
     }
 }
 
 impl Drop for ClearedCredentialsOverride {
     fn drop(&mut self) {
-        match &self.previous {
-            Some(value) => std::env::set_var("RELAYHISTORY_CLAUDE_CREDENTIALS", value),
-            None => std::env::remove_var("RELAYHISTORY_CLAUDE_CREDENTIALS"),
+        for (key, value) in &self.previous {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
         }
     }
 }
@@ -771,7 +785,7 @@ fn statuses_report_missing_credentials_with_the_paths_looked_at() {
     let _cleared = without_credentials_override();
     let home = tempfile::tempdir().unwrap();
     let statuses = remote_connector_statuses_at(home.path());
-    assert_eq!(statuses.len(), 2);
+    assert_eq!(statuses.len(), 3);
     assert!(statuses.iter().all(|status| !status.configured));
     let error = ensure_remote_connectors_configured_at("discovery", home.path())
         .unwrap_err()
@@ -819,10 +833,10 @@ fn a_source_filter_that_excludes_every_configured_connector_is_unsupported() {
     );
     assert!(error.contains("claude-web"), "{error}");
     assert!(!error.contains("codex-cloud"), "{error}");
-    // …and a source no connector will ever serve says so distinctly.
+    // Cloud can serve cursor, but it is not configured in this isolated home.
     let error = ok(&["cursor"]).unwrap_err().to_string();
     assert!(
-        error.contains("no matching remote provider connectors exist"),
+        error.starts_with("no remote provider connectors are configured"),
         "{error}"
     );
     // A misspelled source is an invalid argument, not an unsupported request.
@@ -1011,4 +1025,504 @@ fn a_session_seen_locally_and_remotely_is_one_row_with_both_presences() {
     )
     .unwrap();
     assert_eq!(local_only.len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// cloud: real loopback HTTP, synthetic stored auth, and catalog integration
+// ---------------------------------------------------------------------------
+
+fn cloud_auth(base_url: &str) -> crate::cloud::StoredAuth {
+    crate::cloud::StoredAuth {
+        base_url: base_url.into(),
+        access_token: "rth_at_synthetic".into(),
+        access_token_expires_at: Some("2100-01-01T00:00:00Z".into()),
+        org_id: Some("org-teammates".into()),
+        ..Default::default()
+    }
+}
+
+fn cloud_listing(source: &str, id: &str) -> Value {
+    serde_json::json!({"sessions": [{
+        "source": source, "sessionId": id, "firstTs": "2026-09-08T09:00:00Z",
+        "lastTs": "2026-09-08T10:00:00Z", "eventCount": 2,
+        "summary": "A teammate fixed the connector", "models": ["test-model"]
+    }], "nextCursor": null})
+}
+
+fn cloud_http(pages: Vec<(u16, Value)>) -> (String, std::thread::JoinHandle<Vec<String>>) {
+    use std::io::{BufRead, BufReader, Write};
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let handle = std::thread::spawn(move || {
+        let mut requests = Vec::new();
+        for (status, body) in pages {
+            let start = Instant::now();
+            let (mut stream, _) = loop {
+                match listener.accept() {
+                    Ok(value) => break value,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        assert!(
+                            start.elapsed() < Duration::from_secs(10),
+                            "mock HTTP request timed out"
+                        );
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("{error}"),
+                }
+            };
+            // Accepted sockets inherit nonblocking mode on macOS.
+            stream.set_nonblocking(false).unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(5)))
+                .unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut request = String::new();
+            loop {
+                let mut line = String::new();
+                reader.read_line(&mut line).unwrap();
+                if line == "\r\n" || line.is_empty() {
+                    break;
+                }
+                request.push_str(&line);
+            }
+            // Login/refresh POSTs must be fully consumed before closing the
+            // socket, otherwise unread body bytes can reset the client stream.
+            let content_length = request
+                .lines()
+                .filter_map(|line| line.split_once(':'))
+                .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+                .map(|(_, value)| value.trim().parse::<usize>().unwrap())
+                .unwrap_or(0);
+            let mut body_bytes = vec![0; content_length];
+            reader.read_exact(&mut body_bytes).unwrap();
+            assert!(
+                !request.contains("org_id=") && !request.contains("orgId="),
+                "{request}"
+            );
+            let body = body.to_string();
+            write!(stream, "HTTP/1.1 {status} Test\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).unwrap();
+            requests.push(request);
+        }
+        requests
+    });
+    (base, handle)
+}
+
+#[test]
+fn cloud_unconfigured_empty_home_preserves_error_prefix() {
+    let _isolated = without_credentials_override();
+    let home = tempfile::tempdir().unwrap();
+    let status = remote_connector_statuses_at(home.path())
+        .into_iter()
+        .find(|s| s.connector == CLOUD_CONNECTOR)
+        .unwrap();
+    assert!(!status.configured);
+    let error = ensure_remote_connectors_configured_for_at("discovery", home.path(), &[])
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.starts_with("no remote provider connectors are configured"),
+        "{error}"
+    );
+    assert!(error.contains("cloud: "), "{error}");
+    println!("negative: {error}");
+}
+
+#[test]
+fn cloud_positive_catalog_preserves_source_remote_marker_and_cache() {
+    let _isolated = without_credentials_override();
+    let home = tempfile::tempdir().unwrap();
+    let page = cloud_listing("cursor", "teammate-1");
+    let (base, server) = cloud_http(vec![(200, page.clone()), (200, page)]);
+    crate::cloud::save_auth(&cloud_auth(&base)).unwrap();
+    ensure_remote_connectors_configured_for_at("discovery", home.path(), &["cursor".into()])
+        .unwrap();
+    let conn = catalog();
+    let options = DiscoverOptions {
+        scope: SessionScope::Remote,
+        sources: vec!["cursor".into()],
+        ..Default::default()
+    };
+    let first =
+        crate::discover::discover_sessions_with_env(&env_at(&conn, home.path()), &options, |_| {})
+            .unwrap();
+    assert_eq!(first.discovered, 1);
+    let presence: (String, String, String) = conn.query_row(
+        "SELECT source, location, raw_locator FROM session_presences WHERE session_id = 'teammate-1'", [],
+        |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?))).unwrap();
+    assert_eq!(
+        presence,
+        (
+            "cursor".into(),
+            "remote".into(),
+            "cloud://org-teammates/teammate-1".into()
+        )
+    );
+    let second =
+        crate::discover::discover_sessions_with_env(&env_at(&conn, home.path()), &options, |_| {})
+            .unwrap();
+    assert_eq!(second.discovered, 0);
+    assert_eq!(second.skipped_unchanged, 1);
+    let requests = server.join().unwrap();
+    assert!(requests.iter().all(|r| r.starts_with("GET /v1/sessions?")
+        && r.contains("source=cursor")
+        && r.contains("Authorization: Bearer rth_at_synthetic")));
+    println!(
+        "positive: {presence:?}; second discovery skipped_unchanged={}",
+        second.skipped_unchanged
+    );
+}
+
+#[test]
+fn cloud_teleport_adds_second_presence_and_keeps_local_evidence() {
+    let _isolated = without_credentials_override();
+    let home = tempfile::tempdir().unwrap();
+    let (base, server) = cloud_http(vec![(200, cloud_listing("codex", "teleport-1"))]);
+    crate::cloud::save_auth(&cloud_auth(&base)).unwrap();
+    let conn = catalog();
+    crate::discover::upsert_shallow_session(
+        &conn,
+        &ShallowSession {
+            source: "codex".into(),
+            session_id: "teleport-1".into(),
+            raw_path: Some("/local/rollout.jsonl".into()),
+            cwd: Some("/work/repo".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let options = DiscoverOptions {
+        scope: SessionScope::Remote,
+        sources: vec!["codex".into()],
+        ..Default::default()
+    };
+    crate::discover::discover_sessions_with_env(&env_at(&conn, home.path()), &options, |_| {})
+        .unwrap();
+    let presences: Vec<(String, String)> = conn.prepare(
+        "SELECT location, raw_locator FROM session_presences WHERE source='codex' AND session_id='teleport-1' ORDER BY location"
+    ).unwrap().query_map([], |r| Ok((r.get(0)?, r.get(1)?))).unwrap().collect::<rusqlite::Result<_>>().unwrap();
+    assert_eq!(
+        presences,
+        vec![
+            ("local".into(), "/local/rollout.jsonl".into()),
+            ("remote".into(), "cloud://org-teammates/teleport-1".into())
+        ]
+    );
+    let cwd: String = conn
+        .query_row(
+            "SELECT cwd FROM sessions WHERE source='codex' AND session_id='teleport-1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(cwd, "/work/repo");
+    conn.execute(
+        "DELETE FROM sessions WHERE source='codex' AND session_id='teleport-1'",
+        [],
+    )
+    .unwrap();
+    assert!(
+        ai_hist_core::session_locations(&conn, "codex", "teleport-1")
+            .unwrap()
+            .is_empty()
+    );
+    server.join().unwrap();
+    println!(
+        "teleport session_presences: {presences:?}; canonical deletion cleaned both presences"
+    );
+}
+
+#[test]
+fn cloud_cleartext_guard_is_inherited() {
+    let _isolated = without_credentials_override();
+    let home = tempfile::tempdir().unwrap();
+    let evil = cloud_auth("http://evil.example");
+    crate::cloud::save_auth(&evil).unwrap();
+    let status = remote_connector_statuses_at(home.path())
+        .into_iter()
+        .find(|s| s.connector == CLOUD_CONNECTOR)
+        .unwrap();
+    assert!(!status.configured);
+    assert!(
+        status.detail.contains("refusing to send"),
+        "{}",
+        status.detail
+    );
+    let error =
+        crate::cloud::recall_page(&evil, crate::cloud::RecallResource::Sessions, &[]).unwrap_err();
+    assert!(error.to_string().contains("cleartext"));
+    let loopback = cloud_auth("http://127.0.0.1:8787");
+    crate::cloud::save_auth(&loopback).unwrap();
+    std::env::set_var("RELAYHISTORY_BASE_URL", &loopback.base_url);
+    assert!(crate::cloud::recall_auth().is_ok());
+    println!("cleartext: http://evil.example refused: {error}; http://127.0.0.1:8787 accepted");
+}
+
+#[test]
+fn cloud_status_rejects_bad_missing_and_expiring_tokens_without_hard_errors() {
+    let _isolated = without_credentials_override();
+    let home = tempfile::tempdir().unwrap();
+    for (token, expiry) in [
+        ("other-token", Some("2100-01-01T00:00:00Z")),
+        ("rth_at_test", None),
+        ("rth_at_test", Some("bad-date")),
+        ("rth_at_test", Some("2000-01-01T00:00:00Z")),
+    ] {
+        let mut auth = cloud_auth("https://history.agentrelay.com");
+        auth.access_token = token.into();
+        auth.access_token_expires_at = expiry.map(String::from);
+        crate::cloud::save_auth(&auth).unwrap();
+        assert!(
+            !remote_connector_statuses_at(home.path())
+                .into_iter()
+                .find(|s| s.connector == CLOUD_CONNECTOR)
+                .unwrap()
+                .configured
+        );
+    }
+    std::fs::write(crate::cloud::config_dir().join("auth.json"), "invalid JSON").unwrap();
+    assert!(
+        !remote_connector_statuses_at(home.path())
+            .into_iter()
+            .find(|s| s.connector == CLOUD_CONNECTOR)
+            .unwrap()
+            .configured
+    );
+}
+
+#[test]
+fn cloud_pagination_and_source_filter_preserve_opaque_cursor() {
+    let _isolated = without_credentials_override();
+    let home = tempfile::tempdir().unwrap();
+    let mut first = cloud_listing("trajectory", "one");
+    first["nextCursor"] = Value::String("opaque+/=&".into());
+    let (base, server) = cloud_http(vec![
+        (200, first),
+        (200, cloud_listing("trajectory", "two")),
+    ]);
+    crate::cloud::save_auth(&cloud_auth(&base)).unwrap();
+    let conn = catalog();
+    let options = DiscoverOptions {
+        scope: SessionScope::Remote,
+        sources: vec!["trajectory".into()],
+        ..Default::default()
+    };
+    let result =
+        crate::discover::discover_sessions_with_env(&env_at(&conn, home.path()), &options, |_| {})
+            .unwrap();
+    assert_eq!(result.discovered, 2);
+    for scope in [SessionScope::Remote, SessionScope::All] {
+        let cached = list_session_catalog(
+            &conn,
+            &CatalogListOptions {
+                scope,
+                sources: vec!["trajectory".into()],
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(cached.len(), 2);
+        assert!(cached
+            .iter()
+            .all(|row| row.source == "trajectory" && row.locations == ["remote"]));
+    }
+    assert!(list_session_catalog(
+        &conn,
+        &CatalogListOptions {
+            scope: SessionScope::Local,
+            sources: vec!["trajectory".into()],
+            ..Default::default()
+        }
+    )
+    .unwrap()
+    .is_empty());
+    let requests = server.join().unwrap();
+    let url = url::Url::parse(&format!(
+        "http://mock{}",
+        requests[1].split_whitespace().nth(1).unwrap()
+    ))
+    .unwrap();
+    assert!(url
+        .query_pairs()
+        .any(|(k, v)| k == "cursor" && v == "opaque+/=&"));
+}
+
+#[test]
+fn cloud_recall_helpers_cover_events_and_encode_session_ids() {
+    let _isolated = without_credentials_override();
+    let (base, server) = cloud_http(vec![
+        (200, serde_json::json!({"events": [], "nextCursor": null})),
+        (200, serde_json::json!({"events": [], "nextCursor": null})),
+    ]);
+    let auth = cloud_auth(&base);
+    crate::cloud::save_auth(&auth).unwrap();
+    crate::cloud::recall_page(
+        &auth,
+        crate::cloud::RecallResource::Events,
+        &[("q", "connector fix")],
+    )
+    .unwrap();
+    crate::cloud::recall_page(
+        &auth,
+        crate::cloud::RecallResource::SessionEvents("session/a?b"),
+        &[],
+    )
+    .unwrap();
+    let requests = server.join().unwrap();
+    assert!(requests[0].starts_with("GET /v1/events?"));
+    assert!(
+        requests[1].starts_with("GET /v1/sessions/session%2Fa%3Fb/events "),
+        "{}",
+        requests[1]
+    );
+}
+
+#[test]
+fn cloud_all_sources_fan_out_without_widening_source_choices() {
+    let _isolated = without_credentials_override();
+    let home = tempfile::tempdir().unwrap();
+    let pages = SOURCE_CHOICES
+        .iter()
+        .map(|source| (200, cloud_listing(source, &format!("{source}-team"))))
+        .collect();
+    let (base, server) = cloud_http(pages);
+    crate::cloud::save_auth(&cloud_auth(&base)).unwrap();
+    let conn = catalog();
+    let options = DiscoverOptions {
+        scope: SessionScope::Remote,
+        ..Default::default()
+    };
+    let summary =
+        crate::discover::discover_sessions_with_env(&env_at(&conn, home.path()), &options, |_| {})
+            .unwrap();
+    assert_eq!(summary.discovered, SOURCE_CHOICES.len());
+    assert_eq!(
+        SOURCE_CHOICES,
+        [
+            "claude",
+            "codex",
+            "cursor",
+            "grok",
+            "relay",
+            "trajectory",
+            "opencode"
+        ]
+    );
+    assert!(ensure_remote_connectors_configured_for_at(
+        "discovery",
+        home.path(),
+        &["cloud".into()]
+    )
+    .unwrap_err()
+    .to_string()
+    .contains("invalid source 'cloud'"));
+    let requests = server.join().unwrap();
+    assert_eq!(requests.len(), SOURCE_CHOICES.len());
+}
+
+#[test]
+fn cloud_repeated_cursor_is_a_diagnostic_and_does_not_cache_partial_listing() {
+    let _isolated = without_credentials_override();
+    let home = tempfile::tempdir().unwrap();
+    let mut page = cloud_listing("cursor", "one");
+    page["nextCursor"] = Value::String("repeated".into());
+    let (base, server) = cloud_http(vec![(200, page.clone()), (200, page)]);
+    crate::cloud::save_auth(&cloud_auth(&base)).unwrap();
+    let conn = catalog();
+    let options = DiscoverOptions {
+        scope: SessionScope::Remote,
+        sources: vec!["cursor".into()],
+        ..Default::default()
+    };
+    let error =
+        crate::discover::discover_sessions_with_env(&env_at(&conn, home.path()), &options, |_| {})
+            .unwrap_err();
+    let summary = &error
+        .downcast_ref::<crate::discover::AllProvidersFailed>()
+        .unwrap()
+        .summary;
+    assert!(summary.diagnostics[0].error.contains("repeated nextCursor"));
+    assert!(ai_hist_core::session_locations(&conn, "cursor", "one")
+        .unwrap()
+        .is_empty());
+    server.join().unwrap();
+}
+
+#[test]
+fn cloud_recall_refresh_reuses_rotated_credentials_and_persists_expiry() {
+    let _isolated = without_credentials_override();
+    let (base, server) = cloud_http(vec![
+        (401, serde_json::json!({"error": "expired"})),
+        (
+            200,
+            serde_json::json!({"accessToken": "rth_at_rotated", "refreshToken": "rth_rt_rotated", "accessTokenExpiresAt": "2100-02-01T00:00:00Z"}),
+        ),
+        (200, cloud_listing("cursor", "one")),
+    ]);
+    let mut auth = cloud_auth(&base);
+    auth.refresh_token = Some("rth_rt_synthetic".into());
+    crate::cloud::save_auth(&auth).unwrap();
+    crate::cloud::recall_page(&auth, crate::cloud::RecallResource::Sessions, &[]).unwrap();
+    let stored = crate::cloud::load_auth(Some(&base)).unwrap().unwrap();
+    assert_eq!(stored.access_token, "rth_at_rotated");
+    assert_eq!(
+        stored.access_token_expires_at.as_deref(),
+        Some("2100-02-01T00:00:00Z")
+    );
+    let requests = server.join().unwrap();
+    assert!(requests[1].starts_with("POST /v1/auth/token/refresh "));
+    assert!(requests[2].contains("Authorization: Bearer rth_at_rotated"));
+}
+
+#[test]
+fn cloud_status_requires_sixty_seconds_and_honors_stage_precedence() {
+    let _isolated = without_credentials_override();
+    let mut auth = cloud_auth("https://history.agentrelay.com");
+    auth.access_token_expires_at =
+        Some((chrono::Utc::now() + chrono::Duration::seconds(59)).to_rfc3339());
+    crate::cloud::save_auth(&auth).unwrap();
+    assert!(crate::cloud::recall_auth()
+        .unwrap_err()
+        .to_string()
+        .contains("less than 60s"));
+    auth.access_token_expires_at =
+        Some((chrono::Utc::now() + chrono::Duration::seconds(120)).to_rfc3339());
+    crate::cloud::save_auth(&auth).unwrap();
+    assert!(crate::cloud::recall_auth().is_ok());
+    let stage = cloud_auth("http://127.0.0.1:8787");
+    crate::cloud::save_auth(&stage).unwrap();
+    assert!(crate::cloud::recall_auth()
+        .unwrap_err()
+        .to_string()
+        .contains("2 relayhistory stages"));
+    std::env::set_var("AI_HIST_BASE_URL", &auth.base_url);
+    assert_eq!(crate::cloud::recall_auth().unwrap().base_url, auth.base_url);
+    std::env::set_var("RELAYHISTORY_BASE_URL", &stage.base_url);
+    assert_eq!(
+        crate::cloud::recall_auth().unwrap().base_url,
+        stage.base_url
+    );
+}
+
+#[test]
+fn cloud_login_preserves_server_expiry_for_connector_availability() {
+    let _isolated = without_credentials_override();
+    let (base, server) = cloud_http(vec![(
+        200,
+        serde_json::json!({
+            "accessToken": "rth_at_login", "refreshToken": "rth_rt_login",
+            "accessTokenExpiresAt": "2100-01-01T00:00:00Z", "orgId": "org-teammates"
+        }),
+    )]);
+    let auth = crate::cloud::login(&base, "synthetic-relayauth-token", "test", None).unwrap();
+    crate::cloud::save_auth(&auth).unwrap();
+    assert_eq!(
+        crate::cloud::recall_auth()
+            .unwrap()
+            .access_token_expires_at
+            .as_deref(),
+        Some("2100-01-01T00:00:00Z")
+    );
+    assert!(server.join().unwrap()[0].starts_with("POST /v1/cli/login "));
 }

--- a/crates/ai-hist/src/remote/tests.rs
+++ b/crates/ai-hist/src/remote/tests.rs
@@ -1626,3 +1626,43 @@ fn cloud_recall_rejects_all_tenancy_query_selectors_before_network() {
         );
     }
 }
+
+#[test]
+fn cloud_preserves_presence_less_local_session_during_full_ingestion_gap() {
+    let _isolated = without_credentials_override();
+    let home = tempfile::tempdir().unwrap();
+    let (base, server) = cloud_http(vec![(200, cloud_listing("grok", "legacy-local"))]);
+    crate::cloud::save_auth(&cloud_auth(&base)).unwrap();
+    let conn = catalog();
+    // State between the canonical full-session INSERT and the local presence
+    // write. Existing cache-only reads classify it as local.
+    conn.execute("INSERT INTO sessions(source, session_id, raw_path, discovery_state) VALUES ('grok', 'legacy-local', '/local/chat.json', 'full')", []).unwrap();
+    assert_eq!(
+        list_session_catalog(&conn, &CatalogListOptions::default())
+            .unwrap()
+            .len(),
+        1
+    );
+    let options = DiscoverOptions {
+        scope: SessionScope::Remote,
+        sources: vec!["grok".into()],
+        ..Default::default()
+    };
+    crate::discover::discover_sessions_with_env(&env_at(&conn, home.path()), &options, |_| {})
+        .unwrap();
+    let local = list_session_catalog(&conn, &CatalogListOptions::default()).unwrap();
+    assert_eq!(local.len(), 1);
+    assert_eq!(local[0].raw_path.as_deref(), Some("/local/chat.json"));
+    assert_eq!(local[0].discovery_state, "full");
+    assert_eq!(local[0].locations, ["local", "remote"]);
+    let presences: Vec<(String,String)> = conn.prepare("SELECT location, raw_locator FROM session_presences WHERE source='grok' AND session_id='legacy-local' ORDER BY location").unwrap().query_map([], |r| Ok((r.get(0)?,r.get(1)?))).unwrap().collect::<rusqlite::Result<_>>().unwrap();
+    assert_eq!(
+        presences,
+        vec![
+            ("local".into(), "/local/chat.json".into()),
+            ("remote".into(), "cloud://org-teammates/legacy-local".into())
+        ]
+    );
+    server.join().unwrap();
+    println!("legacy local gap: {presences:?}; canonical raw_path=/local/chat.json; state=full");
+}

--- a/crates/ai-hist/src/remote/tests.rs
+++ b/crates/ai-hist/src/remote/tests.rs
@@ -1097,7 +1097,9 @@ fn cloud_http(pages: Vec<(u16, Value)>) -> (String, std::thread::JoinHandle<Vec<
             let mut body_bytes = vec![0; content_length];
             reader.read_exact(&mut body_bytes).unwrap();
             assert!(
-                !request.contains("org_id=") && !request.contains("orgId="),
+                !["org_id=", "orgId=", "workspace_id=", "workspaceId="]
+                    .iter()
+                    .any(|selector| request.contains(selector)),
                 "{request}"
             );
             let body = body.to_string();
@@ -1217,6 +1219,26 @@ fn cloud_teleport_adds_second_presence_and_keeps_local_evidence() {
         )
         .unwrap();
     assert_eq!(cwd, "/work/repo");
+    let raw_path: String = conn
+        .query_row(
+            "SELECT raw_path FROM sessions WHERE source='codex' AND session_id='teleport-1'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
+    assert_eq!(raw_path, "/local/rollout.jsonl");
+    for scope in [SessionScope::Local, SessionScope::Remote, SessionScope::All] {
+        let rows = list_session_catalog(
+            &conn,
+            &CatalogListOptions {
+                scope,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].raw_path.as_deref(), Some("/local/rollout.jsonl"));
+    }
     conn.execute(
         "DELETE FROM sessions WHERE source='codex' AND session_id='teleport-1'",
         [],
@@ -1229,7 +1251,7 @@ fn cloud_teleport_adds_second_presence_and_keeps_local_evidence() {
     );
     server.join().unwrap();
     println!(
-        "teleport session_presences: {presences:?}; canonical deletion cleaned both presences"
+        "teleport session_presences: {presences:?}; canonical raw_path={raw_path}; canonical deletion cleaned both presences"
     );
 }
 
@@ -1525,4 +1547,82 @@ fn cloud_login_preserves_server_expiry_for_connector_availability() {
         Some("2100-01-01T00:00:00Z")
     );
     assert!(server.join().unwrap()[0].starts_with("POST /v1/cli/login "));
+}
+
+#[test]
+fn cloud_page_cap_retains_bounded_catalog_results() {
+    let _isolated = without_credentials_override();
+    let home = tempfile::tempdir().unwrap();
+    let pages = (0..MAX_LIST_PAGES)
+        .map(|index| {
+            let mut page = cloud_listing("cursor", &format!("bounded-{index}"));
+            page["nextCursor"] = Value::String(format!("next-{}", index + 1));
+            (200, page)
+        })
+        .collect();
+    let (base, server) = cloud_http(pages);
+    crate::cloud::save_auth(&cloud_auth(&base)).unwrap();
+    let conn = catalog();
+    let options = DiscoverOptions {
+        scope: SessionScope::Remote,
+        sources: vec!["cursor".into()],
+        ..Default::default()
+    };
+    let summary =
+        crate::discover::discover_sessions_with_env(&env_at(&conn, home.path()), &options, |_| {})
+            .unwrap();
+    assert_eq!(summary.discovered, MAX_LIST_PAGES);
+    assert!(summary.diagnostics.is_empty());
+    let rows = list_session_catalog(
+        &conn,
+        &CatalogListOptions {
+            scope: SessionScope::Remote,
+            limit: Some(200),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(rows.len(), MAX_LIST_PAGES);
+    assert_eq!(server.join().unwrap().len(), MAX_LIST_PAGES);
+    println!(
+        "page cap: {} HTTP pages, {} retained remote catalog rows",
+        MAX_LIST_PAGES,
+        rows.len()
+    );
+}
+
+#[test]
+fn cloud_status_requires_cached_org_for_provenance() {
+    let _isolated = without_credentials_override();
+    let home = tempfile::tempdir().unwrap();
+    for org_id in [None, Some(""), Some("   ")] {
+        let mut auth = cloud_auth("https://history.agentrelay.com");
+        auth.org_id = org_id.map(String::from);
+        crate::cloud::save_auth(&auth).unwrap();
+        let status = remote_connector_statuses_at(home.path())
+            .into_iter()
+            .find(|s| s.connector == CLOUD_CONNECTOR)
+            .unwrap();
+        assert!(!status.configured);
+        assert!(status.detail.contains("no orgId for provenance"));
+        assert!(configured_remote_providers(home.path(), None).is_empty());
+    }
+}
+
+#[test]
+fn cloud_recall_rejects_all_tenancy_query_selectors_before_network() {
+    let _isolated = without_credentials_override();
+    let auth = cloud_auth("http://127.0.0.1:1");
+    for selector in ["org_id", "orgId", "workspace_id", "workspaceId"] {
+        let error = crate::cloud::recall_page(
+            &auth,
+            crate::cloud::RecallResource::Sessions,
+            &[(selector, "forged")],
+        )
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("tenancy comes from the token"),
+            "{error}"
+        );
+    }
 }

--- a/docs/remote-connectors.md
+++ b/docs/remote-connectors.md
@@ -4,21 +4,22 @@ Remote acquisition (`sessions discover --remote`, `sync --remote`, and the
 remote half of `--all`) runs through provider connectors. A connector
 enumerates the sessions a provider keeps on its own service and lands them in
 the shared session ledger as catalog rows with a `remote` presence. There are
-two connectors:
+three connectors:
 
 | Connector | Source | Lists | Interface |
 |---|---|---|---|
 | `claude-web` | `claude` | Claude Code sessions on claude.ai/code | listing plus the CLI's private teleport-evidence interface, with its stored OAuth token |
 | `codex-cloud` | `codex` | Codex cloud tasks | `codex cloud list --json` and `codex cloud diff TASK_ID` |
+| `cloud` | Upstream source (`claude`, `codex`, `cursor`, `grok`, `relay`, `trajectory`, `opencode`) | Teammate sessions in the token’s organization | `GET /v1/sessions`, using the stored RelayHistory `rth_at_` session |
 
 Local and remote stay presences of one session ledger: a session observed
 both by a local file adapter and by a connector is one catalog row whose
 `locations` are `["local", "remote"]`.
 
-## Configuration is the provider CLI's sign-in
+## Configuration
 
-RelayHistory never runs an auth flow of its own. A connector is **configured**
-when the provider's own CLI has been signed in on this machine:
+The provider connectors use their CLI’s stored sign-in. The `cloud` connector
+reuses the RelayHistory session created by `ai-hist login`:
 
 - `claude-web` — `~/.claude/.credentials.json` exists (the claude.ai OAuth
   token the Claude Code CLI stores at sign-in). If your setup keeps
@@ -27,6 +28,33 @@ when the provider's own CLI has been signed in on this machine:
 - `codex-cloud` — `~/.codex/auth.json` exists (written by `codex login`).
   The `codex` binary must be on `PATH` when the connector runs; the CLI
   handles token refresh itself.
+- `cloud` — `cloud::config_dir()` (normally `~/.agentworkforce/relayhistory`,
+  overridden by `RELAYHISTORY_HOME`) resolves a stored `rth_at_` session with
+  `access_token_expires_at` at least 60 seconds in the future. This RFC 3339
+  expiry is persisted from the service's `accessTokenExpiresAt` during login,
+  mint, and refresh. Legacy auth without expiry remains usable for push, but
+  needs a fresh login/refresh before cloud discovery advertises availability.
+  Missing, malformed, expired, or ambiguous credentials report an unconfigured
+  reason; status probes never refresh or perform network requests.
+
+Cloud stage selection and credential loading live only in `cloud.rs`.
+`RELAYHISTORY_BASE_URL` takes precedence over `AI_HIST_BASE_URL`; without an
+explicit override, a single stored stage is used and multiple stages require
+selection. The normal service URL is `https://history.agentrelay.com`.
+Non-loopback cleartext HTTP is refused, while `http://127.0.0.1:8787` is valid
+for development. Recall requests reuse auth refresh on HTTP 401, refuse
+redirects, and bound each response to 16 MiB and each request to 30 seconds.
+The client never sends an org/workspace selector: tenancy comes from the token.
+
+```bash
+ai-hist login
+ai-hist sessions discover --remote --source cursor
+ai-hist sync --all
+```
+
+Cloud is a connector, **not** a new `--source` value. Its adapters query each
+upstream source independently, preserving source filters and global recency
+ordering. Each source is limited to 100 pages of at most 100 sessions.
 
 Requesting `--remote` acquisition with no connector configured fails loudly
 with the same `no remote provider connectors are configured` error as before
@@ -47,7 +75,7 @@ CLI once refreshes it.
 `codex-cloud` pages through the CLI's listing window: `codex cloud list`
 accepts `--limit` values of 1–20, so the connector requests bounded pages and
 follows the returned `cursor` until the listing (or a requested row cap) is
-exhausted. Both connectors bound one enumeration to 100 pages (10,000 claude
+exhausted. The provider connectors bound one enumeration to 100 pages (10,000 claude
 sessions, 2,000 codex tasks) — bounded work is part of the discovery
 contract; a later run continues from fresher listings.
 
@@ -99,7 +127,9 @@ to fill the gap:
   human-readable identifier the listings offer. Both providers derive it from
   the opening prompt.
 - `raw_path` — the session/task URL (`https://claude.ai/code/<id>`, the
-  ChatGPT task URL).
+  ChatGPT task URL), or `cloud://<orgId>/<sessionId>` for cloud recall.
+  Cloud markers also live on the remote presence, preserving a local locator
+  when the same `(source, session_id)` already exists locally.
 - `repo_url` — for claude-web, the session's `git_repository` source when the
   service records one.
 - Timestamps — `created_at`/`last_event_at` (claude), `updated_at` (codex).
@@ -110,7 +140,9 @@ its available diff is indexed because no transcript export exists.
 
 ## Remote/local identity correlation
 
-Remote and local sessions remain separate rows. A Claude transcript containing
+Different remote and local session IDs remain separate rows. Identical
+`(source, session_id)` keys, including cloud copies of local sessions, have one
+canonical row with both local and remote presences. A Claude transcript containing
 the provider-recorded `remoteSessionId` creates a `materialized_local`
 relationship from the remote ID to the local session ID, but only when that
 exact remote presence already exists. Titles, repositories, prompts, and
@@ -130,6 +162,15 @@ adapters, per presence: the claude stamp tracks `last_event_at`, the codex
 stamp tracks `updated_at` plus task `status` (an applied or failed task whose
 timestamp did not move is still re-read). An unchanged remote session is
 served from the catalog with zero fresh work beyond the listing itself.
+Cloud stamps hash the recall rollup and provenance marker, so a changed summary,
+event count, or timestamp invalidates that presence's cache.
+
+Cloud discovery and sync populate shallow catalog rows. Cached list/search/recent/
+stats APIs retain their existing read semantics; this connector does not ingest
+normalized recall events into the local history tables. `cloud.rs` exposes the
+same authenticated page helper for `GET /v1/events` and
+`GET /v1/sessions/:sessionId/events`, but automatic event ingestion and cloud
+transcript hydration are separate work.
 
 ## Contract stability
 

--- a/docs/remote-connectors.md
+++ b/docs/remote-connectors.md
@@ -35,7 +35,9 @@ reuses the RelayHistory session created by `ai-hist login`:
   mint, and refresh. Legacy auth without expiry remains usable for push, but
   needs a fresh login/refresh before cloud discovery advertises availability.
   Missing, malformed, expired, or ambiguous credentials report an unconfigured
-  reason; status probes never refresh or perform network requests.
+  reason; status probes never refresh or perform network requests. The stored
+  session must also have a non-empty cached `org_id` to construct provenance
+  markers; missing org metadata reports unconfigured before discovery.
 
 Cloud stage selection and credential loading live only in `cloud.rs`.
 `RELAYHISTORY_BASE_URL` takes precedence over `AI_HIST_BASE_URL`; without an
@@ -54,7 +56,9 @@ ai-hist sync --all
 
 Cloud is a connector, **not** a new `--source` value. Its adapters query each
 upstream source independently, preserving source filters and global recency
-ordering. Each source is limited to 100 pages of at most 100 sessions.
+ordering. Each source is limited to 100 pages of at most 100 sessions. Reaching
+that cap retains the fetched catalog rows; malformed or repeated cursors still
+fail rather than silently accepting an invalid listing.
 
 Requesting `--remote` acquisition with no connector configured fails loudly
 with the same `no remote provider connectors are configured` error as before


### PR DESCRIPTION
Remote acquisition could only discover the caller’s Claude/Codex provider sessions. This adds the `cloud` connector so `sessions discover --remote` and `sync --remote|--all` can cache teammate session rollups from RelayHistory, preserving each upstream `(source, session_id)` and a `cloud://<orgId>/<sessionId>` remote presence. A locally observed natural key gains a second presence, retaining its local evidence.

Auth loading, stage selection, secure transport and refresh stay in `cloud.rs`. Cloud availability requires an `rth_at_` token with recorded expiry at least 60 seconds away; status probes are read-only and degrade to an unconfigured reason. Missing cached org metadata also reports unconfigured because it is required for provenance markers. Pagination is bounded, opaque cursors are encoded, repeated cursors fail without caching partial listings, and no client org/workspace selector is sent. Remote trajectory sessions are included in cached remote/all listings while local derived trajectories remain excluded.

**Scope and brief corrections:**

- At this checkout’s `origin/main`, the Cargo package is `ai-hist-engine`; `ai-hist` is the binary. The literal test command in the brief fails below; the equivalent engine/core command passes. No package was renamed.
- `StoredAuth` did not have an expiry field. This persists optional `access_token_expires_at` from the service’s `accessTokenExpiresAt` in login, mint and refresh. Legacy credentials without expiry remain usable by push, but require login/refresh before advertising cloud discovery.
- Existing reads remain cache-only. This increment populates shallow session catalog rows and exposes `remote::cloud_recall_page` for `/v1/sessions`, `/v1/events`, and `/v1/sessions/:sessionId/events`; it does not automatically ingest cloud events into local history or add transcript hydration. The SPEC’s broader per-query network fanout is separate from this brief’s catalog acceptance gates.

**Acceptance evidence** (actual output captured in the isolated worktree; each gate below has its own evidence):

- [x] Engine/core tests pass using the actual Cargo package name. Literal brief command:

```text
$ cargo test -p ai-hist -p ai-hist-core
error: package ID specification `ai-hist` did not match any packages
```

```text
$ cargo test -p ai-hist-engine -p ai-hist-core
test result: ok. 123 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.40s
test result: ok. 273 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 18.05s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 0 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.31s
test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.50s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.94s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 78.05s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

- [x] Negative: empty `RELAYHISTORY_HOME`, cloud unconfigured, and the error begins with the compatibility phrase. From `cargo test -p ai-hist-engine --lib remote::tests::cloud_ -- --nocapture --test-threads=1`:

```text
test remote::tests::cloud_unconfigured_empty_home_preserves_error_prefix ... negative: no remote provider connectors are configured: remote session discovery is not available (claude-web: no claude.ai credentials at /var/folders/6d/0x5fkt8d01gfmmjdzkxqzwnh0000gn/T/.tmpL2MOkp/.claude/.credentials.json (sign in with the Claude Code CLI); codex-cloud: no Codex CLI login at /var/folders/6d/0x5fkt8d01gfmmjdzkxqzwnh0000gn/T/.tmpL2MOkp/.codex/auth.json (run `codex login`); cloud: /var/folders/6d/0x5fkt8d01gfmmjdzkxqzwnh0000gn/T/.tmpxsMuv0: no stored relayhistory session (run `ai-hist login`))
ok
```

- [x] Positive: synthetic stored auth plus real loopback `GET /v1/sessions` yields the provider’s source and remote marker. A second unchanged listing skips catalog work. From the same command:

```text
test remote::tests::cloud_positive_catalog_preserves_source_remote_marker_and_cache ... positive: ("cursor", "remote", "cloud://org-teammates/teammate-1"); second discovery skipped_unchanged=1
ok
```

- [x] Teleport: assertions inspect `session_presences`, retain the local locator/cwd, and prove canonical deletion cleans both presences. From the same command:

```text
test remote::tests::cloud_teleport_adds_second_presence_and_keeps_local_evidence ... teleport session_presences: [("local", "/local/rollout.jsonl"), ("remote", "cloud://org-teammates/teleport-1")]; canonical raw_path=/local/rollout.jsonl; canonical deletion cleaned both presences
ok
```

- [x] Cleartext guard: the connector’s shared auth/request path refuses the stored external HTTP URL and accepts loopback. From the same command:

```text
test remote::tests::cloud_cleartext_guard_is_inherited ... cleartext: http://evil.example refused: refusing to send the relayhistory bearer token in cleartext to `http://evil.example` — use an https:// endpoint. Plain http:// is accepted only for loopback (for example http://127.0.0.1:8787, the `wrangler dev` address).; http://127.0.0.1:8787 accepted
ok
```

- [x] Native binding builds. From `crates/ai-hist-napi`, with the installed Rust toolchain added to PATH:

```text
$ npm ci && npm run build:debug
added 1 package, and audited 2 packages in 3s

1 package is looking for funding
  run `npm fund` for details

found 0 vulnerabilities
npm notice run ai-hist-native@0.14.3 build:debug
npm notice run napi build --platform
    Blocking waiting for file lock on artifact directory
   Compiling ai-hist-napi v0.14.3 (/Users/khaliqgant/Projects/AgentWorkforce/.worktrees/ws1-rh-cloud-connector/crates/ai-hist-napi)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.63s
```

- [x] TypeScript tests pass unchanged. From `sdk-ts`:

```text
$ npm test
ℹ tests 59
ℹ suites 0
ℹ pass 59
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 21898.72
```

```text
git diff --exit-code origin/main -- sdk-ts: exit 0
```

- [x] The connector documentation and README matrix include cloud:

```text
README.md: | `cloud` | Upstream provider source; org-wide teammate sessions | RelayHistory `rth_at_` session under `RELAYHISTORY_HOME` (default `~/.agentworkforce/relayhistory`) |
docs/remote-connectors.md: | `cloud` | Upstream source (`claude`, `codex`, `cursor`, `grok`, `relay`, `trajectory`, `opencode`) | Teammate sessions in the token’s organization | `GET /v1/sessions`, using the stored RelayHistory `rth_at_` session |
```

Additional cloud regressions cover all seven upstream sources, invalid source rejection, trajectory discovery→cached-list roundtrip, expiry persistence through real login and 401 refresh, the 60-second guard, stage precedence, event endpoints, and repeated cursors:

```text
test result: ok. 16 passed; 0 failed; 0 ignored; 0 measured; 257 filtered out; finished in 3.58s
```

`SOURCE_CHOICES` and the core presence/deletion implementation are unchanged; discovery reuses the existing presence upsert path:

```text
git diff --exit-code origin/main -- crates/ai-hist-core/src/lib.rs: exit 0
```

**Review follow-up:** preserved canonical local transcript paths when adding a remote presence; retained bounded catalog results at the page cap; corrected trajectory API documentation; gated availability on cached org provenance; and added checks for all four org/workspace query-selector spellings. The tests above were rerun on these fixes: 427 Rust tests pass (2 existing benchmark ignores), all 59 unchanged SDK tests pass, and the native debug build passes. CodeRabbit withdrew and resolved its status-time refresh suggestion after the strict availability contract was explained.

```text
test remote::tests::cloud_page_cap_retains_bounded_catalog_results ... page cap: 100 HTTP pages, 100 retained remote catalog rows
ok
```

The subsequent review also identified the local ingestion gap between the canonical full-session write and its presence write. Remote upsert now preserves the existing legacy-local classification transactionally before inserting the first remote presence. Fresh remote rows and existing remote-only rows do not gain a local presence. Regression output:

```text
test remote::tests::cloud_preserves_presence_less_local_session_during_full_ingestion_gap ... legacy local gap: [("local", "/local/chat.json"), ("remote", "cloud://org-teammates/legacy-local")]; canonical raw_path=/local/chat.json; state=full
ok
```

The follow-up’s first compilation caught an attempted call to a private core helper:

```text
error[E0624]: method `as_str` is private
```

That call was replaced by an explicit location match, keeping the core API unchanged; the final validation output above is green.

**Failures found and resolved:** the first Rust run failed three existing HTTP tests; a serial run also failed on some new mocks. Actual failure excerpt:

```text
called `Result::unwrap()` on an `Err` value: Os { code: 35, kind: WouldBlock, message: "Resource temporarily unavailable" }

test result: FAILED. 261 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in 41.77s
```

Independent review confirmed macOS accepted sockets inherit `O_NONBLOCK` and a read timeout does not clear it. The three affected test helpers now explicitly switch accepted sockets to blocking mode; the new mock also drains POST bodies. The final normal parallel suite passes without a serial-run workaround. The initial shell also lacked Cargo on PATH; validation used `export PATH=/Users/khaliqgant/.cargo/bin:$PATH`.

Independent review found and verified the trajectory listing fix and auth-expiry tests, with no remaining production-code blocker. `git diff --check` passes. Veto tools were not exposed in this session, so no Veto scan is claimed.

Work was performed only on `feat/ai-hist-cloud-connector` in the required isolated worktree created from `origin/main` (`3e7df69`). **Merge policy: never. Terminal state: human-review. Khaliq owns the merge.**


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



