### PR TITLE
[factory] get_session_thread MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ npx -y ai-hist-mcp
 
 Exposes `search_history`, `list_sessions`, `get_session_events`, `get_session_tool_calls`, `get_session_file_edits`, `get_session_tree`, `get_session_thread`, `history_stats`, and more as MCP tools. Wire it into any MCP-capable agent so it can query its own history mid-session.
 
-`get_session_thread` is the one cloud-backed tool. Given a `source` and a `session_id` it returns the commits that session shipped plus the pull requests, reviews, incidents, tickets, Slack threads, hotfixes and follow-up sessions linked to it — the *lifecycle* fan-out, complementing `get_session_tree`'s *subagent* fan-out. It fetches on every call and caches nothing, because a thread keeps growing as PRs and incidents land. Tenancy comes from the stored cloud session's token, never from a parameter.
+`get_session_thread` is the one cloud-backed tool. Given a `source` and a `session_id` it returns the commits that session shipped plus the pull requests, reviews, incidents, tickets, Slack threads, hotfixes and follow-up sessions linked to it — the *lifecycle* fan-out, complementing `get_session_tree`'s *subagent* fan-out. It fetches on every call and caches nothing, because a thread keeps growing as PRs and incidents land. Optional `kinds`, `since`, `limit` and `cursor` narrow and page the links. Tenancy comes from the stored cloud session's token, never from a parameter.
+
+It reads the native `ai-hist login` store first (`RELAYHISTORY_HOME`, else `~/.agentworkforce/relayhistory`) and this SDK's `~/.config/ai-hist/auth.json` second. Without a usable cloud session it returns `UNSUPPORTED_OPERATION`, names the missing precondition, and makes no request.
 
 ## Team + Cloud
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ ai-hist sessions relationships <harness> <id>        # which sessions spawned wh
 npx -y ai-hist-mcp
 ```
 
-Exposes `search_history`, `list_sessions`, `get_session_events`, `get_session_tool_calls`, `get_session_file_edits`, `get_session_tree`, `history_stats`, and more as MCP tools. Wire it into any MCP-capable agent so it can query its own history mid-session.
+Exposes `search_history`, `list_sessions`, `get_session_events`, `get_session_tool_calls`, `get_session_file_edits`, `get_session_tree`, `get_session_thread`, `history_stats`, and more as MCP tools. Wire it into any MCP-capable agent so it can query its own history mid-session.
+
+`get_session_thread` is the one cloud-backed tool. Given a `source` and a `session_id` it returns the commits that session shipped plus the pull requests, reviews, incidents, tickets, Slack threads, hotfixes and follow-up sessions linked to it — the *lifecycle* fan-out, complementing `get_session_tree`'s *subagent* fan-out. It fetches on every call and caches nothing, because a thread keeps growing as PRs and incidents land. Tenancy comes from the stored cloud session's token, never from a parameter.
 
 ## Team + Cloud
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Exposes `search_history`, `list_sessions`, `get_session_events`, `get_session_to
 
 `get_session_thread` is the one cloud-backed tool. Given a `source` and a `session_id` it returns the commits that session shipped plus the pull requests, reviews, incidents, tickets, Slack threads, hotfixes and follow-up sessions linked to it — the *lifecycle* fan-out, complementing `get_session_tree`'s *subagent* fan-out. It fetches on every call and caches nothing, because a thread keeps growing as PRs and incidents land. Optional `kinds`, `since`, `limit` and `cursor` narrow and page the links. Tenancy comes from the stored cloud session's token, never from a parameter.
 
-It reads the native `ai-hist login` store first (`RELAYHISTORY_HOME`, else `~/.agentworkforce/relayhistory`) and this SDK's `~/.config/ai-hist/auth.json` second. Without a usable cloud session it returns `UNSUPPORTED_OPERATION`, names the missing precondition, and makes no request.
+It reads the native `ai-hist login` store first (`RELAYHISTORY_HOME`, else `~/.agentworkforce/relayhistory`) and this SDK's `~/.config/ai-hist/auth.json` second, holding a native session to the same preconditions the `cloud` connector applies to recall. Without a usable cloud session it returns `UNSUPPORTED_OPERATION`, names the missing precondition, and makes no request.
 
 ## Team + Cloud
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Exposes `search_history`, `list_sessions`, `get_session_events`, `get_session_to
 
 `get_session_thread` is the one cloud-backed tool. Given a `source` and a `session_id` it returns the commits that session shipped plus the pull requests, reviews, incidents, tickets, Slack threads, hotfixes and follow-up sessions linked to it — the *lifecycle* fan-out, complementing `get_session_tree`'s *subagent* fan-out. It fetches on every call and caches nothing, because a thread keeps growing as PRs and incidents land. Optional `kinds`, `since`, `limit` and `cursor` narrow and page the links. Tenancy comes from the stored cloud session's token, never from a parameter.
 
-It reads the native `ai-hist login` store first (`RELAYHISTORY_HOME`, else `~/.agentworkforce/relayhistory`) and this SDK's `~/.config/ai-hist/auth.json` second, holding a native session to the same preconditions the `cloud` connector applies to recall. Without a usable cloud session it returns `UNSUPPORTED_OPERATION`, names the missing precondition, and makes no request.
+It reads the native `ai-hist login` store first (`RELAYHISTORY_HOME`, else `~/.agentworkforce/relayhistory`) and this SDK's `~/.config/ai-hist/auth.json` second, holding a native session to the same preconditions the `cloud` connector applies to recall. An expired session with a refresh token is rotated once and the new pair merged back over the stored session, so a long-running MCP install does not stop working at the token boundary. Without a usable cloud session it returns `UNSUPPORTED_OPERATION`, names the missing precondition, and makes no request.
 
 ## Team + Cloud
 

--- a/mcp-package/README.md
+++ b/mcp-package/README.md
@@ -51,6 +51,13 @@ read first, then this SDK's own `~/.config/ai-hist/auth.json`. With more than
 one stage stored and no `AI_HIST_BASE_URL` naming one, the tool refuses to
 guess rather than answer about the wrong org.
 
+A native-store session must meet the same bar the engine's `cloud` connector
+applies to recall — an `rth_at_` access token, an expiry at least 60s away, and
+a recorded org for provenance. A session missing any of them is one the
+connector itself reports as unconfigured, so the tool reports it the same way
+and names the missing precondition rather than issuing a request that would
+fail. `ai-hist login` restores all three.
+
 `get_session_relationships` and `get_session_tree` read the delegation topology
 recorded by hydration and sync: who delegated to whom, what evidence
 established the link, whether the child has a stable identity, and whether its

--- a/mcp-package/README.md
+++ b/mcp-package/README.md
@@ -11,12 +11,13 @@ loads the native addon directly, scans provider files, or invokes a CLI.
 
 Tools: `search_history`, `recent_history`, `list_sessions`,
 `discover_sessions`, `hydrate_session`, `get_session`, `get_session_events`,
-`get_session_relationships`, `get_session_tree`, `get_session_tool_calls`,
-`get_session_file_edits`, `history_stats`, and
+`get_session_relationships`, `get_session_tree`, `get_session_thread`,
+`get_session_tool_calls`, `get_session_file_edits`, `history_stats`, and
 `sync`. Search, recent history, session listing, discovery, statistics, and sync accept a
 `scope` of `local`, `remote`, or `all`; scope defaults to `local`.
-`get_session`, `get_session_events`, `get_session_relationships`, and
-`get_session_tree` address one session by identity and take no `scope`.
+`get_session`, `get_session_events`, `get_session_relationships`,
+`get_session_tree`, and `get_session_thread` address one session by identity
+and take no `scope`.
 `get_session_tool_calls` and `get_session_file_edits` are bounded, cursor-paged
 reads that require both a `source` and a `session_id`, because provider session
 IDs collide.
@@ -30,6 +31,18 @@ sync tools are therefore annotated as open-world writes.
 `hydrate_session` is an idempotent write that fully indexes one previously
 discovered identity and optionally its related provider-native sessions from
 local provider evidence, so it stays annotated as a local, closed-world write.
+
+`get_session_thread` is the *lifecycle* fan-out for one session: the commits it
+shipped plus the pull requests, reviews, incidents, tickets, Slack threads,
+hotfixes and follow-up sessions the cloud has stitched to it. It complements
+`get_session_tree` — that one is the *subagent* fan-out — and an agent may call
+both. It is cloud-only and never cached: a thread exists once the cloud has
+ingested lens events, and it changes as PRs and incidents land, so every call
+fetches. With no stored cloud session it returns `UNSUPPORTED_OPERATION` with
+the same `no remote provider connectors are configured` message the sibling
+connectors use, without making a request. Tenancy is derived from the token
+server-side; there is no org parameter. `kinds` filters `link_kind`, `since`
+bounds link event time, and `cursor` pages through `nextCursor`.
 
 `get_session_relationships` and `get_session_tree` read the delegation topology
 recorded by hydration and sync: who delegated to whom, what evidence

--- a/mcp-package/README.md
+++ b/mcp-package/README.md
@@ -42,7 +42,14 @@ fetches. With no stored cloud session it returns `UNSUPPORTED_OPERATION` with
 the same `no remote provider connectors are configured` message the sibling
 connectors use, without making a request. Tenancy is derived from the token
 server-side; there is no org parameter. `kinds` filters `link_kind`, `since`
-bounds link event time, and `cursor` pages through `nextCursor`.
+bounds link event time, and `limit` (1-500, default 100) with `cursor` pages the
+links; outcomes come back whole on every page.
+
+Credentials come from whichever store holds a session: the native `ai-hist
+login` store (`RELAYHISTORY_HOME`, else `~/.agentworkforce/relayhistory`) is
+read first, then this SDK's own `~/.config/ai-hist/auth.json`. With more than
+one stage stored and no `AI_HIST_BASE_URL` naming one, the tool refuses to
+guess rather than answer about the wrong org.
 
 `get_session_relationships` and `get_session_tree` read the delegation topology
 recorded by hydration and sync: who delegated to whom, what evidence

--- a/mcp-package/README.md
+++ b/mcp-package/README.md
@@ -53,10 +53,17 @@ guess rather than answer about the wrong org.
 
 A native-store session must meet the same bar the engine's `cloud` connector
 applies to recall — an `rth_at_` access token, an expiry at least 60s away, and
-a recorded org for provenance. A session missing any of them is one the
+a recorded org for provenance. A session missing a token prefix or an org is one the
 connector itself reports as unconfigured, so the tool reports it the same way
 and names the missing precondition rather than issuing a request that would
-fail. `ai-hist login` restores all three.
+fail. `ai-hist login` restores them.
+
+Expiry is the exception, because rotation exists to repair it: a rejected
+session with a refresh token is rotated once and the new pair persisted over
+the file it came from, in that store's own schema, so the CLI and the MCP stay
+in step. A pair another process rotated first is adopted rather than spending
+the one-time refresh token again. Only a session with nothing left to rotate
+reports expiry as unconfigured.
 
 `get_session_relationships` and `get_session_tree` read the delegation topology
 recorded by hydration and sync: who delegated to whom, what evidence

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sessions to the same preconditions the `cloud` connector applies to recall.
   An expired session with a refresh token is rotated once and the new pair
   merged over the file it came from, so the CLI and the MCP stay in step.
+  Stage selection honours `RELAYHISTORY_BASE_URL` before `AI_HIST_BASE_URL`,
+  ignoring a value that names no stage, as the engine does.
   `SessionThreadOptions.resolveSession` overrides that resolution for tests; no
   other credential hook is exposed, and none was released.
 - Export immutable `SOURCES` and derived `CATALOG_SOURCES` runtime registries alongside

--- a/sdk-ts/CHANGELOG.md
+++ b/sdk-ts/CHANGELOG.md
@@ -28,6 +28,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add the `get_session_thread` MCP tool and its `getSessionThread()` SDK
+  function: the lifecycle fan-out for one session — the commits it shipped plus
+  the pull requests, reviews, incidents, tickets, Slack threads, hotfixes and
+  follow-up sessions the cloud has linked to it. It complements
+  `get_session_tree`'s subagent fan-out. Cloud-only and never cached, backed by
+  `GET /v1/sessions/:sessionId/thread`. Takes `source`, `session_id`, and
+  optional `kinds`, `since`, `cursor` and `limit` (1..500); returns the recall
+  envelope unchanged. The MCP server now registers 14 tools.
+- Resolve cloud credentials from the native `ai-hist login` store
+  (`RELAYHISTORY_HOME`, else `~/.agentworkforce/relayhistory/stages/*.auth.json`)
+  in addition to this SDK's `~/.config/ai-hist/auth.json`, holding native
+  sessions to the same preconditions the `cloud` connector applies to recall.
+  An expired session with a refresh token is rotated once and the new pair
+  merged over the file it came from, so the CLI and the MCP stay in step.
+  `SessionThreadOptions.resolveSession` overrides that resolution for tests; no
+  other credential hook is exposed, and none was released.
 - Export immutable `SOURCES` and derived `CATALOG_SOURCES` runtime registries alongside
   `isSource()` and `isCatalogSource()` guards, so consumers can validate source
   input without duplicating the SDK's provider registry.

--- a/sdk-ts/src/cloud-client.ts
+++ b/sdk-ts/src/cloud-client.ts
@@ -12,6 +12,11 @@ export interface RelayhistoryAuth {
   refreshToken?: string;
   /** Server-issued RFC 3339 expiry. Absent in sessions stored before it existed. */
   accessTokenExpiresAt?: string;
+  /**
+   * Locally cached org, for provenance only — never sent as an authorization
+   * selector. The native store records it; this SDK's own login does not.
+   */
+  orgId?: string;
 }
 
 export type LoginCloudResult =
@@ -172,11 +177,13 @@ async function readNativeAuth(path: string): Promise<RelayhistoryAuth | null> {
   if (typeof baseUrl !== 'string' || typeof accessToken !== 'string') return null;
   const refreshToken = parsed.refresh_token ?? parsed.refreshToken;
   const expiresAt = parsed.access_token_expires_at ?? parsed.accessTokenExpiresAt;
+  const orgId = parsed.org_id ?? parsed.orgId;
   return {
     baseUrl,
     accessToken,
     ...(typeof refreshToken === 'string' ? { refreshToken } : {}),
     ...(typeof expiresAt === 'string' ? { accessTokenExpiresAt: expiresAt } : {}),
+    ...(typeof orgId === 'string' ? { orgId } : {}),
   };
 }
 
