### PR TITLE
test: verify npx first search using clean-container artifacts

### DIFF
--- a/scripts/first-search-container.mjs
+++ b/scripts/first-search-container.mjs
@@ -21,9 +21,11 @@ const frames = [{ version: 2, width: 110, height: 28, timestamp: Math.floor(Date
   title: `ai-hist ${mode}: actual clean-container execution`, env: { TERM: 'xterm-256color', SHELL: '/bin/sh' } }];
 const commands = [];
 function execute(args, expected = 0) {
-  const displayed = `npx --yes ${artifact} ${args.join(' ')}`.trim();
+  const invocation = mode === 'before' ? ['--yes', artifact, ...args]
+    : ['--yes', `--package=${artifact}`, '--', 'ai-hist', ...args];
+  const displayed = `npx ${invocation.join(' ')}`;
   frames.push([(performance.now() - start) / 1000, 'o', `$ ${displayed}\r\n`]);
-  const result = spawnSync('npx', ['--yes', artifact, ...args], { env, encoding: 'utf8', timeout: 90_000 });
+  const result = spawnSync('npx', invocation, { env, encoding: 'utf8', timeout: 90_000 });
   commands.push({ command: displayed, exitCode: result.status });
   frames.push([(performance.now() - start) / 1000, 'o', (result.stdout + result.stderr).replace(/\r?\n/g, '\r\n')]);
   assert.equal(result.status, expected, result.stderr);

--- a/scripts/first-search-container.mjs
+++ b/scripts/first-search-container.mjs
@@ -1,0 +1,52 @@
+// Invoked inside a fresh container by verify-first-search.mjs.
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { performance } from 'node:perf_hooks';
+
+const mode = process.argv[2];
+const home = '/tmp/first-search-home';
+const env = { ...process.env, HOME: home, USERPROFILE: home, AI_HIST_DB: `${home}/history.db`,
+  npm_config_cache: `${home}/.npm`, npm_config_update_notifier: 'false', RELAYHISTORY_NO_UPDATE_CHECK: '1' };
+assert.equal(existsSync(home), false, 'home, npm cache and database must start absent');
+mkdirSync(`${home}/.claude/projects/demo`, { recursive: true });
+const prompt = 'find the zero friction needle';
+writeFileSync(`${home}/.claude/projects/demo/first.jsonl`, JSON.stringify({
+  sessionId: 'first-search-fixture', uuid: 'user-1', cwd: '/work/demo', type: 'user',
+  timestamp: '2026-09-08T10:00:00Z', message: { role: 'user', content: prompt },
+}) + '\n');
+const artifact = mode === 'before' ? 'ai-hist@0.14.3' : process.env.AI_HIST_TARBALL;
+const start = performance.now();
+const frames = [{ version: 2, width: 110, height: 28, timestamp: Math.floor(Date.now() / 1000),
+  title: `ai-hist ${mode}: actual clean-container execution`, env: { TERM: 'xterm-256color', SHELL: '/bin/sh' } }];
+const commands = [];
+function execute(args, expected = 0) {
+  const displayed = `npx --yes ${artifact} ${args.join(' ')}`.trim();
+  frames.push([(performance.now() - start) / 1000, 'o', `$ ${displayed}\r\n`]);
+  const result = spawnSync('npx', ['--yes', artifact, ...args], { env, encoding: 'utf8', timeout: 90_000 });
+  commands.push({ command: displayed, exitCode: result.status });
+  frames.push([(performance.now() - start) / 1000, 'o', (result.stdout + result.stderr).replace(/\r?\n/g, '\r\n')]);
+  assert.equal(result.status, expected, result.stderr);
+  return result.stdout;
+}
+try {
+  if (mode === 'before') {
+    execute([], 2);
+    execute(['sessions', 'discover']);
+    execute(['sessions', 'hydrate', 'claude', 'first-search-fixture']);
+  } else {
+    assert.match(execute([]), /Ready: 1 indexed prompt/);
+  }
+  const results = JSON.parse(execute(['search', 'zero friction needle', '--json']));
+  assert.equal(results[0]?.session_id, 'first-search-fixture');
+  assert.equal(results[0]?.prompt, prompt);
+  const elapsedMs = Math.round(performance.now() - start);
+  const result = { mode, elapsedMs, under30Seconds: elapsedMs < 30_000, node: process.version,
+    platform: `${process.platform}-${process.arch}`, fixtureSessions: 1,
+    emptyNpmCache: true, emptyDatabase: true, commands, matchedSession: results[0].session_id };
+  writeFileSync(`/evidence/${mode}.json`, JSON.stringify(result, null, 2) + '\n');
+  console.log(JSON.stringify(result));
+  if (mode === 'after') assert.ok(result.under30Seconds, `First search took ${elapsedMs}ms (budget 30000ms)`);
+} finally {
+  writeFileSync(`/evidence/${mode}.cast`, frames.map((frame) => JSON.stringify(frame)).join('\n') + '\n');
+}

--- a/scripts/first-search-evidence.test.mjs
+++ b/scripts/first-search-evidence.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const verifier = fileURLToPath(new URL('./verify-first-search.mjs', import.meta.url));
+
+test('failed verifier attempts never share stale success evidence or overwrite prior runs', () => {
+  const root = mkdtempSync(join(tmpdir(), 'ai-hist-evidence-'));
+  try {
+    const output = join(root, 'evidence');
+    const emptyPath = join(root, 'no-commands');
+    mkdirSync(output);
+    mkdirSync(emptyPath);
+    for (const name of ['artifact.json', 'before.json', 'after.json', 'before.cast', 'after.cast']) {
+      writeFileSync(join(output, name), 'old-run');
+    }
+    const directories = [];
+    for (let attempt = 0; attempt < 2; attempt++) {
+      // Prevent the real npm/Docker commands from running. Regardless of build
+      // availability, this exercises the verifier's failed-attempt path.
+      const result = spawnSync(process.execPath, [verifier, output], {
+        env: { ...process.env, PATH: emptyPath }, encoding: 'utf8', timeout: 10_000,
+      });
+      assert.equal(result.status, 1, result.stderr);
+      const directory = result.stdout.match(/^Evidence directory: (.+)$/m)?.[1];
+      assert.ok(directory, result.stdout);
+      directories.push(directory);
+      assert.deepEqual(readdirSync(directory), [], 'failed attempts cannot inherit success results');
+      for (const name of ['artifact.json', 'before.json', 'after.json', 'before.cast', 'after.cast']) {
+        assert.equal(readFileSync(join(output, name), 'utf8'), 'old-run');
+      }
+    }
+    assert.notEqual(directories[0], directories[1]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/verify-first-search.mjs
+++ b/scripts/verify-first-search.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const evidence = resolve(process.argv[2] ?? join(root, 'tmp', 'first-search'));
-const image = process.env.AI_HIST_TEST_IMAGE ?? 'node:22-bookworm-slim';
+const image = process.env.AI_HIST_TEST_IMAGE ?? 'node:22-trixie-slim';
 const stage = mkdtempSync(join(tmpdir(), 'ai-hist-pack-'));
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, { encoding: 'utf8', ...options });

--- a/scripts/verify-first-search.mjs
+++ b/scripts/verify-first-search.mjs
@@ -8,7 +8,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const evidence = resolve(process.argv[2] ?? join(root, 'tmp', 'first-search'));
+const evidenceRoot = resolve(process.argv[2] ?? join(root, 'tmp', 'first-search'));
 const image = process.env.AI_HIST_TEST_IMAGE ?? 'node:22-trixie-slim';
 const stage = mkdtempSync(join(tmpdir(), 'ai-hist-pack-'));
 function run(command, args, options = {}) {
@@ -17,7 +17,10 @@ function run(command, args, options = {}) {
   return result.stdout;
 }
 try {
-  mkdirSync(evidence, { recursive: true });
+  mkdirSync(evidenceRoot, { recursive: true });
+  // Keep each attempt isolated, including failures and concurrent invocations.
+  const evidence = mkdtempSync(join(evidenceRoot, 'run-'));
+  process.stdout.write(`Evidence directory: ${evidence}\n`);
   const pkg = JSON.parse(readFileSync(join(root, 'sdk-ts/package.json'), 'utf8'));
   assert.equal(pkg.bin['ai-hist'], './dist/cli.js');
   pkg.dependencies['ai-hist-native'] = pkg.version;

--- a/scripts/verify-first-search.mjs
+++ b/scripts/verify-first-search.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// Exercise an npm tarball, never the source CLI or a standalone ai-hist binary.
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const evidence = resolve(process.argv[2] ?? join(root, 'tmp', 'first-search'));
+const image = process.env.AI_HIST_TEST_IMAGE ?? 'node:22-bookworm-slim';
+const stage = mkdtempSync(join(tmpdir(), 'ai-hist-pack-'));
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { encoding: 'utf8', ...options });
+  if (result.status !== 0) throw new Error(`${command} failed: ${result.error ?? result.stderr ?? result.stdout}`);
+  return result.stdout;
+}
+try {
+  mkdirSync(evidence, { recursive: true });
+  const pkg = JSON.parse(readFileSync(join(root, 'sdk-ts/package.json'), 'utf8'));
+  assert.equal(pkg.bin['ai-hist'], './dist/cli.js');
+  pkg.dependencies['ai-hist-native'] = pkg.version;
+  delete pkg.scripts.prepare;
+  writeFileSync(join(stage, 'package.json'), JSON.stringify(pkg, null, 2));
+  cpSync(join(root, 'sdk-ts/dist'), join(stage, 'dist'), { recursive: true });
+  cpSync(join(root, 'sdk-ts/README.md'), join(stage, 'README.md'));
+  const [packed] = JSON.parse(run('npm', ['pack', '--ignore-scripts', '--json'], { cwd: stage }));
+  assert.ok(packed.files.some((file) => file.path === 'dist/cli.js'));
+  assert.ok(readFileSync(join(stage, 'dist/cli.js'), 'utf8').startsWith('#!/usr/bin/env node'));
+  cpSync(join(root, 'scripts/first-search-container.mjs'), join(stage, 'verify.mjs'));
+  const digest = run('docker', ['image', 'inspect', image, '--format', '{{index .RepoDigests 0}}']).trim();
+  writeFileSync(join(evidence, 'artifact.json'), JSON.stringify({
+    version: pkg.version, integrity: packed.integrity, image: digest,
+    revision: run('git', ['rev-parse', 'HEAD'], { cwd: root }).trim(),
+    timingScope: 'Fresh container with Node/npm; empty npm cache and DB. Includes npm dependencies download, bootstrap, first search. SDK tarball mounted locally; image pull and Node installation excluded.',
+  }, null, 2) + '\n');
+  for (const mode of ['before', 'after']) {
+    process.stdout.write(run('docker', ['run', '--rm',
+      '-v', `${stage}:/artifact:ro`, '-v', `${evidence}:/evidence`,
+      '-e', `AI_HIST_TARBALL=/artifact/${packed.filename}`, image,
+      'node', '/artifact/verify.mjs', mode], { timeout: 180_000 }));
+  }
+} finally {
+  rmSync(stage, { recursive: true, force: true });
+}

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -63,7 +63,7 @@
     "build": "npm run clean && tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "npm run build && node --test dist/*.test.js ../scripts/hydration-benchmark.test.mjs",
+    "test": "npm run build && node --test dist/*.test.js ../scripts/hydration-benchmark.test.mjs ../scripts/first-search-evidence.test.mjs",
     "test:architecture": "node --test dist/architecture.test.js",
     "benchmark": "npm run build && node ../scripts/benchmark-native.mjs",
     "benchmark:hydration": "npm run build && node ../scripts/benchmark-hydration.mjs",

--- a/sdk-ts/src/bootstrap-local.test.ts
+++ b/sdk-ts/src/bootstrap-local.test.ts
@@ -4,11 +4,12 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 import { bootstrapLocal, InvalidArgumentError } from './index.js';
 
 const run = promisify(execFile);
-const cli = new URL('./cli.js', import.meta.url).pathname;
+const cli = fileURLToPath(new URL('./cli.js', import.meta.url));
 const sdk = new URL('./index.js', import.meta.url).href;
 
 test('bootstrap validates its work budget before loading native code', async () => {


### PR DESCRIPTION
Verify first touch using an npm-packed SDK artifact in fresh Docker containers, with empty HOME, DB, and npm cache. The harness checks the package's ai-hist bin and shebang, stages the exact published native dependency, records before/after asciinema output, and asserts the first search actually returns seeded provider evidence within 30 seconds.

Actual run: **5.360 seconds**, Node v22.23.2 / Debian Trixie / Linux arm64, one synthetic Claude session. Includes npm dependency downloads, bootstrap and search; excludes Node installation and image pull. The proposed SDK tarball is mounted locally. Baseline npm 0.14.3 takes 5.765 seconds with four commands (including the initial usage failure), versus two commands after. This is a smoke measurement, not a broad performance guarantee. Evidence is in the stacked README PR under docs/demos/first-search/.

Run `npm --prefix sdk-ts run build`, `docker pull node:22-trixie-slim`, then `node scripts/verify-first-search.mjs /tmp/first-search`. The unreleased bootstrap is not yet on npm latest. Initial Debian Bookworm arm64 testing exposed that published 0.14.3 requires GLIBC_2.39; the default test image is compatible Trixie and the failed baseline recording is retained.

Stacked on the bootstrap branch (WS-11b). No merge requested.

Review follow-up: each verifier attempt now prints a fresh `run-*` subdirectory under the chosen evidence path, isolating its artifact metadata and results from prior or concurrent runs. The failure-path regression test is included in `npm test`.

**Unfixed shipping defect — #119:** published `ai-hist-native-linux-arm64-gnu@0.14.3` does not load on `node:22-bookworm-slim` because it requires `GLIBC_2.39`. Reproduced again with `npx --yes ai-hist@0.14.3 sessions list --db /tmp/ai-hist-empty.db --json` in a fresh arm64 container (exit 1, `NATIVE_LOAD_FAILED`). Trixie is a benchmark-runtime workaround, not a fix to the published artifact.

Updated packed-artifact verifier rerun passed: **22.929 seconds** on Node 22/Trixie Linux x64, with results written into a new `run-t4zLui` directory. This is a separate runtime from the original arm64 measurement. The original evidence remains separate and unchanged; [rerun artifacts](https://github.com/AgentWorkforce/relayhistory/tree/docs/ai-hist-first-search/docs/demos/first-search/review-2026-09-08) are preserved in the documentation branch.
