### PR TITLE
Add secret-safe ai-hist token command with proactive refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,24 @@ ai-hist --version
 ai-hist --version --no-warning
 ```
 
+### Exporting a cloud access token (Rust CLI)
+
+After `ai-hist login` or `ai-hist admin-mint`, the Rust CLI can print the current
+access token for authenticated API calls:
+
+```bash
+export RTH_TOKEN=$(ai-hist token)
+curl -H "Authorization: Bearer $RTH_TOKEN" https://history.agentrelay.com/v1/sessions
+```
+
+`token` prints only the secret and a newline. It refreshes credentials with less
+than 60 seconds remaining (including missing or invalid expiry) before printing.
+Failures return a non-zero status with empty stdout. A terminal-only warning goes
+to stderr because running this command bare leaves the secret in scrollback.
+Select a stage with `--base-url <url>`, then `RELAYHISTORY_BASE_URL` or
+`AI_HIST_BASE_URL`; the fallback is production. With multiple stored stages and
+no explicit selection, it fails with the same ambiguity error as `push`.
+
 ## TypeScript
 
 ```ts

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -291,6 +291,70 @@ pub fn load_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
     }
 }
 
+/// Return an access token with at least 60 seconds of recorded validity remaining.
+/// Unknown legacy expiry is refreshed too: an opaque token cannot prove its own lifetime.
+pub fn access_token(base_url: Option<&str>) -> Result<String> {
+    let explicit_base = base_url
+        .map(|value| normalize_base_url(value).context("invalid relayhistory base URL"))
+        .transpose()?;
+    let env_base = ["RELAYHISTORY_BASE_URL", "AI_HIST_BASE_URL"]
+        .into_iter()
+        .filter_map(|key| std::env::var(key).ok())
+        .find_map(|value| normalize_base_url(&value));
+    // Keep push's ambiguity error even though the fallback destination is production.
+    // JSON type errors can quote credential values from a malformed auth file.
+    let load = |base: Option<&str>| {
+        load_auth(base).map_err(|error| {
+            if error.chain().any(|cause| cause.is::<serde_json::Error>()) {
+                anyhow::anyhow!("could not parse stored relayhistory session; run `ai-hist login`")
+            } else {
+                error
+            }
+        })
+    };
+    let selected = explicit_base.or(env_base);
+    if selected.is_none() {
+        load(None)?;
+    }
+    let base = selected.unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
+    let mut auth = load(Some(&base))?
+        .context("not authenticated — run `ai-hist login` or `ai-hist admin-mint` first")?;
+    if !token_has_valid_lifetime(&auth) {
+        let _refresh_lock = acquire_refresh_lock(&base)?;
+        auth = load(Some(&base))?
+            .context("not authenticated — run `ai-hist login` or `ai-hist admin-mint` first")?;
+        if !token_has_valid_lifetime(&auth) {
+            // Never expose a server response or parser error here: either can echo secrets.
+            // The shared path retains its HTTPS/loopback guard and atomic rotation storage.
+            auth = refresh_and_save_auth(&auth).map_err(|_| {
+                anyhow::anyhow!("refreshing relayhistory session failed; run `ai-hist login` for the selected --base-url")
+            })?;
+        }
+    }
+    anyhow::ensure!(token_has_valid_lifetime(&auth),
+        "refreshed relayhistory access-token expiry is missing, invalid, or less than 60s away; run `ai-hist login`");
+    anyhow::ensure!(
+        auth.access_token.starts_with("rth_at_")
+            && auth.access_token.len() > "rth_at_".len()
+            && auth
+                .access_token
+                .bytes()
+                .all(|byte| byte.is_ascii_graphic()),
+        "stored relayhistory session has an invalid access token; run `ai-hist login`"
+    );
+    Ok(auth.access_token)
+}
+
+fn token_has_valid_lifetime(auth: &StoredAuth) -> bool {
+    let expiry = auth
+        .access_token_expires_at
+        .as_deref()
+        .and_then(crate::parse_iso_ms);
+    expiry.is_some_and(|expiry| {
+        expiry >= chrono::Utc::now().timestamp_millis().saturating_add(60_000)
+    })
+}
+
 /// Store a session only under its base URL. If upgrading from the old one-file layout, preserve
 /// that old stage and cursor before adding the new one; overwriting it is exactly what caused
 /// cross-stage cursor corruption.