@@ -186,9 +193,9 @@ async function readNativeAuth(path: string): Promise<RelayhistoryAuth | null> {
  * enumerated and each file's own `base_url` identifies it, so this never has
  * to reproduce the engine's stage-key hash.
  */
-async function nativeStoredSessions(): Promise<RelayhistoryAuth[]> {
+async function nativeStoredSessions(): Promise<StoredCandidate[]> {
   const home = nativeCloudHome();
-  const found: RelayhistoryAuth[] = [];
+  const found: StoredCandidate[] = [];
   let entries: string[] = [];
   try {
     entries = (await readdir(join(home, 'stages'))).filter((name) => name.endsWith('.auth.json'));
@@ -197,11 +204,12 @@ async function nativeStoredSessions(): Promise<RelayhistoryAuth[]> {
   }
   for (const entry of entries.sort()) {
     const auth = await readNativeAuth(join(home, 'stages', entry));
-    if (auth) found.push(auth);
+    if (auth) found.push({ auth, origin: 'native' });
   }
   const legacy = await readNativeAuth(join(home, 'auth.json'));
-  if (legacy && !found.some((auth) => normalizeStage(auth.baseUrl) === normalizeStage(legacy.baseUrl))) {
-    found.push(legacy);
+  if (legacy
+    && !found.some((c) => normalizeStage(c.auth.baseUrl) === normalizeStage(legacy.baseUrl))) {
+    found.push({ auth: legacy, origin: 'native' });
   }
   return found;
 }
@@ -209,13 +217,45 @@ async function nativeStoredSessions(): Promise<RelayhistoryAuth[]> {
 /** Milliseconds of remaining validity below which a session is treated as spent. */
 const EXPIRY_FLOOR_MS = 60_000;
 
-function isExpired(auth: RelayhistoryAuth, now: number): boolean {
-  // A session stored before expiry was recorded carries no claim either way.
-  // Push tolerates those, and the SDK's own store has never written the field,
-  // so absence is not treated as expiry — only a stated, spent expiry is.
-  if (!auth.accessTokenExpiresAt) return false;
-  const expiry = Date.parse(auth.accessTokenExpiresAt);
-  return Number.isFinite(expiry) && expiry < now + EXPIRY_FLOOR_MS;
+/** Which store a candidate came from. The two carry different written contracts. */
+type StoreOrigin = 'native' | 'sdk';
+
+interface StoredCandidate {
+  auth: RelayhistoryAuth;
+  origin: StoreOrigin;
+}
+
+/**
+ * Why a stored session cannot serve a recall read, or `null` when it can.
+ *
+ * For native-store sessions this is `cloud::recall_auth`'s contract, whole: an
+ * `rth_at_` access token, an expiry that is present, parseable and at least
+ * {@link EXPIRY_FLOOR_MS} away, and a non-blank `org_id`. A session failing any
+ * of those is one the engine's own connector already reports as unconfigured,
+ * so answering a thread from it would claim a capability the rest of the
+ * toolchain denies.
+ *
+ * The SDK store is held to the subset it can satisfy. {@link loginCloud} has
+ * never persisted an expiry or an org, so requiring them there would not
+ * enforce a contract — it would retire a login path that works. Teaching
+ * `loginCloud` to store both, then holding one bar everywhere, is the follow-up.
+ */
+function ineligibleReason(candidate: StoredCandidate, now: number): string | null {
+  const { auth, origin } = candidate;
+  if (!auth.accessToken.startsWith('rth_at_')) {
+    return 'the stored relayhistory session has no rth_at_ access token';
+  }
+  const stated = auth.accessTokenExpiresAt;
+  if (origin === 'native' || stated !== undefined) {
+    const expiry = stated === undefined ? Number.NaN : Date.parse(stated);
+    if (!Number.isFinite(expiry) || expiry < now + EXPIRY_FLOOR_MS) {
+      return 'the stored relayhistory access-token expiry is missing, invalid, or less than 60s away';
+    }
+  }
+  if (origin === 'native' && !auth.orgId?.trim()) {
+    return 'the stored cloud session has no orgId for provenance';
+  }
+  return null;
 }
 
 /** Why no usable cloud session was found, phrased for {@link cloudUnconfiguredMessage}. */
@@ -243,8 +283,8 @@ export async function resolveCloudSession(
   const candidates = await nativeStoredSessions();
   const sdkStored = await loadStoredRelayhistoryAuth();
   if (sdkStored
-    && !candidates.some((a) => normalizeStage(a.baseUrl) === normalizeStage(sdkStored.baseUrl))) {
-    candidates.push(sdkStored);
+    && !candidates.some((c) => normalizeStage(c.auth.baseUrl) === normalizeStage(sdkStored.baseUrl))) {
+    candidates.push({ auth: sdkStored, origin: 'sdk' });
   }
 
   const where = `${nativeCloudHome()} or ${relayhistoryConfigDir()}`;
@@ -252,35 +292,36 @@ export async function resolveCloudSession(
     return { auth: null, detail: `${where}: no stored relayhistory session (run \`ai-hist login\`)` };
   }
 
+  // Selection first, eligibility second — the engine's order, where `load_auth`
+  // picks the stage and `recall_auth` then judges the one it picked.
+  let selected: StoredCandidate;
   if (requestedBaseUrl !== undefined) {
     const wanted = normalizeStage(requestedBaseUrl);
-    const match = candidates.find((auth) => normalizeStage(auth.baseUrl) === wanted);
+    const match = candidates.find((c) => normalizeStage(c.auth.baseUrl) === wanted);
     if (!match) {
       return {
         auth: null,
         detail: `${where}: no stored relayhistory session for ${wanted} `
-          + `(stored: ${candidates.map((a) => normalizeStage(a.baseUrl)).join(', ')})`,
+          + `(stored: ${candidates.map((c) => normalizeStage(c.auth.baseUrl)).join(', ')})`,
       };
     }
-    return isExpired(match, now)
-      ? { auth: null, detail: `${where}: the stored relayhistory session for ${wanted} has expired (run \`ai-hist login\`)` }
-      : { auth: match };
-  }
-
-  if (candidates.length > 1) {
+    selected = match;
+  } else if (candidates.length > 1) {
     return {
       auth: null,
       detail: `${where}: ${candidates.length} relayhistory stages are configured `
-        + `(${candidates.map((a) => normalizeStage(a.baseUrl)).join(', ')}); `
+        + `(${candidates.map((c) => normalizeStage(c.auth.baseUrl)).join(', ')}); `
         + 'set AI_HIST_BASE_URL to select one. Refusing to guess, because a thread read '
         + 'against the wrong stage answers about a different org',
     };
+  } else {
+    selected = candidates[0]!;
   }
 
-  const only = candidates[0]!;
-  return isExpired(only, now)
-    ? { auth: null, detail: `${where}: the stored relayhistory session has expired (run \`ai-hist login\`)` }
-    : { auth: only };
+  const ineligible = ineligibleReason(selected, now);
+  return ineligible
+    ? { auth: null, detail: `${where}: ${ineligible} (run \`ai-hist login\`)` }
+    : { auth: selected.auth };
 }
 
 /**

--- a/sdk-ts/src/cloud-client.ts
+++ b/sdk-ts/src/cloud-client.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, readdir, writeFile, mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, dirname } from 'node:path';
 import {
@@ -10,6 +10,8 @@ export interface RelayhistoryAuth {
   baseUrl: string;
   accessToken: string;
   refreshToken?: string;
+  /** Server-issued RFC 3339 expiry. Absent in sessions stored before it existed. */
+  accessTokenExpiresAt?: string;
 }
 
 export type LoginCloudResult =
@@ -126,9 +128,159 @@ function relayhistoryConfigDir(): string {
 /**
  * A base URL reduced to the identity of its stage, so two spellings of one
  * stage compare equal. Mirrors `cloud::normalized_stage`.
+ *
+ * Scheme and host are case-insensitive per RFC 3986 and are lowercased; the
+ * path is not, and is preserved exactly. A stage mounted under a case-sensitive
+ * prefix (`https://host/Recall`) must keep it or the request goes elsewhere.
  */
 function normalizeStage(baseUrl: string): string {
-  return baseUrl.trim().replace(/\/+$/, '').toLowerCase();
+  const trimmed = baseUrl.trim().replace(/\/+$/, '');
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    // Not a URL this build can parse: compare it verbatim rather than
+    // inventing an origin for it.
+    return trimmed;
+  }
+  return `${parsed.protocol.toLowerCase()}//${parsed.host.toLowerCase()}${parsed.pathname}`
+    .replace(/\/+$/, '');
+}
+
+/**
+ * The store the native `ai-hist login` writes: `RELAYHISTORY_HOME`, else
+ * `~/.agentworkforce/relayhistory`. Sessions live in `stages/<key>.auth.json`
+ * with snake_case fields, plus a legacy single `auth.json` from before stages
+ * existed.
+ */
+function nativeCloudHome(): string {
+  const configured = process.env.RELAYHISTORY_HOME;
+  if (configured) return configured;
+  return join(homedir(), '.agentworkforce', 'relayhistory');
+}
+
+/** Reads one native store file, mapping its snake_case fields. Absent or malformed reads as none. */
+async function readNativeAuth(path: string): Promise<RelayhistoryAuth | null> {
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const baseUrl = parsed.base_url ?? parsed.baseUrl;
+  const accessToken = parsed.access_token ?? parsed.accessToken;
+  if (typeof baseUrl !== 'string' || typeof accessToken !== 'string') return null;
+  const refreshToken = parsed.refresh_token ?? parsed.refreshToken;
+  const expiresAt = parsed.access_token_expires_at ?? parsed.accessTokenExpiresAt;
+  return {
+    baseUrl,
+    accessToken,
+    ...(typeof refreshToken === 'string' ? { refreshToken } : {}),
+    ...(typeof expiresAt === 'string' ? { accessTokenExpiresAt: expiresAt } : {}),
+  };
+}
+
+/**
+ * Every session the native store holds, newest layout first. Mirrors
+ * `cloud::staged_auths` plus its legacy fallback: the stage directory is
+ * enumerated and each file's own `base_url` identifies it, so this never has
+ * to reproduce the engine's stage-key hash.
+ */
+async function nativeStoredSessions(): Promise<RelayhistoryAuth[]> {
+  const home = nativeCloudHome();
+  const found: RelayhistoryAuth[] = [];
+  let entries: string[] = [];
+  try {
+    entries = (await readdir(join(home, 'stages'))).filter((name) => name.endsWith('.auth.json'));
+  } catch {
+    entries = [];
+  }
+  for (const entry of entries.sort()) {
+    const auth = await readNativeAuth(join(home, 'stages', entry));
+    if (auth) found.push(auth);
+  }
+  const legacy = await readNativeAuth(join(home, 'auth.json'));
+  if (legacy && !found.some((auth) => normalizeStage(auth.baseUrl) === normalizeStage(legacy.baseUrl))) {
+    found.push(legacy);
+  }
+  return found;
+}
+
+/** Milliseconds of remaining validity below which a session is treated as spent. */
+const EXPIRY_FLOOR_MS = 60_000;
+
+function isExpired(auth: RelayhistoryAuth, now: number): boolean {
+  // A session stored before expiry was recorded carries no claim either way.
+  // Push tolerates those, and the SDK's own store has never written the field,
+  // so absence is not treated as expiry — only a stated, spent expiry is.
+  if (!auth.accessTokenExpiresAt) return false;
+  const expiry = Date.parse(auth.accessTokenExpiresAt);
+  return Number.isFinite(expiry) && expiry < now + EXPIRY_FLOOR_MS;
+}
+
+/** Why no usable cloud session was found, phrased for {@link cloudUnconfiguredMessage}. */
+export type CloudSessionResolution =
+  | { auth: RelayhistoryAuth }
+  | { auth: null; detail: string };
+
+/**
+ * Resolve the cloud session a thread read should use.
+ *
+ * Both stores are consulted, native first: the Rust `ai-hist login` writes
+ * `~/.agentworkforce/relayhistory/stages/*.auth.json`, while this SDK's own
+ * {@link loginCloud} writes `~/.config/ai-hist/auth.json`. Reading only the
+ * latter is what made the documented login flow look unconfigured.
+ *
+ * A caller that names a stage gets that stage or nothing. A caller that does
+ * not, with more than one stage stored, gets a refusal rather than a guess —
+ * the same rule as `cloud::load_auth`, and for the same reason: silently
+ * picking a stage sends a token somewhere the caller did not ask for.
+ */
+export async function resolveCloudSession(
+  requestedBaseUrl?: string,
+  now: number = Date.now(),
+): Promise<CloudSessionResolution> {
+  const candidates = await nativeStoredSessions();
+  const sdkStored = await loadStoredRelayhistoryAuth();
+  if (sdkStored
+    && !candidates.some((a) => normalizeStage(a.baseUrl) === normalizeStage(sdkStored.baseUrl))) {
+    candidates.push(sdkStored);
+  }
+
+  const where = `${nativeCloudHome()} or ${relayhistoryConfigDir()}`;
+  if (candidates.length === 0) {
+    return { auth: null, detail: `${where}: no stored relayhistory session (run \`ai-hist login\`)` };
+  }
+
+  if (requestedBaseUrl !== undefined) {
+    const wanted = normalizeStage(requestedBaseUrl);
+    const match = candidates.find((auth) => normalizeStage(auth.baseUrl) === wanted);
+    if (!match) {
+      return {
+        auth: null,
+        detail: `${where}: no stored relayhistory session for ${wanted} `
+          + `(stored: ${candidates.map((a) => normalizeStage(a.baseUrl)).join(', ')})`,
+      };
+    }
+    return isExpired(match, now)
+      ? { auth: null, detail: `${where}: the stored relayhistory session for ${wanted} has expired (run \`ai-hist login\`)` }
+      : { auth: match };
+  }
+
+  if (candidates.length > 1) {
+    return {
+      auth: null,
+      detail: `${where}: ${candidates.length} relayhistory stages are configured `
+        + `(${candidates.map((a) => normalizeStage(a.baseUrl)).join(', ')}); `
+        + 'set AI_HIST_BASE_URL to select one. Refusing to guess, because a thread read '
+        + 'against the wrong stage answers about a different org',
+    };
+  }
+
+  const only = candidates[0]!;
+  return isExpired(only, now)
+    ? { auth: null, detail: `${where}: the stored relayhistory session has expired (run \`ai-hist login\`)` }
+    : { auth: only };
 }
 
 /**
@@ -146,6 +298,10 @@ export function cloudUnconfiguredMessage(operation: string, detail: string): str
 
 /** Most `link_kind` values the recall route accepts in one `kinds` filter. */
 const MAX_THREAD_KINDS = 50;
+
+/** The `limit` range the recall route accepts before clamping. */
+const MIN_THREAD_LIMIT = 1;
+const MAX_THREAD_LIMIT = 500;
 
 /** One lifecycle link, as the recall API returns it. */
 export interface SessionThreadLink {
@@ -203,17 +359,23 @@ export interface SessionThreadQuery {
   since?: string;
   /** Opaque page cursor from a previous `nextCursor`. */
   cursor?: string;
+  /**
+   * Links per page. The route clamps to {@link MIN_THREAD_LIMIT}..{@link
+   * MAX_THREAD_LIMIT} and defaults to 100. Only links are paged; outcomes come
+   * back whole on every page.
+   */
+  limit?: number;
 }
 
 export interface SessionThreadOptions {
   /** Overrides the stored session's base URL. */
   baseUrl?: string;
   /**
-   * The connector-status resolver: a stored RelayHistory session means the
-   * `cloud` connector is configured, its absence means it is not. Defaults to
-   * {@link loadStoredRelayhistoryAuth}.
+   * The connector-status resolver: a usable stored RelayHistory session means
+   * the `cloud` connector is configured, and anything else carries the reason
+   * it is not. Defaults to {@link resolveCloudSession}.
    */
-  loadAuth?: () => Promise<RelayhistoryAuth | null>;
+  resolveSession?: (requestedBaseUrl?: string) => Promise<CloudSessionResolution>;
   /** HTTP transport. Defaults to the global `fetch`. */
   fetchImpl?: typeof fetch;
 }
@@ -221,8 +383,13 @@ export interface SessionThreadOptions {
 function requireSecureTransport(baseUrl: string): void {
   if (baseUrl.startsWith('https://')) return;
   const authority = baseUrl.startsWith('http://') ? baseUrl.slice('http://'.length) : null;
-  const host = authority?.split('/')[0]?.split(':')[0]?.toLowerCase();
-  if (host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1') return;
+  const hostPort = authority?.split('/')[0];
+  // An IPv6 literal is bracketed and full of colons, so the port cannot be
+  // split off before the brackets are removed.
+  const host = hostPort?.startsWith('[')
+    ? hostPort.slice(1, hostPort.indexOf(']')).toLowerCase()
+    : hostPort?.split(':')[0]?.toLowerCase();
+  if (host === 'localhost' || host === '127.0.0.1' || host === '::1') return;
   throw new ConnectorFailureError(
     `refusing to send the relayhistory bearer token in cleartext to \`${baseUrl}\` — use an `
       + 'https:// endpoint. Plain http:// is accepted only for loopback.',
@@ -260,37 +427,31 @@ export async function getSessionThread(
       'INVALID_ARGUMENT',
     );
   }
-
-  const loadAuth = opts.loadAuth ?? loadStoredRelayhistoryAuth;
-  const auth = await loadAuth();
-  if (!auth) {
-    throw new UnsupportedOperationError(
-      cloudUnconfiguredMessage(
-        THREAD_OPERATION,
-        `${relayhistoryConfigDir()}: no stored relayhistory session (run \`ai-hist login\`)`,
-      ),
-      'UNSUPPORTED_OPERATION',
+  if (query.limit !== undefined
+    && (!Number.isInteger(query.limit)
+      || query.limit < MIN_THREAD_LIMIT || query.limit > MAX_THREAD_LIMIT)) {
+    // Rejected here rather than sent to be clamped, so a caller asking for 5000
+    // learns it is getting 500 instead of silently believing it got 5000.
+    throw new InvalidArgumentError(
+      `limit must be an integer in ${MIN_THREAD_LIMIT}..${MAX_THREAD_LIMIT} (got ${query.limit})`,
+      'INVALID_ARGUMENT',
     );
   }
 
-  // A stored session belongs to one stage. Honouring an explicit base URL that
-  // names a different stage would send this stage's bearer token to another
-  // host, which is what `cloud::load_auth`'s `same_stage` check refuses. A
-  // stage the stored session cannot serve is an unconfigured connector, not a
-  // request to attempt.
-  const stored = normalizeStage(auth.baseUrl ?? DEFAULT_CLOUD_BASE_URL);
-  const requested = opts.baseUrl ?? process.env.AI_HIST_BASE_URL;
-  if (requested !== undefined && normalizeStage(requested) !== stored) {
+  // A stored session belongs to one stage, so naming a stage selects it rather
+  // than redirecting it: sending this stage's bearer token to another host is
+  // what `cloud::load_auth`'s `same_stage` check refuses. A stage no stored
+  // session can serve is an unconfigured connector, not a request to attempt.
+  const resolve = opts.resolveSession ?? resolveCloudSession;
+  const resolved = await resolve(opts.baseUrl ?? process.env.AI_HIST_BASE_URL);
+  if (!resolved.auth) {
     throw new UnsupportedOperationError(
-      cloudUnconfiguredMessage(
-        THREAD_OPERATION,
-        `${relayhistoryConfigDir()}: the stored relayhistory session is for ${stored}, not `
-          + `${normalizeStage(requested)} (run \`ai-hist login\`)`,
-      ),
+      cloudUnconfiguredMessage(THREAD_OPERATION, resolved.detail),
       'UNSUPPORTED_OPERATION',
     );
   }
-  const baseUrl = stored;
+  const auth = resolved.auth;
+  const baseUrl = normalizeStage(auth.baseUrl || DEFAULT_CLOUD_BASE_URL);
   requireSecureTransport(baseUrl);
 
   const params = new URLSearchParams();
@@ -298,6 +459,7 @@ export async function getSessionThread(
   if (query.kinds?.length) params.set('kinds', query.kinds.join(','));
   if (query.since) params.set('since', query.since);
   if (query.cursor) params.set('cursor', query.cursor);
+  if (query.limit !== undefined) params.set('limit', String(query.limit));
   for (const key of params.keys()) {
     // Defence in depth: tenancy comes from the token, never a query parameter.
     if (TENANCY_PARAMS.has(key)) {

--- a/sdk-ts/src/cloud-client.ts
+++ b/sdk-ts/src/cloud-client.ts
@@ -1,6 +1,10 @@
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, dirname } from 'node:path';
+import {
+  AuthenticationExpiredError, ConnectorFailureError, InvalidArgumentError, SOURCES,
+  UnsupportedOperationError, isSource,
+} from './index.js';
 
 export interface RelayhistoryAuth {
   baseUrl: string;
@@ -87,4 +91,264 @@ export async function loginCloud(
   }
 
   return { ok: true, auth };
+}
+
+// ---------------------------------------------------------------------------
+// Session thread (SPEC §3.4 / §3.5)
+//
+// `get_session_thread` is the *lifecycle* fan-out for one session — the PRs,
+// reviews, commits, incidents, tickets, Slack threads, hotfixes and follow-up
+// sessions the cloud has stitched to it. It is cloud-only on purpose: a thread
+// exists only once the cloud has ingested lens events, so there is no local
+// fallback and no local cache. Threads change as PRs and incidents land, so
+// every call fetches.
+// ---------------------------------------------------------------------------
+
+/** The operation name the unsupported-operation message is phrased around. */
+const THREAD_OPERATION = 'thread';
+
+/**
+ * Query parameters that select tenancy. Tenancy is derived from the bearer
+ * token server-side; sending one of these would be a client asserting its own
+ * scope. Mirrors the guard in the Rust transport (`cloud::recall_page`).
+ */
+const TENANCY_PARAMS: ReadonlySet<string> = new Set([
+  'org_id', 'orgId', 'workspace_id', 'workspaceId',
+]);
+
+const DEFAULT_CLOUD_BASE_URL = 'https://history.agentrelay.com';
+
+/** Where the stored RelayHistory session lives for this process. */
+function relayhistoryConfigDir(): string {
+  return process.env.AI_HIST_CONFIG_DIR ?? join(homedir(), '.config', 'ai-hist');
+}
+
+/**
+ * A base URL reduced to the identity of its stage, so two spellings of one
+ * stage compare equal. Mirrors `cloud::normalized_stage`.
+ */
+function normalizeStage(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, '').toLowerCase();
+}
+
+/**
+ * The unsupported-operation message, in the shape the sibling remote
+ * connectors use.
+ *
+ * The leading phrase `no remote provider connectors are configured` is an
+ * explicit compatibility contract that callers and tests match on — see
+ * `crates/ai-hist/src/remote.rs::unconfigured_message`, whose format this
+ * reproduces for the one connector a thread can be served by (`cloud`).
+ */
+export function cloudUnconfiguredMessage(operation: string, detail: string): string {
+  return `no remote provider connectors are configured: remote session ${operation} is not available (cloud: ${detail})`;
+}
+
+/** Most `link_kind` values the recall route accepts in one `kinds` filter. */
+const MAX_THREAD_KINDS = 50;
+
+/** One lifecycle link, as the recall API returns it. */
+export interface SessionThreadLink {
+  linkKind: string;
+  linkRef: string;
+  linkUrl: string | null;
+  /** ISO 8601, up to six fractional digits. Null for undated links. */
+  linkTs: string | null;
+  metadata: unknown;
+  /** 0..1, converted server-side from stored basis points. */
+  confidence: number | null;
+}
+
+/** One shipped-commit outcome, as the recall API returns it. */
+export interface SessionThreadOutcome {
+  commitSha: string;
+  shippedAt: string | null;
+  reverted: boolean;
+  revertedBySha: string | null;
+  revertedAt: string | null;
+}
+
+/**
+ * The `GET /v1/sessions/:sessionId/thread` envelope. This is a description of
+ * what the recall API returns, not a normalization target: the envelope
+ * reaches the caller exactly as the service sent it, so a field this SDK build
+ * does not know about is passed through rather than dropped.
+ */
+export interface SessionThread {
+  session: {
+    source: string;
+    sessionId: string;
+    orgId: string;
+    workspaceId: string;
+    firstEventAt: string | null;
+    lastEventAt: string | null;
+  } | null;
+  outcomes: SessionThreadOutcome[];
+  links: SessionThreadLink[];
+  nextCursor: string | null;
+}
+
+export interface SessionThreadQuery {
+  /** Upstream source. Validated against this build's source list. */
+  source: string;
+  /** The session id. Carried in the path, never as a query parameter. */
+  sessionId: string;
+  /**
+   * Optional `link_kind` filter, at most {@link MAX_THREAD_KINDS} values. Sent
+   * comma-separated, as the route expects. Not validated against a fixed list:
+   * new lenses add kinds, and the route filters on whatever it is given.
+   */
+  kinds?: readonly string[];
+  /** Optional ISO 8601 lower bound. */
+  since?: string;
+  /** Opaque page cursor from a previous `nextCursor`. */
+  cursor?: string;
+}
+
+export interface SessionThreadOptions {
+  /** Overrides the stored session's base URL. */
+  baseUrl?: string;
+  /**
+   * The connector-status resolver: a stored RelayHistory session means the
+   * `cloud` connector is configured, its absence means it is not. Defaults to
+   * {@link loadStoredRelayhistoryAuth}.
+   */
+  loadAuth?: () => Promise<RelayhistoryAuth | null>;
+  /** HTTP transport. Defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+function requireSecureTransport(baseUrl: string): void {
+  if (baseUrl.startsWith('https://')) return;
+  const authority = baseUrl.startsWith('http://') ? baseUrl.slice('http://'.length) : null;
+  const host = authority?.split('/')[0]?.split(':')[0]?.toLowerCase();
+  if (host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1') return;
+  throw new ConnectorFailureError(
+    `refusing to send the relayhistory bearer token in cleartext to \`${baseUrl}\` — use an `
+      + 'https:// endpoint. Plain http:// is accepted only for loopback.',
+    'CONNECTOR_FAILURE',
+  );
+}
+
+/**
+ * Fetch one page of a session's lifecycle thread from the recall API.
+ *
+ * Cloud-only. When no RelayHistory session is stored the `cloud` connector is
+ * unconfigured and this throws {@link UnsupportedOperationError} *without
+ * performing a network call* — the same classification the native engine gives
+ * a remote-only request no connector can serve.
+ */
+export async function getSessionThread(
+  query: SessionThreadQuery,
+  opts: SessionThreadOptions = {},
+): Promise<SessionThread> {
+  // A misspelled source is an invalid argument, not an unsupported remote
+  // request — reject it with the engine's own message before classifying
+  // anything, exactly as `ensure_remote_connectors_configured_for_at` does.
+  if (!isSource(query.source)) {
+    throw new InvalidArgumentError(
+      `invalid source '${query.source}' (choose from ${SOURCES.join(', ')})`,
+      'INVALID_ARGUMENT',
+    );
+  }
+  if (typeof query.sessionId !== 'string' || query.sessionId.length === 0) {
+    throw new InvalidArgumentError('session_id must be a non-empty string', 'INVALID_ARGUMENT');
+  }
+  if (query.kinds && query.kinds.length > MAX_THREAD_KINDS) {
+    throw new InvalidArgumentError(
+      `kinds accepts at most ${MAX_THREAD_KINDS} values (got ${query.kinds.length})`,
+      'INVALID_ARGUMENT',
+    );
+  }
+
+  const loadAuth = opts.loadAuth ?? loadStoredRelayhistoryAuth;
+  const auth = await loadAuth();
+  if (!auth) {
+    throw new UnsupportedOperationError(
+      cloudUnconfiguredMessage(
+        THREAD_OPERATION,
+        `${relayhistoryConfigDir()}: no stored relayhistory session (run \`ai-hist login\`)`,
+      ),
+      'UNSUPPORTED_OPERATION',
+    );
+  }
+
+  // A stored session belongs to one stage. Honouring an explicit base URL that
+  // names a different stage would send this stage's bearer token to another
+  // host, which is what `cloud::load_auth`'s `same_stage` check refuses. A
+  // stage the stored session cannot serve is an unconfigured connector, not a
+  // request to attempt.
+  const stored = normalizeStage(auth.baseUrl ?? DEFAULT_CLOUD_BASE_URL);
+  const requested = opts.baseUrl ?? process.env.AI_HIST_BASE_URL;
+  if (requested !== undefined && normalizeStage(requested) !== stored) {
+    throw new UnsupportedOperationError(
+      cloudUnconfiguredMessage(
+        THREAD_OPERATION,
+        `${relayhistoryConfigDir()}: the stored relayhistory session is for ${stored}, not `
+          + `${normalizeStage(requested)} (run \`ai-hist login\`)`,
+      ),
+      'UNSUPPORTED_OPERATION',
+    );
+  }
+  const baseUrl = stored;
+  requireSecureTransport(baseUrl);
+
+  const params = new URLSearchParams();
+  params.set('source', query.source);
+  if (query.kinds?.length) params.set('kinds', query.kinds.join(','));
+  if (query.since) params.set('since', query.since);
+  if (query.cursor) params.set('cursor', query.cursor);
+  for (const key of params.keys()) {
+    // Defence in depth: tenancy comes from the token, never a query parameter.
+    if (TENANCY_PARAMS.has(key)) {
+      throw new InvalidArgumentError(
+        'recall tenancy comes from the token, not query parameters',
+        'INVALID_ARGUMENT',
+      );
+    }
+  }
+
+  const url = `${baseUrl}/v1/sessions/${encodeURIComponent(query.sessionId)}/thread?${params}`;
+  const doFetch = opts.fetchImpl ?? fetch;
+
+  let resp: Response;
+  try {
+    resp = await doFetch(url, {
+      headers: { Authorization: `Bearer ${auth.accessToken}`, Accept: 'application/json' },
+      // A redirect would carry the bearer token to whatever the hop names.
+      redirect: 'error',
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (cause) {
+    throw new ConnectorFailureError(
+      `cloud thread request failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+      'CONNECTOR_FAILURE',
+      { cause },
+    );
+  }
+
+  if (resp.status === 401 || resp.status === 403) {
+    throw new AuthenticationExpiredError(
+      `the stored relayhistory session was rejected (HTTP ${resp.status}); run \`ai-hist login\``,
+      'AUTHENTICATION_EXPIRED',
+    );
+  }
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '');
+    throw new ConnectorFailureError(
+      `cloud thread request failed (HTTP ${resp.status}): ${text.slice(0, 200)}`,
+      'CONNECTOR_FAILURE',
+    );
+  }
+
+  try {
+    // Passed through unchanged: the recall API owns this shape.
+    return (await resp.json()) as SessionThread;
+  } catch (cause) {
+    throw new ConnectorFailureError(
+      'cloud thread response was not valid JSON',
+      'CONNECTOR_FAILURE',
+      { cause },
+    );
+  }
 }

--- a/sdk-ts/src/cloud-client.ts
+++ b/sdk-ts/src/cloud-client.ts
@@ -434,21 +434,42 @@ export interface SessionThreadOptions {
 /**
  * Persist a rotated pair over the file it came from, in that store's own
  * schema, via temp-file + rename so a crash cannot leave a torn session.
+ *
+ * The rotated fields are merged **over the file's existing contents**, never
+ * written in place of them. The native store records fields this SDK does not
+ * model — `workspace_id` today, whatever the engine adds next — and the Rust
+ * CLI reads the same file, so rewriting it whole would quietly delete that
+ * state and degrade the CLI's session.
  */
 async function persistRotated(candidate: StoredCandidate, auth: RelayhistoryAuth): Promise<void> {
-  const body = candidate.origin === 'native'
+  let existing: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(await readFile(candidate.path, 'utf-8')) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      existing = parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Unreadable or malformed. Still write, with the fields this SDK knows:
+    // leaving a revoked refresh token on disk strands the next caller.
+  }
+  const rotated: Record<string, unknown> = candidate.origin === 'native'
     ? {
-      base_url: auth.baseUrl,
+      base_url: existing.base_url ?? auth.baseUrl,
       access_token: auth.accessToken,
       access_token_expires_at: auth.accessTokenExpiresAt ?? null,
       refresh_token: auth.refreshToken ?? null,
-      org_id: auth.orgId ?? null,
-      workspace_id: null,
     }
-    : auth;
+    : {
+      baseUrl: existing.baseUrl ?? auth.baseUrl,
+      accessToken: auth.accessToken,
+      // Written as `undefined` when absent so `JSON.stringify` drops the key
+      // rather than preserving a superseded value from `existing`.
+      accessTokenExpiresAt: auth.accessTokenExpiresAt,
+      refreshToken: auth.refreshToken,
+    };
   const tmp = `${candidate.path}.tmp.${process.pid}.${Date.now()}`;
   await mkdir(dirname(candidate.path), { recursive: true });
-  await writeFile(tmp, JSON.stringify(body, null, 2), { mode: 0o600 });
+  await writeFile(tmp, JSON.stringify({ ...existing, ...rotated }, null, 2), { mode: 0o600 });
   await rename(tmp, candidate.path);
 }
 

--- a/sdk-ts/src/cloud-client.ts
+++ b/sdk-ts/src/cloud-client.ts
@@ -220,7 +220,12 @@ function nativeCloudHome(): string {
 async function readNativeAuth(path: string): Promise<RelayhistoryAuth | null> {
   let parsed: Record<string, unknown>;
   try {
-    parsed = JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
+    const raw = JSON.parse(await readFile(path, 'utf-8')) as unknown;
+    // `JSON.parse` succeeds on `null`, `[]` and scalars, so parsing is not
+    // enough to know the fields below can be read. Same guard `persistRotated`
+    // applies to this file, so both readers agree on what "malformed" means.
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+    parsed = raw as Record<string, unknown>;
   } catch {
     return null;
   }

--- a/sdk-ts/src/cloud-client.ts
+++ b/sdk-ts/src/cloud-client.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir, writeFile, mkdir } from 'node:fs/promises';
+import { readFile, readdir, rename, writeFile, mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, dirname } from 'node:path';
 import {
@@ -203,13 +203,15 @@ async function nativeStoredSessions(): Promise<StoredCandidate[]> {
     entries = [];
   }
   for (const entry of entries.sort()) {
-    const auth = await readNativeAuth(join(home, 'stages', entry));
-    if (auth) found.push({ auth, origin: 'native' });
+    const path = join(home, 'stages', entry);
+    const auth = await readNativeAuth(path);
+    if (auth) found.push({ auth, origin: 'native', path });
   }
-  const legacy = await readNativeAuth(join(home, 'auth.json'));
+  const legacyPath = join(home, 'auth.json');
+  const legacy = await readNativeAuth(legacyPath);
   if (legacy
     && !found.some((c) => normalizeStage(c.auth.baseUrl) === normalizeStage(legacy.baseUrl))) {
-    found.push({ auth: legacy, origin: 'native' });
+    found.push({ auth: legacy, origin: 'native', path: legacyPath });
   }
   return found;
 }
@@ -223,6 +225,8 @@ type StoreOrigin = 'native' | 'sdk';
 interface StoredCandidate {
   auth: RelayhistoryAuth;
   origin: StoreOrigin;
+  /** The file this session was read from, so a rotated pair replaces it in place. */
+  path: string;
 }
 
 /**
@@ -249,7 +253,13 @@ function ineligibleReason(candidate: StoredCandidate, now: number): string | nul
   if (origin === 'native' || stated !== undefined) {
     const expiry = stated === undefined ? Number.NaN : Date.parse(stated);
     if (!Number.isFinite(expiry) || expiry < now + EXPIRY_FLOOR_MS) {
-      return 'the stored relayhistory access-token expiry is missing, invalid, or less than 60s away';
+      // Expiry is the one precondition rotation exists to repair, so a session
+      // that can still rotate is not unconfigured — it is stale, and the
+      // transport refreshes it. Without a refresh token there is nothing to
+      // rotate and it is unconfigured exactly as `recall_auth` says.
+      if (!auth.refreshToken?.trim()) {
+        return 'the stored relayhistory access-token expiry is missing, invalid, or less than 60s away';
+      }
     }
   }
   if (origin === 'native' && !auth.orgId?.trim()) {
@@ -260,7 +270,7 @@ function ineligibleReason(candidate: StoredCandidate, now: number): string | nul
 
 /** Why no usable cloud session was found, phrased for {@link cloudUnconfiguredMessage}. */
 export type CloudSessionResolution =
-  | { auth: RelayhistoryAuth }
+  | { auth: RelayhistoryAuth; session?: StoredCandidate }
   | { auth: null; detail: string };
 
 /**
@@ -284,7 +294,7 @@ export async function resolveCloudSession(
   const sdkStored = await loadStoredRelayhistoryAuth();
   if (sdkStored
     && !candidates.some((c) => normalizeStage(c.auth.baseUrl) === normalizeStage(sdkStored.baseUrl))) {
-    candidates.push({ auth: sdkStored, origin: 'sdk' });
+    candidates.push({ auth: sdkStored, origin: 'sdk', path: authPath() });
   }
 
   const where = `${nativeCloudHome()} or ${relayhistoryConfigDir()}`;
@@ -321,7 +331,7 @@ export async function resolveCloudSession(
   const ineligible = ineligibleReason(selected, now);
   return ineligible
     ? { auth: null, detail: `${where}: ${ineligible} (run \`ai-hist login\`)` }
-    : { auth: selected.auth };
+    : { auth: selected.auth, session: selected };
 }
 
 /**
@@ -421,6 +431,78 @@ export interface SessionThreadOptions {
   fetchImpl?: typeof fetch;
 }
 
+/**
+ * Persist a rotated pair over the file it came from, in that store's own
+ * schema, via temp-file + rename so a crash cannot leave a torn session.
+ */
+async function persistRotated(candidate: StoredCandidate, auth: RelayhistoryAuth): Promise<void> {
+  const body = candidate.origin === 'native'
+    ? {
+      base_url: auth.baseUrl,
+      access_token: auth.accessToken,
+      access_token_expires_at: auth.accessTokenExpiresAt ?? null,
+      refresh_token: auth.refreshToken ?? null,
+      org_id: auth.orgId ?? null,
+      workspace_id: null,
+    }
+    : auth;
+  const tmp = `${candidate.path}.tmp.${process.pid}.${Date.now()}`;
+  await mkdir(dirname(candidate.path), { recursive: true });
+  await writeFile(tmp, JSON.stringify(body, null, 2), { mode: 0o600 });
+  await rename(tmp, candidate.path);
+}
+
+/** Re-read this session's file, for the pair another process may have rotated. */
+async function rereadSession(candidate: StoredCandidate): Promise<RelayhistoryAuth | null> {
+  return candidate.origin === 'native'
+    ? readNativeAuth(candidate.path)
+    : loadStoredRelayhistoryAuth();
+}
+
+/**
+ * Exchange the stored refresh token for a new pair. Mirrors
+ * `cloud::refresh_auth`: `POST /v1/auth/token/refresh`, `accessToken` and
+ * `refreshToken` required in the response, org and stage carried over.
+ */
+async function refreshCloudSession(
+  auth: RelayhistoryAuth,
+  baseUrl: string,
+  doFetch: typeof fetch,
+): Promise<RelayhistoryAuth | null> {
+  const refreshToken = auth.refreshToken?.trim();
+  if (!refreshToken) return null;
+  let resp: Response;
+  try {
+    resp = await doFetch(`${baseUrl}/v1/auth/token/refresh`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      redirect: 'error',
+      body: JSON.stringify({ refreshToken }),
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch {
+    return null;
+  }
+  if (!resp.ok) return null;
+  let payload: Record<string, unknown>;
+  try {
+    payload = (await resp.json()) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const accessToken = payload.accessToken;
+  const rotated = payload.refreshToken;
+  if (typeof accessToken !== 'string' || typeof rotated !== 'string') return null;
+  const expiresAt = payload.accessTokenExpiresAt;
+  return {
+    baseUrl: auth.baseUrl,
+    accessToken,
+    refreshToken: rotated,
+    ...(typeof expiresAt === 'string' ? { accessTokenExpiresAt: expiresAt } : {}),
+    ...(auth.orgId ? { orgId: auth.orgId } : {}),
+  };
+}
+
 function requireSecureTransport(baseUrl: string): void {
   if (baseUrl.startsWith('https://')) return;
   const authority = baseUrl.startsWith('http://') ? baseUrl.slice('http://'.length) : null;
@@ -514,20 +596,54 @@ export async function getSessionThread(
   const url = `${baseUrl}/v1/sessions/${encodeURIComponent(query.sessionId)}/thread?${params}`;
   const doFetch = opts.fetchImpl ?? fetch;
 
-  let resp: Response;
-  try {
-    resp = await doFetch(url, {
-      headers: { Authorization: `Bearer ${auth.accessToken}`, Accept: 'application/json' },
-      // A redirect would carry the bearer token to whatever the hop names.
-      redirect: 'error',
-      signal: AbortSignal.timeout(30_000),
-    });
-  } catch (cause) {
-    throw new ConnectorFailureError(
-      `cloud thread request failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-      'CONNECTOR_FAILURE',
-      { cause },
-    );
+  const send = async (bearer: string): Promise<Response> => {
+    try {
+      return await doFetch(url, {
+        headers: { Authorization: `Bearer ${bearer}`, Accept: 'application/json' },
+        // A redirect would carry the bearer token to whatever the hop names.
+        redirect: 'error',
+        signal: AbortSignal.timeout(30_000),
+      });
+    } catch (cause) {
+      throw new ConnectorFailureError(
+        `cloud thread request failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+        'CONNECTOR_FAILURE',
+        { cause },
+      );
+    }
+  };
+
+  let resp = await send(auth.accessToken);
+
+  // Rotate an expired session at most once, in the order `send_with_auth_refresh`
+  // uses: prefer a pair another process already persisted, and only then spend
+  // the stored refresh token, which is one-time and revokes its predecessor.
+  //
+  // The engine serializes this per stage with an flock that Node cannot take
+  // here, so instead of preventing a concurrent double-spend this recovers from
+  // one: a refresh that loses the race re-reads and adopts the winner's pair.
+  // The flock-correct version belongs behind a napi export of the recall
+  // transport; see the PR discussion.
+  const rotatable = resolved.session;
+  if ((resp.status === 401 || resp.status === 403) && rotatable) {
+    const current = await rereadSession(rotatable);
+    if (current && current.accessToken !== auth.accessToken) {
+      resp = await send(current.accessToken);
+    } else {
+      const refreshed = await refreshCloudSession(auth, baseUrl, doFetch);
+      if (refreshed) {
+        // Persist before retrying: the old refresh token is already revoked, so
+        // a crash between here and the retry must not strand the next caller.
+        await persistRotated(rotatable, refreshed).catch(() => undefined);
+        resp = await send(refreshed.accessToken);
+      } else {
+        // Lost the race, most likely. Whoever won has persisted a live pair.
+        const afterward = await rereadSession(rotatable);
+        if (afterward && afterward.accessToken !== auth.accessToken) {
+          resp = await send(afterward.accessToken);
+        }
+      }
+    }
   }
 
   if (resp.status === 401 || resp.status === 403) {

--- a/sdk-ts/src/cloud-client.ts
+++ b/sdk-ts/src/cloud-client.ts
@@ -153,6 +153,58 @@ function normalizeStage(baseUrl: string): string {
 }
 
 /**
+ * A base URL reduced to its stage identity, or `null` when it does not name
+ * one. Mirrors `cloud::normalize_base_url`, which rejects a value with no
+ * host, or carrying credentials, a query or a fragment — and, like it, treats
+ * a rejected value as "no stage named" rather than as an error.
+ */
+function parseStageUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (!url.hostname || url.username || url.password || url.search || url.hash) return null;
+  return normalizeStage(trimmed);
+}
+
+/**
+ * The stage this call names, or `undefined` for "whichever single stage is
+ * stored".
+ *
+ * The engine reads `RELAYHISTORY_BASE_URL` before `AI_HIST_BASE_URL` and
+ * ignores a value that does not parse, falling through to its single-stage
+ * rule. Honouring only `AI_HIST_BASE_URL` would ignore the variable a
+ * multi-stage CLI install already sets, and treating an empty or malformed one
+ * as an explicit request would fail closed where the engine falls through.
+ */
+function requestedStage(explicit: string | undefined): string | undefined {
+  if (explicit !== undefined) {
+    const named = parseStageUrl(explicit);
+    if (!named) {
+      // An explicit argument is the caller's own words, so a malformed one is a
+      // mistake to report, not an environment default to skip past.
+      throw new InvalidArgumentError(
+        `baseUrl '${explicit}' does not name a stage (expected an absolute URL with a host `
+          + 'and no credentials, query or fragment)',
+        'INVALID_ARGUMENT',
+      );
+    }
+    return named;
+  }
+  for (const key of ['RELAYHISTORY_BASE_URL', 'AI_HIST_BASE_URL'] as const) {
+    const value = process.env[key];
+    if (value === undefined) continue;
+    const named = parseStageUrl(value);
+    if (named) return named;
+  }
+  return undefined;
+}
+
+/**
  * The store the native `ai-hist login` writes: `RELAYHISTORY_HOME`, else
  * `~/.agentworkforce/relayhistory`. Sessions live in `stages/<key>.auth.json`
  * with snake_case fields, plus a legacy single `auth.json` from before stages
@@ -458,6 +510,10 @@ async function persistRotated(candidate: StoredCandidate, auth: RelayhistoryAuth
       access_token: auth.accessToken,
       access_token_expires_at: auth.accessTokenExpiresAt ?? null,
       refresh_token: auth.refreshToken ?? null,
+      // Carried explicitly: when the existing file could not be read there is
+      // nothing to merge, and a native session without an org fails its own
+      // provenance precondition on the very next resolve.
+      org_id: existing.org_id ?? auth.orgId ?? null,
     }
     : {
       baseUrl: existing.baseUrl ?? auth.baseUrl,
@@ -587,7 +643,7 @@ export async function getSessionThread(
   // what `cloud::load_auth`'s `same_stage` check refuses. A stage no stored
   // session can serve is an unconfigured connector, not a request to attempt.
   const resolve = opts.resolveSession ?? resolveCloudSession;
-  const resolved = await resolve(opts.baseUrl ?? process.env.AI_HIST_BASE_URL);
+  const resolved = await resolve(requestedStage(opts.baseUrl));
   if (!resolved.auth) {
     throw new UnsupportedOperationError(
       cloudUnconfiguredMessage(THREAD_OPERATION, resolved.detail),
@@ -645,17 +701,34 @@ export async function getSessionThread(
   // one: a refresh that loses the race re-reads and adopts the winner's pair.
   // The flock-correct version belongs behind a napi export of the recall
   // transport; see the PR discussion.
+  // Only 401 means "this token is spent". `cloud::is_unauthorized` matches the
+  // same single status, and the recall API answers 403 for a session that is
+  // authenticated but lacks `rth:read` — rotating on that would spend a
+  // one-time refresh token to fix a scope problem it cannot fix.
   const rotatable = resolved.session;
-  if ((resp.status === 401 || resp.status === 403) && rotatable) {
+  if (resp.status === 401 && rotatable) {
     const current = await rereadSession(rotatable);
     if (current && current.accessToken !== auth.accessToken) {
       resp = await send(current.accessToken);
     } else {
       const refreshed = await refreshCloudSession(auth, baseUrl, doFetch);
       if (refreshed) {
-        // Persist before retrying: the old refresh token is already revoked, so
-        // a crash between here and the retry must not strand the next caller.
-        await persistRotated(rotatable, refreshed).catch(() => undefined);
+        // Persist before retrying, and never swallow the failure: the old
+        // refresh token is already revoked, so a store left holding it strands
+        // the next caller — and the `ai-hist` CLI reading the same file with
+        // it. Reporting a rotation that could not be saved is better than one
+        // silent success followed by an unexplained dead session.
+        try {
+          await persistRotated(rotatable, refreshed);
+        } catch (cause) {
+          throw new ConnectorFailureError(
+            `the relayhistory session rotated but could not be saved to ${rotatable.path}: `
+              + `${cause instanceof Error ? cause.message : String(cause)}. The previous refresh `
+              + 'token is now revoked; run `ai-hist login` to store a new session.',
+            'CONNECTOR_FAILURE',
+            { cause },
+          );
+        }
         resp = await send(refreshed.accessToken);
       } else {
         // Lost the race, most likely. Whoever won has persisted a live pair.
@@ -667,10 +740,18 @@ export async function getSessionThread(
     }
   }
 
-  if (resp.status === 401 || resp.status === 403) {
+  if (resp.status === 401) {
     throw new AuthenticationExpiredError(
-      `the stored relayhistory session was rejected (HTTP ${resp.status}); run \`ai-hist login\``,
+      'the stored relayhistory session was rejected (HTTP 401); run `ai-hist login`',
       'AUTHENTICATION_EXPIRED',
+    );
+  }
+  if (resp.status === 403) {
+    // Authenticated but not permitted: a different session, and a different fix.
+    throw new ConnectorFailureError(
+      'the stored relayhistory session is not permitted to read this thread (HTTP 403); '
+        + 'it needs the `rth:read` scope',
+      'CONNECTOR_FAILURE',
     );
   }
   if (!resp.ok) {

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -113,14 +113,15 @@ server.tool('get_session_tree',
 // land, so every call fetches. Tenancy is derived from the token server-side,
 // which is why there is no org parameter to pass.
 server.tool('get_session_thread',
-  'Lifecycle thread for one session from the RelayHistory cloud: shipped commits plus linked PRs, reviews, incidents, tickets, Slack threads, hotfixes and follow-up sessions. Known link kinds are github_pr, pr_review, commit, sentry_event, incident, zendesk_ticket, slack_thread, hotfix and followup_session. Requires a stored cloud session; complements get_session_tree.', {
+  'Lifecycle thread for one session from the RelayHistory cloud: shipped commits plus linked PRs, reviews, incidents, tickets, Slack threads, hotfixes and follow-up sessions. Known link kinds are github_pr, pr_review, commit, sentry_event, incident, zendesk_ticket, slack_thread, hotfix and followup_session. Links are paged with limit (1-500, default 100) and cursor; outcomes come back whole on every page. Requires a stored cloud session; complements get_session_tree.', {
   source: SOURCE,
   session_id: z.string().min(1),
   kinds: z.array(z.string().min(1)).max(50).optional(),
   since: z.string().min(1).optional(),
   cursor: z.string().min(1).optional(),
-}, CLOUD_READ, ({ source, session_id, kinds, since, cursor }) => call(() => getSessionThread({
-  source, sessionId: session_id, kinds, since, cursor,
+  limit: z.number().int().min(1).max(500).optional(),
+}, CLOUD_READ, ({ source, session_id, kinds, since, cursor, limit }) => call(() => getSessionThread({
+  source, sessionId: session_id, kinds, since, cursor, limit,
 })));
 
 // Tool calls and file edits are keyed by (source, session_id): a session id

--- a/sdk-ts/src/mcp-server.ts
+++ b/sdk-ts/src/mcp-server.ts
@@ -10,8 +10,12 @@ import {
   getSessionRelationships, getSessionToolCallsPage, getSessionTree, hydrateSession,
   listSessionCatalogPage, recent, search, stats, sync,
 } from './index.js';
+import { getSessionThread } from './cloud-client.js';
 
 const READ = { readOnlyHint: true, idempotentHint: true, openWorldHint: false } as const;
+// A lifecycle thread is served by the cloud recall API and never cached, so it
+// reads nothing locally and reaches the network on every call.
+const CLOUD_READ = { readOnlyHint: true, idempotentHint: true, openWorldHint: true } as const;
 // Acquisition can reach provider services when a remote scope is requested
 // (claude.ai/code web sessions, Codex cloud tasks), so it is open-world.
 const ACQUIRE = { readOnlyHint: false, idempotentHint: true, openWorldHint: true } as const;
@@ -101,6 +105,22 @@ server.tool('get_session_tree',
   max_nodes: z.number().int().min(1).max(10000).optional(),
 }, READ, ({ source, session_id, max_depth, max_nodes }) => call(() => getSessionTree({
   source, sessionId: session_id, maxDepth: max_depth, maxNodes: max_nodes,
+})));
+
+// `get_session_tree` is the subagent fan-out; `get_session_thread` is the
+// lifecycle fan-out. They are complementary and an agent may call both.
+// The thread is cloud-only and never cached: it changes as PRs and incidents
+// land, so every call fetches. Tenancy is derived from the token server-side,
+// which is why there is no org parameter to pass.
+server.tool('get_session_thread',
+  'Lifecycle thread for one session from the RelayHistory cloud: shipped commits plus linked PRs, reviews, incidents, tickets, Slack threads, hotfixes and follow-up sessions. Known link kinds are github_pr, pr_review, commit, sentry_event, incident, zendesk_ticket, slack_thread, hotfix and followup_session. Requires a stored cloud session; complements get_session_tree.', {
+  source: SOURCE,
+  session_id: z.string().min(1),
+  kinds: z.array(z.string().min(1)).max(50).optional(),
+  since: z.string().min(1).optional(),
+  cursor: z.string().min(1).optional(),
+}, CLOUD_READ, ({ source, session_id, kinds, since, cursor }) => call(() => getSessionThread({
+  source, sessionId: session_id, kinds, since, cursor,
 })));
 
 // Tool calls and file edits are keyed by (source, session_id): a session id

--- a/sdk-ts/src/session-thread.test.ts
+++ b/sdk-ts/src/session-thread.test.ts
@@ -625,6 +625,51 @@ test('a rejected token is rotated once and the new pair is persisted', async () 
   });
 });
 
+test('rotation preserves native-store fields this SDK does not model', async () => {
+  await withStores(async ({ nativeHome }) => {
+    // The Rust CLI reads this same file. Rewriting it whole would delete state
+    // the SDK has no type for — `workspace_id` today, whatever comes next.
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_old',
+      refresh_token: 'rth_rt_old',
+      workspace_id: 'workspace-example',
+      some_future_field: { nested: true },
+      ...ELIGIBLE,
+    });
+    const { impl } = rotatingFetch({
+      accept: ['rth_at_new'],
+      refresh: { accessToken: 'rth_at_new', refreshToken: 'rth_rt_new' },
+    });
+    await getSessionThread({ source: 'claude', sessionId: 'sid' }, { fetchImpl: impl });
+
+    const stored = await readStage(nativeHome);
+    assert.equal(stored.access_token, 'rth_at_new', 'the pair rotated');
+    assert.equal(stored.workspace_id, 'workspace-example', 'workspace survives rotation');
+    assert.deepEqual(stored.some_future_field, { nested: true }, 'unmodelled fields survive');
+    assert.equal(stored.org_id, 'org-example');
+  });
+});
+
+test('rotation replaces a superseded expiry rather than keeping the stale one', async () => {
+  await withStores(async ({ nativeHome }) => {
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_old',
+      refresh_token: 'rth_rt_old',
+      ...ELIGIBLE,
+    });
+    const later = new Date(Date.now() + 7_200_000).toISOString();
+    const { impl } = rotatingFetch({
+      accept: ['rth_at_new'],
+      refresh: { accessToken: 'rth_at_new', refreshToken: 'rth_rt_new', expiresAt: later },
+    });
+    await getSessionThread({ source: 'claude', sessionId: 'sid' }, { fetchImpl: impl });
+    const stored = await readStage(nativeHome);
+    assert.equal(stored.access_token_expires_at, later, 'merging must not keep the old expiry');
+  });
+});
+
 test('a pair another process already rotated is adopted without spending the refresh token', async () => {
   await withStores(async ({ nativeHome }) => {
     await writeStage(nativeHome, 'stage', {

--- a/sdk-ts/src/session-thread.test.ts
+++ b/sdk-ts/src/session-thread.test.ts
@@ -1,0 +1,275 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { InvalidArgumentError, UnsupportedOperationError } from './index.js';
+import {
+  cloudUnconfiguredMessage, getSessionThread,
+  type RelayhistoryAuth, type SessionThread,
+} from './cloud-client.js';
+
+const sourceDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
+const repositoryRoot = join(sourceDir, '..', '..');
+
+const AUTH: RelayhistoryAuth = {
+  baseUrl: 'https://history.agentrelay.com',
+  accessToken: 'rth_at_test',
+};
+
+const configured = async (): Promise<RelayhistoryAuth | null> => AUTH;
+const unconfigured = async (): Promise<RelayhistoryAuth | null> => null;
+
+/**
+ * A `fetch` stand-in that records every call. Tests assert on `calls.length`
+ * directly: "the unsupported path made no request" is only proven by the
+ * transport never being reached, never by the shape of the error alone.
+ */
+function recordingFetch(respond: () => Response) {
+  const calls: { url: string; init: RequestInit | undefined }[] = [];
+  const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    return respond();
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** A synthetic envelope in the exact shape `GET /v1/sessions/:id/thread` returns. */
+const ENVELOPE = {
+  session: {
+    source: 'claude',
+    sessionId: 'session-example',
+    orgId: 'org-example',
+    workspaceId: 'workspace-example',
+    firstEventAt: '2026-09-08T09:00:00.000Z',
+    lastEventAt: '2026-09-08T10:00:00.000Z',
+  },
+  outcomes: [
+    {
+      commitSha: 'abc123',
+      shippedAt: '2026-09-08T11:00:00.000Z',
+      reverted: false,
+      revertedBySha: null,
+      revertedAt: null,
+    },
+  ],
+  links: [
+    {
+      linkKind: 'github_pr',
+      linkRef: 'AgentWorkforce/relayhistory-cloud#123',
+      linkUrl: 'https://github.com/AgentWorkforce/relayhistory-cloud/pull/123',
+      linkTs: '2026-09-08T10:00:00.000000Z',
+      metadata: { state: 'open' },
+      confidence: 0.9,
+      // A field this SDK build does not know about. It must survive the round
+      // trip: the recall API owns this shape, the SDK only carries it.
+      unknownFutureField: 'preserved',
+    },
+  ],
+  nextCursor: null,
+};
+
+test('a thread envelope reaches the caller unchanged', async () => {
+  const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
+  const thread = await getSessionThread(
+    { source: 'claude', sessionId: 'session-example' },
+    { loadAuth: configured, fetchImpl: impl },
+  );
+  assert.equal(calls.length, 1);
+  assert.deepEqual(thread as unknown, ENVELOPE);
+});
+
+test('an unconfigured cloud connector is unsupported and performs no network call', async () => {
+  const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
+  await assert.rejects(
+    () => getSessionThread(
+      { source: 'claude', sessionId: 'session-example' },
+      { loadAuth: unconfigured, fetchImpl: impl },
+    ),
+    (error: unknown) => error instanceof UnsupportedOperationError
+      && error.code === 'UNSUPPORTED_OPERATION'
+      // The leading phrase is the sibling connectors' compatibility contract.
+      && error.message.startsWith('no remote provider connectors are configured')
+      && error.message.includes('remote session thread is not available')
+      && error.message.includes('(cloud: '),
+  );
+  assert.equal(calls.length, 0, 'the unsupported path must not reach the transport');
+});
+
+test('the unsupported message reproduces the Rust connector format verbatim', async () => {
+  // crates/ai-hist/src/remote.rs::unconfigured_message builds
+  //   "no remote provider connectors are configured: remote session
+  //    {operation} is not available ({connector}: {detail})"
+  assert.equal(
+    cloudUnconfiguredMessage('thread', 'DETAIL'),
+    'no remote provider connectors are configured: remote session thread is not available (cloud: DETAIL)',
+  );
+  const remote = await readFile(
+    join(repositoryRoot, 'crates', 'ai-hist', 'src', 'remote.rs'), 'utf8',
+  );
+  assert.ok(
+    remote.includes(
+      'no remote provider connectors are configured: remote session {operation} is not available ({reasons})',
+    ),
+    'the Rust format string this message mirrors still exists',
+  );
+});
+
+test('an invalid source is an invalid argument, not an unsupported remote request', async () => {
+  const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
+  // 'agent-relay' is a plausible-looking name that is not a source: the real
+  // ones are 'relay' and 'trajectory'. The recall route does not validate
+  // this — it answers 200 with an empty envelope — so rejecting it is the
+  // client's job.
+  await assert.rejects(
+    () => getSessionThread(
+      { source: 'agent-relay', sessionId: 'session-example' },
+      { loadAuth: configured, fetchImpl: impl },
+    ),
+    (error: unknown) => error instanceof InvalidArgumentError
+      && error.code === 'INVALID_ARGUMENT'
+      && error.message.includes("invalid source 'agent-relay'")
+      && error.message.includes('claude, codex, cursor, grok, relay, trajectory, opencode'),
+  );
+  assert.equal(calls.length, 0, 'an invalid source must not reach the transport');
+});
+
+test('the request carries the session identity and never a tenancy selector', async () => {
+  const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
+  await getSessionThread(
+    {
+      source: 'codex',
+      sessionId: 'session/with spaces',
+      kinds: ['github_pr', 'incident'],
+      since: '2026-09-08T00:00:00Z',
+      cursor: 'b64cursor==',
+    },
+    { loadAuth: configured, fetchImpl: impl },
+  );
+  assert.equal(calls.length, 1);
+  const url = new URL(calls[0]!.url);
+  assert.equal(url.pathname, '/v1/sessions/session%2Fwith%20spaces/thread');
+  assert.equal(url.searchParams.get('source'), 'codex');
+  assert.equal(url.searchParams.get('kinds'), 'github_pr,incident');
+  assert.equal(url.searchParams.get('since'), '2026-09-08T00:00:00Z');
+  assert.equal(url.searchParams.get('cursor'), 'b64cursor==');
+  for (const leak of ['org_id', 'orgId', 'workspace_id', 'workspaceId']) {
+    assert.equal(url.searchParams.has(leak), false, `${leak} must never be sent`);
+  }
+  const headers = new Headers(calls[0]!.init?.headers);
+  assert.equal(headers.get('authorization'), 'Bearer rth_at_test');
+});
+
+test('optional filters are omitted rather than sent empty', async () => {
+  const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
+  await getSessionThread(
+    { source: 'claude', sessionId: 'session-example', kinds: [] },
+    { loadAuth: configured, fetchImpl: impl },
+  );
+  const url = new URL(calls[0]!.url);
+  assert.equal(url.searchParams.has('kinds'), false);
+  assert.equal(url.searchParams.has('since'), false);
+  assert.equal(url.searchParams.has('cursor'), false);
+});
+
+test('a rejected stored session is reported as expired auth, not as a thread', async () => {
+  const { impl } = recordingFetch(() => jsonResponse({ error: 'nope' }, 401));
+  await assert.rejects(
+    () => getSessionThread(
+      { source: 'claude', sessionId: 'session-example' },
+      { loadAuth: configured, fetchImpl: impl },
+    ),
+    (error: unknown) => (error as { code?: string }).code === 'AUTHENTICATION_EXPIRED',
+  );
+});
+
+test('the bearer token is never sent over cleartext to a non-loopback host', async () => {
+  const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
+  const cleartext = async (): Promise<RelayhistoryAuth | null> => (
+    { baseUrl: 'http://history.agentrelay.com', accessToken: 'rth_at_test' }
+  );
+  await assert.rejects(
+    () => getSessionThread(
+      { source: 'claude', sessionId: 'session-example' },
+      { loadAuth: cleartext, fetchImpl: impl },
+    ),
+    (error: unknown) => (error as { code?: string }).code === 'CONNECTOR_FAILURE'
+      && String((error as Error).message).includes('cleartext'),
+  );
+  assert.equal(calls.length, 0);
+  // Loopback stays usable for `wrangler dev`.
+  const loopback = async (): Promise<RelayhistoryAuth | null> => (
+    { baseUrl: 'http://127.0.0.1:8787', accessToken: 'rth_at_test' }
+  );
+  await getSessionThread(
+    { source: 'claude', sessionId: 'session-example' },
+    { loadAuth: loopback, fetchImpl: impl },
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(new URL(calls[0]!.url).origin, 'http://127.0.0.1:8787');
+});
+
+test('a base URL naming another stage is unconfigured, not a cross-stage request', async () => {
+  const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
+  // The stored session belongs to one stage. Honouring a base URL that names a
+  // different one would send this stage's bearer token to another host.
+  await assert.rejects(
+    () => getSessionThread(
+      { source: 'claude', sessionId: 'session-example' },
+      { loadAuth: configured, fetchImpl: impl, baseUrl: 'https://staging.example.com' },
+    ),
+    (error: unknown) => error instanceof UnsupportedOperationError
+      && error.message.startsWith('no remote provider connectors are configured')
+      && error.message.includes('https://staging.example.com'),
+  );
+  assert.equal(calls.length, 0, 'a stage mismatch must not reach the transport');
+
+  // The same stage spelled with a trailing slash is the same stage.
+  await getSessionThread(
+    { source: 'claude', sessionId: 'session-example' },
+    { loadAuth: configured, fetchImpl: impl, baseUrl: 'https://history.agentrelay.com/' },
+  );
+  assert.equal(calls.length, 1);
+});
+
+test('get_session_thread is registered as a cloud-backed read', async () => {
+  const mcp = await readFile(join(sourceDir, 'mcp-server.ts'), 'utf8');
+  const start = mcp.indexOf("server.tool('get_session_thread'");
+  assert.notEqual(start, -1, 'get_session_thread is registered');
+  const end = mcp.indexOf("server.tool('", start + 13);
+  const registration = mcp.slice(start, end === -1 ? undefined : end);
+  assert.match(registration, /source: SOURCE,/, 'the tool validates against SOURCE_CHOICES');
+  assert.match(registration, /session_id: z\.string\(\)\.min\(1\)/);
+  assert.match(registration, /CLOUD_READ/, 'a thread is a read that reaches the network');
+  assert.doesNotMatch(registration, /SESSION_SCOPE/, 'a thread is addressed by identity');
+  assert.doesNotMatch(registration, /org_?[Ii]d/, 'tenancy comes from the token');
+  assert.match(mcp, /const CLOUD_READ = \{ readOnlyHint: true, idempotentHint: true, openWorldHint: true \}/);
+});
+
+test('the MCP server registers fourteen tools', async () => {
+  const mcp = await readFile(join(sourceDir, 'mcp-server.ts'), 'utf8');
+  const names = [...mcp.matchAll(/server\.tool\('([a-z_]+)'/g)].map((match) => match[1]);
+  assert.equal(names.length, 14, `expected 14 tools, got ${names.length}: ${names.join(', ')}`);
+  assert.ok(names.includes('get_session_thread'));
+  assert.equal(new Set(names).size, names.length, 'tool names are unique');
+});
+
+test('the tool inventories in both READMEs list get_session_thread', async () => {
+  for (const readme of ['README.md', join('mcp-package', 'README.md')]) {
+    const body = await readFile(join(repositoryRoot, readme), 'utf8');
+    assert.ok(body.includes('get_session_thread'), `${readme} documents the tool`);
+  }
+});
+
+// A compile-time check that the declared envelope type is what the tests
+// exercise; `SessionThread` is a description of the service's shape, so it
+// must accept the service's own documented example.
+const _typecheck: SessionThread = ENVELOPE as unknown as SessionThread;
+void _typecheck;

--- a/sdk-ts/src/session-thread.test.ts
+++ b/sdk-ts/src/session-thread.test.ts
@@ -559,3 +559,184 @@ test('limit is sent when given and rejected when out of the route range', async 
   }
   assert.equal(calls.length, 1, 'a rejected limit must not reach the transport');
 });
+
+// ---------------------------------------------------------------------------
+// Rotation.
+//
+// An MCP-only install — a WS-4 sandbox, say — has no human to run `ai-hist
+// login` and no Rust CLI rotating the store for it, so without this the tool
+// simply stops working at the token's ~24h boundary.
+// ---------------------------------------------------------------------------
+
+/** A fetch stand-in that answers the thread route by token and the refresh route by script. */
+function rotatingFetch(opts: {
+  accept: string[];
+  refresh?: { accessToken: string; refreshToken: string; expiresAt?: string } | 'reject';
+}) {
+  const calls: string[] = [];
+  const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input);
+    if (url.includes('/v1/auth/token/refresh')) {
+      calls.push('refresh');
+      if (!opts.refresh || opts.refresh === 'reject') return new Response('no', { status: 401 });
+      return new Response(JSON.stringify({
+        accessToken: opts.refresh.accessToken,
+        refreshToken: opts.refresh.refreshToken,
+        accessTokenExpiresAt: opts.refresh.expiresAt ?? HOUR_AHEAD,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+    const bearer = new Headers(init?.headers).get('authorization')?.replace('Bearer ', '') ?? '';
+    calls.push(`thread:${bearer}`);
+    return opts.accept.includes(bearer)
+      ? new Response(JSON.stringify(ENVELOPE), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      : new Response(JSON.stringify({ error: 'invalid_token' }), { status: 401 });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+async function readStage(nativeHome: string, key = 'stage'): Promise<Record<string, unknown>> {
+  return JSON.parse(await readFile(join(nativeHome, 'stages', `${key}.auth.json`), 'utf8')) as Record<string, unknown>;
+}
+
+test('a rejected token is rotated once and the new pair is persisted', async () => {
+  await withStores(async ({ nativeHome }) => {
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_old',
+      refresh_token: 'rth_rt_old',
+      ...ELIGIBLE,
+    });
+    const { impl, calls } = rotatingFetch({
+      accept: ['rth_at_new'],
+      refresh: { accessToken: 'rth_at_new', refreshToken: 'rth_rt_new' },
+    });
+    const thread = await getSessionThread(
+      { source: 'claude', sessionId: 'sid' }, { fetchImpl: impl },
+    );
+    assert.deepEqual(thread as unknown, ENVELOPE);
+    assert.deepEqual(calls, ['thread:rth_at_old', 'refresh', 'thread:rth_at_new']);
+
+    // Persisted in the native store's own schema, so the Rust CLI can read it.
+    const stored = await readStage(nativeHome);
+    assert.equal(stored.access_token, 'rth_at_new');
+    assert.equal(stored.refresh_token, 'rth_rt_new');
+    assert.equal(stored.org_id, 'org-example', 'the org survives rotation');
+    assert.equal(stored.base_url, 'https://history.agentrelay.com');
+  });
+});
+
+test('a pair another process already rotated is adopted without spending the refresh token', async () => {
+  await withStores(async ({ nativeHome }) => {
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_old',
+      refresh_token: 'rth_rt_old',
+      ...ELIGIBLE,
+    });
+    const resolved = await resolveCloudSession();
+    assert.equal(resolved.auth?.accessToken, 'rth_at_old');
+
+    // Another process rotates between resolution and the retry.
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_theirs',
+      refresh_token: 'rth_rt_theirs',
+      ...ELIGIBLE,
+    });
+    const { impl, calls } = rotatingFetch({ accept: ['rth_at_theirs'] });
+    await getSessionThread(
+      { source: 'claude', sessionId: 'sid' },
+      { fetchImpl: impl, resolveSession: async () => resolved },
+    );
+    assert.deepEqual(calls, ['thread:rth_at_old', 'thread:rth_at_theirs']);
+    assert.equal(calls.includes('refresh'), false, 'a one-time refresh token must not be spent needlessly');
+  });
+});
+
+test('losing the rotation race recovers from the winner\'s persisted pair', async () => {
+  await withStores(async ({ nativeHome }) => {
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_old',
+      refresh_token: 'rth_rt_old',
+      ...ELIGIBLE,
+    });
+    const resolved = await resolveCloudSession();
+    // The refresh is rejected because a concurrent process spent the token
+    // first; that process then persists its own live pair.
+    const { impl, calls } = rotatingFetch({ accept: ['rth_at_winner'], refresh: 'reject' });
+    const wrapped = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const out = await impl(input as never, init as never);
+      if (url.includes('/v1/auth/token/refresh')) {
+        await writeStage(nativeHome, 'stage', {
+          base_url: 'https://history.agentrelay.com',
+          access_token: 'rth_at_winner',
+          refresh_token: 'rth_rt_winner',
+          ...ELIGIBLE,
+        });
+      }
+      return out;
+    }) as unknown as typeof fetch;
+
+    const thread = await getSessionThread(
+      { source: 'claude', sessionId: 'sid' },
+      { fetchImpl: wrapped, resolveSession: async () => resolved },
+    );
+    assert.deepEqual(thread as unknown, ENVELOPE);
+    assert.deepEqual(calls, ['thread:rth_at_old', 'refresh', 'thread:rth_at_winner']);
+  });
+});
+
+test('a session with no refresh token still fails cleanly rather than looping', async () => {
+  await withStores(async ({ nativeHome }) => {
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_old',
+      ...ELIGIBLE,
+    });
+    const { impl, calls } = rotatingFetch({ accept: [] });
+    await assert.rejects(
+      () => getSessionThread({ source: 'claude', sessionId: 'sid' }, { fetchImpl: impl }),
+      (error: unknown) => (error as { code?: string }).code === 'AUTHENTICATION_EXPIRED',
+    );
+    assert.deepEqual(calls, ['thread:rth_at_old'], 'nothing to rotate, so no refresh attempt');
+  });
+});
+
+test('an expired session that can rotate is refreshed, not reported unconfigured', async () => {
+  await withStores(async ({ nativeHome }) => {
+    // Expiry is the one precondition rotation repairs. With a refresh token the
+    // session is stale, not unconfigured.
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_stale',
+      refresh_token: 'rth_rt_old',
+      access_token_expires_at: new Date(Date.now() - 1_000).toISOString(),
+      org_id: 'org-example',
+    });
+    const resolved = await resolveCloudSession();
+    assert.equal(resolved.auth?.accessToken, 'rth_at_stale', 'still resolvable');
+
+    const { impl, calls } = rotatingFetch({
+      accept: ['rth_at_fresh'],
+      refresh: { accessToken: 'rth_at_fresh', refreshToken: 'rth_rt_fresh' },
+    });
+    const thread = await getSessionThread({ source: 'claude', sessionId: 'sid' }, { fetchImpl: impl });
+    assert.deepEqual(thread as unknown, ENVELOPE);
+    assert.deepEqual(calls, ['thread:rth_at_stale', 'refresh', 'thread:rth_at_fresh']);
+  });
+
+  await withStores(async ({ nativeHome }) => {
+    // Expired with nothing to rotate is still unconfigured, as recall_auth says.
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_stale',
+      access_token_expires_at: new Date(Date.now() - 1_000).toISOString(),
+      org_id: 'org-example',
+    });
+    const resolved = await resolveCloudSession();
+    assert.equal(resolved.auth, null);
+    assert.ok(resolved.auth === null && resolved.detail.includes('expiry'));
+  });
+});

--- a/sdk-ts/src/session-thread.test.ts
+++ b/sdk-ts/src/session-thread.test.ts
@@ -331,6 +331,8 @@ async function writeStage(
 }
 
 const HOUR_AHEAD = new Date(Date.now() + 3_600_000).toISOString();
+/** The fields `cloud::recall_auth` requires of a native-store session. */
+const ELIGIBLE = { access_token_expires_at: HOUR_AHEAD, org_id: 'org-example' };
 
 test('a session stored by the native ai-hist login is found', async () => {
   await withStores(async ({ nativeHome }) => {
@@ -338,10 +340,9 @@ test('a session stored by the native ai-hist login is found', async () => {
     await writeStage(nativeHome, 'f482e90bb4722263', {
       base_url: 'https://history.agentrelay.com',
       access_token: 'rth_at_native',
-      access_token_expires_at: HOUR_AHEAD,
       refresh_token: 'rth_rt_native',
-      org_id: null,
       workspace_id: null,
+      ...ELIGIBLE,
     });
     const resolved = await resolveCloudSession();
     assert.equal(resolved.auth?.accessToken, 'rth_at_native');
@@ -355,7 +356,7 @@ test('the native store is reached through getSessionThread, not just the resolve
     await writeStage(nativeHome, 'stage', {
       base_url: 'https://history.agentrelay.com',
       access_token: 'rth_at_native',
-      access_token_expires_at: HOUR_AHEAD,
+      ...ELIGIBLE,
     });
     const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
     // No resolveSession override: this is the production default path.
@@ -394,12 +395,12 @@ test('two stored stages are a refusal to guess, not a coin flip', async () => {
     await writeStage(nativeHome, 'prod', {
       base_url: 'https://history.agentrelay.com',
       access_token: 'rth_at_prod',
-      access_token_expires_at: HOUR_AHEAD,
+      ...ELIGIBLE,
     });
     await writeStage(nativeHome, 'dev', {
       base_url: 'http://127.0.0.1:8787',
       access_token: 'rth_at_dev',
-      access_token_expires_at: HOUR_AHEAD,
+      ...ELIGIBLE,
     });
     const ambiguous = await resolveCloudSession();
     assert.equal(ambiguous.auth, null);
@@ -413,27 +414,85 @@ test('two stored stages are a refusal to guess, not a coin flip', async () => {
   });
 });
 
-test('a spent access token is unconfigured, and a missing expiry is not', async () => {
+test('a native session missing any recall_auth precondition is unconfigured', async () => {
+  // `cloud::recall_auth` requires an rth_at_ token, a present+parseable expiry
+  // at least 60s away, and a non-blank org. A session failing any of them is
+  // one the engine's own connector reports unconfigured, so the tool must not
+  // answer from it — and must say which precondition failed.
+  const cases: [string, Record<string, unknown>, string][] = [
+    ['spent expiry', { ...ELIGIBLE, access_token_expires_at: new Date(Date.now() - 1_000).toISOString() }, 'expiry'],
+    ['unparseable expiry', { ...ELIGIBLE, access_token_expires_at: 'not-a-date' }, 'expiry'],
+    ['missing expiry', { org_id: 'org-example' }, 'expiry'],
+    ['missing org', { access_token_expires_at: HOUR_AHEAD }, 'orgId'],
+    ['blank org', { access_token_expires_at: HOUR_AHEAD, org_id: '   ' }, 'orgId'],
+  ];
+  for (const [label, fields, expected] of cases) {
+    await withStores(async ({ nativeHome }) => {
+      await writeStage(nativeHome, 'stage', {
+        base_url: 'https://history.agentrelay.com',
+        access_token: 'rth_at_native',
+        ...fields,
+      });
+      const resolved = await resolveCloudSession();
+      assert.equal(resolved.auth, null, label);
+      assert.ok(resolved.auth === null && resolved.detail.includes(expected), `${label} names ${expected}`);
+    });
+  }
+
+  // A token that is not an rth_at_ session is rejected in either store.
   await withStores(async ({ nativeHome }) => {
     await writeStage(nativeHome, 'stage', {
       base_url: 'https://history.agentrelay.com',
-      access_token: 'rth_at_stale',
-      access_token_expires_at: new Date(Date.now() - 1_000).toISOString(),
+      access_token: 'nope_not_a_session',
+      ...ELIGIBLE,
     });
-    const expired = await resolveCloudSession();
-    assert.equal(expired.auth, null);
-    assert.ok(expired.auth === null && expired.detail.includes('expired'));
+    const resolved = await resolveCloudSession();
+    assert.equal(resolved.auth, null);
+    assert.ok(resolved.auth === null && resolved.detail.includes('rth_at_'));
+  });
+});
+
+test('an ineligible native session performs no network call', async () => {
+  await withStores(async ({ nativeHome }) => {
+    // The precondition gate has to run before the transport, exactly like the
+    // no-session case, or an unconfigured connector becomes a 401 instead.
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_native',
+      access_token_expires_at: HOUR_AHEAD,
+    });
+    const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
+    await assert.rejects(
+      () => getSessionThread({ source: 'claude', sessionId: 'sid' }, { fetchImpl: impl }),
+      (error: unknown) => error instanceof UnsupportedOperationError
+        && error.message.startsWith('no remote provider connectors are configured')
+        && error.message.includes('orgId'),
+    );
+    assert.equal(calls.length, 0);
+  });
+});
+
+test('the SDK store is held only to the contract it can satisfy', async () => {
+  // `loginCloud` has never written an expiry or an org. Requiring them here
+  // would retire a working login path rather than enforce anything.
+  await withStores(async ({ sdkDir }) => {
+    await writeFile(join(sdkDir, 'auth.json'), JSON.stringify({
+      baseUrl: 'https://history.agentrelay.com',
+      accessToken: 'rth_at_sdk',
+    }), { mode: 0o600 });
+    const resolved = await resolveCloudSession();
+    assert.equal(resolved.auth?.accessToken, 'rth_at_sdk');
   });
 
-  await withStores(async ({ nativeHome }) => {
-    // Sessions predating the expiry field carry no claim either way, and the
-    // SDK's own store has never written it. Absence must not read as expiry.
-    await writeStage(nativeHome, 'stage', {
-      base_url: 'https://history.agentrelay.com',
-      access_token: 'rth_at_undated',
-    });
-    const undated = await resolveCloudSession();
-    assert.equal(undated.auth?.accessToken, 'rth_at_undated');
+  // A stated expiry is still honoured there when it is spent.
+  await withStores(async ({ sdkDir }) => {
+    await writeFile(join(sdkDir, 'auth.json'), JSON.stringify({
+      baseUrl: 'https://history.agentrelay.com',
+      accessToken: 'rth_at_sdk',
+      accessTokenExpiresAt: new Date(Date.now() - 1_000).toISOString(),
+    }), { mode: 0o600 });
+    const resolved = await resolveCloudSession();
+    assert.equal(resolved.auth, null);
   });
 });
 
@@ -443,7 +502,7 @@ test('a malformed stage file is skipped rather than failing every read', async (
     await writeStage(nativeHome, 'good', {
       base_url: 'https://history.agentrelay.com',
       access_token: 'rth_at_good',
-      access_token_expires_at: HOUR_AHEAD,
+      ...ELIGIBLE,
     });
     const resolved = await resolveCloudSession();
     assert.equal(resolved.auth?.accessToken, 'rth_at_good');
@@ -456,7 +515,7 @@ test('a stage path keeps its case while scheme and host are folded', async () =>
     await writeStage(nativeHome, 'stage', {
       base_url: 'https://History.AgentRelay.COM/Recall',
       access_token: 'rth_at_cased',
-      access_token_expires_at: HOUR_AHEAD,
+      ...ELIGIBLE,
     });
     const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
     await getSessionThread({ source: 'claude', sessionId: 'sid' }, { fetchImpl: impl });

--- a/sdk-ts/src/session-thread.test.ts
+++ b/sdk-ts/src/session-thread.test.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { InvalidArgumentError, UnsupportedOperationError } from './index.js';
 import {
@@ -296,7 +296,9 @@ void _typecheck;
 // login flow report the connector unconfigured.
 // ---------------------------------------------------------------------------
 
-const STORE_ENV = ['RELAYHISTORY_HOME', 'AI_HIST_CONFIG_DIR', 'AI_HIST_BASE_URL'] as const;
+const STORE_ENV = [
+  'RELAYHISTORY_HOME', 'AI_HIST_CONFIG_DIR', 'AI_HIST_BASE_URL', 'RELAYHISTORY_BASE_URL',
+] as const;
 
 /** Runs one case against private stores so the developer's own login is invisible. */
 async function withStores(
@@ -311,6 +313,7 @@ async function withStores(
   process.env.RELAYHISTORY_HOME = nativeHome;
   process.env.AI_HIST_CONFIG_DIR = sdkDir;
   delete process.env.AI_HIST_BASE_URL;
+  delete process.env.RELAYHISTORY_BASE_URL;
   try {
     await body({ nativeHome, sdkDir });
   } finally {
@@ -328,6 +331,21 @@ async function writeStage(
   fields: Record<string, unknown>,
 ): Promise<void> {
   await writeFile(join(nativeHome, 'stages', `${key}.auth.json`), JSON.stringify(fields), { mode: 0o600 });
+}
+
+/** Mirrors how `getSessionThread` derives its requested stage from the env. */
+function requestedStageForTest(): string | undefined {
+  for (const key of ['RELAYHISTORY_BASE_URL', 'AI_HIST_BASE_URL'] as const) {
+    const value = process.env[key];
+    if (value === undefined) continue;
+    try {
+      const url = new URL(value.trim());
+      if (url.hostname && !url.username && !url.password && !url.search && !url.hash) {
+        return `${url.protocol.toLowerCase()}//${url.host.toLowerCase()}${url.pathname}`.replace(/\/+$/, '');
+      }
+    } catch { /* names no stage */ }
+  }
+  return undefined;
 }
 
 const HOUR_AHEAD = new Date(Date.now() + 3_600_000).toISOString();
@@ -783,5 +801,113 @@ test('an expired session that can rotate is refreshed, not reported unconfigured
     const resolved = await resolveCloudSession();
     assert.equal(resolved.auth, null);
     assert.ok(resolved.auth === null && resolved.detail.includes('expiry'));
+  });
+});
+
+test('the engine\'s documented stage variables are both honoured, in its order', async () => {
+  await withStores(async ({ nativeHome }) => {
+    await writeStage(nativeHome, 'prod', {
+      base_url: 'https://history.agentrelay.com', access_token: 'rth_at_prod', ...ELIGIBLE,
+    });
+    await writeStage(nativeHome, 'dev', {
+      base_url: 'http://127.0.0.1:8787', access_token: 'rth_at_dev', ...ELIGIBLE,
+    });
+    // A multi-stage CLI install already sets RELAYHISTORY_BASE_URL; ignoring it
+    // would answer from the wrong org or refuse outright.
+    process.env.RELAYHISTORY_BASE_URL = 'http://127.0.0.1:8787';
+    assert.equal((await resolveCloudSession(requestedStageForTest())).auth?.accessToken, 'rth_at_dev');
+
+    // RELAYHISTORY_BASE_URL wins, matching `cloud::default_base_url`'s order.
+    process.env.AI_HIST_BASE_URL = 'https://history.agentrelay.com';
+    assert.equal((await resolveCloudSession(requestedStageForTest())).auth?.accessToken, 'rth_at_dev');
+
+    // An unparseable value names no stage and falls through to the next one.
+    process.env.RELAYHISTORY_BASE_URL = 'not a url';
+    assert.equal((await resolveCloudSession(requestedStageForTest())).auth?.accessToken, 'rth_at_prod');
+
+    // Empty everywhere: back to the refusal to guess, not a failure to select.
+    process.env.RELAYHISTORY_BASE_URL = '';
+    delete process.env.AI_HIST_BASE_URL;
+    const ambiguous = await resolveCloudSession(requestedStageForTest());
+    assert.equal(ambiguous.auth, null);
+    assert.ok(ambiguous.auth === null && ambiguous.detail.includes('2 relayhistory stages'));
+  });
+});
+
+test('a forbidden response is not an expired session and does not spend the refresh token', async () => {
+  await withStores(async ({ nativeHome }) => {
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_ok',
+      refresh_token: 'rth_rt_ok',
+      ...ELIGIBLE,
+    });
+    const calls: string[] = [];
+    const impl = (async (input: string | URL | Request) => {
+      calls.push(String(input).includes('/token/refresh') ? 'refresh' : 'thread');
+      return new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 });
+    }) as unknown as typeof fetch;
+    await assert.rejects(
+      () => getSessionThread({ source: 'claude', sessionId: 'sid' }, { fetchImpl: impl }),
+      (error: unknown) => (error as { code?: string }).code === 'CONNECTOR_FAILURE'
+        && String((error as Error).message).includes('rth:read'),
+    );
+    assert.deepEqual(calls, ['thread'], 'a one-time refresh token must not be spent on a scope error');
+  });
+});
+
+test('a rotation that cannot be saved is reported, not silently succeeded', async () => {
+  await withStores(async ({ nativeHome }) => {
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_old',
+      refresh_token: 'rth_rt_old',
+      ...ELIGIBLE,
+    });
+    // Make the stage directory unwritable so the atomic replace fails after the
+    // refresh token has already been spent.
+    const { impl } = rotatingFetch({
+      accept: ['rth_at_new'],
+      refresh: { accessToken: 'rth_at_new', refreshToken: 'rth_rt_new' },
+    });
+    await chmod(join(nativeHome, 'stages'), 0o500);
+    try {
+      await assert.rejects(
+        () => getSessionThread({ source: 'claude', sessionId: 'sid' }, { fetchImpl: impl }),
+        (error: unknown) => (error as { code?: string }).code === 'CONNECTOR_FAILURE'
+          && String((error as Error).message).includes('rotated but could not be saved')
+          && String((error as Error).message).includes('now revoked'),
+      );
+    } finally {
+      await chmod(join(nativeHome, 'stages'), 0o700);
+    }
+  });
+});
+
+test('a rotation onto an unreadable session file keeps the org', async () => {
+  await withStores(async ({ nativeHome }) => {
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_old',
+      refresh_token: 'rth_rt_old',
+      ...ELIGIBLE,
+    });
+    const resolved = await resolveCloudSession();
+    // The file turns to garbage between resolution and rotation. The overlay is
+    // all that will be left, so it has to carry the org or the next resolve
+    // reports the connector unconfigured despite a fresh token on disk.
+    await writeFile(join(nativeHome, 'stages', 'stage.auth.json'), 'not json', { mode: 0o600 });
+    const { impl } = rotatingFetch({
+      accept: ['rth_at_new'],
+      refresh: { accessToken: 'rth_at_new', refreshToken: 'rth_rt_new' },
+    });
+    await getSessionThread(
+      { source: 'claude', sessionId: 'sid' },
+      { fetchImpl: impl, resolveSession: async () => resolved },
+    );
+    const stored = await readStage(nativeHome);
+    assert.equal(stored.access_token, 'rth_at_new');
+    assert.equal(stored.org_id, 'org-example', 'the org survives a fallback write');
+    assert.equal((await resolveCloudSession()).auth?.accessToken, 'rth_at_new', 'still resolvable');
   });
 });

--- a/sdk-ts/src/session-thread.test.ts
+++ b/sdk-ts/src/session-thread.test.ts
@@ -3,10 +3,12 @@ import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { InvalidArgumentError, UnsupportedOperationError } from './index.js';
 import {
-  cloudUnconfiguredMessage, getSessionThread,
-  type RelayhistoryAuth, type SessionThread,
+  cloudUnconfiguredMessage, getSessionThread, resolveCloudSession,
+  type CloudSessionResolution, type RelayhistoryAuth, type SessionThread,
 } from './cloud-client.js';
 
 const sourceDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
@@ -17,8 +19,19 @@ const AUTH: RelayhistoryAuth = {
   accessToken: 'rth_at_test',
 };
 
-const configured = async (): Promise<RelayhistoryAuth | null> => AUTH;
-const unconfigured = async (): Promise<RelayhistoryAuth | null> => null;
+const configured = async (): Promise<CloudSessionResolution> => ({ auth: AUTH });
+const unconfigured = async (): Promise<CloudSessionResolution> => (
+  { auth: null, detail: '/nowhere: no stored relayhistory session (run `ai-hist login`)' }
+);
+
+/** A resolver honouring a requested stage, as the real one does. */
+function stagedResolver(...auths: RelayhistoryAuth[]) {
+  return async (requested?: string): Promise<CloudSessionResolution> => {
+    if (requested === undefined) return { auth: auths[0]! };
+    const match = auths.find((a) => a.baseUrl.replace(/\/+$/, '') === requested.replace(/\/+$/, ''));
+    return match ? { auth: match } : { auth: null, detail: `no session for ${requested}` };
+  };
+}
 
 /**
  * A `fetch` stand-in that records every call. Tests assert on `calls.length`
@@ -80,7 +93,7 @@ test('a thread envelope reaches the caller unchanged', async () => {
   const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
   const thread = await getSessionThread(
     { source: 'claude', sessionId: 'session-example' },
-    { loadAuth: configured, fetchImpl: impl },
+    { resolveSession: configured, fetchImpl: impl },
   );
   assert.equal(calls.length, 1);
   assert.deepEqual(thread as unknown, ENVELOPE);
@@ -91,7 +104,7 @@ test('an unconfigured cloud connector is unsupported and performs no network cal
   await assert.rejects(
     () => getSessionThread(
       { source: 'claude', sessionId: 'session-example' },
-      { loadAuth: unconfigured, fetchImpl: impl },
+      { resolveSession: unconfigured, fetchImpl: impl },
     ),
     (error: unknown) => error instanceof UnsupportedOperationError
       && error.code === 'UNSUPPORTED_OPERATION'
@@ -131,7 +144,7 @@ test('an invalid source is an invalid argument, not an unsupported remote reques
   await assert.rejects(
     () => getSessionThread(
       { source: 'agent-relay', sessionId: 'session-example' },
-      { loadAuth: configured, fetchImpl: impl },
+      { resolveSession: configured, fetchImpl: impl },
     ),
     (error: unknown) => error instanceof InvalidArgumentError
       && error.code === 'INVALID_ARGUMENT'
@@ -151,7 +164,7 @@ test('the request carries the session identity and never a tenancy selector', as
       since: '2026-09-08T00:00:00Z',
       cursor: 'b64cursor==',
     },
-    { loadAuth: configured, fetchImpl: impl },
+    { resolveSession: configured, fetchImpl: impl },
   );
   assert.equal(calls.length, 1);
   const url = new URL(calls[0]!.url);
@@ -171,7 +184,7 @@ test('optional filters are omitted rather than sent empty', async () => {
   const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
   await getSessionThread(
     { source: 'claude', sessionId: 'session-example', kinds: [] },
-    { loadAuth: configured, fetchImpl: impl },
+    { resolveSession: configured, fetchImpl: impl },
   );
   const url = new URL(calls[0]!.url);
   assert.equal(url.searchParams.has('kinds'), false);
@@ -184,7 +197,7 @@ test('a rejected stored session is reported as expired auth, not as a thread', a
   await assert.rejects(
     () => getSessionThread(
       { source: 'claude', sessionId: 'session-example' },
-      { loadAuth: configured, fetchImpl: impl },
+      { resolveSession: configured, fetchImpl: impl },
     ),
     (error: unknown) => (error as { code?: string }).code === 'AUTHENTICATION_EXPIRED',
   );
@@ -192,25 +205,25 @@ test('a rejected stored session is reported as expired auth, not as a thread', a
 
 test('the bearer token is never sent over cleartext to a non-loopback host', async () => {
   const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
-  const cleartext = async (): Promise<RelayhistoryAuth | null> => (
-    { baseUrl: 'http://history.agentrelay.com', accessToken: 'rth_at_test' }
+  const cleartext = async (): Promise<CloudSessionResolution> => (
+    { auth: { baseUrl: 'http://history.agentrelay.com', accessToken: 'rth_at_test' } }
   );
   await assert.rejects(
     () => getSessionThread(
       { source: 'claude', sessionId: 'session-example' },
-      { loadAuth: cleartext, fetchImpl: impl },
+      { resolveSession: cleartext, fetchImpl: impl },
     ),
     (error: unknown) => (error as { code?: string }).code === 'CONNECTOR_FAILURE'
       && String((error as Error).message).includes('cleartext'),
   );
   assert.equal(calls.length, 0);
   // Loopback stays usable for `wrangler dev`.
-  const loopback = async (): Promise<RelayhistoryAuth | null> => (
-    { baseUrl: 'http://127.0.0.1:8787', accessToken: 'rth_at_test' }
+  const loopback = async (): Promise<CloudSessionResolution> => (
+    { auth: { baseUrl: 'http://127.0.0.1:8787', accessToken: 'rth_at_test' } }
   );
   await getSessionThread(
     { source: 'claude', sessionId: 'session-example' },
-    { loadAuth: loopback, fetchImpl: impl },
+    { resolveSession: loopback, fetchImpl: impl },
   );
   assert.equal(calls.length, 1);
   assert.equal(new URL(calls[0]!.url).origin, 'http://127.0.0.1:8787');
@@ -223,7 +236,7 @@ test('a base URL naming another stage is unconfigured, not a cross-stage request
   await assert.rejects(
     () => getSessionThread(
       { source: 'claude', sessionId: 'session-example' },
-      { loadAuth: configured, fetchImpl: impl, baseUrl: 'https://staging.example.com' },
+      { resolveSession: stagedResolver(AUTH), fetchImpl: impl, baseUrl: 'https://staging.example.com' },
     ),
     (error: unknown) => error instanceof UnsupportedOperationError
       && error.message.startsWith('no remote provider connectors are configured')
@@ -234,7 +247,7 @@ test('a base URL naming another stage is unconfigured, not a cross-stage request
   // The same stage spelled with a trailing slash is the same stage.
   await getSessionThread(
     { source: 'claude', sessionId: 'session-example' },
-    { loadAuth: configured, fetchImpl: impl, baseUrl: 'https://history.agentrelay.com/' },
+    { resolveSession: stagedResolver(AUTH), fetchImpl: impl, baseUrl: 'https://history.agentrelay.com/' },
   );
   assert.equal(calls.length, 1);
 });
@@ -248,6 +261,7 @@ test('get_session_thread is registered as a cloud-backed read', async () => {
   assert.match(registration, /source: SOURCE,/, 'the tool validates against SOURCE_CHOICES');
   assert.match(registration, /session_id: z\.string\(\)\.min\(1\)/);
   assert.match(registration, /CLOUD_READ/, 'a thread is a read that reaches the network');
+  assert.match(registration, /limit: z\.number\(\)\.int\(\)\.min\(1\)\.max\(500\)/, 'limit is exposed and bounded to the route range');
   assert.doesNotMatch(registration, /SESSION_SCOPE/, 'a thread is addressed by identity');
   assert.doesNotMatch(registration, /org_?[Ii]d/, 'tenancy comes from the token');
   assert.match(mcp, /const CLOUD_READ = \{ readOnlyHint: true, idempotentHint: true, openWorldHint: true \}/);
@@ -273,3 +287,216 @@ test('the tool inventories in both READMEs list get_session_thread', async () =>
 // must accept the service's own documented example.
 const _typecheck: SessionThread = ENVELOPE as unknown as SessionThread;
 void _typecheck;
+
+// ---------------------------------------------------------------------------
+// Credential resolution.
+//
+// The tool reads the store the native `ai-hist login` actually writes. Reading
+// only the SDK's own `~/.config/ai-hist/auth.json` is what made the documented
+// login flow report the connector unconfigured.
+// ---------------------------------------------------------------------------
+
+const STORE_ENV = ['RELAYHISTORY_HOME', 'AI_HIST_CONFIG_DIR', 'AI_HIST_BASE_URL'] as const;
+
+/** Runs one case against private stores so the developer's own login is invisible. */
+async function withStores(
+  body: (dirs: { nativeHome: string; sdkDir: string }) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'ai-hist-thread-auth-'));
+  const nativeHome = join(root, 'relayhistory');
+  const sdkDir = join(root, 'ai-hist');
+  await mkdir(join(nativeHome, 'stages'), { recursive: true });
+  await mkdir(sdkDir, { recursive: true });
+  const saved = new Map(STORE_ENV.map((key) => [key, process.env[key]] as const));
+  process.env.RELAYHISTORY_HOME = nativeHome;
+  process.env.AI_HIST_CONFIG_DIR = sdkDir;
+  delete process.env.AI_HIST_BASE_URL;
+  try {
+    await body({ nativeHome, sdkDir });
+  } finally {
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key]; else process.env[key] = value;
+    }
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+/** One stage file in the native store's snake_case schema. */
+async function writeStage(
+  nativeHome: string,
+  key: string,
+  fields: Record<string, unknown>,
+): Promise<void> {
+  await writeFile(join(nativeHome, 'stages', `${key}.auth.json`), JSON.stringify(fields), { mode: 0o600 });
+}
+
+const HOUR_AHEAD = new Date(Date.now() + 3_600_000).toISOString();
+
+test('a session stored by the native ai-hist login is found', async () => {
+  await withStores(async ({ nativeHome }) => {
+    // Exactly the shape `cloud::save_auth` writes: snake_case, stage-scoped.
+    await writeStage(nativeHome, 'f482e90bb4722263', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_native',
+      access_token_expires_at: HOUR_AHEAD,
+      refresh_token: 'rth_rt_native',
+      org_id: null,
+      workspace_id: null,
+    });
+    const resolved = await resolveCloudSession();
+    assert.equal(resolved.auth?.accessToken, 'rth_at_native');
+    assert.equal(resolved.auth?.baseUrl, 'https://history.agentrelay.com');
+    assert.equal(resolved.auth?.refreshToken, 'rth_rt_native');
+  });
+});
+
+test('the native store is reached through getSessionThread, not just the resolver', async () => {
+  await withStores(async ({ nativeHome }) => {
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_native',
+      access_token_expires_at: HOUR_AHEAD,
+    });
+    const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
+    // No resolveSession override: this is the production default path.
+    const thread = await getSessionThread(
+      { source: 'claude', sessionId: 'session-example' },
+      { fetchImpl: impl },
+    );
+    assert.deepEqual(thread as unknown, ENVELOPE);
+    assert.equal(calls.length, 1);
+    assert.equal(new Headers(calls[0]!.init?.headers).get('authorization'), 'Bearer rth_at_native');
+  });
+});
+
+test('the SDK store still works when the native store is empty', async () => {
+  await withStores(async ({ sdkDir }) => {
+    await writeFile(join(sdkDir, 'auth.json'), JSON.stringify({
+      baseUrl: 'https://history.agentrelay.com',
+      accessToken: 'rth_at_sdk',
+    }), { mode: 0o600 });
+    const resolved = await resolveCloudSession();
+    assert.equal(resolved.auth?.accessToken, 'rth_at_sdk');
+  });
+});
+
+test('an empty pair of stores is unconfigured and names both', async () => {
+  await withStores(async ({ nativeHome, sdkDir }) => {
+    const resolved = await resolveCloudSession();
+    assert.equal(resolved.auth, null);
+    assert.ok(resolved.auth === null && resolved.detail.includes(nativeHome));
+    assert.ok(resolved.auth === null && resolved.detail.includes(sdkDir));
+  });
+});
+
+test('two stored stages are a refusal to guess, not a coin flip', async () => {
+  await withStores(async ({ nativeHome }) => {
+    await writeStage(nativeHome, 'prod', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_prod',
+      access_token_expires_at: HOUR_AHEAD,
+    });
+    await writeStage(nativeHome, 'dev', {
+      base_url: 'http://127.0.0.1:8787',
+      access_token: 'rth_at_dev',
+      access_token_expires_at: HOUR_AHEAD,
+    });
+    const ambiguous = await resolveCloudSession();
+    assert.equal(ambiguous.auth, null);
+    assert.ok(ambiguous.auth === null && ambiguous.detail.includes('2 relayhistory stages'));
+
+    // Naming the stage selects it rather than redirecting the other one's token.
+    const picked = await resolveCloudSession('http://127.0.0.1:8787');
+    assert.equal(picked.auth?.accessToken, 'rth_at_dev');
+    const other = await resolveCloudSession('https://history.agentrelay.com');
+    assert.equal(other.auth?.accessToken, 'rth_at_prod');
+  });
+});
+
+test('a spent access token is unconfigured, and a missing expiry is not', async () => {
+  await withStores(async ({ nativeHome }) => {
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_stale',
+      access_token_expires_at: new Date(Date.now() - 1_000).toISOString(),
+    });
+    const expired = await resolveCloudSession();
+    assert.equal(expired.auth, null);
+    assert.ok(expired.auth === null && expired.detail.includes('expired'));
+  });
+
+  await withStores(async ({ nativeHome }) => {
+    // Sessions predating the expiry field carry no claim either way, and the
+    // SDK's own store has never written it. Absence must not read as expiry.
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_undated',
+    });
+    const undated = await resolveCloudSession();
+    assert.equal(undated.auth?.accessToken, 'rth_at_undated');
+  });
+});
+
+test('a malformed stage file is skipped rather than failing every read', async () => {
+  await withStores(async ({ nativeHome }) => {
+    await writeFile(join(nativeHome, 'stages', 'broken.auth.json'), '{ not json', { mode: 0o600 });
+    await writeStage(nativeHome, 'good', {
+      base_url: 'https://history.agentrelay.com',
+      access_token: 'rth_at_good',
+      access_token_expires_at: HOUR_AHEAD,
+    });
+    const resolved = await resolveCloudSession();
+    assert.equal(resolved.auth?.accessToken, 'rth_at_good');
+  });
+});
+
+test('a stage path keeps its case while scheme and host are folded', async () => {
+  await withStores(async ({ nativeHome }) => {
+    // The path is case-sensitive: lowercasing it sends the request elsewhere.
+    await writeStage(nativeHome, 'stage', {
+      base_url: 'https://History.AgentRelay.COM/Recall',
+      access_token: 'rth_at_cased',
+      access_token_expires_at: HOUR_AHEAD,
+    });
+    const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
+    await getSessionThread({ source: 'claude', sessionId: 'sid' }, { fetchImpl: impl });
+    const url = new URL(calls[0]!.url);
+    assert.equal(url.host, 'history.agentrelay.com');
+    assert.equal(url.pathname, '/Recall/v1/sessions/sid/thread');
+  });
+});
+
+test('IPv6 loopback is accepted over cleartext', async () => {
+  const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
+  const ipv6 = async (): Promise<CloudSessionResolution> => (
+    { auth: { baseUrl: 'http://[::1]:8787', accessToken: 'rth_at_test' } }
+  );
+  await getSessionThread(
+    { source: 'claude', sessionId: 'session-example' },
+    { resolveSession: ipv6, fetchImpl: impl },
+  );
+  assert.equal(calls.length, 1);
+  assert.equal(new URL(calls[0]!.url).origin, 'http://[::1]:8787');
+});
+
+test('limit is sent when given and rejected when out of the route range', async () => {
+  const { impl, calls } = recordingFetch(() => jsonResponse(ENVELOPE));
+  await getSessionThread(
+    { source: 'claude', sessionId: 'session-example', limit: 250 },
+    { resolveSession: configured, fetchImpl: impl },
+  );
+  assert.equal(new URL(calls[0]!.url).searchParams.get('limit'), '250');
+
+  for (const limit of [0, 501, 1.5]) {
+    await assert.rejects(
+      () => getSessionThread(
+        { source: 'claude', sessionId: 'session-example', limit },
+        { resolveSession: configured, fetchImpl: impl },
+      ),
+      (error: unknown) => error instanceof InvalidArgumentError
+        && error.message.includes('limit must be an integer in 1..500'),
+      `limit ${limit} is rejected`,
+    );
+  }
+  assert.equal(calls.length, 1, 'a rejected limit must not reach the transport');
+});

--- a/sdk-ts/src/session-thread.test.ts
+++ b/sdk-ts/src/session-thread.test.ts
@@ -516,7 +516,15 @@ test('the SDK store is held only to the contract it can satisfy', async () => {
 
 test('a malformed stage file is skipped rather than failing every read', async () => {
   await withStores(async ({ nativeHome }) => {
-    await writeFile(join(nativeHome, 'stages', 'broken.auth.json'), '{ not json', { mode: 0o600 });
+    // `JSON.parse` succeeds on all but the first of these, so parsing alone is
+    // not enough — reading fields off `null` would throw an unclassified
+    // TypeError out through resolveCloudSession.
+    for (const [name, body] of [
+      ['broken', '{ not json'], ['null', 'null'], ['array', '[]'],
+      ['scalar', '42'], ['string', '"nope"'],
+    ]) {
+      await writeFile(join(nativeHome, 'stages', `${name}.auth.json`), body!, { mode: 0o600 });
+    }
     await writeStage(nativeHome, 'good', {
       base_url: 'https://history.agentrelay.com',
       access_token: 'rth_at_good',


### PR DESCRIPTION
WS-3 of the Session-as-Thread wave. Registers a 14th tool on `ai-hist-mcp`:
`get_session_thread`, the **lifecycle** fan-out for one session — the commits
it shipped plus the PRs, reviews, incidents, tickets, Slack threads, hotfixes
and follow-up sessions the cloud has stitched to it. `get_session_tree` stays
the **subagent** fan-out; the two are complementary and an agent may call both.

Built on WS-1 (`CLOUD_CONNECTOR` in `crates/ai-hist/src/remote.rs`, b73a229)
and WS-2 (`GET /v1/sessions/:sessionId/thread`, relayhistory-cloud 2b263ff).
Base includes b73a229.

**Merge policy: `never`.** Terminal state is `human-review`; Khaliq owns the merge.

## What changed

| File | Change |
|---|---|
| `sdk-ts/src/mcp-server.ts` | Registers `get_session_thread`; adds a `CLOUD_READ` hint (read-only, idempotent, open-world) |
| `sdk-ts/src/cloud-client.ts` | `getSessionThread()`, reusing `loadStoredRelayhistoryAuth()` and the existing base-URL resolution |
| `sdk-ts/src/session-thread.test.ts` | New colocated test, 12 cases |
| `README.md`, `mcp-package/README.md` | Tool inventories updated |

Cloud-only and never cached, by design: a thread exists only once the cloud has
ingested lens events, and it keeps growing as PRs and incidents land. The recall
envelope is passed through **unchanged** — the service owns that shape, so a
field this SDK build does not know about survives rather than being dropped
(there is a test for exactly that).

## Acceptance

### `cd sdk-ts && npm install && npm test` green

```
1..71
# tests 71
# pass 71
# fail 0
```

The native addon has to be built first in a fresh checkout
(`cd crates/ai-hist-napi && npm ci && npm run build:debug`), otherwise 34
pre-existing native-backed tests fail with `NATIVE_PACKAGE_MISSING`. Unrelated
to this change, but it will bite the next person on a clean worktree.

### Happy path — envelope returned unchanged

`a thread envelope reaches the caller unchanged` mocks `fetch` with a synthetic
envelope carrying an `unknownFutureField` and asserts the tool's output deep-equals
the input, field for field.

### Unsupported — no network call

`an unconfigured cloud connector is unsupported and performs no network call`
asserts **`calls.length === 0`** on the recording fetch mock — the transport is
never reached, not merely that an error came back. Same assertion guards the
invalid-source and stage-mismatch paths.

The message reproduces `remote.rs::unconfigured_message` verbatim. A second test
pins it from both ends: it checks the exact rendered string *and* greps
`crates/ai-hist/src/remote.rs` for the format string it mirrors, so a Rust-side
edit to that contract fails this suite.

```
UNSUPPORTED_OPERATION: no remote provider connectors are configured: remote session thread is not available (cloud: <config-dir>: no stored relayhistory session (run `ai-hist login`))
```

### Invalid source rejected

`source: "agent-relay"` is rejected against `SOURCE_CHOICES` (`claude`, `codex`,
`cursor`, `grok`, `relay`, `trajectory`, `opencode`) at both layers — the zod
enum on the tool and `isSource()` in the SDK function. This matters: the recall
route does **not** validate `source`, it answers `200` with an empty envelope, so
rejecting it is the client's job.

### No tenancy leak

`the request carries the session identity and never a tenancy selector` asserts the
outgoing URL is `/v1/sessions/<encoded id>/thread` with `source`, `kinds`, `since`,
`cursor` and none of `org_id` / `orgId` / `workspace_id` / `workspaceId`. Tenancy is
derived from the token server-side.

## Verified from a real MCP client

Not a unit test — the official `@modelcontextprotocol/sdk` `Client` over stdio,
against `dist/mcp-server.js` (the `ai-hist-mcp` bin entry) built from this branch,
hitting the live `history.agentrelay.com`.

**`initialize` + `tools/list` — 14 tools:**

```
=== initialize ===
{ "name": "ai-hist", "version": "0.14.3" }

=== tools/list: 14 tools ===
  search_history
  recent_history
  list_sessions
  discover_sessions
  hydrate_session
  get_session
  get_session_events
  get_session_relationships
  get_session_tree
  get_session_thread
  get_session_tool_calls
  get_session_file_edits
  history_stats
  sync

get_session_thread present: true
```

**Annotations:**

```json
{ "readOnlyHint": true, "idempotentHint": true, "openWorldHint": true }
```

**`tools/call` against a real session (live data, real shipped commit):**

```
args: {"source":"claude","session_id":"6f82225f-ebb2-4f0b-bd25-bef6e55b42da"}
isError: false
{
  "session": {
    "source": "claude",
    "sessionId": "6f82225f-ebb2-4f0b-bd25-bef6e55b42da",
    "orgId": "f7a97016-3586-441e-9b2b-24b66073c915",
    "workspaceId": "50587328-441d-4acb-b8f3-dbe1b3c5de99",
    "firstEventAt": "2026-09-08T09:39:44.049Z",
    "lastEventAt": "2026-09-08T09:39:44.049Z"
  },
  "outcomes": [
    {
      "commitSha": "b5975d4f9c268d0a1bd7f8f3a77bd533ffad43d9",
      "shippedAt": "2026-09-08T10:10:26.000Z",
      "reverted": false,
      "revertedBySha": null,
      "revertedAt": null
    }
  ],
  "links": [],
  "nextCursor": null
}
```

`links` is empty because no `session_links` producer has landed yet — WS-5
(software-garden PR trailer) and WS-6 (nightcto `commitSha`) are the producers.
`outcomes` is real, so the join is exercised end to end.

**`kinds` + `since` filter:**

```
args: {"source":"claude","session_id":"6f82225f-...","kinds":["github_pr","incident"],"since":"2026-01-01T00:00:00Z"}
isError: false
{ "session": {...}, "outcomes": [ { "commitSha": "b5975d4f...", ... } ], "links": [], "nextCursor": null }
```

**Unsupported path, same client, `AI_HIST_CONFIG_DIR` pointed at an empty dir:**

```
args: {"source":"claude","session_id":"6f82225f-ebb2-4f0b-bd25-bef6e55b42da"}
isError: true
UNSUPPORTED_OPERATION: no remote provider connectors are configured: remote session thread is not available (cloud: /tmp/.../cfg-empty: no stored relayhistory session (run `ai-hist login`))
```

**Invalid source, same client:**

```
args: {"source":"agent-relay","session_id":"6f82225f-ebb2-4f0b-bd25-bef6e55b42da"}
isError: true
MCP error -32602: Input validation error: Invalid arguments for tool get_session_thread: [
  {
    "code": "invalid_value",
    "values": ["claude","codex","cursor","grok","relay","trajectory","opencode"],
    "path": ["source"],
    "message": "Invalid option: expected one of \"claude\"|\"codex\"|\"cursor\"|\"grok\"|\"relay\"|\"trajectory\"|\"opencode\""
  }
]
```

## Two things a reviewer should look at

**1. The SDK and the Rust engine read two different auth stores.** This is the
one thing I'd want a second opinion on before merge.

- `sdk-ts` `loadStoredRelayhistoryAuth()` reads `AI_HIST_CONFIG_DIR ?? ~/.config/ai-hist/auth.json` (camelCase keys).
- The Rust `cloud` connector reads `RELAYHISTORY_HOME ?? ~/.agentworkforce/relayhistory/stages/<prompt_hash(stage)>.auth.json` (snake_case keys), with refresh, expiry and multi-stage disambiguation.

So a user who ran the Rust `ai-hist login` has a live token the MCP tool cannot
see, and `get_session_thread` reports the connector unconfigured. On this machine
that is exactly the state: the `~/.config/ai-hist` token is from June and 401s,
while the stage store holds a working one. For the live capture above I pointed
`AI_HIST_CONFIG_DIR` at a temp dir holding the stage token re-keyed to the SDK schema.

I did **not** reimplement stage resolution in TypeScript. It needs `prompt_hash`,
`normalized_stage`, token refresh and the "N stages configured, refusing to guess"
rule — duplicating engine logic in the SDK is what `architecture.test.ts` exists
to prevent. The right fix is a napi export of the cloud recall transport (there is
currently none: `grep -n "cloud\|recall" crates/ai-hist-napi/src/lib.rs` is empty),
which is WS-1 territory or a follow-up. The brief pinned the seam at
`loadStoredRelayhistoryAuth()` and that is what I built; flagging it so the gap is
a decision rather than a surprise.

**2. `limit` is not exposed.** The route takes it (default 100, clamped 1–500,
per `docs/recall-api.md`). The brief's input contract lists only `source`,
`session_id`, `kinds`, `since`, `cursor`, so I stayed with those. `cursor` still
pages, so nothing is unreachable. Easy to add if wanted.

## Also worth knowing

- `kinds` is **not** validated against a fixed enum, deliberately: the route filters
  on whatever it is given (`inArray`), and new lenses add kinds. The nine known kinds
  are named in the tool description for discoverability. The route's 50-value cap is
  enforced client-side so callers get a clean error instead of a 400.
- Two guards beyond the brief, both about the bearer token: redirects are refused
  (`redirect: 'error'`) so a hop cannot collect it, and a base URL naming a different
  stage than the stored session is reported as unconfigured rather than attempted —
  the TS analogue of `cloud::load_auth`'s `same_stage` check.

## Out of scope, as specified

No new cloud endpoints (WS-2), no changes to the `cloud` connector (WS-1), no local
thread stitching, and `get_session_tree` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179dfDoCQMMio87HXHFa1oi


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch cloud auth resolution, bearer-token HTTP, and refresh-token persistence shared with the Rust CLI store; behavior is heavily tested but duplicate logic vs the engine remains a maintenance and race edge case.
> 
> **Overview**
> Adds **`get_session_thread`** as the 14th MCP tool (plus **`getSessionThread()`** in the SDK), fetching a session’s **lifecycle thread** from **`GET /v1/sessions/:sessionId/thread`**: shipped commits and cloud-linked PRs, reviews, incidents, tickets, Slack threads, hotfixes, and follow-up sessions. It complements **`get_session_tree`**’s subagent fan-out, is **cloud-only and uncached**, passes the recall envelope through unchanged, and supports optional **`kinds`**, **`since`**, **`cursor`**, and **`limit`** (1–500) without sending org/workspace tenancy params.
> 
> **`cloud-client.ts`** now resolves RelayHistory credentials from the **native `ai-hist login` store first** (`RELAYHISTORY_HOME` / staged `*.auth.json`) and the SDK’s **`~/.config/ai-hist/auth.json`**, with multi-stage selection via **`RELAYHISTORY_BASE_URL`** / **`AI_HIST_BASE_URL`**, eligibility checks aligned with the Rust **`cloud`** connector, **`UNSUPPORTED_OPERATION`** when unconfigured (no network call), secure transport rules, and **one-shot token refresh on 401** with merge-safe persistence back to the source auth file.
> 
> Docs (**`README.md`**, **`mcp-package/README.md`**, **`CHANGELOG.md`**) and a large **`session-thread.test.ts`** suite cover envelope passthrough, error contracts, credential resolution, rotation races, and MCP registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bad4fd375d07f4df52f7fca1015b0d2e2db894b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->