### PR TITLE
feat: add npx first-search verification and pretty session output

### DIFF
--- a/scripts/first-search-container.mjs
+++ b/scripts/first-search-container.mjs
@@ -21,9 +21,11 @@ const frames = [{ version: 2, width: 110, height: 28, timestamp: Math.floor(Date
   title: `ai-hist ${mode}: actual clean-container execution`, env: { TERM: 'xterm-256color', SHELL: '/bin/sh' } }];
 const commands = [];
 function execute(args, expected = 0) {
-  const displayed = `npx --yes ${artifact} ${args.join(' ')}`.trim();
+  const invocation = mode === 'before' ? ['--yes', artifact, ...args]
+    : ['--yes', `--package=${artifact}`, '--', 'ai-hist', ...args];
+  const displayed = `npx ${invocation.join(' ')}`;
   frames.push([(performance.now() - start) / 1000, 'o', `$ ${displayed}\r\n`]);
-  const result = spawnSync('npx', ['--yes', artifact, ...args], { env, encoding: 'utf8', timeout: 90_000 });
+  const result = spawnSync('npx', invocation, { env, encoding: 'utf8', timeout: 90_000 });
   commands.push({ command: displayed, exitCode: result.status });
   frames.push([(performance.now() - start) / 1000, 'o', (result.stdout + result.stderr).replace(/\r?\n/g, '\r\n')]);
   assert.equal(result.status, expected, result.stderr);

--- a/scripts/first-search-container.mjs
+++ b/scripts/first-search-container.mjs
@@ -1,0 +1,52 @@
+// Invoked inside a fresh container by verify-first-search.mjs.
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { performance } from 'node:perf_hooks';
+
+const mode = process.argv[2];
+const home = '/tmp/first-search-home';
+const env = { ...process.env, HOME: home, USERPROFILE: home, AI_HIST_DB: `${home}/history.db`,
+  npm_config_cache: `${home}/.npm`, npm_config_update_notifier: 'false', RELAYHISTORY_NO_UPDATE_CHECK: '1' };
+assert.equal(existsSync(home), false, 'home, npm cache and database must start absent');
+mkdirSync(`${home}/.claude/projects/demo`, { recursive: true });
+const prompt = 'find the zero friction needle';
+writeFileSync(`${home}/.claude/projects/demo/first.jsonl`, JSON.stringify({
+  sessionId: 'first-search-fixture', uuid: 'user-1', cwd: '/work/demo', type: 'user',
+  timestamp: '2026-09-08T10:00:00Z', message: { role: 'user', content: prompt },
+}) + '\n');
+const artifact = mode === 'before' ? 'ai-hist@0.14.3' : process.env.AI_HIST_TARBALL;
+const start = performance.now();
+const frames = [{ version: 2, width: 110, height: 28, timestamp: Math.floor(Date.now() / 1000),
+  title: `ai-hist ${mode}: actual clean-container execution`, env: { TERM: 'xterm-256color', SHELL: '/bin/sh' } }];
+const commands = [];
+function execute(args, expected = 0) {
+  const displayed = `npx --yes ${artifact} ${args.join(' ')}`.trim();
+  frames.push([(performance.now() - start) / 1000, 'o', `$ ${displayed}\r\n`]);
+  const result = spawnSync('npx', ['--yes', artifact, ...args], { env, encoding: 'utf8', timeout: 90_000 });
+  commands.push({ command: displayed, exitCode: result.status });
+  frames.push([(performance.now() - start) / 1000, 'o', (result.stdout + result.stderr).replace(/\r?\n/g, '\r\n')]);
+  assert.equal(result.status, expected, result.stderr);
+  return result.stdout;
+}
+try {
+  if (mode === 'before') {
+    execute([], 2);
+    execute(['sessions', 'discover']);
+    execute(['sessions', 'hydrate', 'claude', 'first-search-fixture']);
+  } else {
+    assert.match(execute([]), /Ready: 1 indexed prompt/);
+  }
+  const results = JSON.parse(execute(['search', 'zero friction needle', '--json']));
+  assert.equal(results[0]?.session_id, 'first-search-fixture');
+  assert.equal(results[0]?.prompt, prompt);
+  const elapsedMs = Math.round(performance.now() - start);
+  const result = { mode, elapsedMs, under30Seconds: elapsedMs < 30_000, node: process.version,
+    platform: `${process.platform}-${process.arch}`, fixtureSessions: 1,
+    emptyNpmCache: true, emptyDatabase: true, commands, matchedSession: results[0].session_id };
+  writeFileSync(`/evidence/${mode}.json`, JSON.stringify(result, null, 2) + '\n');
+  console.log(JSON.stringify(result));
+  if (mode === 'after') assert.ok(result.under30Seconds, `First search took ${elapsedMs}ms (budget 30000ms)`);
+} finally {
+  writeFileSync(`/evidence/${mode}.cast`, frames.map((frame) => JSON.stringify(frame)).join('\n') + '\n');
+}

--- a/scripts/first-search-evidence.test.mjs
+++ b/scripts/first-search-evidence.test.mjs
@@ -5,8 +5,50 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
+import { resolveImage } from './first-search-image.mjs';
 
 const verifier = fileURLToPath(new URL('./verify-first-search.mjs', import.meta.url));
+
+test('locally built images without registry digests are used without pulling', () => {
+  const calls = [];
+  const identity = resolveImage((command, args) => {
+    calls.push({ command, args });
+    // Model Docker rejecting an unconditional index into empty RepoDigests.
+    assert.match(args.at(-1), /{{if \.RepoDigests}}.*{{else}}{{\.Id}}{{end}}/);
+    return 'sha256:local-image\n';
+  }, 'local-first-search:test');
+  assert.equal(identity, 'sha256:local-image');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].command, 'docker');
+  assert.deepEqual(calls[0].args.slice(0, 3), ['image', 'inspect', 'local-first-search:test']);
+});
+
+test('an absent image is pulled before retrying inspection', () => {
+  const calls = [];
+  let available = false;
+  const identity = resolveImage((command, args) => {
+    assert.equal(command, 'docker');
+    assert.equal(args.includes('node:test'), true);
+    calls.push(args[0]);
+    if (args[0] === 'pull') {
+      available = true;
+      return null;
+    }
+    if (!available) throw new Error('No such image');
+    return 'node@sha256:registry-digest\n';
+  }, 'node:test');
+  assert.equal(identity, 'node@sha256:registry-digest');
+  assert.deepEqual(calls, ['image', 'pull', 'image']);
+});
+
+test('a failed image pull aborts verification', () => {
+  const calls = [];
+  assert.throws(() => resolveImage((command, args) => {
+    calls.push(args[0]);
+    throw new Error(args[0] === 'pull' ? 'pull denied' : 'No such image');
+  }, 'missing:test'), /pull denied/);
+  assert.deepEqual(calls, ['image', 'pull']);
+});
 
 test('failed verifier attempts never share stale success evidence or overwrite prior runs', () => {
   const root = mkdtempSync(join(tmpdir(), 'ai-hist-evidence-'));

--- a/scripts/first-search-evidence.test.mjs
+++ b/scripts/first-search-evidence.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const verifier = fileURLToPath(new URL('./verify-first-search.mjs', import.meta.url));
+
+test('failed verifier attempts never share stale success evidence or overwrite prior runs', () => {
+  const root = mkdtempSync(join(tmpdir(), 'ai-hist-evidence-'));
+  try {
+    const output = join(root, 'evidence');
+    const emptyPath = join(root, 'no-commands');
+    mkdirSync(output);
+    mkdirSync(emptyPath);
+    for (const name of ['artifact.json', 'before.json', 'after.json', 'before.cast', 'after.cast']) {
+      writeFileSync(join(output, name), 'old-run');
+    }
+    const directories = [];
+    for (let attempt = 0; attempt < 2; attempt++) {
+      // Prevent the real npm/Docker commands from running. Regardless of build
+      // availability, this exercises the verifier's failed-attempt path.
+      const result = spawnSync(process.execPath, [verifier, output], {
+        env: { ...process.env, PATH: emptyPath }, encoding: 'utf8', timeout: 10_000,
+      });
+      assert.equal(result.status, 1, result.stderr);
+      const directory = result.stdout.match(/^Evidence directory: (.+)$/m)?.[1];
+      assert.ok(directory, result.stdout);
+      directories.push(directory);
+      assert.deepEqual(readdirSync(directory), [], 'failed attempts cannot inherit success results');
+      for (const name of ['artifact.json', 'before.json', 'after.json', 'before.cast', 'after.cast']) {
+        assert.equal(readFileSync(join(output, name), 'utf8'), 'old-run');
+      }
+    }
+    assert.notEqual(directories[0], directories[1]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/first-search-image.mjs
+++ b/scripts/first-search-image.mjs
@@ -1,0 +1,11 @@
+// Preserve locally built images, which may have no registry digest.
+export function resolveImage(run, image) {
+  const inspectArgs = ['image', 'inspect', image, '--format',
+    '{{if .RepoDigests}}{{index .RepoDigests 0}}{{else}}{{.Id}}{{end}}'];
+  try {
+    return run('docker', inspectArgs).trim();
+  } catch {
+    run('docker', ['pull', image], { stdio: 'inherit' });
+    return run('docker', inspectArgs).trim();
+  }
+}

--- a/scripts/verify-first-search.mjs
+++ b/scripts/verify-first-search.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from 'node:url';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const evidence = resolve(process.argv[2] ?? join(root, 'tmp', 'first-search'));
-const image = process.env.AI_HIST_TEST_IMAGE ?? 'node:22-bookworm-slim';
+const image = process.env.AI_HIST_TEST_IMAGE ?? 'node:22-trixie-slim';
 const stage = mkdtempSync(join(tmpdir(), 'ai-hist-pack-'));
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, { encoding: 'utf8', ...options });

--- a/scripts/verify-first-search.mjs
+++ b/scripts/verify-first-search.mjs
@@ -8,7 +8,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const evidence = resolve(process.argv[2] ?? join(root, 'tmp', 'first-search'));
+const evidenceRoot = resolve(process.argv[2] ?? join(root, 'tmp', 'first-search'));
 const image = process.env.AI_HIST_TEST_IMAGE ?? 'node:22-trixie-slim';
 const stage = mkdtempSync(join(tmpdir(), 'ai-hist-pack-'));
 function run(command, args, options = {}) {
@@ -17,7 +17,10 @@ function run(command, args, options = {}) {
   return result.stdout;
 }
 try {
-  mkdirSync(evidence, { recursive: true });
+  mkdirSync(evidenceRoot, { recursive: true });
+  // Keep each attempt isolated, including failures and concurrent invocations.
+  const evidence = mkdtempSync(join(evidenceRoot, 'run-'));
+  process.stdout.write(`Evidence directory: ${evidence}\n`);
   const pkg = JSON.parse(readFileSync(join(root, 'sdk-ts/package.json'), 'utf8'));
   assert.equal(pkg.bin['ai-hist'], './dist/cli.js');
   pkg.dependencies['ai-hist-native'] = pkg.version;

--- a/scripts/verify-first-search.mjs
+++ b/scripts/verify-first-search.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// Exercise an npm tarball, never the source CLI or a standalone ai-hist binary.
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const evidence = resolve(process.argv[2] ?? join(root, 'tmp', 'first-search'));
+const image = process.env.AI_HIST_TEST_IMAGE ?? 'node:22-bookworm-slim';
+const stage = mkdtempSync(join(tmpdir(), 'ai-hist-pack-'));
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { encoding: 'utf8', ...options });
+  if (result.status !== 0) throw new Error(`${command} failed: ${result.error ?? result.stderr ?? result.stdout}`);
+  return result.stdout;
+}
+try {
+  mkdirSync(evidence, { recursive: true });
+  const pkg = JSON.parse(readFileSync(join(root, 'sdk-ts/package.json'), 'utf8'));
+  assert.equal(pkg.bin['ai-hist'], './dist/cli.js');
+  pkg.dependencies['ai-hist-native'] = pkg.version;
+  delete pkg.scripts.prepare;
+  writeFileSync(join(stage, 'package.json'), JSON.stringify(pkg, null, 2));
+  cpSync(join(root, 'sdk-ts/dist'), join(stage, 'dist'), { recursive: true });
+  cpSync(join(root, 'sdk-ts/README.md'), join(stage, 'README.md'));
+  const [packed] = JSON.parse(run('npm', ['pack', '--ignore-scripts', '--json'], { cwd: stage }));
+  assert.ok(packed.files.some((file) => file.path === 'dist/cli.js'));
+  assert.ok(readFileSync(join(stage, 'dist/cli.js'), 'utf8').startsWith('#!/usr/bin/env node'));
+  cpSync(join(root, 'scripts/first-search-container.mjs'), join(stage, 'verify.mjs'));
+  const digest = run('docker', ['image', 'inspect', image, '--format', '{{index .RepoDigests 0}}']).trim();
+  writeFileSync(join(evidence, 'artifact.json'), JSON.stringify({
+    version: pkg.version, integrity: packed.integrity, image: digest,
+    revision: run('git', ['rev-parse', 'HEAD'], { cwd: root }).trim(),
+    timingScope: 'Fresh container with Node/npm; empty npm cache and DB. Includes npm dependencies download, bootstrap, first search. SDK tarball mounted locally; image pull and Node installation excluded.',
+  }, null, 2) + '\n');
+  for (const mode of ['before', 'after']) {
+    process.stdout.write(run('docker', ['run', '--rm',
+      '-v', `${stage}:/artifact:ro`, '-v', `${evidence}:/evidence`,
+      '-e', `AI_HIST_TARBALL=/artifact/${packed.filename}`, image,
+      'node', '/artifact/verify.mjs', mode], { timeout: 180_000 }));
+  }
+} finally {
+  rmSync(stage, { recursive: true, force: true });
+}

--- a/scripts/verify-first-search.mjs
+++ b/scripts/verify-first-search.mjs
@@ -6,6 +6,7 @@ import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } f
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolveImage } from './first-search-image.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const evidenceRoot = resolve(process.argv[2] ?? join(root, 'tmp', 'first-search'));
@@ -32,7 +33,7 @@ try {
   assert.ok(packed.files.some((file) => file.path === 'dist/cli.js'));
   assert.ok(readFileSync(join(stage, 'dist/cli.js'), 'utf8').startsWith('#!/usr/bin/env node'));
   cpSync(join(root, 'scripts/first-search-container.mjs'), join(stage, 'verify.mjs'));
-  const digest = run('docker', ['image', 'inspect', image, '--format', '{{index .RepoDigests 0}}']).trim();
+  const digest = resolveImage(run, image);
   writeFileSync(join(evidence, 'artifact.json'), JSON.stringify({
     version: pkg.version, integrity: packed.integrity, image: digest,
     revision: run('git', ['rev-parse', 'HEAD'], { cwd: root }).trim(),

--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -63,7 +63,7 @@
     "build": "npm run clean && tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch --preserveWatchOutput",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "npm run build && node --test dist/*.test.js ../scripts/hydration-benchmark.test.mjs",
+    "test": "npm run build && node --test dist/*.test.js ../scripts/hydration-benchmark.test.mjs ../scripts/first-search-evidence.test.mjs",
     "test:architecture": "node --test dist/architecture.test.js",
     "benchmark": "npm run build && node ../scripts/benchmark-native.mjs",
     "benchmark:hydration": "npm run build && node ../scripts/benchmark-hydration.mjs",

--- a/sdk-ts/src/bootstrap-local.test.ts
+++ b/sdk-ts/src/bootstrap-local.test.ts
@@ -41,6 +41,12 @@ test('SDK bootstrap retries an empty home, indexes native evidence, and skips a 
     assert.equal(first.hydratedSessions, 1);
     const found = await run(process.execPath, [cli, 'search', 'bootstrap needle', '--json'], { env });
     assert.equal(JSON.parse(found.stdout)[0].session_id, 'first');
+    const pretty = await run(process.execPath, [cli, 'sessions', 'list', '--pretty'], { env });
+    assert.match(pretty.stdout, /✦ \[claude\].*first.*find the bootstrap needle/);
+    assert.doesNotMatch(pretty.stdout, /\x1b/);
+    await assert.rejects(run(process.execPath, [cli, 'sessions', 'list', '--pretty', '--json'], { env }),
+      (error: unknown) => (error as { code: number; stderr: string }).code === 2
+        && (error as { stderr: string }).stderr.includes('mutually exclusive'));
     await rm(folder, { recursive: true });
     const second = await run(process.execPath, [cli, '--json'], { env });
     assert.equal(JSON.parse(second.stdout).already_indexed, true);

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -3,7 +3,7 @@
 import { readFile } from 'node:fs/promises';
 
 import {
-  bootstrapLocal, discoverSessions, getSession, getSessionEventsPage, getSessionFileEditsPage,
+  bootstrapLocal, discoverSessions, formatSessionRow, getSession, getSessionEventsPage, getSessionFileEditsPage,
   getSessionRelationships, getSessionToolCallsPage, getSessionTree, hydrateSession,
   listSessionCatalogPage, recent, resumeCommand, search, stats, sync,
   type CatalogCursor, type EvidenceCursor, type HistoryEntry, type SessionFileEditsPage,
@@ -14,7 +14,7 @@ type Parsed = { positional: string[]; flags: Map<string, Array<string | true>> }
 
 type PackageMetadata = { version?: string };
 
-const BOOLEAN_FLAGS = new Set(['all', 'fts', 'json', 'local', 'no-bootstrap', 'no-related', 'no-warning', 'remote', 'version']);
+const BOOLEAN_FLAGS = new Set(['all', 'fts', 'json', 'local', 'no-bootstrap', 'no-related', 'no-warning', 'pretty', 'remote', 'version']);
 const VALUE_FLAGS = new Set([
   'after', 'after-ms', 'after-session-id', 'after-source', 'before-ms', 'db', 'limit',
   'max-depth', 'max-nodes', 'project', 'source', 'tag', 'tokens',
@@ -196,7 +196,7 @@ function usage(message?: string): never {
   if (message) process.stderr.write(`ai-hist: ${message}\n\n`);
   process.stderr.write(`Usage:
   ai-hist [--no-bootstrap] [--db PATH] [--json]
-  ai-hist sessions list [--local | --remote | --all] [--source SOURCE]... [--limit N] [--before-ms MS] [--after JSON | --after-source SOURCE --after-session-id ID [--after-ms MS]] [--json]
+  ai-hist sessions list [--pretty] [--local | --remote | --all] [--source SOURCE]... [--limit N] [--before-ms MS] [--after JSON | --after-source SOURCE --after-session-id ID [--after-ms MS]] [--json]
   ai-hist sessions discover [--local | --remote | --all] [--source SOURCE] [--limit N] [--json]
   ai-hist sessions hydrate SOURCE SESSION_ID [--local | --remote | --all] [--no-related] [--db PATH] [--json]
   ai-hist sessions relationships SOURCE SESSION_ID [--db PATH] [--json]
@@ -536,15 +536,23 @@ async function main(): Promise<void> {
   if (command === 'sessions' && subcommand === 'list') {
     validateFlags(args, 'sessions list', [
       'after', 'after-ms', 'after-session-id', 'after-source', 'all', 'before-ms', 'db',
-      'json', 'limit', 'local', 'remote', 'source',
+      'json', 'limit', 'local', 'pretty', 'remote', 'source',
     ]);
     rejectSurplusPositionals(rest, 'sessions list');
     const sources = textFlags(args, 'source');
-    output(await listSessionCatalogPage({
+    if (json && args.flags.has('pretty')) usage('--pretty and --json are mutually exclusive');
+    const page = await listSessionCatalogPage({
       dbPath: textFlag(args, 'db'), scope: scopeFlag(args), sources: sources.length ? sources as never : undefined,
       limit: numberFlag(args, 'limit'), beforeMs: numberFlag(args, 'before-ms'),
       after: catalogCursorFlag(args),
-    }), json);
+    });
+    if (args.flags.has('pretty')) {
+      const color = Boolean(process.stdout.isTTY) && process.env.NO_COLOR === undefined;
+      process.stdout.write(page.sessions.length
+        ? `${page.sessions.map((session) => formatSessionRow(session, { color })).join('\n')}\n`
+        : 'No sessions in the catalog.\n');
+      if (page.nextCursor) process.stdout.write(`more available: --after '${JSON.stringify(page.nextCursor)}'\n`);
+    } else output(page, json);
     return;
   }
   if (command === 'sessions' && subcommand === 'discover') {

--- a/sdk-ts/src/format-session-row.test.ts
+++ b/sdk-ts/src/format-session-row.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { formatSessionRow, InvalidArgumentError, type CatalogSession } from './index.js';
+
+const session: CatalogSession = {
+  source: 'claude', sessionId: 'session-1', cwd: '/work/demo', gitBranch: null,
+  firstActivityMs: null, lastActivityMs: 0, firstPrompt: 'Fix the search', lastAssistantText: null,
+  models: [], originator: null, agentVersion: null, repoUrl: null, initialCommit: null,
+  workspaceRoots: [], rawPath: null, sourceStamp: null, discoveryState: 'shallow', fromCache: true,
+  locations: ['local'],
+};
+
+test('pretty SDK rows expose source, icon, age, identity, location and prompt', () => {
+  assert.equal(formatSessionRow(session, { nowMs: 120_000 }),
+    '✦ [claude] 2m ago [local]  session-1  /work/demo  Fix the search');
+  assert.match(formatSessionRow(session, { nowMs: 120_000, color: true }), /\x1b\[36m✦ \[claude\]\x1b\[0m/);
+  assert.doesNotMatch(formatSessionRow(session), /\x1b/);
+});
+
+test('pretty rows handle absent/future dates and untrusted multiline provider text', () => {
+  assert.match(formatSessionRow({ ...session, lastActivityMs: null }), /unknown age/);
+  assert.match(formatSessionRow({ ...session, lastActivityMs: 2000 }, { nowMs: 1000 }), /just now/);
+  const text = formatSessionRow({ ...session, firstPrompt: 'hello\n\x1b[31mthere\tfriend', cwd: '/tmp\nfolder' });
+  assert.doesNotMatch(text, /[\x00-\x1f\x7f-\x9f]/);
+  assert.match(text, /hello \[31mthere friend/);
+  assert.match(formatSessionRow({ ...session, firstPrompt: '😀😀😀' }, { maxPromptLength: 2 }), /😀😀…$/);
+  assert.throws(() => formatSessionRow(session, { maxPromptLength: 0 }), InvalidArgumentError);
+});

--- a/sdk-ts/src/format-session-row.test.ts
+++ b/sdk-ts/src/format-session-row.test.ts
@@ -26,3 +26,12 @@ test('pretty rows handle absent/future dates and untrusted multiline provider te
   assert.match(formatSessionRow({ ...session, firstPrompt: '😀😀😀' }, { maxPromptLength: 2 }), /😀😀…$/);
   assert.throws(() => formatSessionRow(session, { maxPromptLength: 0 }), InvalidArgumentError);
 });
+
+test('pretty rows reject invalid clocks and handle provider rows received at runtime', () => {
+  for (const nowMs of [NaN, Infinity, -Infinity]) {
+    assert.throws(() => formatSessionRow(session, { nowMs }), InvalidArgumentError);
+  }
+  // Remote native catalogs may include trajectory even though local discovery excludes it.
+  const remote = { ...session, source: 'trajectory', locations: ['remote'] } as unknown as CatalogSession;
+  assert.match(formatSessionRow(remote), /↗ \[trajectory\].*\[remote\]/);
+});

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -1406,6 +1406,36 @@ export async function sync(options: SyncOptions = {}): Promise<SyncResult> {
   });
 }
 
+export interface FormatSessionRowOptions {
+  /** Opt in to ANSI colour. Default false for logs and SDK consumers. */
+  color?: boolean;
+  nowMs?: number;
+  maxPromptLength?: number;
+}
+
+/** Format a catalog session for a terminal without reading providers or the DB. */
+export function formatSessionRow(session: CatalogSession, options: FormatSessionRowOptions = {}): string {
+  const max = options.maxPromptLength ?? 96;
+  if (!Number.isInteger(max) || max < 1 || max > 1000) {
+    throw new InvalidArgumentError('maxPromptLength must be an integer between 1 and 1000', 'INVALID_ARGUMENT');
+  }
+  const clean = (value: string) => value.replace(/[\u0000-\u001f\u007f-\u009f]/g, ' ').replace(/\s+/g, ' ').trim();
+  const icons: Record<CatalogSource, string> = {
+    claude: '✦', codex: '◇', cursor: '▸', grok: '◉', relay: '↔', opencode: '⌘',
+  };
+  const ageMs = session.lastActivityMs === null ? null : Math.max(0, (options.nowMs ?? Date.now()) - session.lastActivityMs);
+  const age = ageMs === null ? 'unknown age' : ageMs < 60_000 ? 'just now'
+    : ageMs < 3_600_000 ? `${Math.floor(ageMs / 60_000)}m ago`
+    : ageMs < 86_400_000 ? `${Math.floor(ageMs / 3_600_000)}h ago`
+    : `${Math.floor(ageMs / 86_400_000)}d ago`;
+  const paint = (text: string, code: number) => options.color ? `\u001b[${code}m${text}\u001b[0m` : text;
+  const prompt = Array.from(clean(session.firstPrompt ?? '(no prompt)'));
+  const preview = prompt.length > max ? `${prompt.slice(0, max).join('')}…` : prompt.join('');
+  const locations = session.locations.length ? ` [${session.locations.join(',')}]` : '';
+  return `${paint(`${icons[session.source]} [${session.source}]`, 36)} ${paint(age, 2)}${locations}  `
+    + `${clean(session.sessionId)}  ${session.cwd ? `${clean(session.cwd)}  ` : ''}${preview}`;
+}
+
 export interface BootstrapLocalOptions {
   dbPath?: string;
   /** Maximum sessions to discover and index on first use. Default 20. */

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -1415,13 +1415,16 @@ export interface FormatSessionRowOptions {
 
 /** Format a catalog session for a terminal without reading providers or the DB. */
 export function formatSessionRow(session: CatalogSession, options: FormatSessionRowOptions = {}): string {
+  if (options.nowMs !== undefined && !Number.isFinite(options.nowMs)) {
+    throw new InvalidArgumentError('nowMs must be finite', 'INVALID_ARGUMENT');
+  }
   const max = options.maxPromptLength ?? 96;
   if (!Number.isInteger(max) || max < 1 || max > 1000) {
     throw new InvalidArgumentError('maxPromptLength must be an integer between 1 and 1000', 'INVALID_ARGUMENT');
   }
   const clean = (value: string) => value.replace(/[\u0000-\u001f\u007f-\u009f]/g, ' ').replace(/\s+/g, ' ').trim();
-  const icons: Record<CatalogSource, string> = {
-    claude: '✦', codex: '◇', cursor: '▸', grok: '◉', relay: '↔', opencode: '⌘',
+  const icons: Record<Source, string> = {
+    claude: '✦', codex: '◇', cursor: '▸', grok: '◉', relay: '↔', opencode: '⌘', trajectory: '↗',
   };
   const ageMs = session.lastActivityMs === null ? null : Math.max(0, (options.nowMs ?? Date.now()) - session.lastActivityMs);
   const age = ageMs === null ? 'unknown age' : ageMs < 60_000 ? 'just now'
@@ -1432,7 +1435,7 @@ export function formatSessionRow(session: CatalogSession, options: FormatSession
   const prompt = Array.from(clean(session.firstPrompt ?? '(no prompt)'));
   const preview = prompt.length > max ? `${prompt.slice(0, max).join('')}…` : prompt.join('');
   const locations = session.locations.length ? ` [${session.locations.join(',')}]` : '';
-  return `${paint(`${icons[session.source]} [${session.source}]`, 36)} ${paint(age, 2)}${locations}  `
+  return `${paint(`${icons[session.source] ?? '•'} [${clean(session.source)}]`, 36)} ${paint(age, 2)}${locations}  `
     + `${clean(session.sessionId)}  ${session.cwd ? `${clean(session.cwd)}  ` : ''}${preview}`;
 }
 


### PR DESCRIPTION
Add clean-container verification of packed npx first search and public SDK `formatSessionRow()` with the thin `ai-hist sessions list --pretty` adapter. This PR supersedes closed #114 and contains the remaining npx and pretty work together, based directly on main after #113 merged as 3d559edf.

The container harness installs the packed candidate SDK with the published native dependency, boots a fresh home/database/npm cache with one synthetic Claude session, and verifies the first search result. Each invocation isolates its evidence directory; an SDK CI regression prevents stale results from a prior attempt being mistaken for success. The measured interval includes npm dependencies, bootstrap, and search, and excludes container image download and Node setup; the SDK tarball is mounted locally. Actual clean-container candidate runs measured 5.360 seconds on arm64 and 22.929 seconds on the review rerun on x64 using Node 22/Trixie. These are fixture measurements, not a universal fresh-machine guarantee.

Pretty rows show provider badges, relative age, session identity, location, project directory, and a bounded prompt preview. SDK ANSI color is opt-in; the CLI uses TTY detection and respects NO_COLOR. Formatter clocks must be finite, provider controls are sanitized, Unicode truncation preserves code points, and remote trajectory rows have a badge. `--pretty` and `--json` are mutually exclusive.

Known shipping defect (#119): the original published 0.14.3 arm64 artifact failed to load on `node:22-bookworm-slim` with `GLIBC_2.39 not found` / `NATIVE_LOAD_FAILED`. QA has since confirmed the issue remains in 0.15.0 and affects both x64 and arm64 on `node:22-slim`, `node:22`, Debian 12, and Ubuntu 22.04. The original reproduction was correct but under-scoped. A separate hotfix lane owns the native build correction. Trixie permits this benchmark to run; it does not fix compatibility on the affected systems.

Validation after rebasing onto origin/main:

- Before rebase: SDK suite 66 tests, 66 passed, 0 failed, 0 skipped.
- After rebase: SDK suite 66 tests, 66 passed, 0 failed, 0 skipped; TypeScript typecheck passed.
- Both runs used the same published native 0.14.3 artifact. SDK and harness trees are byte-identical before and after rebase; `git diff --check` passes.
- Bootstrap commits 21300744 and b9b786b3 were omitted because #113 squash-merged them. The duplicate file-URL fix was already upstream and dropped automatically. Seven remaining commits preserve the npx test, pretty formatting, and their review fixes.

No merge requested.

Review follow-up: image resolution now inspects locally first, falls back to the image ID when RepoDigests is empty, and pulls/retries only after inspection fails. All four verifier regression tests passed, covering local images, a cold cache, failed pulls, and evidence isolation.
