### PR TITLE
feat: bootstrap local history on first ai-hist invocation

### DIFF
--- a/sdk-ts/src/bootstrap-local.test.ts
+++ b/sdk-ts/src/bootstrap-local.test.ts
@@ -4,11 +4,12 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 import { bootstrapLocal, InvalidArgumentError } from './index.js';
 
 const run = promisify(execFile);
-const cli = new URL('./cli.js', import.meta.url).pathname;
+const cli = fileURLToPath(new URL('./cli.js', import.meta.url));
 const sdk = new URL('./index.js', import.meta.url).href;
 
 test('bootstrap validates its work budget before loading native code', async () => {

--- a/sdk-ts/src/bootstrap-local.test.ts
+++ b/sdk-ts/src/bootstrap-local.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import test from 'node:test';
+import { bootstrapLocal, InvalidArgumentError } from './index.js';
+
+const run = promisify(execFile);
+const cli = new URL('./cli.js', import.meta.url).pathname;
+const sdk = new URL('./index.js', import.meta.url).href;
+
+test('bootstrap validates its work budget before loading native code', async () => {
+  for (const limit of [0, -1, 1001, 1.5, NaN]) {
+    await assert.rejects(bootstrapLocal({ limit }), InvalidArgumentError);
+  }
+});
+
+test('SDK bootstrap retries an empty home, indexes native evidence, and skips a ready database', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'ai-hist-bootstrap-'));
+  const env = { ...process.env, HOME: home, USERPROFILE: home, AI_HIST_DB: join(home, 'history.db') };
+  const call = async () => JSON.parse((await run(process.execPath, ['--input-type=module', '-e',
+    `import { bootstrapLocal } from ${JSON.stringify(sdk)}; console.log(JSON.stringify(await bootstrapLocal()));`,
+  ], { env })).stdout);
+  try {
+    assert.equal((await call()).status, 'empty');
+    const folder = join(home, '.claude', 'projects', 'app');
+    await mkdir(folder, { recursive: true });
+    await writeFile(join(folder, 'first.jsonl'), JSON.stringify({
+      sessionId: 'first', uuid: 'user-first', cwd: '/work/app', type: 'user',
+      message: { role: 'user', content: 'find the bootstrap needle' }, timestamp: '2026-09-08T10:00:00Z',
+    }) + '\n');
+    const skipped = await run(process.execPath, [cli, '--no-bootstrap', '--json'], { env });
+    assert.equal(JSON.parse(skipped.stdout).sessions.length, 0);
+    const first = await call();
+    assert.equal(first.status, 'ready');
+    assert.equal(first.alreadyIndexed, false);
+    assert.equal(first.indexedPrompts, 1);
+    assert.equal(first.hydratedSessions, 1);
+    const found = await run(process.execPath, [cli, 'search', 'bootstrap needle', '--json'], { env });
+    assert.equal(JSON.parse(found.stdout)[0].session_id, 'first');
+    await rm(folder, { recursive: true });
+    const second = await run(process.execPath, [cli, '--json'], { env });
+    assert.equal(JSON.parse(second.stdout).already_indexed, true);
+    assert.equal(JSON.parse(second.stdout).discovery, null);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('bare CLI discovers and indexes on first invocation with an explicit database', async () => {
+  const home = await mkdtemp(join(tmpdir(), 'ai-hist-first-cli-'));
+  const env = { ...process.env, HOME: home, USERPROFILE: home };
+  try {
+    const folder = join(home, '.codex', 'sessions', '2026', '09', '08');
+    await mkdir(folder, { recursive: true });
+    await writeFile(join(folder, 'rollout-first.jsonl'), [
+      { timestamp: '2026-09-08T10:00:00Z', type: 'session_meta', payload: { id: 'codex-first', cwd: '/work/app' } },
+      { timestamp: '2026-09-08T10:00:01Z', type: 'event_msg', payload: { type: 'user_message', message: 'codex bootstrap needle' } },
+    ].map((row) => JSON.stringify(row)).join('\n') + '\n');
+    const db = join(home, 'custom.db');
+    const first = await run(process.execPath, [cli, '--db', db], { env });
+    assert.match(first.stdout, /Ready: 1 indexed prompt/);
+    const found = await run(process.execPath, [cli, 'search', 'bootstrap needle', '--db', db, '--json'], { env });
+    assert.equal(JSON.parse(found.stdout)[0].session_id, 'codex-first');
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -3,7 +3,7 @@
 import { readFile } from 'node:fs/promises';
 
 import {
-  discoverSessions, getSession, getSessionEventsPage, getSessionFileEditsPage,
+  bootstrapLocal, discoverSessions, getSession, getSessionEventsPage, getSessionFileEditsPage,
   getSessionRelationships, getSessionToolCallsPage, getSessionTree, hydrateSession,
   listSessionCatalogPage, recent, resumeCommand, search, stats, sync,
   type CatalogCursor, type EvidenceCursor, type HistoryEntry, type SessionFileEditsPage,
@@ -14,7 +14,7 @@ type Parsed = { positional: string[]; flags: Map<string, Array<string | true>> }
 
 type PackageMetadata = { version?: string };
 
-const BOOLEAN_FLAGS = new Set(['all', 'fts', 'json', 'local', 'no-related', 'no-warning', 'remote', 'version']);
+const BOOLEAN_FLAGS = new Set(['all', 'fts', 'json', 'local', 'no-bootstrap', 'no-related', 'no-warning', 'remote', 'version']);
 const VALUE_FLAGS = new Set([
   'after', 'after-ms', 'after-session-id', 'after-source', 'before-ms', 'db', 'limit',
   'max-depth', 'max-nodes', 'project', 'source', 'tag', 'tokens',
@@ -195,6 +195,7 @@ function output(value: unknown, json: boolean): void {
 function usage(message?: string): never {
   if (message) process.stderr.write(`ai-hist: ${message}\n\n`);
   process.stderr.write(`Usage:
+  ai-hist [--no-bootstrap] [--db PATH] [--json]
   ai-hist sessions list [--local | --remote | --all] [--source SOURCE]... [--limit N] [--before-ms MS] [--after JSON | --after-source SOURCE --after-session-id ID [--after-ms MS]] [--json]
   ai-hist sessions discover [--local | --remote | --all] [--source SOURCE] [--limit N] [--json]
   ai-hist sessions hydrate SOURCE SESSION_ID [--local | --remote | --all] [--no-related] [--db PATH] [--json]
@@ -516,6 +517,22 @@ async function main(): Promise<void> {
   const [command, subcommand, ...rest] = args.positional;
   const json = args.flags.has('json');
 
+  if (command === undefined) {
+    validateFlags(args, 'ai-hist', ['db', 'json', 'no-bootstrap']);
+    if (args.flags.has('no-bootstrap')) {
+      output(await listSessionCatalogPage({ dbPath: textFlag(args, 'db') }), json);
+      return;
+    }
+    const result = await bootstrapLocal({ dbPath: textFlag(args, 'db') });
+    if (json) output(result, true);
+    else {
+      process.stdout.write(result.indexedPrompts > 0
+        ? `Ready: ${result.indexedPrompts} indexed prompt(s). Search with: ai-hist search "your query"\n`
+        : 'No searchable local sessions found. Start a coding-agent session, then run ai-hist again.\n');
+      if (result.status === 'partial') process.stderr.write('Some local sessions could not be fully indexed; run ai-hist --json for diagnostics.\n');
+    }
+    return;
+  }
   if (command === 'sessions' && subcommand === 'list') {
     validateFlags(args, 'sessions list', [
       'after', 'after-ms', 'after-session-id', 'after-source', 'all', 'before-ms', 'db',

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -1406,6 +1406,63 @@ export async function sync(options: SyncOptions = {}): Promise<SyncResult> {
   });
 }
 
+export interface BootstrapLocalOptions {
+  dbPath?: string;
+  /** Maximum sessions to discover and index on first use. Default 20. */
+  limit?: number;
+}
+
+export interface BootstrapLocalResult {
+  status: 'ready' | 'empty' | 'partial';
+  alreadyIndexed: boolean;
+  indexedPrompts: number;
+  hydratedSessions: number;
+  discovery: DiscoverResult | null;
+  diagnostics: Array<{ source: string; sessionId: string; code: string; message: string }>;
+}
+
+/**
+ * Prepare a first local search with the native discovery and hydration APIs.
+ * Existing searchable databases are left alone; use sync() for a full refresh.
+ * Discovery is bounded and related sessions are excluded from first-touch work.
+ */
+export async function bootstrapLocal(options: BootstrapLocalOptions = {}): Promise<BootstrapLocalResult> {
+  const limit = options.limit ?? 20;
+  if (!Number.isInteger(limit) || limit < 1 || limit > 1000) {
+    throw new InvalidArgumentError('bootstrap limit must be an integer between 1 and 1000', 'INVALID_ARGUMENT');
+  }
+  const local = { dbPath: options.dbPath, scope: 'local' as const };
+  const existing = await stats(local);
+  if (existing.total > 0) {
+    return { status: 'ready', alreadyIndexed: true, indexedPrompts: existing.total,
+      hydratedSessions: 0, discovery: null, diagnostics: [] };
+  }
+  const discovery = await discoverSessions({ ...local, limit });
+  const diagnostics: BootstrapLocalResult['diagnostics'] = [];
+  let hydratedSessions = 0;
+  for (const session of discovery.sessions.slice(0, limit)) {
+    try {
+      const result = await hydrateSession({ ...local, source: session.source,
+        sessionId: session.sessionId, includeRelated: false });
+      hydratedSessions++;
+      if (result.capability !== 'full') {
+        diagnostics.push({ source: session.source, sessionId: session.sessionId,
+          code: 'CAPABILITY_LIMITED', message: `Provider exposes ${result.capability} evidence` });
+      }
+    } catch (error) {
+      if (!(error instanceof SessionSourceUnavailableError || error instanceof SessionSourceMismatchError
+        || error instanceof HydrationUnsupportedError || error instanceof HydrationFailedError)) throw error;
+      diagnostics.push({ source: session.source, sessionId: session.sessionId,
+        code: error.code, message: error.message });
+    }
+  }
+  const indexed = await stats(local);
+  const partial = diagnostics.length > 0 || discovery.diagnostics.length > 0
+    || discovery.providers.some((provider) => provider.failed);
+  return { status: partial ? 'partial' : indexed.total > 0 ? 'ready' : 'empty',
+    alreadyIndexed: false, indexedPrompts: indexed.total, hydratedSessions, discovery, diagnostics };
+}
+
 export function resumeCommand(entry: Pick<HistoryEntry, 'source' | 'sessionId' | 'project' | 'locations'>): string | null {
   if (!entry.sessionId) return null;
   if (entry.locations.length > 0 && !entry.locations.includes('local')) return null;


### PR DESCRIPTION
Bare `ai-hist` currently exits with usage on first invocation. Add the public async `bootstrapLocal()` SDK API and call it from the CLI so an empty local index discovers and hydrates up to 20 sessions before reporting search readiness.

The SDK orchestrates existing native APIs; provider parsing and indexing stay in Rust. Existing searchable indexes skip acquisition. `--no-bootstrap` offers a cache-only invocation. Empty homes can retry later, limited provider evidence is reported, and SDK callers can set a 1–1000 session budget. This bounds session count, not the size of an individual transcript; use `sync()` for a full refresh.

Validation: `npm --prefix sdk-ts run typecheck` and `npm --prefix sdk-ts test` pass (62 tests), including native-backed fresh-home, retry, ready-index, and explicit-DB tests. Tests use the published 0.14.3 native addon because the shared checkout's ignored addon was stale. A separate stacked PR adds packed-artifact clean-container timings and recordings. No merge requested (WS-11a).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