@@ -903,11 +967,17 @@ fn send_with_auth_refresh(
     {
         return Err(map_error(unauthorized));
     }
-    let refreshed = refresh_auth(&current).context("refreshing relayhistory session")?;
+    let refreshed = refresh_and_save_auth(&current)?;
+    send(&refreshed).map_err(|error| map_error(*error))
+}
+
+// Callers hold the stage refresh lock and reload the current pair before entering.
+fn refresh_and_save_auth(auth: &StoredAuth) -> Result<StoredAuth> {
+    let refreshed = refresh_auth(auth).context("refreshing relayhistory session")?;
     // Refresh tokens rotate and invalidate their predecessor. Persist the new pair atomically
     // before retrying so a crash or network failure cannot strand the client on the old token.
     save_auth(&refreshed).context("persisting refreshed relayhistory session")?;
-    send(&refreshed).map_err(|error| map_error(*error))
+    Ok(refreshed)
 }
 
 fn refresh_auth(auth: &StoredAuth) -> Result<StoredAuth> {

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -294,9 +294,7 @@ pub fn load_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
 /// Return an access token with at least 60 seconds of recorded validity remaining.
 /// Unknown legacy expiry is refreshed too: an opaque token cannot prove its own lifetime.
 pub fn access_token(base_url: Option<&str>) -> Result<String> {
-    let explicit_base = base_url
-        .map(|value| normalize_base_url(value).context("invalid relayhistory base URL"))
-        .transpose()?;
+    let explicit_base = base_url.map(normalized_stage).transpose()?;
     let env_base = ["RELAYHISTORY_BASE_URL", "AI_HIST_BASE_URL"]
         .into_iter()
         .filter_map(|key| std::env::var(key).ok())

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -631,6 +631,13 @@ enum Command {
         #[arg(long, default_value = "local-dev")]
         label: String,
     },
+    /// Print the current access token alone (a secret); refresh it before expiry.
+    Token {
+        /// Select the cloud stage; defaults to RELAYHISTORY_BASE_URL/AI_HIST_BASE_URL, then prod.
+        /// Required when multiple stages are configured and neither environment variable is set.
+        #[arg(long)]
+        base_url: Option<String>,
+    },
     /// Fetch a cloud session transcript for offline reading (never imports into SQLite).
     Replay {
         session_id: String,
@@ -949,6 +956,16 @@ pub fn run() -> Result<()> {
     // Pre-dispatch them so the common connection setup below cannot initialize the schema or
     // wait on SQLite before contention is detected.
     match &cli.command {
+        Command::Token { base_url } => {
+            use std::io::IsTerminal;
+            let token = cloud::access_token(base_url.as_deref())?;
+            if std::io::stdout().is_terminal() {
+                eprintln!("Warning: this access token is a secret and will remain in terminal scrollback.");
+            }
+            // Write only after selection, refresh, persistence, and validation all succeed.
+            writeln!(std::io::stdout().lock(), "{token}")?;
+            return Ok(());
+        }
         // The common read-only path can create or migrate SQLite. A cloud replay must
         // also work on a fresh machine without creating a local history store.
         Command::Replay {
@@ -1007,6 +1024,7 @@ pub fn run() -> Result<()> {
     };
 
     match cli.command {
+        Command::Token { .. } => unreachable!("token is dispatched before opening SQLite"),
         Command::Replay { .. } => unreachable!("replay is dispatched before opening SQLite"),
         Command::Search {
             scope,

--- a/crates/ai-hist/tests/token.rs
+++ b/crates/ai-hist/tests/token.rs
@@ -1,0 +1,316 @@
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const PROD: &str = "https://history.agentrelay.com";
+const FUTURE: &str = "2999-01-01T00:00:00Z";
+const OLD: &str = "rth_at_old_fixture";
+const NEW: &str = "rth_at_new_fixture";
+const REFRESH: &str = "rth_rt_old_fixture";
+
+fn save(home: &Path, base: &str, token: &str, expiry: Option<&str>) -> PathBuf {
+    let stages = home.join("stages");
+    std::fs::create_dir_all(&stages).unwrap();
+    let path = stages.join(format!("{}.auth.json", ai_hist_core::prompt_hash(base)));
+    std::fs::write(
+        &path,
+        json!({"base_url": base, "access_token": token,
+        "access_token_expires_at": expiry, "refresh_token": REFRESH})
+        .to_string(),
+    )
+    .unwrap();
+    path
+}
+
+fn command(home: &Path) -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_ai-hist"));
+    cmd.env("RELAYHISTORY_HOME", home)
+        .env_remove("RELAYHISTORY_BASE_URL")
+        .env_remove("AI_HIST_BASE_URL")
+        .env("RUST_LOG", "trace")
+        .arg("--db")
+        .arg(home.join("must-not-create.db"))
+        .arg("token");
+    cmd
+}
+
+fn success(output: &Output, expected: &str) {
+    assert!(output.status.success());
+    assert!(
+        output.stdout == format!("{expected}\n").as_bytes(),
+        "stdout must be exactly the expected access token and one newline"
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "piped invocation must have no diagnostics"
+    );
+}
+
+fn failure(output: &Output) -> String {
+    assert!(!output.status.success());
+    assert!(
+        output.stdout.is_empty(),
+        "failure must not print anything to stdout"
+    );
+    let err = String::from_utf8(output.stderr.clone()).unwrap();
+    for secret in [OLD, NEW, REFRESH] {
+        assert!(
+            !err.contains(secret),
+            "diagnostics must not include credentials"
+        );
+    }
+    err
+}
+
+// A loopback HTTP exchange: require the old refresh credential; serve exactly one request.
+fn refresh_server(status: u16, response: Value) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    listener.set_nonblocking(true).unwrap();
+    let handle = thread::spawn(move || {
+        let start = Instant::now();
+        let mut stream = loop {
+            match listener.accept() {
+                Ok((stream, _)) => break stream,
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    assert!(
+                        start.elapsed() < Duration::from_secs(10),
+                        "refresh was skipped"
+                    );
+                    thread::sleep(Duration::from_millis(5));
+                }
+                Err(err) => panic!("{err}"),
+            }
+        };
+        stream.set_nonblocking(false).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut line = String::new();
+        reader.read_line(&mut line).unwrap();
+        assert!(line.starts_with("POST /v1/auth/token/refresh "));
+        let mut length = 0;
+        loop {
+            line.clear();
+            reader.read_line(&mut line).unwrap();
+            if line == "\r\n" {
+                break;
+            }
+            if let Some(value) = line.to_ascii_lowercase().strip_prefix("content-length:") {
+                length = value.trim().parse().unwrap();
+            }
+        }
+        let mut body = vec![0; length];
+        reader.read_exact(&mut body).unwrap();
+        let body: Value = serde_json::from_slice(&body).unwrap();
+        assert!(body["refreshToken"] == REFRESH);
+        let body = response.to_string();
+        write!(stream, "HTTP/1.1 {status} Test\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).unwrap();
+    });
+    (base, handle)
+}
+
+#[test]
+fn token_is_exactly_one_line_and_never_opens_sqlite() {
+    let home = tempfile::tempdir().unwrap();
+    let path = save(home.path(), PROD, OLD, Some(FUTURE));
+    let before = std::fs::read(&path).unwrap();
+    success(&command(home.path()).output().unwrap(), OLD);
+    assert!(!home.path().join("must-not-create.db").exists());
+    assert!(before == std::fs::read(path).unwrap());
+    assert_eq!(
+        std::fs::read_dir(home.path().join("stages"))
+            .unwrap()
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn unauthenticated_has_existing_error_and_empty_stdout() {
+    let home = tempfile::tempdir().unwrap();
+    let err = failure(&command(home.path()).output().unwrap());
+    assert!(err.contains("not authenticated — run `ai-hist login` or `ai-hist admin-mint` first"));
+    assert_eq!(std::fs::read_dir(home.path()).unwrap().count(), 0);
+}
+
+#[test]
+fn stage_selection_honors_explicit_url_then_environment_and_rejects_ambiguity() {
+    let home = tempfile::tempdir().unwrap();
+    let dev = "http://localhost:8787";
+    save(home.path(), PROD, OLD, Some(FUTURE));
+    save(home.path(), dev, NEW, Some(FUTURE));
+    let err = failure(&command(home.path()).output().unwrap());
+    assert!(err.contains("2 relayhistory stages are configured; pass --base-url to select one."));
+    success(
+        &command(home.path())
+            .env("AI_HIST_BASE_URL", dev)
+            .output()
+            .unwrap(),
+        NEW,
+    );
+    success(
+        &command(home.path())
+            .env("AI_HIST_BASE_URL", dev)
+            .env("RELAYHISTORY_BASE_URL", PROD)
+            .output()
+            .unwrap(),
+        OLD,
+    );
+    success(
+        &command(home.path())
+            .env("RELAYHISTORY_BASE_URL", PROD)
+            .args(["--base-url", dev])
+            .output()
+            .unwrap(),
+        NEW,
+    );
+}
+
+#[test]
+fn expired_near_expiry_and_unknown_expiry_refresh_and_print_the_new_persisted_value() {
+    let near = (chrono::Utc::now() + chrono::Duration::seconds(10)).to_rfc3339();
+    for expiry in [
+        Some("2000-01-01T00:00:00Z"),
+        Some(near.as_str()),
+        None,
+        Some("invalid"),
+    ] {
+        let home = tempfile::tempdir().unwrap();
+        let (base, server) = refresh_server(
+            200,
+            json!({"accessToken": NEW,
+            "refreshToken": "rth_rt_new_fixture", "accessTokenExpiresAt": FUTURE}),
+        );
+        let path = save(home.path(), &base, OLD, expiry);
+        let output = command(home.path())
+            .args(["--base-url", &base])
+            .output()
+            .unwrap();
+        server.join().unwrap(); // Fails if no refresh request was made.
+        success(&output, NEW); // Fails if the old value is printed after refreshing.
+        let saved: Value = serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+        assert!(saved["access_token"] == NEW);
+        assert!(saved["refresh_token"] == "rth_rt_new_fixture");
+        // Server has closed: a second call must use the persisted new pair without refresh.
+        success(
+            &command(home.path())
+                .args(["--base-url", &base])
+                .output()
+                .unwrap(),
+            NEW,
+        );
+    }
+}
+
+#[test]
+fn refresh_failures_never_echo_response_credentials() {
+    for (status, response) in [
+        (401, json!({"error": format!("{OLD} {NEW} {REFRESH}")})),
+        (
+            200,
+            json!({"accessToken": NEW, "refreshToken": "rth_rt_new_fixture",
+            "accessTokenExpiresAt": "2000-01-01T00:00:00Z"}),
+        ),
+        (200, json!({"error": REFRESH})),
+    ] {
+        let home = tempfile::tempdir().unwrap();
+        let (base, server) = refresh_server(status, response);
+        save(home.path(), &base, OLD, Some("2000-01-01T00:00:00Z"));
+        let output = command(home.path())
+            .args(["--base-url", &base])
+            .output()
+            .unwrap();
+        server.join().unwrap();
+        failure(&output);
+    }
+}
+
+#[test]
+fn malformed_storage_and_multiline_access_tokens_do_not_leak() {
+    let home = tempfile::tempdir().unwrap();
+    let path = save(home.path(), PROD, OLD, Some(FUTURE));
+    // A wrong root type makes serde's error quote the string (and thus the secret).
+    std::fs::write(&path, json!(OLD).to_string()).unwrap();
+    failure(&command(home.path()).output().unwrap());
+    save(
+        home.path(),
+        PROD,
+        &format!("{OLD}\n{REFRESH}"),
+        Some(FUTURE),
+    );
+    failure(&command(home.path()).output().unwrap());
+}
+
+#[test]
+fn cleartext_is_allowed_for_local_printing_but_never_for_refresh() {
+    let home = tempfile::tempdir().unwrap();
+    let base = "http://example.invalid";
+    save(home.path(), base, OLD, Some(FUTURE));
+    success(
+        &command(home.path())
+            .args(["--base-url", base])
+            .output()
+            .unwrap(),
+        OLD,
+    );
+    save(home.path(), base, OLD, Some("2000-01-01T00:00:00Z"));
+    failure(
+        &command(home.path())
+            .args(["--base-url", base])
+            .output()
+            .unwrap(),
+    );
+}
+
+#[test]
+fn simultaneous_token_commands_share_one_refresh() {
+    let home = tempfile::tempdir().unwrap();
+    let (base, server) = refresh_server(
+        200,
+        json!({"accessToken": NEW,
+        "refreshToken": "rth_rt_new_fixture", "accessTokenExpiresAt": FUTURE}),
+    );
+    save(home.path(), &base, OLD, Some("2000-01-01T00:00:00Z"));
+    let children: Vec<_> = (0..4)
+        .map(|_| {
+            command(home.path())
+                .args(["--base-url", &base])
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .unwrap()
+        })
+        .collect();
+    for child in children {
+        success(&child.wait_with_output().unwrap(), NEW);
+    }
+    server.join().unwrap();
+}
+
+#[test]
+fn expired_session_without_refresh_token_fails_without_stdout() {
+    let home = tempfile::tempdir().unwrap();
+    let path = save(home.path(), PROD, OLD, Some("2000-01-01T00:00:00Z"));
+    let mut auth: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    auth["refresh_token"] = Value::Null;
+    std::fs::write(path, auth.to_string()).unwrap();
+    failure(&command(home.path()).output().unwrap());
+}
+
+#[test]
+fn legacy_auth_is_supported_and_default_stage_is_production() {
+    let home = tempfile::tempdir().unwrap();
+    let path = save(home.path(), PROD, OLD, Some(FUTURE));
+    std::fs::rename(path, home.path().join("auth.json")).unwrap();
+    success(&command(home.path()).output().unwrap(), OLD);
+
+    let home = tempfile::tempdir().unwrap();
+    save(home.path(), "http://localhost:8787", OLD, Some(FUTURE));
+    assert!(failure(&command(home.path()).output().unwrap()).contains("not authenticated"));
+}

--- a/crates/ai-hist/tests/token.rs
+++ b/crates/ai-hist/tests/token.rs
@@ -140,6 +140,20 @@ fn unauthenticated_has_existing_error_and_empty_stdout() {
 }
 
 #[test]
+fn invalid_explicit_base_url_reports_rejected_value_and_expected_format() {
+    let home = tempfile::tempdir().unwrap();
+    let rejected = "not-a-url";
+    let err = failure(
+        &command(home.path())
+            .args(["--base-url", rejected])
+            .output()
+            .unwrap(),
+    );
+    assert!(err.contains(&format!("invalid relayhistory base URL `{rejected}`")));
+    assert!(err.contains("expected an absolute URL without credentials, query, or fragment"));
+}
+
+#[test]
 fn stage_selection_honors_explicit_url_then_environment_and_rejects_ambiguity() {
     let home = tempfile::tempdir().unwrap();
     let dev = "http://localhost:8787";


### PR DESCRIPTION
Readers of generated PR comments can now obtain `$RTH_TOKEN` with `export RTH_TOKEN=$(ai-hist token)` instead of reading internal stage files. The Rust CLI prints only the access token and one newline, and exits with empty stdout on authentication or refresh failures.

- Selects `--base-url`, then `RELAYHISTORY_BASE_URL` / `AI_HIST_BASE_URL`, then production; preserves push's ambiguity error when multiple stored stages have no explicit selection.
- Requires at least 60 seconds of recorded validity. Expired, near-expiry, missing-expiry, and invalid-expiry sessions use cloud.rs's existing refresh request, stage lock, and atomic persistence. Concurrent callers reload after acquiring the lock and reuse an already rotated pair.
- Dispatches before opening SQLite. Reuses existing credential storage only, retains the HTTPS/loopback transport guard, and suppresses credential-bearing refresh bodies and malformed-storage parser errors. A TTY-only stderr warning explains the scrollback exposure; pipes receive no warning.
- Documents the one-liner in README. This follows the brief's Rust CLI scope; the separate npm CLI does not currently expose the existing login/push/replay commands either.

Validation:

- `cargo test -p ai-hist-engine -p ai-hist-core`: passed (427 tests, 2 pre-existing benchmark tests ignored; doc tests passed).
- `cargo test -p ai-hist-engine --test token`: all 10 subprocess tests passed, including exact stdout, empty stdout on errors, stage precedence/ambiguity, legacy storage, concurrent rotation, transport handling, and secret-safe diagnostics with `RUST_LOG=trace`.
- The expiry regression test stores distinct old and new fixture tokens. Its loopback server requires `POST /v1/auth/token/refresh` carrying the old refresh credential and fails if that request never arrives. The test requires stdout to equal the NEW access token plus exactly one newline, checks that both rotated credentials were persisted, and repeats the command after the server closes. Skipping refresh or printing the stale token fails this test.
- `cargo fmt --all --check` and `git diff --cached --check` passed. Reviewed `git diff --cached | rg 'rth_at_|eprintln!|println!|writeln!'`: only prefix validation, synthetic test fixtures, a secret-free warning, and the intended stdout write; no token logging.
- Live production check used `export RTH_TOKEN=$(ai-hist token)` and an authenticated GET (curl user agent). The access token stayed in memory/environment; only the response summary was printed:

```text
Authenticated GET /v1/sessions?limit=1: HTTP 200
Response keys: correlationId, nextCursor, sessions
Sessions returned: 1
```

Python's default urllib user agent initially received a Cloudflare text/plain 403; the same bearer succeeded with a curl user agent. No credentials or session contents were printed.

Based on `b73a229`. Veto tools were not available in this session; review was performed directly. Do not merge: Khaliq owns the merge.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

