### PR TITLE
feat: expose native cloud enablement, token and replay in npm SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           ./node_modules/.bin/ai-hist sessions list --db "$SMOKE/missing.db" --json
           node --input-type=module -e 'await import("ai-hist")'
           node -e 'require("ai-hist/package.json")'
+          AI_HIST_TEST_PACKAGE_DIR="$SMOKE/node_modules/ai-hist" node --test "$GITHUB_WORKSPACE/sdk-ts/dist/cloud-commands.test.js"
 
   node-22-sdk:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "napi-build",
  "napi-derive",
  "rusqlite",
+ "serde_json",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ ai-hist sync --all                     # ingest local and remote together
 ai-hist search "auth rewrite" --all    # search both at once
 ```
 
+Optional: `ai-hist enable-cloud` authenticates and syncs your sessions to RelayHistory Cloud. Threading commits to a PR is a separate opt-in hook install. See [cloud setup, Git hooks, and sharing](docs/enable-cloud.md).
+
 Remote acquisition runs through connectors that reuse sign-ins you already have: `claude-web` lists your claude.ai/code sessions from the Claude Code CLI's stored OAuth token, and `codex-cloud` lists Codex cloud tasks through `codex cloud list --json`. With no connector configured, `--remote` fails loudly rather than silently falling back to local. See [remote connectors](docs/remote-connectors.md).
 
 A hosted layer for sharing sessions across a team — so every PR threads back to the session that produced it — is in progress at `history.agentrelay.com`; its connector is not yet wired into the npm CLI. Want early access, or to self-host it? Reach out at hello@agentrelay.com.

--- a/crates/ai-hist-core/src/outbox.rs
+++ b/crates/ai-hist-core/src/outbox.rs
@@ -319,7 +319,7 @@ pub fn build_outbox_batch(
         })?;
         for row in rows {
             let link = row?;
-            if records.len() >= MAX_RECORDS {
+            if records.len() + 2 > MAX_RECORDS {
                 break;
             }
             next.commit_link_id = next.commit_link_id.max(link.id);
@@ -334,7 +334,7 @@ pub fn build_outbox_batch(
                 link.repo.as_deref(),
                 &mut remotes,
             );
-            records.push(map_session_outcome(
+            let outcome = map_session_outcome(
                 &SessionCommitLink {
                     source: &link.source,
                     session_id: &link.session_id,
@@ -350,7 +350,22 @@ pub fn build_outbox_batch(
                 },
                 &project_id,
                 files,
-            ));
+            );
+            if let Some(task_ref) = link
+                .evidence_json
+                .as_deref()
+                .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+                .and_then(|value| value.get("github_pr").cloned())
+            {
+                let mut event = outcome.clone();
+                event.kind = "event".into();
+                event.lens = Some("github".into());
+                event.event_type = "github_pr".into();
+                event.event_id = format!("github_pr:{}", outcome.event_id);
+                event.task_ref = Some(task_ref);
+                records.push(event);
+            }
+            records.push(outcome);
         }
     }
 

--- a/crates/ai-hist-napi/Cargo.toml
+++ b/crates/ai-hist-napi/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib"]
 ai-hist-core = { path = "../ai-hist-core" }
 ai-hist-engine = { path = "../ai-hist" }
 anyhow = "1"
+serde_json = "1"
 napi = { version = "2", default-features = false, features = ["napi4", "tokio_rt"] }
 napi-derive = "2"
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -436,6 +436,20 @@ export interface CloudOptions {
   relayAccessToken?: string
   label?: string
 }
+export declare function accessToken(baseUrl?: string | undefined | null): Promise<string>
+export interface ReplayOptions {
+  baseUrl?: string
+  limit?: number
+  maxContent?: number
+  json?: boolean
+  out?: string
+}
+export interface ReplayResult {
+  eventCount: number
+  transcript?: string
+  outputPath?: string
+}
+export declare function replay(sessionId: string, options?: ReplayOptions | undefined | null): Promise<ReplayResult>
 export interface CloudAuth {
   baseUrl: string
   accessToken: string

--- a/crates/ai-hist-napi/index.d.ts
+++ b/crates/ai-hist-napi/index.d.ts
@@ -430,3 +430,27 @@ export interface SyncPushResult {
 }
 /** Cloud capture hook retained for Agent Relay integration. */
 export declare function syncAndPush(): Promise<SyncPushResult>
+export interface CloudOptions {
+  dbPath?: string
+  baseUrl?: string
+  relayAccessToken?: string
+  label?: string
+}
+export interface CloudAuth {
+  baseUrl: string
+  accessToken: string
+  refreshToken?: string
+}
+export interface CloudPushResult {
+  baseUrl: string
+  sent: number
+  accepted: number
+  syncSkipped: boolean
+}
+export declare function cloudLoadAuth(baseUrl?: string | undefined | null): Promise<CloudAuth | null>
+export declare function cloudLogin(options?: CloudOptions | undefined | null): Promise<CloudAuth>
+export declare function enableCloud(options?: CloudOptions | undefined | null): Promise<CloudPushResult>
+export declare function pushCloud(options?: CloudOptions | undefined | null): Promise<CloudPushResult>
+export declare function installGitHooks(optionsJson: string, node: string, sdkUrl: string): Promise<string>
+export declare function linkGitCommit(optionsJson: string): Promise<string>
+export declare function createShareableTrace(sessionId: string, visibility: string, source?: string | undefined | null, baseUrl?: string | undefined | null): Promise<string>

--- a/crates/ai-hist-napi/index.js
+++ b/crates/ai-hist-napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { nativeContractVersion, nativeBuildProfile, search, recent, getSession, getSessionEventsPage, getSessionToolCallsPage, getSessionFileEditsPage, stats, listSessionCatalogPage, listSessionCatalog, discoverSessions, hydrateSession, getSessionRelationships, getSessionTree, getSessionChildrenPage, sync, syncLocal, syncAndPush, cloudLoadAuth, cloudLogin, enableCloud, pushCloud, installGitHooks, linkGitCommit, createShareableTrace } = nativeBinding
+const { nativeContractVersion, nativeBuildProfile, search, recent, getSession, getSessionEventsPage, getSessionToolCallsPage, getSessionFileEditsPage, stats, listSessionCatalogPage, listSessionCatalog, discoverSessions, hydrateSession, getSessionRelationships, getSessionTree, getSessionChildrenPage, sync, syncLocal, syncAndPush, accessToken, replay, cloudLoadAuth, cloudLogin, enableCloud, pushCloud, installGitHooks, linkGitCommit, createShareableTrace } = nativeBinding
 
 module.exports.nativeContractVersion = nativeContractVersion
 module.exports.nativeBuildProfile = nativeBuildProfile
@@ -331,6 +331,8 @@ module.exports.getSessionChildrenPage = getSessionChildrenPage
 module.exports.sync = sync
 module.exports.syncLocal = syncLocal
 module.exports.syncAndPush = syncAndPush
+module.exports.accessToken = accessToken
+module.exports.replay = replay
 module.exports.cloudLoadAuth = cloudLoadAuth
 module.exports.cloudLogin = cloudLogin
 module.exports.enableCloud = enableCloud

--- a/crates/ai-hist-napi/index.js
+++ b/crates/ai-hist-napi/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { nativeContractVersion, nativeBuildProfile, search, recent, getSession, getSessionEventsPage, getSessionToolCallsPage, getSessionFileEditsPage, stats, listSessionCatalogPage, listSessionCatalog, discoverSessions, hydrateSession, getSessionRelationships, getSessionTree, getSessionChildrenPage, sync, syncLocal, syncAndPush } = nativeBinding
+const { nativeContractVersion, nativeBuildProfile, search, recent, getSession, getSessionEventsPage, getSessionToolCallsPage, getSessionFileEditsPage, stats, listSessionCatalogPage, listSessionCatalog, discoverSessions, hydrateSession, getSessionRelationships, getSessionTree, getSessionChildrenPage, sync, syncLocal, syncAndPush, cloudLoadAuth, cloudLogin, enableCloud, pushCloud, installGitHooks, linkGitCommit, createShareableTrace } = nativeBinding
 
 module.exports.nativeContractVersion = nativeContractVersion
 module.exports.nativeBuildProfile = nativeBuildProfile
@@ -331,3 +331,10 @@ module.exports.getSessionChildrenPage = getSessionChildrenPage
 module.exports.sync = sync
 module.exports.syncLocal = syncLocal
 module.exports.syncAndPush = syncAndPush
+module.exports.cloudLoadAuth = cloudLoadAuth
+module.exports.cloudLogin = cloudLogin
+module.exports.enableCloud = enableCloud
+module.exports.pushCloud = pushCloud
+module.exports.installGitHooks = installGitHooks
+module.exports.linkGitCommit = linkGitCommit
+module.exports.createShareableTrace = createShareableTrace

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -31,7 +31,7 @@ use ai_hist_core::{
 use napi_derive::napi;
 
 /// Bump whenever native object shapes or semantics require an SDK change.
-pub const NATIVE_CONTRACT_VERSION: u32 = 8;
+pub const NATIVE_CONTRACT_VERSION: u32 = 9;
 const DEFAULT_LIMIT: i64 = 50;
 const DEFAULT_EVENT_LIMIT: i64 = 200;
 
@@ -1576,6 +1576,61 @@ pub struct CloudOptions {
     pub base_url: Option<String>,
     pub relay_access_token: Option<String>,
     pub label: Option<String>,
+}
+
+#[napi]
+pub async fn access_token(base_url: Option<String>) -> napi::Result<String> {
+    napi::tokio::task::spawn_blocking(move || {
+        ai_hist_engine::cloud::access_token(base_url.as_deref())
+    })
+    .await
+    .map_err(worker_error)?
+    // access_token deliberately sanitizes refresh/parser errors. Preserve that
+    // boundary; do not attach the auth state or a server response to this error.
+    .map_err(|error| native_error("CLOUD_TOKEN_FAILED", format!("{error:#}")))
+}
+
+#[napi(object)]
+#[derive(Default)]
+pub struct ReplayOptions {
+    pub base_url: Option<String>,
+    pub limit: Option<u32>,
+    pub max_content: Option<u32>,
+    pub json: Option<bool>,
+    pub out: Option<String>,
+}
+
+#[napi(object)]
+pub struct ReplayResult {
+    pub event_count: i64,
+    pub transcript: Option<String>,
+    pub output_path: Option<String>,
+}
+
+#[napi]
+pub async fn replay(
+    session_id: String,
+    options: Option<ReplayOptions>,
+) -> napi::Result<ReplayResult> {
+    let options = options.unwrap_or_default();
+    napi::tokio::task::spawn_blocking(move || {
+        ai_hist_engine::replay::replay(
+            &session_id,
+            options.base_url.as_deref(),
+            options.limit.map(|n| n as usize),
+            options.max_content.map(|n| n as usize),
+            options.json.unwrap_or(false),
+            options.out.as_deref().map(std::path::Path::new),
+        )
+    })
+    .await
+    .map_err(worker_error)?
+    .map(|result| ReplayResult {
+        event_count: result.event_count as i64,
+        transcript: result.transcript,
+        output_path: result.output_path,
+    })
+    .map_err(|error| native_error("CLOUD_REPLAY_FAILED", format!("{error:#}")))
 }
 
 #[napi(object)]

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -31,7 +31,7 @@ use ai_hist_core::{
 use napi_derive::napi;
 
 /// Bump whenever native object shapes or semantics require an SDK change.
-pub const NATIVE_CONTRACT_VERSION: u32 = 7;
+pub const NATIVE_CONTRACT_VERSION: u32 = 8;
 const DEFAULT_LIMIT: i64 = 50;
 const DEFAULT_EVENT_LIMIT: i64 = 200;
 
@@ -1567,4 +1567,71 @@ pub async fn sync_and_push() -> napi::Result<SyncPushResult> {
         authenticated: outcome.authenticated,
         sync_skipped: outcome.sync_skipped,
     })
+}
+
+#[napi(object)]
+#[derive(Default)]
+pub struct CloudOptions {
+    pub db_path: Option<String>,
+    pub base_url: Option<String>,
+    pub relay_access_token: Option<String>,
+    pub label: Option<String>,
+}
+
+#[napi(object)]
+pub struct CloudAuth {
+    pub base_url: String,
+    pub access_token: String,
+    pub refresh_token: Option<String>,
+}
+
+impl From<ai_hist_engine::cloud::StoredAuth> for CloudAuth {
+    fn from(auth: ai_hist_engine::cloud::StoredAuth) -> Self {
+        Self { base_url: auth.base_url, access_token: auth.access_token, refresh_token: auth.refresh_token }
+    }
+}
+
+#[napi(object)]
+pub struct CloudPushResult {
+    pub base_url: String,
+    pub sent: i64,
+    pub accepted: i64,
+    pub sync_skipped: bool,
+}
+
+impl From<ai_hist_engine::cloud::CloudPushOutcome> for CloudPushResult {
+    fn from(outcome: ai_hist_engine::cloud::CloudPushOutcome) -> Self {
+        Self { base_url: outcome.base_url, sent: outcome.sent as i64, accepted: outcome.accepted as i64, sync_skipped: outcome.sync_skipped }
+    }
+}
+
+#[napi]
+pub async fn cloud_load_auth(base_url: Option<String>) -> napi::Result<Option<CloudAuth>> {
+    napi::tokio::task::spawn_blocking(move || ai_hist_engine::cloud::load_sdk_auth(base_url.as_deref()))
+        .await.map_err(worker_error)?.map(|auth| auth.map(Into::into))
+        .map_err(|error| native_error("CLOUD_AUTH_FAILED", format!("{error:#}")))
+}
+
+#[napi]
+pub async fn cloud_login(options: Option<CloudOptions>) -> napi::Result<CloudAuth> {
+    let options = options.unwrap_or_default();
+    napi::tokio::task::spawn_blocking(move || ai_hist_engine::cloud::login_for_sdk(options.base_url.as_deref(), options.relay_access_token.as_deref(), options.label.as_deref()))
+        .await.map_err(worker_error)?.map(Into::into)
+        .map_err(|error| native_error("CLOUD_LOGIN_FAILED", format!("{error:#}")))
+}
+
+#[napi]
+pub async fn enable_cloud(options: Option<CloudOptions>) -> napi::Result<CloudPushResult> {
+    let options = options.unwrap_or_default();
+    napi::tokio::task::spawn_blocking(move || ai_hist_engine::cloud::enable_for_sdk(&db_path(options.db_path), options.base_url.as_deref(), options.relay_access_token.as_deref(), options.label.as_deref()))
+        .await.map_err(worker_error)?.map(Into::into)
+        .map_err(|error| native_error("CLOUD_ENABLE_FAILED", format!("{error:#}")))
+}
+
+#[napi]
+pub async fn push_cloud(options: Option<CloudOptions>) -> napi::Result<CloudPushResult> {
+    let options = options.unwrap_or_default();
+    napi::tokio::task::spawn_blocking(move || ai_hist_engine::cloud::push_for_sdk(&db_path(options.db_path), options.base_url.as_deref()))
+        .await.map_err(worker_error)?.map(Into::into)
+        .map_err(|error| native_error("CLOUD_PUSH_FAILED", format!("{error:#}")))
 }

--- a/crates/ai-hist-napi/src/lib.rs
+++ b/crates/ai-hist-napi/src/lib.rs
@@ -1587,7 +1587,11 @@ pub struct CloudAuth {
 
 impl From<ai_hist_engine::cloud::StoredAuth> for CloudAuth {
     fn from(auth: ai_hist_engine::cloud::StoredAuth) -> Self {
-        Self { base_url: auth.base_url, access_token: auth.access_token, refresh_token: auth.refresh_token }
+        Self {
+            base_url: auth.base_url,
+            access_token: auth.access_token,
+            refresh_token: auth.refresh_token,
+        }
     }
 }
 
@@ -1601,37 +1605,114 @@ pub struct CloudPushResult {
 
 impl From<ai_hist_engine::cloud::CloudPushOutcome> for CloudPushResult {
     fn from(outcome: ai_hist_engine::cloud::CloudPushOutcome) -> Self {
-        Self { base_url: outcome.base_url, sent: outcome.sent as i64, accepted: outcome.accepted as i64, sync_skipped: outcome.sync_skipped }
+        Self {
+            base_url: outcome.base_url,
+            sent: outcome.sent as i64,
+            accepted: outcome.accepted as i64,
+            sync_skipped: outcome.sync_skipped,
+        }
     }
 }
 
 #[napi]
 pub async fn cloud_load_auth(base_url: Option<String>) -> napi::Result<Option<CloudAuth>> {
-    napi::tokio::task::spawn_blocking(move || ai_hist_engine::cloud::load_sdk_auth(base_url.as_deref()))
-        .await.map_err(worker_error)?.map(|auth| auth.map(Into::into))
-        .map_err(|error| native_error("CLOUD_AUTH_FAILED", format!("{error:#}")))
+    napi::tokio::task::spawn_blocking(move || {
+        ai_hist_engine::cloud::load_sdk_auth(base_url.as_deref())
+    })
+    .await
+    .map_err(worker_error)?
+    .map(|auth| auth.map(Into::into))
+    .map_err(|error| native_error("CLOUD_AUTH_FAILED", format!("{error:#}")))
 }
 
 #[napi]
 pub async fn cloud_login(options: Option<CloudOptions>) -> napi::Result<CloudAuth> {
     let options = options.unwrap_or_default();
-    napi::tokio::task::spawn_blocking(move || ai_hist_engine::cloud::login_for_sdk(options.base_url.as_deref(), options.relay_access_token.as_deref(), options.label.as_deref()))
-        .await.map_err(worker_error)?.map(Into::into)
-        .map_err(|error| native_error("CLOUD_LOGIN_FAILED", format!("{error:#}")))
+    napi::tokio::task::spawn_blocking(move || {
+        ai_hist_engine::cloud::login_for_sdk(
+            options.base_url.as_deref(),
+            options.relay_access_token.as_deref(),
+            options.label.as_deref(),
+        )
+    })
+    .await
+    .map_err(worker_error)?
+    .map(Into::into)
+    .map_err(|error| native_error("CLOUD_LOGIN_FAILED", format!("{error:#}")))
 }
 
 #[napi]
 pub async fn enable_cloud(options: Option<CloudOptions>) -> napi::Result<CloudPushResult> {
     let options = options.unwrap_or_default();
-    napi::tokio::task::spawn_blocking(move || ai_hist_engine::cloud::enable_for_sdk(&db_path(options.db_path), options.base_url.as_deref(), options.relay_access_token.as_deref(), options.label.as_deref()))
-        .await.map_err(worker_error)?.map(Into::into)
-        .map_err(|error| native_error("CLOUD_ENABLE_FAILED", format!("{error:#}")))
+    napi::tokio::task::spawn_blocking(move || {
+        ai_hist_engine::cloud::enable_for_sdk(
+            &db_path(options.db_path),
+            options.base_url.as_deref(),
+            options.relay_access_token.as_deref(),
+            options.label.as_deref(),
+        )
+    })
+    .await
+    .map_err(worker_error)?
+    .map(Into::into)
+    .map_err(|error| native_error("CLOUD_ENABLE_FAILED", format!("{error:#}")))
 }
 
 #[napi]
 pub async fn push_cloud(options: Option<CloudOptions>) -> napi::Result<CloudPushResult> {
     let options = options.unwrap_or_default();
-    napi::tokio::task::spawn_blocking(move || ai_hist_engine::cloud::push_for_sdk(&db_path(options.db_path), options.base_url.as_deref()))
-        .await.map_err(worker_error)?.map(Into::into)
-        .map_err(|error| native_error("CLOUD_PUSH_FAILED", format!("{error:#}")))
+    napi::tokio::task::spawn_blocking(move || {
+        ai_hist_engine::cloud::push_for_sdk(&db_path(options.db_path), options.base_url.as_deref())
+    })
+    .await
+    .map_err(worker_error)?
+    .map(Into::into)
+    .map_err(|error| native_error("CLOUD_PUSH_FAILED", format!("{error:#}")))
+}
+
+#[napi]
+pub async fn install_git_hooks(
+    options_json: String,
+    node: String,
+    sdk_url: String,
+) -> napi::Result<String> {
+    napi::tokio::task::spawn_blocking(move || {
+        let options = serde_json::from_str(&options_json)?;
+        ai_hist_engine::git_sdk::install(options, &node, &sdk_url)
+    })
+    .await
+    .map_err(worker_error)?
+    .map_err(|error: anyhow::Error| native_error("GIT_HOOK_FAILED", format!("{error:#}")))
+}
+
+#[napi]
+pub async fn link_git_commit(options_json: String) -> napi::Result<String> {
+    napi::tokio::task::spawn_blocking(move || {
+        let options = serde_json::from_str(&options_json)?;
+        ai_hist_engine::git_sdk::link(options)
+    })
+    .await
+    .map_err(worker_error)?
+    .map_err(|error: anyhow::Error| native_error("GIT_LINK_FAILED", format!("{error:#}")))
+}
+
+#[napi]
+pub async fn create_shareable_trace(
+    session_id: String,
+    visibility: String,
+    source: Option<String>,
+    base_url: Option<String>,
+) -> napi::Result<String> {
+    napi::tokio::task::spawn_blocking(move || {
+        ai_hist_engine::cloud::create_share(
+            &session_id,
+            &visibility,
+            source.as_deref(),
+            base_url.as_deref(),
+        )
+        .map(|value| value.to_string())
+    })
+    .await
+    .map_err(worker_error)?
+    .map_err(|error| native_error("CLOUD_SHARE_FAILED", format!("{error:#}")))
 }

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -294,6 +294,16 @@ pub fn load_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
     }
 }
 
+/// Replace parser errors before they surface: a serde_json failure can quote the
+/// credential values it choked on, and this command's output is a secret.
+fn sanitize_auth_error(error: anyhow::Error) -> anyhow::Error {
+    if error.chain().any(|cause| cause.is::<serde_json::Error>()) {
+        anyhow::anyhow!("could not parse stored relayhistory session; run `ai-hist login`")
+    } else {
+        error
+    }
+}
+
 /// Return an access token with at least 60 seconds of recorded validity remaining.
 /// Unknown legacy expiry is refreshed too: an opaque token cannot prove its own lifetime.
 pub fn access_token(base_url: Option<&str>) -> Result<String> {
@@ -302,24 +312,23 @@ pub fn access_token(base_url: Option<&str>) -> Result<String> {
         .into_iter()
         .filter_map(|key| std::env::var(key).ok())
         .find_map(|value| normalize_base_url(&value));
-    // Keep push's ambiguity error even though the fallback destination is production.
-    // JSON type errors can quote credential values from a malformed auth file.
-    // Use the SDK loader, not load_auth: npm users upgrading from the TypeScript
-    // client have credentials only in ~/.config/ai-hist/auth.json. token is one of
-    // the two commands this exists to deliver, so it must migrate that store the
-    // same way enableCloud, pushCloud, loadStoredRelayhistoryAuth and shares do.
-    let load = |base: Option<&str>| {
-        load_sdk_auth(base).map_err(|error| {
-            if error.chain().any(|cause| cause.is::<serde_json::Error>()) {
-                anyhow::anyhow!("could not parse stored relayhistory session; run `ai-hist login`")
-            } else {
-                error
-            }
-        })
-    };
+    // Resolve the destination with the SDK loader, not load_auth: npm users
+    // upgrading from the TypeScript client have credentials only in
+    // ~/.config/ai-hist/auth.json. token is one of the two commands this exists
+    // to deliver, so it must migrate that store the same way enableCloud,
+    // pushCloud, loadStoredRelayhistoryAuth and shares do.
+    let load = |base: Option<&str>| load_sdk_auth(base).map_err(sanitize_auth_error);
     let selected = explicit_base.or(env_base);
     if selected.is_none() {
-        load(None)?;
+        // Keep push's ambiguity error even though the fallback destination is
+        // production. This probe must use load_auth: load_sdk_auth counts ANY
+        // non-empty RELAYHISTORY_BASE_URL/AI_HIST_BASE_URL as a stage selection
+        // and falls back to production, whereas a selection here means a value
+        // that actually normalizes. Routing the probe through it would let a
+        // malformed selector skip the multi-stage refusal and print another
+        // stage's credential. Migration is irrelevant to a probe that only asks
+        // whether the destination is ambiguous.
+        load_auth(None).map_err(sanitize_auth_error)?;
     }
     let base = selected.unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
     let mut auth = load(Some(&base))?

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -304,8 +304,12 @@ pub fn access_token(base_url: Option<&str>) -> Result<String> {
         .find_map(|value| normalize_base_url(&value));
     // Keep push's ambiguity error even though the fallback destination is production.
     // JSON type errors can quote credential values from a malformed auth file.
+    // Use the SDK loader, not load_auth: npm users upgrading from the TypeScript
+    // client have credentials only in ~/.config/ai-hist/auth.json. token is one of
+    // the two commands this exists to deliver, so it must migrate that store the
+    // same way enableCloud, pushCloud, loadStoredRelayhistoryAuth and shares do.
     let load = |base: Option<&str>| {
-        load_auth(base).map_err(|error| {
+        load_sdk_auth(base).map_err(|error| {
             if error.chain().any(|cause| cause.is::<serde_json::Error>()) {
                 anyhow::anyhow!("could not parse stored relayhistory session; run `ai-hist login`")
             } else {

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -324,9 +324,18 @@ fn env_selected_stage() -> Result<Option<String>> {
 /// value and returns production, and load_sdk_auth cannot tell a synthesized origin
 /// from a deliberate one.
 pub fn resolve_base_url(base_url: Option<&str>) -> Result<String> {
+    Ok(resolve_stage(base_url)?.unwrap_or_else(|| DEFAULT_BASE_URL.to_string()))
+}
+
+/// The selected stage, preserving the difference between "no selection" and
+/// "production". Callers that must end up somewhere use resolve_base_url; callers
+/// that pass the result to load_auth/load_sdk_auth must use this, because turning
+/// an absent selection into production suppresses the multi-stage refusal — the
+/// caller would silently read production instead of being told to choose.
+pub fn resolve_stage(base_url: Option<&str>) -> Result<Option<String>> {
     match base_url {
-        Some(explicit) => Ok(explicit.to_string()),
-        None => Ok(env_selected_stage()?.unwrap_or_else(|| DEFAULT_BASE_URL.to_string())),
+        Some(explicit) => Ok(Some(explicit.to_string())),
+        None => env_selected_stage(),
     }
 }
 
@@ -1980,7 +1989,11 @@ pub fn login_for_sdk(
     token: Option<&str>,
     label: Option<&str>,
 ) -> Result<StoredAuth> {
-    let base = base_url.map(str::to_owned).unwrap_or_else(default_base_url);
+    // resolve_base_url, not default_base_url: the latter ignores a malformed
+    // RELAYHISTORY_BASE_URL/AI_HIST_BASE_URL and returns production, so a typo
+    // would authenticate against prod. Login must end up somewhere, so an unset
+    // environment still takes the default — only a malformed one is an error.
+    let base = resolve_base_url(base_url)?;
     let base = normalized_stage(&base)?;
     let label = label.unwrap_or("ai-hist enable-cloud");
     let auth = match token {

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -3752,15 +3752,32 @@ exit 0"#,
 /// no credential exists for that destination. Never let a stale SDK token replace
 /// a refreshed Rust token, and retain load_auth's refusal to guess between stages.
 pub fn load_sdk_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
+    let env_base = ["RELAYHISTORY_BASE_URL", "AI_HIST_BASE_URL"]
+        .iter()
+        .any(|key| {
+            std::env::var(key)
+                .ok()
+                .is_some_and(|v| !v.trim().is_empty())
+        })
+        .then(default_base_url);
+    let base_url = base_url.or(env_base.as_deref());
     if let Some(auth) = load_auth(base_url)? {
         return Ok(Some(auth));
     }
-    let legacy = std::env::var_os("AI_HIST_CONFIG_DIR").map(PathBuf::from)
+    let legacy = std::env::var_os("AI_HIST_CONFIG_DIR")
+        .map(PathBuf::from)
         .unwrap_or_else(|| {
-            PathBuf::from(std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE")).unwrap_or_default())
-                .join(".config/ai-hist")
-        }).join("auth.json");
-    if !legacy.exists() { return Ok(None); }
+            PathBuf::from(
+                std::env::var_os("HOME")
+                    .or_else(|| std::env::var_os("USERPROFILE"))
+                    .unwrap_or_default(),
+            )
+            .join(".config/ai-hist")
+        })
+        .join("auth.json");
+    if !legacy.exists() {
+        return Ok(None);
+    }
     let auth = read_auth(&legacy)?;
     if base_url.is_some_and(|base| !same_stage(base, &auth.base_url)) {
         return Ok(None);
@@ -3772,7 +3789,11 @@ pub fn load_sdk_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
 
 /// Exchange a caller-supplied Cloud bearer or run the existing Cloud device login.
 /// Both SDK and CLI persist credentials exclusively through the Rust stage store.
-pub fn login_for_sdk(base_url: Option<&str>, token: Option<&str>, label: Option<&str>) -> Result<StoredAuth> {
+pub fn login_for_sdk(
+    base_url: Option<&str>,
+    token: Option<&str>,
+    label: Option<&str>,
+) -> Result<StoredAuth> {
     let base = base_url.map(str::to_owned).unwrap_or_else(default_base_url);
     let base = normalized_stage(&base)?;
     let label = label.unwrap_or("ai-hist enable-cloud");
@@ -3780,7 +3801,10 @@ pub fn login_for_sdk(base_url: Option<&str>, token: Option<&str>, label: Option<
         Some(token) => login(&base, token, label, Some("sync"))?,
         None => login_via_cloud(&base, "sync", None, label)?,
     };
-    anyhow::ensure!(auth.access_token.starts_with("rth_at_"), "cloud login did not return a service-local access token");
+    anyhow::ensure!(
+        auth.access_token.starts_with("rth_at_"),
+        "cloud login did not return a service-local access token"
+    );
     save_auth(&auth)?;
     Ok(auth)
 }
@@ -3796,25 +3820,47 @@ pub struct CloudPushOutcome {
 /// cursor from local maxima: only push's server-confirmed progress may advance it.
 pub fn push_for_sdk(db_path: &std::path::Path, base_url: Option<&str>) -> Result<CloudPushOutcome> {
     let auth = load_sdk_auth(base_url)?.context("cloud is not enabled; call enableCloud first")?;
+    crate::SYNC_QUIET.store(true, crate::AtomicOrdering::Relaxed);
     let (conn, sync_skipped) = crate::prepare_sync_and_push_db(db_path)?;
     let machine = MachineIdentity {
-        id: machine_id()?, hostname: machine_hostname(),
+        id: machine_id()?,
+        hostname: machine_hostname(),
         os: Some(std::env::consts::OS.to_string()),
         cli_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         ..Default::default()
     };
-    let mut outcome = CloudPushOutcome { base_url: auth.base_url.clone(), sent: 0, accepted: 0, sync_skipped };
+    let mut outcome = CloudPushOutcome {
+        base_url: auth.base_url.clone(),
+        sent: 0,
+        accepted: 0,
+        sync_skipped,
+    };
     loop {
         let cursor = load_cursor(&auth.base_url)?;
-        let report = push(&conn, &UreqIngestor, &auth, &machine, &cursor, 500, &HashSet::new())?;
+        let report = push(
+            &conn,
+            &UreqIngestor,
+            &auth,
+            &machine,
+            &cursor,
+            500,
+            &HashSet::new(),
+        )?;
         outcome.sent += report.sent as u64;
         outcome.accepted += report.accepted;
-        if report.cursor == cursor { break; }
+        if report.cursor == cursor {
+            break;
+        }
     }
     Ok(outcome)
 }
 
-pub fn enable_for_sdk(db_path: &std::path::Path, base_url: Option<&str>, token: Option<&str>, label: Option<&str>) -> Result<CloudPushOutcome> {
+pub fn enable_for_sdk(
+    db_path: &std::path::Path,
+    base_url: Option<&str>,
+    token: Option<&str>,
+    label: Option<&str>,
+) -> Result<CloudPushOutcome> {
     // Explicit tokens request reauthentication; otherwise reuse stage credentials.
     let auth = if token.is_some() {
         login_for_sdk(base_url, token, label)?
@@ -3825,4 +3871,50 @@ pub fn enable_for_sdk(db_path: &std::path::Path, base_url: Option<&str>, token: 
         }
     };
     push_for_sdk(db_path, Some(&auth.base_url))
+}
+
+/// Create a frozen share with the existing refresh-capable transport.
+pub fn create_share(
+    session_id: &str,
+    visibility: &str,
+    source: Option<&str>,
+    base_url: Option<&str>,
+) -> Result<serde_json::Value> {
+    anyhow::ensure!(!session_id.trim().is_empty(), "sessionId must not be empty");
+    anyhow::ensure!(
+        ["public", "private", "direct-link"].contains(&visibility),
+        "visibility must be public, private or direct-link"
+    );
+    let auth = load_sdk_auth(base_url)?.context("cloud is not enabled; call enableCloud first")?;
+    require_secure_transport(&auth.base_url)?;
+    let url = format!(
+        "{}/v1/sessions/{}/shares",
+        normalized_stage(&auth.base_url)?,
+        encode_path_segment(session_id)
+    );
+    let response = send_with_auth_refresh(
+        &auth,
+        |current| {
+            ureq::post(&url)
+                .set("Authorization", &format!("Bearer {}", current.access_token))
+                .timeout(std::time::Duration::from_secs(30))
+                .send_json({
+                    let mut body = serde_json::json!({ "visibility": visibility });
+                    if let Some(source) = source {
+                        body["source"] = serde_json::json!(source);
+                    }
+                    body
+                })
+                .map_err(Box::new)
+        },
+        map_http_err,
+    )?;
+    let value: serde_json::Value = response.into_json()?;
+    let share_url = field(&value, "url")?;
+    let parsed = Url::parse(&share_url)?;
+    anyhow::ensure!(
+        parsed.origin() == Url::parse(&auth.base_url)?.origin() && parsed.path().starts_with("/s/"),
+        "server returned an unexpected share URL"
+    );
+    Ok(value)
 }

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -294,6 +294,27 @@ pub fn load_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
     }
 }
 
+/// The stage selected by the environment, if any. A non-empty value that does not
+/// normalize is a mistake rather than a request for production: reject it, because
+/// default_base_url() would silently substitute the production origin. Never echo
+/// the value — normalize_base_url rejects URLs carrying embedded credentials, so a
+/// rejected value is exactly the kind that may hold one.
+///
+/// access_token and load_sdk_auth must share this: when they disagreed about what
+/// counts as a selection, a malformed selector silently meant production.
+fn env_selected_stage() -> Result<Option<String>> {
+    match ["RELAYHISTORY_BASE_URL", "AI_HIST_BASE_URL"]
+        .into_iter()
+        .filter_map(|key| std::env::var(key).ok().map(|value| (key, value)))
+        .find(|(_, value)| !value.trim().is_empty())
+    {
+        Some((key, value)) => Ok(Some(normalize_base_url(&value).with_context(|| {
+            format!("{key} is not a usable base URL; unset it or set a full https:// origin")
+        })?)),
+        None => Ok(None),
+    }
+}
+
 /// Replace parser errors before they surface: a serde_json failure can quote the
 /// credential values it choked on, and this command's output is a secret.
 fn sanitize_auth_error(error: anyhow::Error) -> anyhow::Error {
@@ -308,10 +329,12 @@ fn sanitize_auth_error(error: anyhow::Error) -> anyhow::Error {
 /// Unknown legacy expiry is refreshed too: an opaque token cannot prove its own lifetime.
 pub fn access_token(base_url: Option<&str>) -> Result<String> {
     let explicit_base = base_url.map(normalized_stage).transpose()?;
-    let env_base = ["RELAYHISTORY_BASE_URL", "AI_HIST_BASE_URL"]
-        .into_iter()
-        .filter_map(|key| std::env::var(key).ok())
-        .find_map(|value| normalize_base_url(&value));
+    // An explicit destination wins outright; the environment is not consulted, so
+    // a broken variable cannot block a caller who already chose a stage.
+    let env_base = match explicit_base {
+        Some(_) => None,
+        None => env_selected_stage()?,
+    };
     // Resolve the destination with the SDK loader, not load_auth: npm users
     // upgrading from the TypeScript client have credentials only in
     // ~/.config/ai-hist/auth.json. token is one of the two commands this exists
@@ -1900,21 +1923,13 @@ fn humanize_secs(secs: u64) -> String {
 /// no credential exists for that destination. Never let a stale SDK token replace
 /// a refreshed Rust token, and retain load_auth's refusal to guess between stages.
 pub fn load_sdk_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
-    // A non-empty selector that does not normalize is a mistake, not a request for
-    // production. default_base_url() swallows malformed values and returns the
-    // production origin, so treating "set" as "selected" would silently retarget
-    // the caller's stage — reading, and for enable/push writing, against prod.
-    // Never echo the value: normalize_base_url rejects embedded credentials, so a
-    // rejected value is exactly the kind that may carry them.
-    let env_base = match ["RELAYHISTORY_BASE_URL", "AI_HIST_BASE_URL"]
-        .into_iter()
-        .filter_map(|key| std::env::var(key).ok().map(|value| (key, value)))
-        .find(|(_, value)| !value.trim().is_empty())
-    {
-        Some((key, value)) => Some(normalize_base_url(&value).with_context(|| {
-            format!("{key} is not a usable base URL; unset it or set a full https:// origin")
-        })?),
-        None => None,
+    // An explicit destination wins outright, so a malformed variable must not
+    // block a caller who already chose a stage. Only when nothing was passed does
+    // the environment decide, and then a malformed value is an error rather than a
+    // silent fallback to production.
+    let env_base = match base_url {
+        Some(_) => None,
+        None => env_selected_stage()?,
     };
     let base_url = base_url.or(env_base.as_deref());
     if let Some(auth) = load_auth(base_url)? {

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -1883,6 +1883,177 @@ fn humanize_secs(secs: u64) -> String {
     }
 }
 
+/// Read the canonical stage store, importing the old TypeScript store only when
+/// no credential exists for that destination. Never let a stale SDK token replace
+/// a refreshed Rust token, and retain load_auth's refusal to guess between stages.
+pub fn load_sdk_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
+    let env_base = ["RELAYHISTORY_BASE_URL", "AI_HIST_BASE_URL"]
+        .iter()
+        .any(|key| {
+            std::env::var(key)
+                .ok()
+                .is_some_and(|v| !v.trim().is_empty())
+        })
+        .then(default_base_url);
+    let base_url = base_url.or(env_base.as_deref());
+    if let Some(auth) = load_auth(base_url)? {
+        return Ok(Some(auth));
+    }
+    let legacy = std::env::var_os("AI_HIST_CONFIG_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(
+                std::env::var_os("HOME")
+                    .or_else(|| std::env::var_os("USERPROFILE"))
+                    .unwrap_or_default(),
+            )
+            .join(".config/ai-hist")
+        })
+        .join("auth.json");
+    if !legacy.exists() {
+        return Ok(None);
+    }
+    let auth = read_auth(&legacy)?;
+    if base_url.is_some_and(|base| !same_stage(base, &auth.base_url)) {
+        return Ok(None);
+    }
+    require_secure_transport(&auth.base_url)?;
+    save_auth(&auth)?;
+    Ok(Some(auth))
+}
+
+/// Exchange a caller-supplied Cloud bearer or run the existing Cloud device login.
+/// Both SDK and CLI persist credentials exclusively through the Rust stage store.
+pub fn login_for_sdk(
+    base_url: Option<&str>,
+    token: Option<&str>,
+    label: Option<&str>,
+) -> Result<StoredAuth> {
+    let base = base_url.map(str::to_owned).unwrap_or_else(default_base_url);
+    let base = normalized_stage(&base)?;
+    let label = label.unwrap_or("ai-hist enable-cloud");
+    let auth = match token {
+        Some(token) => login(&base, token, label, Some("sync"))?,
+        None => login_via_cloud(&base, "sync", None, label)?,
+    };
+    anyhow::ensure!(
+        auth.access_token.starts_with("rth_at_"),
+        "cloud login did not return a service-local access token"
+    );
+    save_auth(&auth)?;
+    Ok(auth)
+}
+
+pub struct CloudPushOutcome {
+    pub base_url: String,
+    pub sent: u64,
+    pub accepted: u64,
+    pub sync_skipped: bool,
+}
+
+/// Drain the existing outbox at the selected stage. Login never initializes a
+/// cursor from local maxima: only push's server-confirmed progress may advance it.
+pub fn push_for_sdk(db_path: &std::path::Path, base_url: Option<&str>) -> Result<CloudPushOutcome> {
+    let auth = load_sdk_auth(base_url)?.context("cloud is not enabled; call enableCloud first")?;
+    crate::SYNC_QUIET.store(true, crate::AtomicOrdering::Relaxed);
+    let (conn, sync_skipped) = crate::prepare_sync_and_push_db(db_path)?;
+    let machine = MachineIdentity {
+        id: machine_id()?,
+        hostname: machine_hostname(),
+        os: Some(std::env::consts::OS.to_string()),
+        cli_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        ..Default::default()
+    };
+    let mut outcome = CloudPushOutcome {
+        base_url: auth.base_url.clone(),
+        sent: 0,
+        accepted: 0,
+        sync_skipped,
+    };
+    loop {
+        let cursor = load_cursor(&auth.base_url)?;
+        let report = push(
+            &conn,
+            &UreqIngestor,
+            &auth,
+            &machine,
+            &cursor,
+            500,
+            &HashSet::new(),
+        )?;
+        outcome.sent += report.sent as u64;
+        outcome.accepted += report.accepted;
+        if report.cursor == cursor {
+            break;
+        }
+    }
+    Ok(outcome)
+}
+
+pub fn enable_for_sdk(
+    db_path: &std::path::Path,
+    base_url: Option<&str>,
+    token: Option<&str>,
+    label: Option<&str>,
+) -> Result<CloudPushOutcome> {
+    // Explicit tokens request reauthentication; otherwise reuse stage credentials.
+    let auth = if token.is_some() {
+        login_for_sdk(base_url, token, label)?
+    } else {
+        match load_sdk_auth(base_url)? {
+            Some(auth) => auth,
+            None => login_for_sdk(base_url, None, label)?,
+        }
+    };
+    push_for_sdk(db_path, Some(&auth.base_url))
+}
+
+/// Create a frozen share with the existing refresh-capable transport.
+pub fn create_share(
+    session_id: &str,
+    visibility: &str,
+    source: Option<&str>,
+    base_url: Option<&str>,
+) -> Result<serde_json::Value> {
+    anyhow::ensure!(!session_id.trim().is_empty(), "sessionId must not be empty");
+    anyhow::ensure!(
+        ["public", "private", "direct-link"].contains(&visibility),
+        "visibility must be public, private or direct-link"
+    );
+    let auth = load_sdk_auth(base_url)?.context("cloud is not enabled; call enableCloud first")?;
+    require_secure_transport(&auth.base_url)?;
+    let url = format!(
+        "{}/v1/sessions/{}/shares",
+        normalized_stage(&auth.base_url)?,
+        encode_path_segment(session_id)
+    );
+    let response = send_with_auth_refresh(
+        &auth,
+        |current| {
+            ureq::post(&url)
+                .set("Authorization", &format!("Bearer {}", current.access_token))
+                .timeout(std::time::Duration::from_secs(30))
+                .send_json({
+                    let mut body = serde_json::json!({ "visibility": visibility });
+                    if let Some(source) = source {
+                        body["source"] = serde_json::json!(source);
+                    }
+                    body
+                })
+                .map_err(Box::new)
+        },
+        map_http_err,
+    )?;
+    let value: serde_json::Value = response.into_json()?;
+    let share_url = field(&value, "url")?;
+    let parsed = Url::parse(&share_url)?;
+    anyhow::ensure!(
+        parsed.origin() == Url::parse(&auth.base_url)?.origin() && parsed.path().starts_with("/s/"),
+        "server returned an unexpected share URL"
+    );
+    Ok(value)
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
@@ -3746,175 +3917,4 @@ exit 0"#,
         assert_eq!(encode_path_segment("a?b=c"), "a%3Fb%3Dc");
         assert_eq!(encode_path_segment("a b"), "a%20b");
     }
-}
-
-/// Read the canonical stage store, importing the old TypeScript store only when
-/// no credential exists for that destination. Never let a stale SDK token replace
-/// a refreshed Rust token, and retain load_auth's refusal to guess between stages.
-pub fn load_sdk_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
-    let env_base = ["RELAYHISTORY_BASE_URL", "AI_HIST_BASE_URL"]
-        .iter()
-        .any(|key| {
-            std::env::var(key)
-                .ok()
-                .is_some_and(|v| !v.trim().is_empty())
-        })
-        .then(default_base_url);
-    let base_url = base_url.or(env_base.as_deref());
-    if let Some(auth) = load_auth(base_url)? {
-        return Ok(Some(auth));
-    }
-    let legacy = std::env::var_os("AI_HIST_CONFIG_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            PathBuf::from(
-                std::env::var_os("HOME")
-                    .or_else(|| std::env::var_os("USERPROFILE"))
-                    .unwrap_or_default(),
-            )
-            .join(".config/ai-hist")
-        })
-        .join("auth.json");
-    if !legacy.exists() {
-        return Ok(None);
-    }
-    let auth = read_auth(&legacy)?;
-    if base_url.is_some_and(|base| !same_stage(base, &auth.base_url)) {
-        return Ok(None);
-    }
-    require_secure_transport(&auth.base_url)?;
-    save_auth(&auth)?;
-    Ok(Some(auth))
-}
-
-/// Exchange a caller-supplied Cloud bearer or run the existing Cloud device login.
-/// Both SDK and CLI persist credentials exclusively through the Rust stage store.
-pub fn login_for_sdk(
-    base_url: Option<&str>,
-    token: Option<&str>,
-    label: Option<&str>,
-) -> Result<StoredAuth> {
-    let base = base_url.map(str::to_owned).unwrap_or_else(default_base_url);
-    let base = normalized_stage(&base)?;
-    let label = label.unwrap_or("ai-hist enable-cloud");
-    let auth = match token {
-        Some(token) => login(&base, token, label, Some("sync"))?,
-        None => login_via_cloud(&base, "sync", None, label)?,
-    };
-    anyhow::ensure!(
-        auth.access_token.starts_with("rth_at_"),
-        "cloud login did not return a service-local access token"
-    );
-    save_auth(&auth)?;
-    Ok(auth)
-}
-
-pub struct CloudPushOutcome {
-    pub base_url: String,
-    pub sent: u64,
-    pub accepted: u64,
-    pub sync_skipped: bool,
-}
-
-/// Drain the existing outbox at the selected stage. Login never initializes a
-/// cursor from local maxima: only push's server-confirmed progress may advance it.
-pub fn push_for_sdk(db_path: &std::path::Path, base_url: Option<&str>) -> Result<CloudPushOutcome> {
-    let auth = load_sdk_auth(base_url)?.context("cloud is not enabled; call enableCloud first")?;
-    crate::SYNC_QUIET.store(true, crate::AtomicOrdering::Relaxed);
-    let (conn, sync_skipped) = crate::prepare_sync_and_push_db(db_path)?;
-    let machine = MachineIdentity {
-        id: machine_id()?,
-        hostname: machine_hostname(),
-        os: Some(std::env::consts::OS.to_string()),
-        cli_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-        ..Default::default()
-    };
-    let mut outcome = CloudPushOutcome {
-        base_url: auth.base_url.clone(),
-        sent: 0,
-        accepted: 0,
-        sync_skipped,
-    };
-    loop {
-        let cursor = load_cursor(&auth.base_url)?;
-        let report = push(
-            &conn,
-            &UreqIngestor,
-            &auth,
-            &machine,
-            &cursor,
-            500,
-            &HashSet::new(),
-        )?;
-        outcome.sent += report.sent as u64;
-        outcome.accepted += report.accepted;
-        if report.cursor == cursor {
-            break;
-        }
-    }
-    Ok(outcome)
-}
-
-pub fn enable_for_sdk(
-    db_path: &std::path::Path,
-    base_url: Option<&str>,
-    token: Option<&str>,
-    label: Option<&str>,
-) -> Result<CloudPushOutcome> {
-    // Explicit tokens request reauthentication; otherwise reuse stage credentials.
-    let auth = if token.is_some() {
-        login_for_sdk(base_url, token, label)?
-    } else {
-        match load_sdk_auth(base_url)? {
-            Some(auth) => auth,
-            None => login_for_sdk(base_url, None, label)?,
-        }
-    };
-    push_for_sdk(db_path, Some(&auth.base_url))
-}
-
-/// Create a frozen share with the existing refresh-capable transport.
-pub fn create_share(
-    session_id: &str,
-    visibility: &str,
-    source: Option<&str>,
-    base_url: Option<&str>,
-) -> Result<serde_json::Value> {
-    anyhow::ensure!(!session_id.trim().is_empty(), "sessionId must not be empty");
-    anyhow::ensure!(
-        ["public", "private", "direct-link"].contains(&visibility),
-        "visibility must be public, private or direct-link"
-    );
-    let auth = load_sdk_auth(base_url)?.context("cloud is not enabled; call enableCloud first")?;
-    require_secure_transport(&auth.base_url)?;
-    let url = format!(
-        "{}/v1/sessions/{}/shares",
-        normalized_stage(&auth.base_url)?,
-        encode_path_segment(session_id)
-    );
-    let response = send_with_auth_refresh(
-        &auth,
-        |current| {
-            ureq::post(&url)
-                .set("Authorization", &format!("Bearer {}", current.access_token))
-                .timeout(std::time::Duration::from_secs(30))
-                .send_json({
-                    let mut body = serde_json::json!({ "visibility": visibility });
-                    if let Some(source) = source {
-                        body["source"] = serde_json::json!(source);
-                    }
-                    body
-                })
-                .map_err(Box::new)
-        },
-        map_http_err,
-    )?;
-    let value: serde_json::Value = response.into_json()?;
-    let share_url = field(&value, "url")?;
-    let parsed = Url::parse(&share_url)?;
-    anyhow::ensure!(
-        parsed.origin() == Url::parse(&auth.base_url)?.origin() && parsed.path().starts_with("/s/"),
-        "server returned an unexpected share URL"
-    );
-    Ok(value)
 }

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -315,6 +315,21 @@ fn env_selected_stage() -> Result<Option<String>> {
     }
 }
 
+/// Resolve a concrete destination for a caller that needs one up front. An explicit
+/// value wins; otherwise a malformed environment selector is an error rather than a
+/// silent production fallback, and an unset environment takes the default.
+///
+/// Callers that synthesize a destination with default_base_url() and then pass it as
+/// though the user chose it lose that check: default_base_url() swallows a malformed
+/// value and returns production, and load_sdk_auth cannot tell a synthesized origin
+/// from a deliberate one.
+pub fn resolve_base_url(base_url: Option<&str>) -> Result<String> {
+    match base_url {
+        Some(explicit) => Ok(explicit.to_string()),
+        None => Ok(env_selected_stage()?.unwrap_or_else(|| DEFAULT_BASE_URL.to_string())),
+    }
+}
+
 /// Replace parser errors before they surface: a serde_json failure can quote the
 /// credential values it choked on, and this command's output is a secret.
 fn sanitize_auth_error(error: anyhow::Error) -> anyhow::Error {

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -31,13 +31,16 @@ const DEFAULT_BASE_URL: &str = "https://history.agentrelay.com";
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct StoredAuth {
     /// Base URL of the relayhistory-cloud service, e.g. `http://localhost:8787`.
+    #[serde(alias = "baseUrl")]
     pub base_url: String,
+    #[serde(alias = "accessToken")]
     pub access_token: String,
     /// Server-issued expiry (RFC 3339). Legacy sessions without this remain
     /// usable by push, but cannot advertise recall availability until login/refresh.
     #[serde(default, alias = "accessTokenExpiresAt")]
     pub access_token_expires_at: Option<String>,
     #[serde(default)]
+    #[serde(alias = "refreshToken")]
     pub refresh_token: Option<String>,
     /// Local cache only — never authoritative; the server owns tenancy from the token.
     #[serde(default)]
@@ -3743,4 +3746,83 @@ exit 0"#,
         assert_eq!(encode_path_segment("a?b=c"), "a%3Fb%3Dc");
         assert_eq!(encode_path_segment("a b"), "a%20b");
     }
+}
+
+/// Read the canonical stage store, importing the old TypeScript store only when
+/// no credential exists for that destination. Never let a stale SDK token replace
+/// a refreshed Rust token, and retain load_auth's refusal to guess between stages.
+pub fn load_sdk_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
+    if let Some(auth) = load_auth(base_url)? {
+        return Ok(Some(auth));
+    }
+    let legacy = std::env::var_os("AI_HIST_CONFIG_DIR").map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE")).unwrap_or_default())
+                .join(".config/ai-hist")
+        }).join("auth.json");
+    if !legacy.exists() { return Ok(None); }
+    let auth = read_auth(&legacy)?;
+    if base_url.is_some_and(|base| !same_stage(base, &auth.base_url)) {
+        return Ok(None);
+    }
+    require_secure_transport(&auth.base_url)?;
+    save_auth(&auth)?;
+    Ok(Some(auth))
+}
+
+/// Exchange a caller-supplied Cloud bearer or run the existing Cloud device login.
+/// Both SDK and CLI persist credentials exclusively through the Rust stage store.
+pub fn login_for_sdk(base_url: Option<&str>, token: Option<&str>, label: Option<&str>) -> Result<StoredAuth> {
+    let base = base_url.map(str::to_owned).unwrap_or_else(default_base_url);
+    let base = normalized_stage(&base)?;
+    let label = label.unwrap_or("ai-hist enable-cloud");
+    let auth = match token {
+        Some(token) => login(&base, token, label, Some("sync"))?,
+        None => login_via_cloud(&base, "sync", None, label)?,
+    };
+    anyhow::ensure!(auth.access_token.starts_with("rth_at_"), "cloud login did not return a service-local access token");
+    save_auth(&auth)?;
+    Ok(auth)
+}
+
+pub struct CloudPushOutcome {
+    pub base_url: String,
+    pub sent: u64,
+    pub accepted: u64,
+    pub sync_skipped: bool,
+}
+
+/// Drain the existing outbox at the selected stage. Login never initializes a
+/// cursor from local maxima: only push's server-confirmed progress may advance it.
+pub fn push_for_sdk(db_path: &std::path::Path, base_url: Option<&str>) -> Result<CloudPushOutcome> {
+    let auth = load_sdk_auth(base_url)?.context("cloud is not enabled; call enableCloud first")?;
+    let (conn, sync_skipped) = crate::prepare_sync_and_push_db(db_path)?;
+    let machine = MachineIdentity {
+        id: machine_id()?, hostname: machine_hostname(),
+        os: Some(std::env::consts::OS.to_string()),
+        cli_version: Some(env!("CARGO_PKG_VERSION").to_string()),
+        ..Default::default()
+    };
+    let mut outcome = CloudPushOutcome { base_url: auth.base_url.clone(), sent: 0, accepted: 0, sync_skipped };
+    loop {
+        let cursor = load_cursor(&auth.base_url)?;
+        let report = push(&conn, &UreqIngestor, &auth, &machine, &cursor, 500, &HashSet::new())?;
+        outcome.sent += report.sent as u64;
+        outcome.accepted += report.accepted;
+        if report.cursor == cursor { break; }
+    }
+    Ok(outcome)
+}
+
+pub fn enable_for_sdk(db_path: &std::path::Path, base_url: Option<&str>, token: Option<&str>, label: Option<&str>) -> Result<CloudPushOutcome> {
+    // Explicit tokens request reauthentication; otherwise reuse stage credentials.
+    let auth = if token.is_some() {
+        login_for_sdk(base_url, token, label)?
+    } else {
+        match load_sdk_auth(base_url)? {
+            Some(auth) => auth,
+            None => login_for_sdk(base_url, None, label)?,
+        }
+    };
+    push_for_sdk(db_path, Some(&auth.base_url))
 }

--- a/crates/ai-hist/src/cloud.rs
+++ b/crates/ai-hist/src/cloud.rs
@@ -1900,14 +1900,22 @@ fn humanize_secs(secs: u64) -> String {
 /// no credential exists for that destination. Never let a stale SDK token replace
 /// a refreshed Rust token, and retain load_auth's refusal to guess between stages.
 pub fn load_sdk_auth(base_url: Option<&str>) -> Result<Option<StoredAuth>> {
-    let env_base = ["RELAYHISTORY_BASE_URL", "AI_HIST_BASE_URL"]
-        .iter()
-        .any(|key| {
-            std::env::var(key)
-                .ok()
-                .is_some_and(|v| !v.trim().is_empty())
-        })
-        .then(default_base_url);
+    // A non-empty selector that does not normalize is a mistake, not a request for
+    // production. default_base_url() swallows malformed values and returns the
+    // production origin, so treating "set" as "selected" would silently retarget
+    // the caller's stage — reading, and for enable/push writing, against prod.
+    // Never echo the value: normalize_base_url rejects embedded credentials, so a
+    // rejected value is exactly the kind that may carry them.
+    let env_base = match ["RELAYHISTORY_BASE_URL", "AI_HIST_BASE_URL"]
+        .into_iter()
+        .filter_map(|key| std::env::var(key).ok().map(|value| (key, value)))
+        .find(|(_, value)| !value.trim().is_empty())
+    {
+        Some((key, value)) => Some(normalize_base_url(&value).with_context(|| {
+            format!("{key} is not a usable base URL; unset it or set a full https:// origin")
+        })?),
+        None => None,
+    };
     let base_url = base_url.or(env_base.as_deref());
     if let Some(auth) = load_auth(base_url)? {
         return Ok(Some(auth));

--- a/crates/ai-hist/src/git_sdk.rs
+++ b/crates/ai-hist/src/git_sdk.rs
@@ -84,25 +84,27 @@ pub fn install(mut options: GitLinkOptions, node: &str, sdk_url: &str) -> Result
         serde_json::to_string(&options)?
     );
     fs::write(&script, body)?;
-    let existing = fs::read_to_string(&hook).unwrap_or_else(|_| "#!/bin/sh\n".into());
     let marker = "# ai-hist SDK hook";
-    if !existing.contains(marker) {
-        // Do not reinterpret a non-shell hook by appending shell syntax to it.
+    let backup = hook.with_file_name("post-commit.before-ai-hist");
+    let existing = fs::read_to_string(&hook).unwrap_or_default();
+    if !existing.is_empty() && !existing.contains(marker) {
         anyhow::ensure!(
-            existing.starts_with("#!/bin/sh")
-                || existing.starts_with("#!/bin/bash")
-                || existing.starts_with("#!/usr/bin/env bash"),
-            "post-commit is not a shell hook; refusing to modify it"
+            !backup.exists(),
+            "hook backup already exists; refusing to overwrite it"
         );
-        fs::write(
-            &hook,
-            format!(
-                "{existing}\n{marker}\n{} {} || echo 'ai-hist: commit linkage failed' >&2\n",
-                sh_single_quote(node),
-                sh_single_quote(&script.display().to_string())
-            ),
-        )?;
+        fs::rename(&hook, &backup)?;
     }
+    // Wrap the original instead of appending after a possible `exit 0`. Retain
+    // its interpreter and exit code, and record our link even if it exits early.
+    let previous = if backup.exists() {
+        format!(
+            "{} \"$@\"\nprevious_status=$?\n",
+            sh_single_quote(&backup.display().to_string())
+        )
+    } else {
+        "previous_status=0\n".to_string()
+    };
+    fs::write(&hook, format!("#!/bin/sh\n{marker}\n{previous}{} {} || echo 'ai-hist: commit linkage failed' >&2\nexit \"$previous_status\"\n", sh_single_quote(node), sh_single_quote(&script.display().to_string())))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;

--- a/crates/ai-hist/src/git_sdk.rs
+++ b/crates/ai-hist/src/git_sdk.rs
@@ -127,19 +127,27 @@ pub fn install(mut options: GitLinkOptions, node: &str, sdk_url: &str) -> Result
     // Resolve before comparing: an unresolved `..` can satisfy the lexical
     // containment check while `create_dir_all` lands outside the repository.
     let resolved_parent = resolve_against_existing(hook_parent)?;
-    anyhow::ensure!(resolved_parent.starts_with(&common),
+    // Repository-local hook directories are legitimate: husky and friends live
+    // in the work tree, not under .git. Only a directory belonging to neither
+    // this repository's common dir nor its work tree is another repo's business.
+    let worktree = root.canonicalize()?;
+    let shared_hooks = resolved_parent.starts_with(&common);
+    anyhow::ensure!(shared_hooks || resolved_parent.starts_with(&worktree),
         "Git uses an external shared core.hooksPath; refusing to change another repository's hooks. Configure a repository-local hooks directory first");
-    // Linked worktrees share the common dir's hooks, but this hook embeds one
-    // fixed sessionId and repo. Installing from a worktree would attribute every
-    // other worktree's commits to this session, so refuse instead of corrupting
-    // the linkage we exist to record.
-    let git_dir = git_stdout(&root, &["rev-parse", "--git-dir"])?;
-    let git_dir = root.join(git_dir.trim()).canonicalize()?;
-    anyhow::ensure!(
-        git_dir == common,
-        "this is a linked Git worktree and its hooks are shared with the main worktree; \
-         install from the main worktree instead"
-    );
+    // Hooks under the common dir are shared by every linked worktree, but this
+    // hook embeds one fixed sessionId and repo. Installing from a worktree would
+    // attribute every other worktree's commits to this session, so refuse rather
+    // than corrupt the linkage we exist to record. A work-tree-local hooks
+    // directory is per-worktree and stays allowed.
+    if shared_hooks {
+        let git_dir = git_stdout(&root, &["rev-parse", "--git-dir"])?;
+        let git_dir = root.join(git_dir.trim()).canonicalize()?;
+        anyhow::ensure!(
+            git_dir == common,
+            "this is a linked Git worktree and its hooks are shared with the main worktree; \
+             install from the main worktree, or set a worktree-local core.hooksPath first"
+        );
+    }
     let script = hook.with_file_name("ai-hist-post-commit.mjs");
     fs::create_dir_all(hook.parent().context("missing hook parent")?)?;
     let body = format!(

--- a/crates/ai-hist/src/git_sdk.rs
+++ b/crates/ai-hist/src/git_sdk.rs
@@ -32,7 +32,9 @@ fn pr_ref(raw: &str) -> Result<String> {
             && url.fragment().is_none()
             && segments.len() == 4
             && segments[2] == "pull"
-            && segments[3].parse::<u64>().is_ok_and(|n| n > 0)
+            && segments[3]
+                .parse::<u64>()
+                .is_ok_and(|n| n > 0 && n.to_string() == segments[3])
             && segments[..2].iter().all(|s| !s.is_empty()
                 && s.chars()
                     .all(|c| c.is_ascii_alphanumeric() || "_.-".contains(c))),
@@ -72,10 +74,40 @@ pub fn install(mut options: GitLinkOptions, node: &str, sdk_url: &str) -> Result
     options.repo = root.display().to_string();
     options.db_path = fs::canonicalize(&options.db_path)?.display().to_string();
     options.source = Some(resolve_source(&options)?);
+    if options.pr_url.is_none() {
+        // Resolve an existing PR once at install time. The post-commit path is
+        // deliberately offline. A repository override also works without gh.
+        options.pr_url = git_stdout(&root, &["config", "--get", "ai-hist.pr-url"])
+            .ok()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        if options.pr_url.is_none() {
+            options.pr_url = std::process::Command::new("gh")
+                .current_dir(&root)
+                .env("GH_PROMPT_DISABLED", "1")
+                .args(["pr", "view", "--json", "url", "--jq", ".url"])
+                .output()
+                .ok()
+                .filter(|out| out.status.success())
+                .and_then(|out| String::from_utf8(out.stdout).ok())
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty());
+        }
+    }
     if let Some(url) = &options.pr_url {
         pr_ref(url)?;
     }
     let hook = git_path(&root, "hooks/post-commit")?;
+    let common = git_stdout(&root, &["rev-parse", "--git-common-dir"])?;
+    let common = root.join(common.trim()).canonicalize()?;
+    let hook_parent = hook.parent().context("missing hook parent")?;
+    let resolved_parent = if hook_parent.exists() {
+        hook_parent.canonicalize()?
+    } else {
+        hook_parent.to_path_buf()
+    };
+    anyhow::ensure!(resolved_parent.starts_with(&common),
+        "Git uses an external shared core.hooksPath; refusing to change another repository's hooks. Configure a repository-local hooks directory first");
     let script = hook.with_file_name("ai-hist-post-commit.mjs");
     fs::create_dir_all(hook.parent().context("missing hook parent")?)?;
     let body = format!(
@@ -110,7 +142,7 @@ pub fn install(mut options: GitLinkOptions, node: &str, sdk_url: &str) -> Result
         use std::os::unix::fs::PermissionsExt;
         fs::set_permissions(&hook, fs::Permissions::from_mode(0o755))?;
     }
-    Ok(hook.display().to_string())
+    Ok(json!({"hookPath": hook.display().to_string(), "prUrl": options.pr_url}).to_string())
 }
 
 pub fn link(options: GitLinkOptions) -> Result<String> {

--- a/crates/ai-hist/src/git_sdk.rs
+++ b/crates/ai-hist/src/git_sdk.rs
@@ -69,6 +69,29 @@ fn resolve_source(options: &GitLinkOptions) -> Result<String> {
     Ok(sources[0].clone())
 }
 
+/// Resolve a path whose tail may not exist yet: canonicalize the nearest existing
+/// ancestor, then apply the remaining components so `..` cannot escape it.
+fn resolve_against_existing(path: &Path) -> Result<std::path::PathBuf> {
+    let Some(base) = path.ancestors().find(|candidate| candidate.exists()) else {
+        return Ok(path.to_path_buf());
+    };
+    let mut resolved = base.canonicalize()?;
+    for component in path
+        .strip_prefix(base)
+        .unwrap_or(Path::new(""))
+        .components()
+    {
+        match component {
+            std::path::Component::ParentDir => {
+                resolved.pop();
+            }
+            std::path::Component::CurDir => {}
+            other => resolved.push(other.as_os_str()),
+        }
+    }
+    Ok(resolved)
+}
+
 pub fn install(mut options: GitLinkOptions, node: &str, sdk_url: &str) -> Result<String> {
     let root = git_repo_root(Path::new(&options.repo))?;
     options.repo = root.display().to_string();
@@ -101,13 +124,22 @@ pub fn install(mut options: GitLinkOptions, node: &str, sdk_url: &str) -> Result
     let common = git_stdout(&root, &["rev-parse", "--git-common-dir"])?;
     let common = root.join(common.trim()).canonicalize()?;
     let hook_parent = hook.parent().context("missing hook parent")?;
-    let resolved_parent = if hook_parent.exists() {
-        hook_parent.canonicalize()?
-    } else {
-        hook_parent.to_path_buf()
-    };
+    // Resolve before comparing: an unresolved `..` can satisfy the lexical
+    // containment check while `create_dir_all` lands outside the repository.
+    let resolved_parent = resolve_against_existing(hook_parent)?;
     anyhow::ensure!(resolved_parent.starts_with(&common),
         "Git uses an external shared core.hooksPath; refusing to change another repository's hooks. Configure a repository-local hooks directory first");
+    // Linked worktrees share the common dir's hooks, but this hook embeds one
+    // fixed sessionId and repo. Installing from a worktree would attribute every
+    // other worktree's commits to this session, so refuse instead of corrupting
+    // the linkage we exist to record.
+    let git_dir = git_stdout(&root, &["rev-parse", "--git-dir"])?;
+    let git_dir = root.join(git_dir.trim()).canonicalize()?;
+    anyhow::ensure!(
+        git_dir == common,
+        "this is a linked Git worktree and its hooks are shared with the main worktree; \
+         install from the main worktree instead"
+    );
     let script = hook.with_file_name("ai-hist-post-commit.mjs");
     fs::create_dir_all(hook.parent().context("missing hook parent")?)?;
     let body = format!(
@@ -118,8 +150,14 @@ pub fn install(mut options: GitLinkOptions, node: &str, sdk_url: &str) -> Result
     fs::write(&script, body)?;
     let marker = "# ai-hist SDK hook";
     let backup = hook.with_file_name("post-commit.before-ai-hist");
-    let existing = fs::read_to_string(&hook).unwrap_or_default();
-    if !existing.is_empty() && !existing.contains(marker) {
+    // A compiled or non-UTF-8 hook still deserves preservation: only a missing
+    // file means there is nothing to back up. Decoding failure is not emptiness.
+    let needs_backup = match fs::read_to_string(&hook) {
+        Ok(text) => !text.is_empty() && !text.contains(marker),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => true,
+    };
+    if needs_backup {
         anyhow::ensure!(
             !backup.exists(),
             "hook backup already exists; refusing to overwrite it"

--- a/crates/ai-hist/src/git_sdk.rs
+++ b/crates/ai-hist/src/git_sdk.rs
@@ -1,0 +1,140 @@
+//! Explicit-session Git linkage for the npm SDK. No network runs in post-commit.
+use crate::{
+    git_branch, git_commit_files, git_commit_numstat, git_commit_time_ms, git_path, git_repo_root,
+    git_stdout, sh_single_quote,
+};
+use ai_hist_core::open_db;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::{fs, path::Path};
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitLinkOptions {
+    pub repo: String,
+    pub session_id: String,
+    pub source: Option<String>,
+    pub db_path: String,
+    pub pr_url: Option<String>,
+}
+
+fn pr_ref(raw: &str) -> Result<String> {
+    let url = url::Url::parse(raw)?;
+    let segments: Vec<_> = url.path().trim_start_matches('/').split('/').collect();
+    anyhow::ensure!(
+        url.scheme() == "https"
+            && url.host_str() == Some("github.com")
+            && url.username().is_empty()
+            && url.password().is_none()
+            && url.port().is_none()
+            && url.query().is_none()
+            && url.fragment().is_none()
+            && segments.len() == 4
+            && segments[2] == "pull"
+            && segments[3].parse::<u64>().is_ok_and(|n| n > 0)
+            && segments[..2].iter().all(|s| !s.is_empty()
+                && s.chars()
+                    .all(|c| c.is_ascii_alphanumeric() || "_.-".contains(c))),
+        "prUrl must be https://github.com/OWNER/REPO/pull/NUMBER"
+    );
+    Ok(format!("{}/{}#{}", segments[0], segments[1], segments[3]))
+}
+
+fn resolve_source(options: &GitLinkOptions) -> Result<String> {
+    anyhow::ensure!(
+        !options.session_id.trim().is_empty(),
+        "sessionId must not be empty"
+    );
+    let conn = open_db(Path::new(&options.db_path))?;
+    let mut stmt = conn.prepare("SELECT DISTINCT source FROM sessions WHERE session_id = ? UNION SELECT DISTINCT source FROM history WHERE session_id = ?")?;
+    let sources = stmt
+        .query_map([&options.session_id, &options.session_id], |r| {
+            r.get::<_, String>(0)
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    if let Some(source) = &options.source {
+        anyhow::ensure!(
+            sources.contains(source),
+            "session not found for requested source; sync or hydrate it first"
+        );
+        return Ok(source.clone());
+    }
+    anyhow::ensure!(
+        sources.len() == 1,
+        "session must exist with exactly one source; sync first or pass source explicitly"
+    );
+    Ok(sources[0].clone())
+}
+
+pub fn install(mut options: GitLinkOptions, node: &str, sdk_url: &str) -> Result<String> {
+    let root = git_repo_root(Path::new(&options.repo))?;
+    options.repo = root.display().to_string();
+    options.db_path = fs::canonicalize(&options.db_path)?.display().to_string();
+    options.source = Some(resolve_source(&options)?);
+    if let Some(url) = &options.pr_url {
+        pr_ref(url)?;
+    }
+    let hook = git_path(&root, "hooks/post-commit")?;
+    let script = hook.with_file_name("ai-hist-post-commit.mjs");
+    fs::create_dir_all(hook.parent().context("missing hook parent")?)?;
+    let body = format!(
+        "import {{ linkGitCommit }} from {};\nawait linkGitCommit({});\n",
+        serde_json::to_string(sdk_url)?,
+        serde_json::to_string(&options)?
+    );
+    fs::write(&script, body)?;
+    let existing = fs::read_to_string(&hook).unwrap_or_else(|_| "#!/bin/sh\n".into());
+    let marker = "# ai-hist SDK hook";
+    if !existing.contains(marker) {
+        // Do not reinterpret a non-shell hook by appending shell syntax to it.
+        anyhow::ensure!(
+            existing.starts_with("#!/bin/sh")
+                || existing.starts_with("#!/bin/bash")
+                || existing.starts_with("#!/usr/bin/env bash"),
+            "post-commit is not a shell hook; refusing to modify it"
+        );
+        fs::write(
+            &hook,
+            format!(
+                "{existing}\n{marker}\n{} {} || echo 'ai-hist: commit linkage failed' >&2\n",
+                sh_single_quote(node),
+                sh_single_quote(&script.display().to_string())
+            ),
+        )?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&hook, fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(hook.display().to_string())
+}
+
+pub fn link(options: GitLinkOptions) -> Result<String> {
+    let source = resolve_source(&options)?;
+    let root = git_repo_root(Path::new(&options.repo))?;
+    let sha = git_stdout(&root, &["rev-parse", "--verify", "HEAD^{commit}"])?
+        .trim()
+        .to_owned();
+    let branch = git_branch(&root).ok();
+    let commit_ms = git_commit_time_ms(&root, &sha)?;
+    let files = serde_json::to_string(&git_commit_files(&root, &sha)?)?;
+    let numstat = serde_json::to_string(&git_commit_numstat(&root, &sha)?)?;
+    let mut evidence = json!({"commit_time_ms": commit_ms});
+    if let Some(url) = &options.pr_url {
+        evidence["github_pr"] = json!({"system":"github", "id":pr_ref(url)?, "url":url});
+    }
+    let conn = open_db(Path::new(&options.db_path))?;
+    conn.execute("INSERT INTO session_commit_links (source, session_id, repo, branch, commit_sha, note_ref, match_method, confidence, files_json, numstat_json, evidence_json, created_at_ms) VALUES (?,?,?,?,?,'refs/notes/ai-hist','explicit_session',1,?,?,?,?) ON CONFLICT(source, session_id, commit_sha, match_method) DO NOTHING",
+        rusqlite::params![source, options.session_id, root.display().to_string(), branch, sha, files, numstat, evidence.to_string(), chrono::Utc::now().timestamp_millis()])?;
+    let note = format!("ai-hist:{}:{}", source, options.session_id);
+    let prior = git_stdout(&root, &["notes", "--ref=ai-hist", "show", &sha]).unwrap_or_default();
+    if !prior.lines().any(|line| line == note) {
+        git_stdout(
+            &root,
+            &["notes", "--ref=ai-hist", "append", "-m", &note, &sha],
+        )?;
+    }
+    Ok(sha)
+}

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -23,7 +23,7 @@ use std::io::{self, BufRead, BufReader, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-mod cloud;
+pub mod cloud;
 mod codex;
 /// Fast, shallow coding-agent session discovery and the cache-only catalog
 /// listing that backs it.

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -36,7 +36,7 @@ mod relationships;
 /// Remote session connectors (claude.ai/code web sessions, Codex cloud tasks)
 /// and their availability reporting.
 pub mod remote;
-mod replay;
+pub mod replay;
 
 pub use discover::{
     discover_sessions, discover_sessions_collect, discover_sessions_with_env,

--- a/crates/ai-hist/src/lib.rs
+++ b/crates/ai-hist/src/lib.rs
@@ -28,6 +28,7 @@ mod codex;
 /// Fast, shallow coding-agent session discovery and the cache-only catalog
 /// listing that backs it.
 pub mod discover;
+pub mod git_sdk;
 mod hydrate;
 mod learn;
 /// Recording the delegation evidence each provider leaves behind.

--- a/crates/ai-hist/src/replay.rs
+++ b/crates/ai-hist/src/replay.rs
@@ -37,9 +37,11 @@ pub fn replay(
     out: Option<&Path>,
 ) -> Result<ReplayOutput> {
     anyhow::ensure!(!session_id.trim().is_empty(), "sessionId must not be empty");
-    let base_url = base_url
-        .map(String::from)
-        .unwrap_or_else(cloud::default_base_url);
+    // Resolve rather than defaulting: default_base_url() turns a malformed
+    // RELAYHISTORY_BASE_URL/AI_HIST_BASE_URL into the production origin, and
+    // passing that on as an explicit destination would let replay silently hit
+    // production where token rejects the same selector.
+    let base_url = cloud::resolve_base_url(base_url)?;
     // load_sdk_auth, not load_auth: an npm user upgrading from the TypeScript
     // client keeps credentials in ~/.config/ai-hist/auth.json, and replay must
     // migrate that store like the rest of the SDK surface.

--- a/crates/ai-hist/src/replay.rs
+++ b/crates/ai-hist/src/replay.rs
@@ -40,7 +40,10 @@ pub fn replay(
     let base_url = base_url
         .map(String::from)
         .unwrap_or_else(cloud::default_base_url);
-    let auth = cloud::load_auth(Some(&base_url))?.context(
+    // load_sdk_auth, not load_auth: an npm user upgrading from the TypeScript
+    // client keeps credentials in ~/.config/ai-hist/auth.json, and replay must
+    // migrate that store like the rest of the SDK surface.
+    let auth = cloud::load_sdk_auth(Some(&base_url))?.context(
         "not authenticated for the selected stage — run `ai-hist login` or `ai-hist admin-mint` first",
     )?;
     let events = cloud::replay_events(&auth, session_id, limit, max_content)?;

--- a/crates/ai-hist/src/replay.rs
+++ b/crates/ai-hist/src/replay.rs
@@ -37,15 +37,16 @@ pub fn replay(
     out: Option<&Path>,
 ) -> Result<ReplayOutput> {
     anyhow::ensure!(!session_id.trim().is_empty(), "sessionId must not be empty");
-    // Resolve rather than defaulting: default_base_url() turns a malformed
-    // RELAYHISTORY_BASE_URL/AI_HIST_BASE_URL into the production origin, and
-    // passing that on as an explicit destination would let replay silently hit
-    // production where token rejects the same selector.
-    let base_url = cloud::resolve_base_url(base_url)?;
+    // resolve_stage, not resolve_base_url: an absent selection must stay absent.
+    // Turning it into production here would hand load_sdk_auth a value that looks
+    // chosen, suppressing the multi-stage refusal, so replay would silently read
+    // production while token declines to guess. A malformed selector is still an
+    // error rather than a silent fallback.
+    let stage = cloud::resolve_stage(base_url)?;
     // load_sdk_auth, not load_auth: an npm user upgrading from the TypeScript
     // client keeps credentials in ~/.config/ai-hist/auth.json, and replay must
     // migrate that store like the rest of the SDK surface.
-    let auth = cloud::load_sdk_auth(Some(&base_url))?.context(
+    let auth = cloud::load_sdk_auth(stage.as_deref())?.context(
         "not authenticated for the selected stage — run `ai-hist login` or `ai-hist admin-mint` first",
     )?;
     let events = cloud::replay_events(&auth, session_id, limit, max_content)?;

--- a/crates/ai-hist/src/replay.rs
+++ b/crates/ai-hist/src/replay.rs
@@ -13,6 +13,30 @@ pub fn run(
     json: bool,
     out: Option<&Path>,
 ) -> Result<()> {
+    let result = replay(session_id, base_url, limit, max_content, json, out)?;
+    if let Some(body) = result.transcript {
+        io::stdout().lock().write_all(body.as_bytes())?;
+    }
+    Ok(())
+}
+
+/// A completed replay. File output stays in Rust so every caller gets the same
+/// fetch-before-write and atomic replacement guarantees. SDK calls never print.
+pub struct ReplayOutput {
+    pub event_count: usize,
+    pub transcript: Option<String>,
+    pub output_path: Option<String>,
+}
+
+pub fn replay(
+    session_id: &str,
+    base_url: Option<&str>,
+    limit: Option<usize>,
+    max_content: Option<usize>,
+    json: bool,
+    out: Option<&Path>,
+) -> Result<ReplayOutput> {
+    anyhow::ensure!(!session_id.trim().is_empty(), "sessionId must not be empty");
     let base_url = base_url
         .map(String::from)
         .unwrap_or_else(cloud::default_base_url);
@@ -32,13 +56,18 @@ pub fn run(
     };
     // Finish fetching before touching the destination: an expired token on page two
     // must not overwrite an existing offline transcript with only page one.
-    if let Some(path) = out {
+    let transcript = if let Some(path) = out {
         write_atomically(path, body.as_bytes())
             .with_context(|| format!("writing replay to {}", path.display()))?;
+        None
     } else {
-        io::stdout().lock().write_all(body.as_bytes())?;
-    }
-    Ok(())
+        Some(body)
+    };
+    Ok(ReplayOutput {
+        event_count: events.len(),
+        transcript,
+        output_path: out.map(|path| path.display().to_string()),
+    })
 }
 
 /// Write via a temporary file in the destination's own directory, then atomically replace.

--- a/crates/ai-hist/tests/replay.rs
+++ b/crates/ai-hist/tests/replay.rs
@@ -72,6 +72,11 @@ fn save_auth(home: &Path, base: &str, legacy: bool) {
 fn replay(home: &Path, base: &str, args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_ai-hist"))
         .env("RELAYHISTORY_HOME", home)
+        // replay migrates the legacy TypeScript store under HOME; pin it so the
+        // developer's real ~/.config/ai-hist/auth.json cannot influence results.
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("AI_HIST_CONFIG_DIR", home.join("legacy-sdk"))
         .env("RELAYHISTORY_BASE_URL", base)
         .env_remove("AI_HIST_BASE_URL")
         .arg("--db")

--- a/crates/ai-hist/tests/replay.rs
+++ b/crates/ai-hist/tests/replay.rs
@@ -375,3 +375,33 @@ fn explicit_base_url_wins_over_a_malformed_environment() {
     server.join().unwrap();
     assert!(String::from_utf8_lossy(&output.stdout).contains("No events found."));
 }
+
+// An absent selection must stay absent all the way to load_auth. Turning it into
+// production would hand the loader a value that looks chosen, suppressing the
+// multi-stage refusal, so replay would silently read production while token
+// declines to guess. Both commands must refuse.
+#[test]
+fn multiple_stages_without_a_selector_refuse_to_guess() {
+    let home = tempfile::tempdir().unwrap();
+    save_auth(home.path(), "https://history.agentrelay.com", false);
+    save_auth(home.path(), "http://localhost:8787", false);
+    let output = Command::new(env!("CARGO_BIN_EXE_ai-hist"))
+        .env("RELAYHISTORY_HOME", home.path())
+        .env("HOME", home.path())
+        .env("USERPROFILE", home.path())
+        .env("AI_HIST_CONFIG_DIR", home.path().join("legacy-sdk"))
+        .env_remove("RELAYHISTORY_BASE_URL")
+        .env_remove("AI_HIST_BASE_URL")
+        .arg("--db")
+        .arg(home.path().join("must-not-create.db"))
+        .arg("replay")
+        .arg("some-session")
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let err = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        err.contains("stages are configured; pass --base-url to select one"),
+        "replay must refuse to guess between stages, not default to production: {err}"
+    );
+}

--- a/crates/ai-hist/tests/replay.rs
+++ b/crates/ai-hist/tests/replay.rs
@@ -343,3 +343,35 @@ fn replay_explicit_base_url_overrides_default_and_does_not_open_an_invalid_db() 
         "not sqlite"
     );
 }
+
+// replay used to synthesize its destination with default_base_url(), which turns
+// a malformed selector into the production origin, and then passed that on as if
+// the user had chosen it. The result was replay silently hitting production while
+// token rejected the very same selector. Both must reject it.
+#[test]
+fn malformed_base_url_env_is_rejected_instead_of_silently_using_production() {
+    let home = tempfile::tempdir().unwrap();
+    let output = replay(home.path(), "not-a-url", &["some-session"]);
+    assert!(!output.status.success());
+    let err = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        err.contains("RELAYHISTORY_BASE_URL is not a usable base URL"),
+        "a malformed selector must be reported, not replaced by production: {err}"
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "a rejected destination must not print a transcript"
+    );
+}
+
+// An explicit destination still wins over a broken environment, matching token.
+#[test]
+fn explicit_base_url_wins_over_a_malformed_environment() {
+    let home = tempfile::tempdir().unwrap();
+    let (base, server) = server(vec![(200, json!({"events": [], "nextCursor": null}))]);
+    save_auth(home.path(), &base, false);
+    let output = replay(home.path(), "not-a-url", &["unknown", "--base-url", &base]);
+    success(&output);
+    server.join().unwrap();
+    assert!(String::from_utf8_lossy(&output.stdout).contains("No events found."));
+}

--- a/crates/ai-hist/tests/token.rs
+++ b/crates/ai-hist/tests/token.rs
@@ -355,3 +355,26 @@ fn unnormalizable_base_url_env_still_refuses_between_stages() {
         "a malformed stage selector must not silently select production: {err}"
     );
 }
+
+// default_base_url() ignores a malformed selector and returns production, so
+// treating "the variable is set" as "production was chosen" would silently
+// retarget the caller's stage. A malformed selector must be reported, and the
+// message must never echo the value: normalize_base_url rejects URLs carrying
+// embedded credentials, so a rejected value is exactly the kind that may hold one.
+#[test]
+fn malformed_base_url_env_is_rejected_without_echoing_the_value() {
+    let home = tempfile::tempdir().unwrap();
+    save(home.path(), PROD, OLD, Some(FUTURE));
+    let secret_shaped = "https://user:hunter2@example.com/path?q=1";
+    let mut cmd = command(home.path());
+    cmd.env("RELAYHISTORY_BASE_URL", secret_shaped);
+    let err = failure(&cmd.output().unwrap());
+    assert!(
+        err.contains("RELAYHISTORY_BASE_URL is not a usable base URL"),
+        "a malformed selector must be named, not silently replaced by production: {err}"
+    );
+    assert!(
+        !err.contains("hunter2") && !err.contains(secret_shaped),
+        "the rejected value must never be echoed: {err}"
+    );
+}

--- a/crates/ai-hist/tests/token.rs
+++ b/crates/ai-hist/tests/token.rs
@@ -337,23 +337,34 @@ fn legacy_auth_is_supported_and_default_stage_is_production() {
     assert!(failure(&command(home.path()).output().unwrap()).contains("not authenticated"));
 }
 
-// access_token treats a stage selector as "selected" only when it normalizes,
-// while load_sdk_auth treats any non-empty RELAYHISTORY_BASE_URL as a selection
-// and falls back to production. If the ambiguity probe goes through the latter,
-// a malformed selector silently turns a multi-stage refusal into the production
-// credential — token would print the wrong stage's secret.
+// With no selector at all and several stages configured, token must refuse to
+// guess rather than fall back to production. The ambiguity probe stays on
+// load_auth for this reason: load_sdk_auth infers a destination from the
+// environment, which would defeat the refusal.
 #[test]
-fn unnormalizable_base_url_env_still_refuses_between_stages() {
+fn multiple_stages_without_a_selector_refuse_to_guess() {
     let home = tempfile::tempdir().unwrap();
     save(home.path(), PROD, OLD, Some(FUTURE));
     save(home.path(), "http://localhost:8787", NEW, Some(FUTURE));
-    let mut cmd = command(home.path());
-    cmd.env("RELAYHISTORY_BASE_URL", "not-a-url");
-    let err = failure(&cmd.output().unwrap());
+    let err = failure(&command(home.path()).output().unwrap());
     assert!(
         err.contains("stages are configured; pass --base-url to select one"),
-        "a malformed stage selector must not silently select production: {err}"
+        "an unselected multi-stage setup must not silently select production: {err}"
     );
+}
+
+// An explicit destination wins outright. A broken environment variable must not
+// block a caller who already chose a stage, or --base-url becomes unusable on any
+// machine with a stale or mistyped selector exported.
+#[test]
+fn explicit_base_url_wins_over_a_malformed_environment() {
+    let home = tempfile::tempdir().unwrap();
+    save(home.path(), PROD, OLD, Some(FUTURE));
+    let mut cmd = command(home.path());
+    cmd.env("RELAYHISTORY_BASE_URL", "not-a-url")
+        .arg("--base-url")
+        .arg(PROD);
+    success(&cmd.output().unwrap(), OLD);
 }
 
 // default_base_url() ignores a malformed selector and returns production, so

--- a/crates/ai-hist/tests/token.rs
+++ b/crates/ai-hist/tests/token.rs
@@ -389,3 +389,36 @@ fn malformed_base_url_env_is_rejected_without_echoing_the_value() {
         "the rejected value must never be echoed: {err}"
     );
 }
+
+// login_for_sdk resolved a missing destination with default_base_url(), which
+// ignores a malformed selector and returns production — so loginCloud and
+// enableCloud would authenticate against prod where token rejects that selector.
+// The SDK entrypoint is exercised directly; the CLI token path is covered above.
+#[test]
+fn sdk_login_rejects_a_malformed_selector_instead_of_using_production() {
+    let home = tempfile::tempdir().unwrap();
+    let previous: Vec<(String, Option<std::ffi::OsString>)> = [
+        "RELAYHISTORY_HOME",
+        "RELAYHISTORY_BASE_URL",
+        "AI_HIST_BASE_URL",
+    ]
+    .iter()
+    .map(|k| (k.to_string(), std::env::var_os(k)))
+    .collect();
+    std::env::set_var("RELAYHISTORY_HOME", home.path());
+    std::env::set_var("RELAYHISTORY_BASE_URL", "not-a-url");
+    std::env::remove_var("AI_HIST_BASE_URL");
+    let error = ai_hist_engine::cloud::login_for_sdk(None, Some("relay-token"), None)
+        .expect_err("a malformed selector must not authenticate against production");
+    let message = format!("{error:#}");
+    for (key, value) in previous {
+        match value {
+            Some(value) => std::env::set_var(&key, value),
+            None => std::env::remove_var(&key),
+        }
+    }
+    assert!(
+        message.contains("RELAYHISTORY_BASE_URL is not a usable base URL"),
+        "the variable must be named: {message}"
+    );
+}

--- a/crates/ai-hist/tests/token.rs
+++ b/crates/ai-hist/tests/token.rs
@@ -28,7 +28,15 @@ fn save(home: &Path, base: &str, token: &str, expiry: Option<&str>) -> PathBuf {
 
 fn command(home: &Path) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_ai-hist"));
+    // token migrates the legacy TypeScript store, which lives under HOME rather
+    // than RELAYHISTORY_HOME. Pin both, or these tests read the developer's real
+    // ~/.config/ai-hist/auth.json and pass or fail by machine state. The legacy
+    // dir is deliberately a subpath that stays absent unless a test creates it,
+    // so it cannot collide with the RELAYHISTORY_HOME/auth.json legacy location.
     cmd.env("RELAYHISTORY_HOME", home)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("AI_HIST_CONFIG_DIR", home.join("legacy-sdk"))
         .env_remove("RELAYHISTORY_BASE_URL")
         .env_remove("AI_HIST_BASE_URL")
         .env("RUST_LOG", "trace")

--- a/crates/ai-hist/tests/token.rs
+++ b/crates/ai-hist/tests/token.rs
@@ -336,3 +336,22 @@ fn legacy_auth_is_supported_and_default_stage_is_production() {
     save(home.path(), "http://localhost:8787", OLD, Some(FUTURE));
     assert!(failure(&command(home.path()).output().unwrap()).contains("not authenticated"));
 }
+
+// access_token treats a stage selector as "selected" only when it normalizes,
+// while load_sdk_auth treats any non-empty RELAYHISTORY_BASE_URL as a selection
+// and falls back to production. If the ambiguity probe goes through the latter,
+// a malformed selector silently turns a multi-stage refusal into the production
+// credential — token would print the wrong stage's secret.
+#[test]
+fn unnormalizable_base_url_env_still_refuses_between_stages() {
+    let home = tempfile::tempdir().unwrap();
+    save(home.path(), PROD, OLD, Some(FUTURE));
+    save(home.path(), "http://localhost:8787", NEW, Some(FUTURE));
+    let mut cmd = command(home.path());
+    cmd.env("RELAYHISTORY_BASE_URL", "not-a-url");
+    let err = failure(&cmd.output().unwrap());
+    assert!(
+        err.contains("stages are configured; pass --base-url to select one"),
+        "a malformed stage selector must not silently select production: {err}"
+    );
+}

--- a/docs/enable-cloud.md
+++ b/docs/enable-cloud.md
@@ -1,0 +1,63 @@
+# Your sessions, threaded to your PRs, in one command
+
+```sh
+ai-hist enable-cloud
+```
+
+The npm CLI calls the async SDK. It reuses your selected RelayHistory stage or
+starts Agent Relay's device login, exchanges that identity for a service-local
+`rth_at_*` session, syncs local history, drains the outbox, and keeps pushing once
+per minute until Ctrl-C. Install `agent-relay` for the interactive login flow;
+a preauthenticated embedding host can pass `relayAccessToken` to the SDK.
+The loop runs in the current process; it is not an installed background daemon.
+
+Use `--once` to drain and exit, `--interval 30` to change the interval, and
+`--base-url https://dev.history.agentrelay.com` to select development explicitly.
+The existing Rust trust gate requires
+`RELAYHISTORY_ALLOW_UNTRUSTED_CLOUD_BASE_URL=1` for the trusted dev exchange.
+Never use production for development acceptance tests.
+
+```ts
+import { enableCloud, installGitHooks, createShareableTrace } from 'ai-hist';
+
+const cloud = await enableCloud({ intervalMs: 60_000 });
+await installGitHooks({
+  repo: process.cwd(),
+  sessionId: 'YOUR_SESSION_ID',
+  source: 'claude',
+  prUrl: 'https://github.com/OWNER/REPO/pull/123',
+});
+// The next commit writes refs/notes/ai-hist plus a durable local link.
+// The next successful push projects it to session_links.link_kind='github_pr'.
+const trace = await createShareableTrace('YOUR_SESSION_ID', {
+  source: 'claude', visibility: 'direct-link',
+});
+console.log(trace.url);
+await cloud.stop();
+```
+
+Hooks use an explicit, already-indexed session. Pass the existing PR URL; when a
+PR is created later, reinstall the hook with its URL before the next commit.
+They perform no network I/O and preserve the previous post-commit hook in
+`post-commit.before-ai-hist`. Git notes append session IDs without replacing other
+notes. They are local until you explicitly push `refs/notes/ai-hist`; cloud
+linkage travels through the durable outbox independently.
+The design follows [Traces' Git-hook documentation](https://traces.com/docs/sharing/git-hooks):
+explicit session IDs, Git notes, and separate upload.
+
+Cloud login, refresh, URL normalization, migration, stage hashing, atomic state
+writes, cursor locks, and outbox batching remain in Rust. The compatibility
+`ai-hist/cloud` export now reads the same Rust store as the engine. It imports the
+old `~/.config/ai-hist/auth.json` only if the requested stage lacks canonical
+credentials; stale SDK tokens never overwrite refreshed Rust tokens. No new
+TypeScript auth store is written. Multiple stages require an explicit selection.
+A new stage starts from its own cursor; enabling cloud never seeds it from the
+local maximum or another stage's watermark.
+
+Sharing creates a frozen snapshot of already-pushed convergence events. Public
+shares permit indexing; direct-link shares are bearer URLs with noindex headers;
+private shares require the same user, organization, workspace and read scope.
+Private links can be read with an authenticated HTTP client; there is no browser
+login page on the share route yet. The creator must own the session. Later events
+are excluded. Revoke with authenticated `DELETE /v1/shares/:token`. The server
+caps snapshots at 10,000 events and 5 MB and rejects oversized sessions explicitly.

--- a/docs/enable-cloud.md
+++ b/docs/enable-cloud.md
@@ -1,8 +1,11 @@
-# Your sessions, threaded to your PRs, in one command
+# Cloud sync in one command, PR threading in one more
 
 ```sh
 ai-hist enable-cloud
 ```
+
+`enable-cloud` authenticates and syncs. It does not install Git hooks: threading
+commits to a PR needs the separate `installGitHooks()` step described below.
 
 The npm CLI calls the async SDK. It reuses your selected RelayHistory stage or
 starts Agent Relay's device login, exchanges that identity for a service-local

--- a/docs/enable-cloud.md
+++ b/docs/enable-cloud.md
@@ -36,9 +36,13 @@ console.log(trace.url);
 await cloud.stop();
 ```
 
-Hooks use an explicit, already-indexed session. Pass the existing PR URL; when a
-PR is created later, reinstall the hook with its URL before the next commit.
-They perform no network I/O and preserve the previous post-commit hook in
+Hooks use an explicit, already-indexed session. Installation finds an existing PR
+through `git config ai-hist.pr-url` or `gh pr view`, or you can pass `prUrl` directly.
+The result reports `prUrl: null` when no PR was found. When a PR is created later,
+reinstall the hook before the next commit.
+Installations with an external shared `core.hooksPath` are rejected rather than
+modifying other repositories; configure a repository-local hooks directory first.
+Hooks perform no network I/O and preserve the previous post-commit hook in
 `post-commit.before-ai-hist`. Git notes append session IDs without replacing other
 notes. They are local until you explicitly push `refs/notes/ai-hist`; cloud
 linkage travels through the durable outbox independently.

--- a/docs/native-sdk-migration.md
+++ b/docs/native-sdk-migration.md
@@ -66,7 +66,11 @@ for await (const event of sessionEvents(id, { limit: 200 })) consume(event);
 ```
 
 The 1.0 CLI covers `sessions list`, `sessions discover`, `search`, `recent`,
-`session`, `events`, `stats`, and `sync`. Removed legacy cloud/Pair/tag/
+`session`, `events`, `stats`, `sync`, `token`, `replay`, and `enable-cloud`.
+`accessToken()` and `replay()` expose the existing Rust cloud operations through
+NAPI. Token output stays secret-only on stdout; replay pagination, rendering and
+atomic `--out` replacement remain in Rust and never open the local history DB.
+Removed legacy cloud/Pair/tag/
 trajectory convenience commands must migrate to dedicated services or future
 native-backed SDK operations; they are not retained through subprocess or
 JavaScript-SQL fallbacks.

--- a/docs/ws12-validation.md
+++ b/docs/ws12-validation.md
@@ -113,3 +113,52 @@ on missing/expired Cloudflare credentials; the authorized dev workflow supplied
 its existing environment credentials and completed deployment successfully.
 Earlier dev recall 404s were resolved by this deployment; persistence is now
 verified by exact event content and the session-link read above.
+
+## Rebase onto 0.15.1 and re-verification against the installed artifact
+
+The branch was rebased from its original base (`865a536`, release 0.15.0) onto
+`5188b13` (release 0.15.1), picking up the four changes that landed underneath
+it: `2fd5bbc` (Rust `token`), `3d559ed` (first-run bootstrap), `5f3246b`
+(npx first-search verification and pretty session output) and `d56f64d` (the
+native Linux glibc floor). The only conflicts were in `sdk-ts/src/cli.ts` and
+both were unions rather than competing edits: `BOOLEAN_FLAGS` now carries both
+main's `pretty` and this branch's `once`, and the usage block lists both
+`enable-cloud` and `sessions list --pretty`.
+
+The bootstrap seam was checked explicitly: `bootstrapLocal` runs only on a bare
+`ai-hist` invocation with no command, so it cannot write to stdout ahead of
+`token`. `token` writes the token and nothing else to stdout; the
+secret-in-scrollback warning goes to stderr and only when stdout is a TTY.
+
+Post-rebase evidence, all on darwin-arm64 with mise Node 22.22.2:
+
+- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets
+  -- -A clippy::too_many_arguments -D warnings` clean.
+- Native contract: `verify-native-contract.mjs` reports contract version 9
+  agreeing across the Rust binding source, the TypeScript SDK source and the
+  built addon; `git diff --exit-code -- crates/ai-hist-napi/index.d.ts` clean,
+  so the checked-in declarations match what the build regenerates.
+- `sdk-ts`: `tsc --noEmit` clean, `npm test` 73/73 passing.
+- `node --test scripts/*.test.mjs`: 10/10 passing.
+
+### Verified against the artifact, not the source
+
+Packing and installing the tarballs the way CI does — SDK, loader and the
+darwin-arm64 platform addon — into a scratch project, and then running the
+installed `./node_modules/.bin/ai-hist`:
+
+- The installed CLI's usage block lists `ai-hist token [--base-url URL]` and
+  `ai-hist replay SESSION_ID [--base-url URL] [--limit N] [--max-content N]
+  [--json] [--out PATH]`.
+- For contrast, the same check against the actually-published `ai-hist@0.15.1`
+  from the registry lists neither: zero matches for `token` or `replay`. This
+  independently reproduces the QA report that the published CLI cannot reach
+  these commands.
+- `cloud-commands.test.js` was rerun with `AI_HIST_TEST_PACKAGE_DIR` pointed at
+  the installed package and passed, covering token stdout exactness, proactive
+  refresh with credential rotation, secret-safe failures, stage selection,
+  replay pagination and atomic `--out` replacement.
+- The specific failure QA reported — `$(ai-hist token)` silently yielding an
+  empty string — was reproduced as a shell command substitution against a
+  fixture cloud using the installed binary. It captured a 27-character token
+  identical to the one the fixture issued, with a non-zero length.

--- a/docs/ws12-validation.md
+++ b/docs/ws12-validation.md
@@ -446,3 +446,42 @@ with zero warnings, `cargo test --workspace` 0 with 443 passed and 0 failed,
 `tsc` 0, `npm test` 0 with 110/110, `scripts` 10/10, contract 9, `index.d.ts`
 clean. Against the repacked and reinstalled artifact both suites pass, `replay`
 renders and paginates, and `$(ai-hist token)` captures a real token.
+
+## Fixing the primitive instead of the call sites
+
+Two more High findings and one Major arrived, and all three had the same origin:
+`default_base_url()` ignores a value that does not normalize and returns
+production, and callers were synthesizing a destination with it and then passing
+the result on as though the user had chosen it.
+
+- `replay` turned an *absent* selection into production before calling
+  `load_sdk_auth`, which suppressed the multi-stage refusal. With several stages
+  and no selector it silently read production while `token` declined to guess.
+- `login_for_sdk` resolved a missing destination with `default_base_url()`, so
+  `loginCloud` and `enableCloud` with an explicit relay token would
+  *authenticate* against production when the selector was malformed.
+
+An earlier note in this document called tightening `default_base_url()`
+out of scope. That judgement was wrong, and these two findings are the cost of
+it: every fix that stopped at a call site left the leaky primitive in place for
+the next caller. The scope boundary was what kept generating defects.
+
+Resolution keeps the distinction the loaders depend on:
+
+- `resolve_stage(Option<&str>) -> Result<Option<String>>` preserves the
+  difference between "no selection" and "production". Callers that pass their
+  result to `load_auth`/`load_sdk_auth` must use it, because collapsing an
+  absent selection into production suppresses the refusal to guess.
+- `resolve_base_url` is now just `resolve_stage(..)?.unwrap_or(DEFAULT)`, for
+  callers such as login that must end up somewhere concrete.
+
+`replay` uses `resolve_stage`; `login_for_sdk` uses `resolve_base_url`. A
+malformed selector is an error in both, an unset one defaults only where
+defaulting is meaningful, and the multi-stage refusal survives.
+
+Re-verified: `cargo fmt --check` 0, `clippy -D warnings` 0 with zero warnings,
+`cargo test --workspace` 0 with 445 passed and 0 failed — 15 token and 11 replay
+tests, where this PR began with 11 and 8. `tsc` 0, `npm test` 0 with 110/110,
+`scripts` 10/10, contract 9, `index.d.ts` clean. Against the repacked and
+reinstalled artifact both suites pass, `replay` renders and paginates, and
+`$(ai-hist token)` captures a real token.

--- a/docs/ws12-validation.md
+++ b/docs/ws12-validation.md
@@ -351,3 +351,34 @@ Re-verified: `cargo fmt --check` 0, `clippy -D warnings` 0 with zero warnings,
 with 75/75, `scripts` 10/10, contract 9, `index.d.ts` clean. Against the
 repacked and reinstalled artifact both suites pass, `replay` renders and
 paginates, and `$(ai-hist token)` captures a real token.
+
+## Consolidating the selector rule, and explicit destinations winning
+
+Rejecting a malformed selector introduced a narrower defect that cursor caught:
+`load_sdk_auth` validated the environment *before* considering the caller's
+`base_url`, so a stale or mistyped exported variable blocked an explicit
+`--base-url` or SDK `baseUrl` even though that value would have won anyway.
+
+Both problems trace to the same shape: `access_token` and `load_sdk_auth` each
+carried their own idea of what counted as a stage selection, and they disagreed.
+They now share one `env_selected_stage()`, and both apply the same precedence —
+an explicit destination wins outright and the environment is not consulted at
+all; only when nothing was passed does the environment decide, and then a
+malformed value is an error rather than a silent fallback to production.
+
+Three properties now have tests, where before they were one function's
+implicit behaviour:
+
+- several stages and no selector refuses to guess, rather than defaulting to
+  production;
+- a malformed selector is reported by variable name, with neither the value nor
+  an embedded password reaching stderr;
+- an explicit `--base-url` succeeds even when the environment variable is
+  malformed.
+
+Re-verified: `cargo fmt --check` 0, `clippy -D warnings` 0 with zero warnings,
+`cargo test --workspace` 0 with 441 passed and 0 failed, 14 token tests where
+this PR began with 11, `tsc` 0, `npm test` 0 with 75/75, `scripts` 10/10,
+contract 9, `index.d.ts` clean. Against the repacked and reinstalled artifact
+both suites pass, `replay` renders and paginates, and `$(ai-hist token)`
+captures a real token.

--- a/docs/ws12-validation.md
+++ b/docs/ws12-validation.md
@@ -4,6 +4,42 @@ Drafts: https://github.com/AgentWorkforce/relayhistory/pull/117 and
 https://github.com/AgentWorkforce/relayhistory-cloud/pull/43. No merge or
 production deployment has been performed.
 
+## Added scope: npm token and replay
+
+The branch is rebased on published 0.15.0's source (`865a536`). It reuses #111's
+`cloud::access_token` and refactors the existing Rust replay entrypoint into a
+shared result-returning operation. NAPI contract **9** exposes both to the public
+async SDK (`accessToken`, `replay`) and the npm CLI (`token`, `replay`).
+
+Validation on code head `8969793`:
+
+- All 66 SDK tests passed after the rebase, including first-run bootstrap,
+  architecture constraints, the 525-record cloud fixture and both new commands.
+- Existing Rust integration suites passed: 11 token tests and 8 replay tests.
+  Workspace Clippy passed before the rebase; the rebase only brought forward
+  the release metadata and existing bootstrap behavior.
+- Fresh local npm tarballs for the SDK, native loader and Darwin ARM64 addon
+  were installed in an isolated directory. The command suite passed against
+  that installed artifact, including exact token stdout, proactive rotation,
+  redacted refresh/parser failures, explicit/environment stage selection and
+  ambiguity refusal, short-page pagination, opaque cursors, truncation markers,
+  repeated cursor rejection, and preservation of existing output on failure.
+- The same test suite now runs in CI's installed SDK/CLI smoke step against
+  Linux tarballs. Source and built addon agree on native contract 9.
+- Live dev, using the earlier isolated synthetic session's auth: the installed
+  npm `token --base-url https://dev.history.agentrelay.com` exited 0, returned
+  exactly one service-token line and emitted no stderr. The token was captured
+  in memory and was not printed in the validation log.
+- Installed npm `replay ws12-cloud-demo-1788873511810 --base-url
+  https://dev.history.agentrelay.com --limit 1 --json` exited 0 and returned all
+  three events, including exact prompt `prompt:1788873511858:558f0daa0735f957`.
+  It used the Rust pagination path and never imported into SQLite.
+
+These are locally built artifacts, not a new npm publication. Cloud PR #42's
+instructions become usable from the registry after the owner merges/releases
+the client. This lane has not merged or published anything. No additional
+sharing implementation was undertaken for this scope addition.
+
 ## Artifact and CI evidence
 
 - Native source, SDK and built addon agree on contract 8.

--- a/docs/ws12-validation.md
+++ b/docs/ws12-validation.md
@@ -382,3 +382,28 @@ this PR began with 11, `tsc` 0, `npm test` 0 with 75/75, `scripts` 10/10,
 contract 9, `index.d.ts` clean. Against the repacked and reinstalled artifact
 both suites pass, `replay` renders and paginates, and `$(ai-hist token)`
 captures a real token.
+
+## replay resolved its destination differently from token
+
+cursor found the last gap in this family. `replay` synthesized its destination
+with `default_base_url()` and then passed the result to `load_sdk_auth` as
+though the caller had chosen it. Because `default_base_url()` turns a value that
+does not normalize into the production origin, and `load_sdk_auth` cannot tell a
+synthesized origin from a deliberate one, a malformed selector made `replay`
+silently read production while `token` rejected the same selector.
+
+Destination resolution is now a single shared `cloud::resolve_base_url`: an
+explicit value wins, a malformed environment selector is an error, and only an
+unset environment takes the default. `replay` uses it instead of defaulting.
+
+That is the third defect in this family, and all three had one shape — two code
+paths each deciding for themselves what a stage selection means. The rule now
+lives in one place (`env_selected_stage`, wrapped by `resolve_base_url`), which
+is why this fix removes a call site rather than adding a guard to one.
+
+Re-verified: `cargo fmt --check` 0, `clippy -D warnings` 0 with zero warnings,
+`cargo test --workspace` 0 with 443 passed and 0 failed — 14 token and 10 replay
+tests, where this PR began with 11 and 8. `tsc` 0, `npm test` 0 with 75/75,
+`scripts` 10/10, contract 9, `index.d.ts` clean. Against the repacked and
+reinstalled artifact both suites pass, `replay` renders and paginates, and
+`$(ai-hist token)` captures a real token.

--- a/docs/ws12-validation.md
+++ b/docs/ws12-validation.md
@@ -17,11 +17,13 @@ production deployment has been performed.
 - Follow-up hook checks found inherited broker `core.hooksPath` pointing at a
   shared temporary directory. The installer now rejects external shared hook
   paths, and tests use isolated Git configuration. It also resolves an existing
-  PR at install time through repository config or gh. Final rebuilt fixture pending.
+  PR at install time through repository config or gh. The final fixture and full
+  Node 22 SDK suite passed in GitHub CI on head 1b91b25.
 - Server: 4 sharing route tests and 15 existing session-link tests passed, package
   typecheck passed, Wrangler deployment dry-run passed. Sharing tests use real
   PGlite DDL and verify anonymous/private access, owner and tenant isolation,
-  frozen snapshots, escaped HTML, and revocation.
+  frozen snapshots, escaped HTML, and revocation. Full server CI (formatting,
+  typecheck and all tests) passed on f475d7c in run 34232491784.
 - Live dev: the npm command with fresh isolated ai-hist state exchanged an
   existing real Agent Relay Cloud identity and reported sent=1, accepted=1 for
   synthetic session `ws12-cloud-demo-1788873511810`. This was not a fresh browser
@@ -37,14 +39,16 @@ SQLite shared-memory I/O failures. Broad server runs stalled/timed out. These
 runs are not claimed green. Only WS-12's reproducible Rust target cache was
 removed to recover space; the built addon and committed sources were retained.
 
-SST dev plan attempts remained in provider dependency installation. A direct npm
-install of the generated platform dependencies completed, but SST returned to
-its own provider install. No plan, deploy, or migration was applied.
+SST dev plan attempts initially stalled in provider dependency installation. A
+direct npm install of the generated platform dependencies completed. SST then
+failed explicitly: Cloudflare API not initialized; CLOUDFLARE_API_TOKEN (or API
+key plus email) must be configured. No plan, deploy, or migration was applied.
 
 ## Remaining acceptance
 
-1. Build the final addon and SDK, rerun the focused fixture and broader tests on
-   a healthy machine. `node --test sdk-ts/dist/cloud.test.js` exercises the public
+1. Client Node 22 SDK and Windows CI passed. The main verify job found a Clippy
+   item-order warning; the SDK cloud functions have now been moved before the
+   test module. Verify the subsequent CI run. `node --test sdk-ts/dist/cloud.test.js` exercises the public
    SDK and actual npm CLI, including an offline post-commit and native sharing.
 2. Review `sst diff --stage dev`, deploy the cloud companion to dev, and apply
    its additive `0010_trace_shares.sql` to the verified dev Neon branch.

--- a/docs/ws12-validation.md
+++ b/docs/ws12-validation.md
@@ -42,7 +42,7 @@ sharing implementation was undertaken for this scope addition.
 
 ## Artifact and CI evidence
 
-- Native source, SDK and built addon agree on contract 8.
+- Native source, SDK and built addon agree on contract 9.
 - Client head e98b4ec passed all required CI jobs in
   https://github.com/AgentWorkforce/relayhistory/actions/runs/34236408938:
   Rust formatting, Clippy and workspace tests; native contract; Node 20 SDK;
@@ -320,3 +320,34 @@ Re-verified: `cargo fmt --check` 0, `clippy -D warnings` 0 with zero warnings,
 with 75/75, `scripts` 10/10, contract 9, `index.d.ts` clean. Against the
 repacked and reinstalled artifact both suites pass, including the legacy-store
 case, and `$(ai-hist token)` still captures a real token.
+
+## Root cause: a malformed stage selector silently meant production
+
+The probe fix above cured the symptom in `access_token`. CodeRabbit's security
+review found the cause, which affected every `load_sdk_auth` caller —
+`enableCloud`, `pushCloud`, `loadStoredRelayhistoryAuth` and
+`createShareableTrace` as well as token and replay's destination resolution.
+
+`default_base_url()` ignores a value that does not normalize and returns the
+production origin. `load_sdk_auth` asked only whether the variable was
+*non-empty* before calling it, so a malformed `RELAYHISTORY_BASE_URL` or
+`AI_HIST_BASE_URL` — a typo, a truncated value, a shell-mangled one — silently
+resolved to production: reading against prod, and for enable/push writing
+against it.
+
+`load_sdk_auth` now rejects a non-empty selector that fails to normalize instead
+of falling back. The error names the variable and never echoes the value:
+`normalize_base_url` rejects URLs carrying embedded credentials, so a rejected
+value is exactly the kind that may contain one. The regression test asserts both
+halves — that the variable is named, and that neither the value nor its embedded
+password appears in stderr.
+
+This is the second defect in this file produced by the same root cause, and the
+fifth today from the split auth store overall. The two stores want consolidating
+rather than further call-site patching.
+
+Re-verified: `cargo fmt --check` 0, `clippy -D warnings` 0 with zero warnings,
+`cargo test --workspace` 0 with 440 passed and 0 failed, `tsc` 0, `npm test` 0
+with 75/75, `scripts` 10/10, contract 9, `index.d.ts` clean. Against the
+repacked and reinstalled artifact both suites pass, `replay` renders and
+paginates, and `$(ai-hist token)` captures a real token.

--- a/docs/ws12-validation.md
+++ b/docs/ws12-validation.md
@@ -1,66 +1,79 @@
-# WS-12 validation and remaining rollout
+# WS-12 validation
 
 Drafts: https://github.com/AgentWorkforce/relayhistory/pull/117 and
 https://github.com/AgentWorkforce/relayhistory-cloud/pull/43. No merge or
 production deployment has been performed.
 
-## Evidence
+## Artifact and CI evidence
 
-- Native source, SDK and built addon agreed on contract 8.
-- Rust cloud transport: 50 tests passed (stage isolation, refresh rotation,
-  atomic auth/cursor writes, failed pushes and transcript watermarks).
-- Rust outbox: 29 tests passed.
-- Initial built npm fixture: all 525 unique synthetic prompts arrived in two
-  batches; the Rust Agent Relay login handoff ran; SDK auth adopted the refreshed
-  token; stale SDK auth did not override it; a failed second-stage push left the
-  first-stage cursor unchanged; a real commit generated Git notes and a PR event.
-- Follow-up hook checks found inherited broker `core.hooksPath` pointing at a
-  shared temporary directory. The installer now rejects external shared hook
-  paths, and tests use isolated Git configuration. It also resolves an existing
-  PR at install time through repository config or gh. The final fixture and full
-  Node 22 SDK suite passed in GitHub CI on head 1b91b25.
-- Server: 4 sharing route tests and 15 existing session-link tests passed, package
-  typecheck passed, Wrangler deployment dry-run passed. Sharing tests use real
-  PGlite DDL and verify anonymous/private access, owner and tenant isolation,
-  frozen snapshots, escaped HTML, and revocation. Full server CI (formatting,
-  typecheck and all tests) passed on f475d7c in run 34232491784.
-- Live dev: the npm command with fresh isolated ai-hist state exchanged an
-  existing real Agent Relay Cloud identity and reported sent=1, accepted=1 for
-  synthetic session `ws12-cloud-demo-1788873511810`. This was not a fresh browser
-  device approval. The deployed service returned 404 for all recall/session/turn
-  routes while /health returned 200, so persistence is NOT verified from the ack.
+- Native source, SDK and built addon agree on contract 8.
+- Client head e98b4ec passed all required CI jobs in
+  https://github.com/AgentWorkforce/relayhistory/actions/runs/34236408938:
+  Rust formatting, Clippy and workspace tests; native contract; Node 20 SDK;
+  installed npm tarball SDK/CLI smoke; Node 22 SDK; Windows state replacement.
+- The Node 22 SDK suite passed all 61 tests. Its actual built npm command fixture
+  runs with fresh isolated HOME/state and a simulated Agent Relay device-flow
+  service: all 525 unique synthetic prompts arrive in two batches; token refresh,
+  stale legacy SDK auth, stage isolation, failed pushes, Git notes, prior hook
+  chaining, external shared-hook rejection and native sharing are exercised.
+  The final built addon also passed this focused fixture locally on September 8.
+- Local Rust transport tests: 50 passed. Local outbox tests: 29 passed.
+- Server head f475d7c passed formatting, typecheck and the full test suite in
+  https://github.com/AgentWorkforce/relayhistory-cloud/actions/runs/34232491784.
+  Four PGlite sharing route tests cover visibility, owner/tenant isolation,
+  escaping, frozen content and revocation; 15 session-link tests also pass.
 
-## Environment failures
+## Live dev demonstration — September 8, 2026
 
-Homebrew Node 26 stopped loading mid-run because libada.3.dylib disappeared.
-Subsequent commands use the existing mise Node 22.22.2 installation. The disk
-then filled; the broad SDK run had 44 passes and 17 failures including ENOSPC and
-SQLite shared-memory I/O failures. Broad server runs stalled/timed out. These
-runs are not claimed green. Only WS-12's reproducible Rust target cache was
-removed to recover space; the built addon and committed sources were retained.
+The dev workflow on the cloud draft branch succeeded, including credential
+preflight, all tests, additive Neon migrations, SST diff, dev deployment and
+post-deploy stage-binding/health verification:
+https://github.com/AgentWorkforce/relayhistory-cloud/actions/runs/34236389791.
 
-SST dev plan attempts initially stalled in provider dependency installation. A
-direct npm install of the generated platform dependencies completed. SST then
-failed explicitly: Cloudflare API not initialized; CLOUDFLARE_API_TOKEN (or API
-key plus email) must be configured. No plan, deploy, or migration was applied.
+1. With fresh isolated ai-hist HOME/state, the built npm command
+   `ai-hist enable-cloud --base-url https://dev.history.agentrelay.com --once --json`
+   exchanged an existing real Agent Relay Cloud identity and returned
+   `sent=1, accepted=1`. This demonstrates fresh ai-hist setup, not a fresh browser
+   device approval. The trusted-dev opt-in was set in this isolated fixture.
+2. After deployment, authenticated `GET /v1/events?session=ws12-cloud-demo-1788873511810`
+   returned HTTP 200 and the exact persisted synthetic event
+   `prompt:1788873511858:558f0daa0735f957`, with content
+   `Synthetic WS-12 acceptance fixture ws12-cloud-demo-1788873511810: prove one-command cloud push.`
+3. The final SDK installed a repository-local hook for that indexed session and
+   https://github.com/AgentWorkforce/relayhistory/pull/117. An actual Git commit
+   (`c965e86c7a54a354d8c7a7917a487da474e3adcb`) appended the session note. The next
+   `pushCloud()` returned `sent=2, accepted=2`.
+4. `GET /v1/sessions/ws12-cloud-demo-1788873511810/thread?source=claude`
+   returned HTTP 200 with the persisted session-link projection:
 
-## Remaining acceptance
+   ```json
+   {
+     "linkKind": "github_pr",
+     "linkRef": "AgentWorkforce/relayhistory#117",
+     "linkUrl": "https://github.com/AgentWorkforce/relayhistory/pull/117",
+     "confidence": 1
+   }
+   ```
 
-1. Client Node 22 SDK and Windows CI passed. The main verify job found a Clippy
-   item-order warning; the SDK cloud functions have now been moved before the
-   test module. Verify the subsequent CI run. `node --test sdk-ts/dist/cloud.test.js` exercises the public
-   SDK and actual npm CLI, including an offline post-commit and native sharing.
-2. Review `sst diff --stage dev`, deploy the cloud companion to dev, and apply
-   its additive `0010_trace_shares.sql` to the verified dev Neon branch.
-3. Run `ai-hist enable-cloud --base-url https://dev.history.agentrelay.com --once`
-   with the existing trusted-dev opt-in. Query the exact synthetic event IDs,
-   then commit through the installed hook and query
-   session_links.link_kind='github_pr' (the actual column is link_kind).
-4. Call createShareableTrace and open the returned dev /s/<token> URL. The hosted
-   PR-link row and share URL demonstrations are still outstanding.
+5. `createShareableTrace(sessionId, {visibility: 'direct-link', source: 'claude', baseUrl})`
+   returned a frozen three-event snapshot at this demo URL:
+   https://dev.history.agentrelay.com/s/be1f610eace1cb5debf2bb6cb97dd61d9e979ec801690ae1862b21a869c93c64
+   An anonymous HTTP GET returned 200, the exact synthetic prompt in rendered
+   HTML, and `X-Robots-Tag: noindex, nofollow, noarchive`. Browser visual inspection
+   was unavailable because the browser runtime import was rejected by its tool.
+
+## Practical limits and environment notes
 
 The SDK push loop is foreground/in-process. Agent Relay must be installed for
 interactive device login. Hooks use an existing indexed session; PRs created
 after installation require rerunning installation. Shares contain frozen
 convergence events; private URL reads currently require an authenticated HTTP
 client. See enable-cloud.md and the cloud PR's docs/sharing.md.
+
+Early broad local runs were interrupted by a broken Homebrew Node, ENOSPC and
+host overload. Subsequent commands used mise Node 22.22.2; only this worktree's
+reproducible Rust cache was removed to recover space. Local SST attempts failed
+on missing/expired Cloudflare credentials; the authorized dev workflow supplied
+its existing environment credentials and completed deployment successfully.
+Earlier dev recall 404s were resolved by this deployment; persistence is now
+verified by exact event content and the session-link read above.

--- a/docs/ws12-validation.md
+++ b/docs/ws12-validation.md
@@ -407,3 +407,42 @@ tests, where this PR began with 11 and 8. `tsc` 0, `npm test` 0 with 75/75,
 `scripts` 10/10, contract 9, `index.d.ts` clean. Against the repacked and
 reinstalled artifact both suites pass, `replay` renders and paginates, and
 `$(ai-hist token)` captures a real token.
+
+## Rebase onto #112, and the cloud-client deduplication deferred
+
+`#112` (`bc1e9a5`, get_session_thread MCP tool) landed while CI ran, and it
+touched `sdk-ts/src/cloud-client.ts` — the file this branch had reduced to a
+three-line re-export. `#112` added `getSessionThread` there together with its own
+stage resolution, rotation and recall HTTP client.
+
+Taking this branch's side of that conflict would have silently deleted a feature
+that merged the same day. Main's file is kept intact instead, and this branch's
+deduplication of `cloud-client.ts` is dropped. Nothing in the token/replay
+delivery depends on it: the napi bridge, the legacy-store migration and the
+shared destination rule are all unaffected, and `#112`'s tests pass alongside
+them (the TypeScript suite is now 110 tests, up from 75).
+
+The cost is honest debt rather than a hidden regression. `loginCloud` and
+`loadStoredRelayhistoryAuth` now exist twice in the package: the Rust-backed
+versions in `index.ts` and the TypeScript ones in `cloud-client.ts`, the latter
+still writing `~/.config/ai-hist/auth.json` directly. That is the split auth
+store in its most literal form — two credential implementations in one package —
+and it is the same root cause behind the defects recorded above.
+
+The architecture test was rewritten rather than deleted. Asserting that
+`cloud-client.ts` delegates everything to the SDK is no longer true, so it now
+asserts the narrower thing this change did establish: `enableCloud`, `pushCloud`,
+`accessToken`, `replay` and `createShareableTrace` have exactly one
+implementation and `cloud-client.ts` must not add a second. The remaining
+duplication is named in a comment there so the next reader finds it.
+
+Consolidating `getSessionThread` onto the Rust auth store is the follow-up. It
+was deliberately not attempted here: this PR had blocked the cloud client all
+day, and porting a recall client's auth under time pressure is how the defects
+above were produced in the first place.
+
+Re-verified on the rebased head: `cargo fmt --check` 0, `clippy -D warnings` 0
+with zero warnings, `cargo test --workspace` 0 with 443 passed and 0 failed,
+`tsc` 0, `npm test` 0 with 110/110, `scripts` 10/10, contract 9, `index.d.ts`
+clean. Against the repacked and reinstalled artifact both suites pass, `replay`
+renders and paginates, and `$(ai-hist token)` captures a real token.

--- a/docs/ws12-validation.md
+++ b/docs/ws12-validation.md
@@ -288,3 +288,35 @@ and `replay` and `$(ai-hist token)` still run from the installed binary.
 Note for follow-up, outside this PR's surface: `cloud::recall_auth` also uses
 `load_auth` and would show the same gap for legacy npm users. It is a CLI-side
 path not exposed by this change, so it was left alone rather than expanding scope.
+
+## Follow-up: the legacy-store fix regressed the stage-ambiguity probe
+
+cursor caught a regression introduced by the fix above. `access_token` calls
+`load(None)` purely as a probe: it exists to raise push's multi-stage refusal
+when no destination has been selected. Routing that probe through
+`load_sdk_auth` broke it, because the two functions disagree on what counts as
+a selection:
+
+- `access_token` treats a stage selector as chosen only if it *normalizes*
+  (`find_map(normalize_base_url)`).
+- `load_sdk_auth` treats *any non-empty* `RELAYHISTORY_BASE_URL` or
+  `AI_HIST_BASE_URL` as a selection and falls back to production
+  (`.any(|v| !v.trim().is_empty()).then(default_base_url)`).
+
+So with several stages configured and a malformed selector such as
+`RELAYHISTORY_BASE_URL=not-a-url`, the refusal was skipped and `token` printed
+the production credential — the wrong stage's secret, silently.
+
+The probe now uses `load_auth` again while destination resolution keeps
+`load_sdk_auth`, so legacy migration is preserved. Migration is irrelevant to a
+probe that only asks whether the destination is ambiguous.
+
+The regression test was written before the fix and observed to fail in the
+telling way: not on the assertion message but on `!output.status.success()` —
+`token` *succeeded* where it had to refuse.
+
+Re-verified: `cargo fmt --check` 0, `clippy -D warnings` 0 with zero warnings,
+`cargo test --workspace` 0 with 439 passed and 0 failed, `tsc` 0, `npm test` 0
+with 75/75, `scripts` 10/10, contract 9, `index.d.ts` clean. Against the
+repacked and reinstalled artifact both suites pass, including the legacy-store
+case, and `$(ai-hist token)` still captures a real token.

--- a/docs/ws12-validation.md
+++ b/docs/ws12-validation.md
@@ -1,0 +1,62 @@
+# WS-12 validation and remaining rollout
+
+Drafts: https://github.com/AgentWorkforce/relayhistory/pull/117 and
+https://github.com/AgentWorkforce/relayhistory-cloud/pull/43. No merge or
+production deployment has been performed.
+
+## Evidence
+
+- Native source, SDK and built addon agreed on contract 8.
+- Rust cloud transport: 50 tests passed (stage isolation, refresh rotation,
+  atomic auth/cursor writes, failed pushes and transcript watermarks).
+- Rust outbox: 29 tests passed.
+- Initial built npm fixture: all 525 unique synthetic prompts arrived in two
+  batches; the Rust Agent Relay login handoff ran; SDK auth adopted the refreshed
+  token; stale SDK auth did not override it; a failed second-stage push left the
+  first-stage cursor unchanged; a real commit generated Git notes and a PR event.
+- Follow-up hook checks found inherited broker `core.hooksPath` pointing at a
+  shared temporary directory. The installer now rejects external shared hook
+  paths, and tests use isolated Git configuration. It also resolves an existing
+  PR at install time through repository config or gh. Final rebuilt fixture pending.
+- Server: 4 sharing route tests and 15 existing session-link tests passed, package
+  typecheck passed, Wrangler deployment dry-run passed. Sharing tests use real
+  PGlite DDL and verify anonymous/private access, owner and tenant isolation,
+  frozen snapshots, escaped HTML, and revocation.
+- Live dev: the npm command with fresh isolated ai-hist state exchanged an
+  existing real Agent Relay Cloud identity and reported sent=1, accepted=1 for
+  synthetic session `ws12-cloud-demo-1788873511810`. This was not a fresh browser
+  device approval. The deployed service returned 404 for all recall/session/turn
+  routes while /health returned 200, so persistence is NOT verified from the ack.
+
+## Environment failures
+
+Homebrew Node 26 stopped loading mid-run because libada.3.dylib disappeared.
+Subsequent commands use the existing mise Node 22.22.2 installation. The disk
+then filled; the broad SDK run had 44 passes and 17 failures including ENOSPC and
+SQLite shared-memory I/O failures. Broad server runs stalled/timed out. These
+runs are not claimed green. Only WS-12's reproducible Rust target cache was
+removed to recover space; the built addon and committed sources were retained.
+
+SST dev plan attempts remained in provider dependency installation. A direct npm
+install of the generated platform dependencies completed, but SST returned to
+its own provider install. No plan, deploy, or migration was applied.
+
+## Remaining acceptance
+
+1. Build the final addon and SDK, rerun the focused fixture and broader tests on
+   a healthy machine. `node --test sdk-ts/dist/cloud.test.js` exercises the public
+   SDK and actual npm CLI, including an offline post-commit and native sharing.
+2. Review `sst diff --stage dev`, deploy the cloud companion to dev, and apply
+   its additive `0010_trace_shares.sql` to the verified dev Neon branch.
+3. Run `ai-hist enable-cloud --base-url https://dev.history.agentrelay.com --once`
+   with the existing trusted-dev opt-in. Query the exact synthetic event IDs,
+   then commit through the installed hook and query
+   session_links.link_kind='github_pr' (the actual column is link_kind).
+4. Call createShareableTrace and open the returned dev /s/<token> URL. The hosted
+   PR-link row and share URL demonstrations are still outstanding.
+
+The SDK push loop is foreground/in-process. Agent Relay must be installed for
+interactive device login. Hooks use an existing indexed session; PRs created
+after installation require rerunning installation. Shares contain frozen
+convergence events; private URL reads currently require an authenticated HTTP
+client. See enable-cloud.md and the cloud PR's docs/sharing.md.

--- a/docs/ws12-validation.md
+++ b/docs/ws12-validation.md
@@ -238,3 +238,53 @@ $ ai-hist replay sess-117 --json --out transcript.json
 
 `$(ai-hist token)` again captured a 27-character token rather than an empty
 string, and `cloud-commands.test.js` passed against the installed package.
+
+## The split auth store: token and replay must migrate the legacy npm credentials
+
+cursor flagged that `accessToken()` and `replay()` loaded credentials with
+`load_auth`, which never reads or migrates `~/.config/ai-hist/auth.json`, while
+the four other cloud entrypoints in this same change — `enableCloud`,
+`pushCloud`, `loadStoredRelayhistoryAuth` and `createShareableTrace` — go through
+`load_sdk_auth`, which does import it.
+
+That inconsistency defeated the purpose of the PR. An existing npm SDK user has
+credentials in the legacy TypeScript store by definition and not in the Rust
+stage store, so after upgrading they would still have found `token` and `replay`
+unusable — the exact population these commands exist to serve. Both now use
+`load_sdk_auth`.
+
+The regression test is deliberately a negative control rather than a passing
+assertion alone. With the fix reverted it fails with the precise user-visible
+symptom:
+
+```
+code: 1
+stderr: 'ai-hist: CLOUD_TOKEN_FAILED: not authenticated — run `ai-hist login` …'
+```
+
+and with the fix it serves the legacy token and migrates it into the canonical
+stage store. It runs against the installed package under
+`AI_HIST_TEST_PACKAGE_DIR`, so it proves the behaviour in the shipped CLI.
+
+### A test-isolation defect this exposed
+
+`crates/ai-hist/tests/token.rs` and `tests/replay.rs` pinned `RELAYHISTORY_HOME`
+but not `HOME`, so once `token` began consulting the legacy store these tests
+read the developer's real `~/.config/ai-hist/auth.json`. Two of them failed
+locally for that reason. They would have passed in CI, where no such file exists,
+which makes this a latent machine-dependent flake rather than a new break. Both
+harnesses now pin `HOME`, `USERPROFILE` and `AI_HIST_CONFIG_DIR` to the test's
+temporary directory.
+
+### Re-verified
+
+`cargo fmt --check` 0, `clippy -D warnings` 0 with zero warnings,
+`cargo test --workspace` 0 with 438 passed and 0 failed, `tsc --noEmit` 0,
+`npm test` 0 with 75/75, `scripts/*.test.mjs` 0 with 10/10, native contract 9
+agreeing across all three sources, `index.d.ts` diff clean. Against the repacked
+and reinstalled artifact both suites pass, including the new legacy-store case,
+and `replay` and `$(ai-hist token)` still run from the installed binary.
+
+Note for follow-up, outside this PR's surface: `cloud::recall_auth` also uses
+`load_auth` and would show the same gap for legacy npm users. It is a CLI-side
+path not exposed by this change, so it was left alone rather than expanding scope.

--- a/docs/ws12-validation.md
+++ b/docs/ws12-validation.md
@@ -162,3 +162,79 @@ installed `./node_modules/.bin/ai-hist`:
   empty string — was reproduced as a shell command substitution against a
   fixture cloud using the installed binary. It captured a 27-character token
   identical to the one the fixture issued, with a non-zero length.
+
+## Review round: four independent reviewers converged on the hook-install path
+
+Rebased again onto `6e6acac` (#118's README rewrite). The README conflict was
+resolved in main's favour: #118's landing copy is kept, and the cloud entrypoint
+is reintroduced lower down described accurately, since `enable-cloud`
+authenticates and syncs but does not install Git hooks.
+
+Six review threads landed on the PR. Four of them — from CodeRabbit and
+cursor — pointed at `crates/ai-hist/src/git_sdk.rs`. That convergence was
+correct; all four described real defects in hook installation.
+
+**P1, installing fixed hooks from a linked worktree.** Confirmed against real
+Git rather than by reading: in a linked worktree
+`git rev-parse --git-path hooks/post-commit` resolves to the *main* worktree's
+shared `.git/hooks/post-commit`, so the existing containment check passed and
+installation proceeded. The written hook embeds one fixed `sessionId` and `repo`,
+so every other worktree's commits would have fired it and been attributed to the
+wrong session — corrupting exactly the linkage the feature exists to record. Now
+refused by comparing `--git-dir` with `--git-common-dir`, and scoped so it only
+fires for hooks that are actually shared.
+
+**P2, resolving a nonexistent hooks path.** `core.hooksPath` containing `..`
+satisfied the containment check lexically while `create_dir_all` resolved
+outside the repository. The nearest existing ancestor is now canonicalized and
+the remaining components applied before comparison.
+
+**P2, preserving existing hooks.** A compiled or non-UTF-8 `post-commit` made
+`read_to_string` fail; `unwrap_or_default` turned that into an empty string, so
+no backup was taken and the hook was overwritten, contrary to the stated
+preservation contract. Only a missing file now counts as nothing to preserve.
+
+**cursor, repo-local hooks rejected.** The guard treated any `core.hooksPath`
+outside the common dir as external, so legitimate repository-local directories
+such as husky's `.husky` were refused — while the error told the user to
+configure exactly such a directory. Hook directories inside the work tree are
+now accepted; only paths belonging to neither the common dir nor the work tree
+are refused. This also makes the worktree guard meaningful rather than dead:
+work-tree-local hooks are per-worktree and stay allowed.
+
+The two CodeRabbit minors are fixed as well: `--interval` is validated in the
+seconds the caller typed rather than reporting a millisecond bound, and the
+`enable-cloud` copy no longer claims one command threads sessions to PRs. A
+nitpick about `URL.pathname` not decoding percent-encoding was taken too, so a
+checkout path containing a space resolves `cli.js`.
+
+A regression test covers all four hook behaviours. It is not vacuous: it first
+failed for an unrelated reason, which proved the guarded code path was reached,
+then passed on the specific assertions once the fixture seeded a session.
+
+### Re-verified after the fixes
+
+`cargo fmt --check` 0, `clippy -D warnings` 0 with zero warnings,
+`cargo test --workspace` 0 with 438 passed, `tsc --noEmit` 0, `npm test` 0 with
+74/74, `scripts/*.test.mjs` 0 with 10/10, native contract 9 agreeing across all
+three sources, `index.d.ts` diff clean.
+
+The artifact was repacked and reinstalled, and both commands were run from the
+installed binary:
+
+```
+$ ai-hist replay sess-117
+Session sess-117 — 2 event(s), oldest first
+
+[2026-09-09T10:00:00Z] claude / prompt (e1)
+rebase 117 onto current main
+
+[2026-09-09T10:00:05Z] claude / response (e2)
+rebased; two union conflicts in cli.ts
+
+$ ai-hist replay sess-117 --json --out transcript.json
+(stdout empty; file holds 2 events e1, e2; pagination exercised)
+```
+
+`$(ai-hist token)` again captured a 27-character token rather than an empty
+string, and `cloud-commands.test.js` passed against the installed package.

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -187,3 +187,7 @@ evidence, and connector/parser failures with dedicated error subclasses.
 
 The old synchronous `AiHist` class and `openAiHist()` API were removed in 1.0.
 See [the migration guide](https://github.com/AgentWorkforce/relayhistory/blob/main/docs/native-sdk-migration.md).
+
+## Cloud opt-in
+
+Run `ai-hist enable-cloud` to log in, drain local history and keep pushing. Use `--once` to exit after draining. The async SDK exports `enableCloud`, `pushCloud`, `installGitHooks` and `createShareableTrace`; cloud transport and stage-scoped auth stay in Rust. Interactive login requires Agent Relay. See [cloud setup](https://github.com/AgentWorkforce/relayhistory/blob/main/docs/enable-cloud.md).

--- a/sdk-ts/README.md
+++ b/sdk-ts/README.md
@@ -191,3 +191,30 @@ See [the migration guide](https://github.com/AgentWorkforce/relayhistory/blob/ma
 ## Cloud opt-in
 
 Run `ai-hist enable-cloud` to log in, drain local history and keep pushing. Use `--once` to exit after draining. The async SDK exports `enableCloud`, `pushCloud`, `installGitHooks` and `createShareableTrace`; cloud transport and stage-scoped auth stay in Rust. Interactive login requires Agent Relay. See [cloud setup](https://github.com/AgentWorkforce/relayhistory/blob/main/docs/enable-cloud.md).
+
+## Cloud token and replay
+
+The npm CLI uses the same Rust engine as the public async SDK:
+
+```bash
+export RTH_TOKEN=$(ai-hist token)
+ai-hist replay SESSION_ID
+ai-hist replay SESSION_ID --json --out transcript.json
+```
+
+```ts
+import { accessToken, replay } from 'ai-hist';
+
+const token = await accessToken(); // Secret: do not log it.
+const result = await replay('SESSION_ID', { json: true });
+const events = JSON.parse(result.transcript!);
+await replay('SESSION_ID', { json: true, out: 'transcript.json' });
+```
+
+Both APIs accept `baseUrl` (`--base-url` in the CLI) for explicit stage selection.
+Token refresh and persistence run in Rust before returning a token with at least
+60 seconds of recorded validity. Piped `token` stdout contains only the token
+and one newline; failures leave stdout empty. Replay fetches every page in
+server order; `limit` is the page size, and `maxContent` caps each event's content.
+File output replaces its destination atomically only after all pages succeed.
+Neither command opens or imports into the local history database.

--- a/sdk-ts/src/architecture.test.ts
+++ b/sdk-ts/src/architecture.test.ts
@@ -92,10 +92,23 @@ test('MCP evidence tools require both halves of a session identity', async () =>
 });
 
 
-test('cloud compatibility entrypoint delegates auth and transport to the SDK', async () => {
+// cloud-client.ts still carries #112's getSessionThread recall client together
+// with its own stage resolution, rotation and `~/.config/ai-hist/auth.json`
+// handling, so it is not yet a pure delegation to the native SDK. It also still
+// defines loginCloud and loadStoredRelayhistoryAuth alongside the Rust-backed
+// versions in index.ts — a second credential implementation in the same package.
+// Consolidating that is tracked in docs/ws12-validation.md and deliberately not
+// attempted here. Until then, guard the narrower invariant this change did
+// establish: the operations moved to Rust must have exactly one implementation.
+test('cloud compatibility entrypoint does not reimplement the native cloud operations', async () => {
   const source = await readFile(join(sourceDir, 'cloud-client.ts'), 'utf8');
   assert.match(source, /from '\.\/index\.js'/);
-  assert.doesNotMatch(source, /fetch\(|writeFile|readFile|auth\.json|refreshToken:/);
+  for (const operation of ['enableCloud', 'pushCloud', 'accessToken', 'replay', 'createShareableTrace']) {
+    assert.equal(
+      source.includes(`export async function ${operation}`), false,
+      `${operation} has one native implementation; cloud-client must not add a second`,
+    );
+  }
 });
 
 test('token and replay SDK operations delegate to native code', async () => {

--- a/sdk-ts/src/architecture.test.ts
+++ b/sdk-ts/src/architecture.test.ts
@@ -8,7 +8,7 @@ const sourceDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
 const repositoryRoot = join(sourceDir, '..', '..');
 
 test('production TypeScript has one native implementation', async () => {
-  const files = ['index.ts', 'cli.ts', 'mcp-server.ts'];
+  const files = ['index.ts', 'cli.ts', 'mcp-server.ts', 'cloud-client.ts'];
   const source = (await Promise.all(files.map((file) => readFile(join(sourceDir, file), 'utf8')))).join('\n');
   for (const forbidden of ['sql.js', 'node:child_process', 'AI_HIST_RUST_BIN', "fallback: 'jsonl'", 'readFile(dbPath)']) {
     assert.equal(source.includes(forbidden), false, `production source contains ${forbidden}`);
@@ -89,4 +89,11 @@ test('MCP evidence tools require both halves of a session identity', async () =>
     assert.match(registration, /after: EVIDENCE_CURSOR\.optional\(\)/, `${tool} paginates`);
     assert.match(registration, /READ/, `${tool} is a cache-only read`);
   }
+});
+
+
+test('cloud compatibility entrypoint delegates auth and transport to the SDK', async () => {
+  const source = await readFile(join(sourceDir, 'cloud-client.ts'), 'utf8');
+  assert.match(source, /from '\.\/index\.js'/);
+  assert.doesNotMatch(source, /fetch\(|writeFile|readFile|auth\.json|refreshToken:/);
 });

--- a/sdk-ts/src/architecture.test.ts
+++ b/sdk-ts/src/architecture.test.ts
@@ -97,3 +97,11 @@ test('cloud compatibility entrypoint delegates auth and transport to the SDK', a
   assert.match(source, /from '\.\/index\.js'/);
   assert.doesNotMatch(source, /fetch\(|writeFile|readFile|auth\.json|refreshToken:/);
 });
+
+test('token and replay SDK operations delegate to native code', async () => {
+  const source = await readFile(join(sourceDir, 'index.ts'), 'utf8');
+  const cloudCommands = source.slice(source.indexOf('export async function accessToken('), source.indexOf('export interface CloudOptions'));
+  assert.match(cloudCommands, /native\.accessToken\(/);
+  assert.match(cloudCommands, /native\.replay\(/);
+  assert.doesNotMatch(cloudCommands, /fetch\(|readFile|writeFile|auth\.json|nextCursor|refreshToken/);
+});

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -559,9 +559,15 @@ async function main(): Promise<void> {
   if (command === 'enable-cloud') {
     validateFlags(args, 'enable-cloud', ['base-url', 'db', 'interval', 'once', 'json']);
     rejectSurplusPositionals(args.positional.slice(1), 'enable-cloud');
+    // --interval is seconds; validate before converting so the error names the
+    // unit the caller actually typed rather than a millisecond bound.
+    const intervalSeconds = numberFlag(args, 'interval') ?? 60;
+    if (!Number.isSafeInteger(intervalSeconds) || intervalSeconds < 1 || intervalSeconds > 2_147_483) {
+      usage('--interval must be a whole number of seconds between 1 and 2147483');
+    }
     const handle = await enableCloud({
       baseUrl: textFlag(args, 'base-url'), dbPath: textFlag(args, 'db'),
-      intervalMs: (numberFlag(args, 'interval') ?? 60) * 1000,
+      intervalMs: intervalSeconds * 1000,
       watch: !args.flags.has('once'),
       onPush: (result) => output(result, json),
     });

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -6,7 +6,7 @@ import {
   bootstrapLocal, discoverSessions, formatSessionRow, getSession, getSessionEventsPage, getSessionFileEditsPage,
   getSessionRelationships, getSessionToolCallsPage, getSessionTree, hydrateSession,
   listSessionCatalogPage, recent, resumeCommand, search, stats, sync,
-  enableCloud,
+  enableCloud, accessToken, replay,
   type CatalogCursor, type EvidenceCursor, type HistoryEntry, type SessionFileEditsPage,
   type SessionRelationship, type SessionScope, type SessionToolCallsPage,
 } from './index.js';
@@ -17,7 +17,7 @@ type PackageMetadata = { version?: string };
 
 const BOOLEAN_FLAGS = new Set(['all', 'fts', 'json', 'local', 'no-bootstrap', 'no-related', 'no-warning', 'once', 'pretty', 'remote', 'version']);
 const VALUE_FLAGS = new Set([
-  'base-url', 'interval', 'after', 'after-ms', 'after-session-id', 'after-source', 'before-ms', 'db', 'limit',
+  'base-url', 'interval', 'max-content', 'out', 'after', 'after-ms', 'after-session-id', 'after-source', 'before-ms', 'db', 'limit',
   'max-depth', 'max-nodes', 'project', 'source', 'tag', 'tokens',
 ]);
 const KNOWN_FLAGS = new Set([...BOOLEAN_FLAGS, ...VALUE_FLAGS]);
@@ -211,6 +211,8 @@ function usage(message?: string): never {
   ai-hist events SESSION_ID [--source SOURCE] [--limit N] [--after JSON] [--json]
   ai-hist resume QUERY... [--local | --remote | --all] [--db PATH] [--fts] [--json]
   ai-hist pack QUERY... [--local | --remote | --all] [--source SOURCE] [--project PATH] [--tag TAG] [--limit N] [--tokens N] [--db PATH] [--fts] [--json]
+  ai-hist token [--base-url URL]
+  ai-hist replay SESSION_ID [--base-url URL] [--limit N] [--max-content N] [--json] [--out PATH]
   ai-hist stats [--local | --remote | --all] [--json]
   ai-hist sync [--local | --remote | --all] [--db PATH] [--json]
 `);
@@ -533,6 +535,25 @@ async function main(): Promise<void> {
         : 'No searchable local sessions found. Start a coding-agent session, then run ai-hist again.\n');
       if (result.status === 'partial') process.stderr.write('Some local sessions could not be fully indexed; run ai-hist --json for diagnostics.\n');
     }
+    return;
+  }
+  if (command === 'token') {
+    validateFlags(args, 'token', ['base-url']);
+    rejectSurplusPositionals(args.positional.slice(1), 'token');
+    const token = await accessToken({ baseUrl: textFlag(args, 'base-url') });
+    if (process.stdout.isTTY) process.stderr.write('Warning: this access token is a secret and will remain in terminal scrollback.\n');
+    process.stdout.write(`${token}\n`);
+    return;
+  }
+  if (command === 'replay') {
+    validateFlags(args, 'replay', ['base-url', 'limit', 'max-content', 'json', 'out']);
+    if (!subcommand) usage('replay requires SESSION_ID');
+    rejectSurplusPositionals(rest, 'replay');
+    const result = await replay(subcommand, {
+      baseUrl: textFlag(args, 'base-url'), limit: nonNegativeIntFlag(args, 'limit'),
+      maxContent: nonNegativeIntFlag(args, 'max-content'), json, out: textFlag(args, 'out'),
+    });
+    if (result.transcript !== null) process.stdout.write(result.transcript);
     return;
   }
   if (command === 'enable-cloud') {

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -6,6 +6,7 @@ import {
   bootstrapLocal, discoverSessions, formatSessionRow, getSession, getSessionEventsPage, getSessionFileEditsPage,
   getSessionRelationships, getSessionToolCallsPage, getSessionTree, hydrateSession,
   listSessionCatalogPage, recent, resumeCommand, search, stats, sync,
+  enableCloud,
   type CatalogCursor, type EvidenceCursor, type HistoryEntry, type SessionFileEditsPage,
   type SessionRelationship, type SessionScope, type SessionToolCallsPage,
 } from './index.js';
@@ -14,9 +15,9 @@ type Parsed = { positional: string[]; flags: Map<string, Array<string | true>> }
 
 type PackageMetadata = { version?: string };
 
-const BOOLEAN_FLAGS = new Set(['all', 'fts', 'json', 'local', 'no-bootstrap', 'no-related', 'no-warning', 'pretty', 'remote', 'version']);
+const BOOLEAN_FLAGS = new Set(['all', 'fts', 'json', 'local', 'no-bootstrap', 'no-related', 'no-warning', 'once', 'pretty', 'remote', 'version']);
 const VALUE_FLAGS = new Set([
-  'after', 'after-ms', 'after-session-id', 'after-source', 'before-ms', 'db', 'limit',
+  'base-url', 'interval', 'after', 'after-ms', 'after-session-id', 'after-source', 'before-ms', 'db', 'limit',
   'max-depth', 'max-nodes', 'project', 'source', 'tag', 'tokens',
 ]);
 const KNOWN_FLAGS = new Set([...BOOLEAN_FLAGS, ...VALUE_FLAGS]);
@@ -196,6 +197,7 @@ function usage(message?: string): never {
   if (message) process.stderr.write(`ai-hist: ${message}\n\n`);
   process.stderr.write(`Usage:
   ai-hist [--no-bootstrap] [--db PATH] [--json]
+  ai-hist enable-cloud [--base-url URL] [--db PATH] [--interval SECONDS] [--once] [--json]
   ai-hist sessions list [--pretty] [--local | --remote | --all] [--source SOURCE]... [--limit N] [--before-ms MS] [--after JSON | --after-source SOURCE --after-session-id ID [--after-ms MS]] [--json]
   ai-hist sessions discover [--local | --remote | --all] [--source SOURCE] [--limit N] [--json]
   ai-hist sessions hydrate SOURCE SESSION_ID [--local | --remote | --all] [--no-related] [--db PATH] [--json]
@@ -533,6 +535,25 @@ async function main(): Promise<void> {
     }
     return;
   }
+  if (command === 'enable-cloud') {
+    validateFlags(args, 'enable-cloud', ['base-url', 'db', 'interval', 'once', 'json']);
+    rejectSurplusPositionals(args.positional.slice(1), 'enable-cloud');
+    const handle = await enableCloud({
+      baseUrl: textFlag(args, 'base-url'), dbPath: textFlag(args, 'db'),
+      intervalMs: (numberFlag(args, 'interval') ?? 60) * 1000,
+      watch: !args.flags.has('once'),
+      onPush: (result) => output(result, json),
+    });
+    const { stop, ...result } = handle;
+    output(result, json);
+    if (!args.flags.has('once')) {
+      const shutdown = () => { void stop(); };
+      process.once('SIGINT', shutdown);
+      process.once('SIGTERM', shutdown);
+    }
+    return;
+  }
+
   if (command === 'sessions' && subcommand === 'list') {
     validateFlags(args, 'sessions list', [
       'after', 'after-ms', 'after-session-id', 'after-source', 'all', 'before-ms', 'db',

--- a/sdk-ts/src/cloud-commands.test.ts
+++ b/sdk-ts/src/cloud-commands.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
-import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -14,6 +14,15 @@ const packageDir = process.env.AI_HIST_TEST_PACKAGE_DIR;
 const sdkUrl = packageDir ? pathToFileURL(join(packageDir, 'dist/index.js')) : new URL('./index.js', import.meta.url);
 const cli = packageDir ? join(packageDir, 'dist/cli.js') : fileURLToPath(new URL('./cli.js', import.meta.url));
 const sdk: typeof import('./index.js') = await import(sdkUrl.href);
+
+async function runCli(cwd: string, ...args: string[]) {
+  const child = spawn(process.execPath, [cli, ...args], { env: process.env, cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+  let stdout = '', stderr = '';
+  child.stdout.on('data', (chunk) => { stdout += chunk; });
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+  const [code] = await once(child, 'close');
+  return { code, stdout, stderr };
+}
 
 test('native npm token and replay: secrets, rotation, stages, pagination and atomic output', { timeout: 120_000 }, async () => {
   const saved = { ...process.env };
@@ -76,7 +85,7 @@ test('native npm token and replay: secrets, rotation, stages, pagination and ato
     assert.equal((await sdk.loginCloud('fixture-relay-token', { baseUrl })).ok, true);
     const authPath = join(state, 'stages', (await readdir(join(state, 'stages'))).find(f => f.endsWith('.auth.json'))!);
     const auth = JSON.parse(await readFile(authPath, 'utf8'));
-    const token = await command('token', '--base-url', baseUrl);
+    const token = await runCli(root, 'token', '--base-url', baseUrl);
     assert.deepEqual(token, { code: 0, stdout: oldToken + '\n', stderr: '' });
     assert.equal(await sdk.accessToken({ baseUrl }), oldToken);
     assert.equal(refreshes, 0);
@@ -142,6 +151,60 @@ test('native npm token and replay: secrets, rotation, stages, pagination and ato
     for (const key of Object.keys(process.env)) if (!(key in saved)) delete process.env[key];
     Object.assign(process.env, saved);
     server.closeAllConnections(); await new Promise<void>(resolve => server.close(() => resolve()));
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// The whole point of shipping token and replay through npm is the npm user, who
+// upgrading from the TypeScript client has credentials ONLY in the legacy
+// ~/.config/ai-hist/auth.json store. If these two commands read the Rust stage
+// store alone they fail for exactly the population they exist to serve.
+test('token and replay migrate the legacy TypeScript credential store', { timeout: 60_000 }, async () => {
+  const saved = { ...process.env };
+  const root = await mkdtemp(join(tmpdir(), 'ai-hist-legacy-auth-'));
+  const legacyToken = 'rth_at_legacy_sdk_store';
+  const events = [{ eventId: 'l1', ts: '2026-09-09T09:00:00Z', source: 'claude', kind: 'prompt', content: 'legacy store prompt' }];
+  const server = createServer((req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    const url = new URL(req.url!, 'http://fixture');
+    if (url.pathname === '/v1/sessions/legacy-session/events') {
+      assert.equal(req.headers.authorization, `Bearer ${legacyToken}`);
+      res.end(JSON.stringify({ events, nextCursor: null }));
+    } else { res.statusCode = 404; res.end('{}'); }
+  });
+  server.listen(0, '127.0.0.1'); await once(server, 'listening');
+  const baseUrl = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+  try {
+    const legacyDir = join(root, 'legacy-sdk');
+    const state = join(root, 'state');
+    Object.assign(process.env, {
+      HOME: root, USERPROFILE: root, RELAYHISTORY_HOME: state,
+      AI_HIST_CONFIG_DIR: legacyDir, RELAYHISTORY_NO_UPDATE_CHECK: '1',
+    });
+    for (const key of ['RELAYHISTORY_BASE_URL', 'AI_HIST_BASE_URL', 'CLOUD_API_ACCESS_TOKEN', 'CODEX_HOME']) delete process.env[key];
+
+    // Only the legacy store exists; the Rust stage store is untouched.
+    await mkdir(legacyDir, { recursive: true });
+    await writeFile(join(legacyDir, 'auth.json'), JSON.stringify({
+      baseUrl, accessToken: legacyToken, accessTokenExpiresAt: '2999-01-01T00:00:00Z',
+    }));
+    await assert.rejects(readdir(join(state, 'stages')), 'no Rust stage credential exists yet');
+
+    const token = await runCli(root, 'token', '--base-url', baseUrl);
+    assert.deepEqual(token, { code: 0, stdout: `${legacyToken}\n`, stderr: '' },
+      'token must serve the legacy npm user, not report "not authenticated"');
+
+    // The import is a migration, so the canonical store now holds it.
+    const stages = await readdir(join(state, 'stages'));
+    assert.ok(stages.some((file) => file.endsWith('.auth.json')), 'the legacy credential was migrated');
+
+    const replayed = await runCli(root, 'replay', 'legacy-session', '--base-url', baseUrl, '--json');
+    assert.equal(replayed.code, 0, replayed.stderr);
+    assert.deepEqual(JSON.parse(replayed.stdout), events);
+  } finally {
+    for (const key of Object.keys(process.env)) if (!(key in saved)) delete process.env[key];
+    Object.assign(process.env, saved);
+    server.closeAllConnections(); await new Promise<void>((resolve) => server.close(() => resolve()));
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/sdk-ts/src/cloud-commands.test.ts
+++ b/sdk-ts/src/cloud-commands.test.ts
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import test from 'node:test';
+
+// CI reruns this suite against the packed/installed SDK and platform addon.
+// Import and CLI resolution must both point at that artifact when requested.
+const packageDir = process.env.AI_HIST_TEST_PACKAGE_DIR;
+const sdkUrl = packageDir ? pathToFileURL(join(packageDir, 'dist/index.js')) : new URL('./index.js', import.meta.url);
+const cli = packageDir ? join(packageDir, 'dist/cli.js') : fileURLToPath(new URL('./cli.js', import.meta.url));
+const sdk: typeof import('./index.js') = await import(sdkUrl.href);
+
+test('native npm token and replay: secrets, rotation, stages, pagination and atomic output', { timeout: 120_000 }, async () => {
+  const saved = { ...process.env };
+  const root = await mkdtemp(join(tmpdir(), 'ai-hist-cloud-commands-'));
+  const state = join(root, 'state');
+  const oldToken = 'rth_at_old_fixture';
+  const newToken = 'rth_at_rotated_fixture';
+  const refreshToken = 'rth_rt_fixture';
+  const future = '2999-01-01T00:00:00Z';
+  let refreshes = 0, failRefresh = false;
+  let pageMode: 'ok' | 'fail' | 'repeat' = 'ok';
+  const requests: URL[] = [];
+  const events = [
+    { eventId: 'tie-a', ts: '2026-09-08T12:00:00Z', source: 'claude', kind: 'prompt', content: 'first synthetic prompt', futureField: { preserved: true } },
+    { eventId: 'tie-b', ts: '2026-09-08T12:00:00Z', source: 'claude', kind: 'response', content: '', contentTruncated: true },
+  ];
+  const cursor = 'opaque:tie-a/next+page=';
+  const server = createServer(async (req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    const url = new URL(req.url!, 'http://fixture');
+    if (url.pathname.endsWith('/v1/cli/login')) {
+      res.end(JSON.stringify({ accessToken: oldToken, refreshToken, accessTokenExpiresAt: future }));
+    } else if (url.pathname === '/v1/auth/token/refresh') {
+      refreshes++;
+      let raw = ''; for await (const chunk of req) raw += chunk;
+      assert.equal(JSON.parse(raw).refreshToken, refreshToken);
+      if (failRefresh) { res.statusCode = 401; res.end(JSON.stringify({ error: `${oldToken} ${newToken} ${refreshToken}` })); }
+      else res.end(JSON.stringify({ accessToken: newToken, refreshToken: 'rth_rt_rotated_fixture', accessTokenExpiresAt: future }));
+    } else if (url.pathname === '/v1/sessions/session%2Fwith%20space/events') {
+      assert.equal(req.headers.authorization, `Bearer ${newToken}`);
+      requests.push(url);
+      if (url.searchParams.has('cursor') && pageMode === 'fail') { res.statusCode = 503; res.end('{}'); }
+      else res.end(JSON.stringify({
+        events: [events[url.searchParams.has('cursor') ? 1 : 0]],
+        nextCursor: !url.searchParams.has('cursor') || pageMode === 'repeat' ? cursor : null,
+      }));
+    } else { res.statusCode = 404; res.end('{}'); }
+  });
+  server.listen(0, '127.0.0.1'); await once(server, 'listening');
+  const baseUrl = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+  async function command(...args: string[]) {
+    const child = spawn(process.execPath, [cli, ...args], { env: process.env, cwd: root, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '', stderr = '';
+    child.stdout.on('data', chunk => { stdout += chunk; });
+    child.stderr.on('data', chunk => { stderr += chunk; });
+    const [code] = await once(child, 'close');
+    return { code, stdout, stderr };
+  }
+  function failed(result: Awaited<ReturnType<typeof command>>) {
+    assert.notEqual(result.code, 0);
+    assert.equal(result.stdout, '');
+    for (const secret of [oldToken, newToken, refreshToken]) assert.equal(result.stderr.includes(secret), false);
+  }
+  try {
+    Object.assign(process.env, { HOME: root, USERPROFILE: root, RELAYHISTORY_HOME: state, AI_HIST_CONFIG_DIR: join(root, 'legacy-sdk'), AI_HIST_DB: join(root, 'must-not-open.db'), RUST_LOG: 'trace', RELAYHISTORY_NO_UPDATE_CHECK: '1' });
+    for (const key of ['RELAYHISTORY_BASE_URL', 'AI_HIST_BASE_URL', 'CLOUD_API_ACCESS_TOKEN', 'CODEX_HOME']) delete process.env[key];
+    await writeFile(process.env.AI_HIST_DB!, 'not a SQLite database');
+    failed(await command('token', '--base-url', baseUrl));
+    failed(await command('replay', 'session/with space', '--base-url', baseUrl));
+    assert.equal((await sdk.loginCloud('fixture-relay-token', { baseUrl })).ok, true);
+    const authPath = join(state, 'stages', (await readdir(join(state, 'stages'))).find(f => f.endsWith('.auth.json'))!);
+    const auth = JSON.parse(await readFile(authPath, 'utf8'));
+    const token = await command('token', '--base-url', baseUrl);
+    assert.deepEqual(token, { code: 0, stdout: oldToken + '\n', stderr: '' });
+    assert.equal(await sdk.accessToken({ baseUrl }), oldToken);
+    assert.equal(refreshes, 0);
+    await writeFile(authPath, JSON.stringify({ ...auth, access_token_expires_at: '2000-01-01T00:00:00Z' }));
+    const refreshed = await command('token', '--base-url', baseUrl);
+    assert.deepEqual(refreshed, { code: 0, stdout: newToken + '\n', stderr: '' });
+    assert.equal(refreshes, 1);
+    assert.equal(JSON.parse(await readFile(authPath, 'utf8')).refresh_token, 'rth_rt_rotated_fixture');
+    assert.equal(await sdk.accessToken({ baseUrl }), newToken);
+
+    const replayArgs = ['replay', 'session/with space', '--base-url', baseUrl, '--limit', '3', '--max-content', '7'];
+    const replayed = await command(...replayArgs, '--json');
+    assert.equal(replayed.code, 0, replayed.stderr);
+    assert.deepEqual(JSON.parse(replayed.stdout), events);
+    assert.equal(replayed.stderr, '');
+    assert.equal(requests.length, 2, 'a short first page must not stop pagination');
+    assert.equal(requests[1].searchParams.get('cursor'), cursor);
+    for (const url of requests) {
+      assert.equal(url.searchParams.get('order'), 'asc');
+      assert.equal(url.searchParams.get('limit'), '3');
+      assert.equal(url.searchParams.get('maxContent'), '7');
+    }
+    const direct = await sdk.replay('session/with space', { baseUrl });
+    assert.equal(direct.eventCount, 2);
+    assert.equal(direct.outputPath, null);
+    assert.match(direct.transcript!, /CONTENT TRUNCATED/);
+    assert.ok(direct.transcript!.indexOf('tie-a') < direct.transcript!.indexOf('tie-b'));
+    const out = join(root, 'offline transcript.json');
+    await writeFile(out, 'original');
+    assert.deepEqual(await command(...replayArgs, '--json', '--out', out), { code: 0, stdout: '', stderr: '' });
+    const complete = await readFile(out, 'utf8');
+    assert.deepEqual(JSON.parse(complete), events);
+    pageMode = 'fail';
+    failed(await command(...replayArgs, '--json', '--out', out));
+    assert.equal(await readFile(out, 'utf8'), complete);
+    pageMode = 'repeat';
+    const repeated = await command(...replayArgs, '--out', out);
+    failed(repeated); assert.match(repeated.stderr, /repeated nextCursor/);
+    assert.equal(await readFile(out, 'utf8'), complete);
+    pageMode = 'ok';
+    const savedReplay = await sdk.replay('session/with space', { baseUrl, out, json: true });
+    assert.deepEqual(savedReplay, { eventCount: 2, transcript: null, outputPath: out });
+
+    await writeFile(authPath, JSON.stringify({ ...auth, access_token_expires_at: null }));
+    failRefresh = true;
+    const rejected = await command('token', '--base-url', baseUrl);
+    failed(rejected); assert.match(rejected.stderr, /refreshing relayhistory session failed/);
+    await writeFile(authPath, JSON.stringify({ ...auth, access_token: { secret: oldToken } }));
+    const malformed = await command('token', '--base-url', baseUrl);
+    failed(malformed); assert.match(malformed.stderr, /could not parse stored relayhistory session/);
+    await writeFile(authPath, JSON.stringify(auth));
+    assert.equal((await sdk.loginCloud('fixture-relay-token', { baseUrl: baseUrl + '/other' })).ok, true);
+    const ambiguous = await command('token');
+    failed(ambiguous); assert.match(ambiguous.stderr, /Refusing to guess/);
+    process.env.RELAYHISTORY_BASE_URL = baseUrl;
+    assert.deepEqual(await command('token'), { code: 0, stdout: oldToken + '\n', stderr: '' });
+    assert.equal((await command('token', '--base-url', baseUrl + '/other')).stdout, oldToken + '\n');
+    for (const args of [['token', '--json'], ['token', 'extra'], ['replay'], [...replayArgs, 'extra'], [...replayArgs, '--limit', '-1']]) failed(await command(...args));
+    await assert.rejects(sdk.replay('session', { limit: -1 }), /limit must be an integer/);
+    assert.equal(await readFile(process.env.AI_HIST_DB!, 'utf8'), 'not a SQLite database');
+    assert.equal((await readdir(state)).some(name => name.endsWith('.db')), false);
+  } finally {
+    for (const key of Object.keys(process.env)) if (!(key in saved)) delete process.env[key];
+    Object.assign(process.env, saved);
+    server.closeAllConnections(); await new Promise<void>(resolve => server.close(() => resolve()));
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/sdk-ts/src/cloud.test.ts
+++ b/sdk-ts/src/cloud.test.ts
@@ -49,6 +49,12 @@ test('npm command: fresh auth to 525-record push, refresh, stage isolation, SDK 
   const baseUrl = `http://127.0.0.1:${address.port}`;
   const dbPath = join(root, 'history.db');
   try {
+    // The broker can inject a shared hooksPath using command-scope Git config.
+    // Test repositories must not inherit or mutate that shared hook directory.
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('GIT_CONFIG_') || ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_COMMON_DIR'].includes(key)) delete process.env[key];
+    }
+    process.env.GIT_CONFIG_NOSYSTEM = '1';
     process.env.HOME = root;
     process.env.USERPROFILE = root;
     process.env.RELAYHISTORY_HOME = join(root, 'auth');
@@ -84,7 +90,10 @@ test('npm command: fresh auth to 525-record push, refresh, stage isolation, SDK 
     await run('git', ['config', 'user.email', 'test@example.com'], process.env, repo);
     await run('git', ['config', 'user.name', 'SDK test'], process.env, repo);
     await writeFile(join(repo, '.git', 'hooks', 'post-commit'), '#!/bin/sh\necho old-hook > old-hook-ran\nexit 0\n', { mode: 0o755 });
-    const hook = await installGitHooks({ repo, sessionId: 'session-a', source: 'claude', dbPath, prUrl: 'https://github.com/AgentWorkforce/relayhistory/pull/123' });
+    await run('git', ['config', 'ai-hist.pr-url', 'https://github.com/AgentWorkforce/relayhistory/pull/123'], process.env, repo);
+    const hook = await installGitHooks({ repo, sessionId: 'session-a', source: 'claude', dbPath });
+    assert.equal(hook.prUrl, 'https://github.com/AgentWorkforce/relayhistory/pull/123');
+    assert.match(await readFile(hook.hookPath, 'utf8'), /post-commit.before-ai-hist/);
     assert.equal((await stat(hook.hookPath)).mode & 0o111, 0o111);
     await writeFile(join(repo, 'file.txt'), 'fixture');
     await run('git', ['add', 'file.txt'], process.env, repo);

--- a/sdk-ts/src/cloud.test.ts
+++ b/sdk-ts/src/cloud.test.ts
@@ -142,7 +142,7 @@ test('npm command: fresh auth to 525-record push, refresh, stage isolation, SDK 
 
 // Regression cover for the three hook-install guards. Each one protects a case
 // where installing would silently damage state the caller expected preserved.
-test('hook install refuses linked worktrees, escaping hooksPath, and preserves opaque hooks', { timeout: 60_000 }, async () => {
+test('hook install: worktree and escape refusals, repo-local hooks accepted, opaque hooks preserved', { timeout: 60_000 }, async () => {
   const saved = { ...process.env };
   const root = await mkdtemp(join(tmpdir(), 'ai-hist-hook-guards-'));
   try {
@@ -184,6 +184,14 @@ test('hook install refuses linked worktrees, escaping hooksPath, and preserves o
       installGitHooks({ repo, sessionId: 'session-a', source: 'claude', dbPath }),
       /external shared core.hooksPath/);
     await assert.rejects(stat(outside), 'the escaping hooks directory must not be created');
+
+    // A repository-local hooks directory such as husky's lives in the work tree
+    // rather than under .git. It belongs to this repo, so it must be accepted.
+    await run('git', ['config', 'core.hooksPath', '.husky'], process.env, repo);
+    const husky = await installGitHooks({ repo, sessionId: 'session-a', source: 'claude', dbPath });
+    // macOS resolves TMPDIR through /private, so compare the repo-relative tail.
+    assert.match(husky.hookPath, /[/\\]repo[/\\]\.husky[/\\]post-commit$/);
+    assert.match(await readFile(husky.hookPath, 'utf8'), /ai-hist SDK hook/);
 
     // A compiled or otherwise non-UTF-8 hook is still the user's hook: it must
     // be backed up, not silently overwritten because decoding failed.

--- a/sdk-ts/src/cloud.test.ts
+++ b/sdk-ts/src/cloud.test.ts
@@ -6,6 +6,7 @@ import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import { createShareableTrace, enableCloud, installGitHooks, loadStoredRelayhistoryAuth, pushCloud, sync } from './index.js';
 
 async function run(bin: string, args: string[], env: NodeJS.ProcessEnv, cwd?: string) {
@@ -75,7 +76,7 @@ test('npm command: fresh auth to 525-record push, refresh, stage isolation, SDK 
     const transcripts = join(root, '.claude', 'projects', 'fixture');
     await mkdir(transcripts, { recursive: true });
     await writeFile(join(transcripts, 'session-a.jsonl'), Array.from({ length: 525 }, (_, i) => JSON.stringify({ type: 'user', uuid: `u-${i}`, sessionId: 'session-a', timestamp: new Date(1_783_000_000_000 + i * 1000).toISOString(), message: { role: 'user', content: `synthetic cloud prompt ${i}` } })).join('\n'));
-    const cli = new URL('./cli.js', import.meta.url).pathname;
+    const cli = fileURLToPath(new URL('./cli.js', import.meta.url));
     const stdout = await run(process.execPath, [cli, 'enable-cloud', '--base-url', baseUrl, '--db', dbPath, '--once', '--json'], process.env);
     assert.equal(JSON.parse(stdout).sent, 525);
     const prompts = bodies.flatMap((body) => body.records).map((row) => row.content);
@@ -135,6 +136,67 @@ test('npm command: fresh auth to 525-record push, refresh, stage isolation, SDK 
     for (const key of Object.keys(process.env)) if (!(key in saved)) delete process.env[key];
     Object.assign(process.env, saved);
     server.closeAllConnections(); await new Promise<void>((resolve) => server.close(() => resolve()));
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+// Regression cover for the three hook-install guards. Each one protects a case
+// where installing would silently damage state the caller expected preserved.
+test('hook install refuses linked worktrees, escaping hooksPath, and preserves opaque hooks', { timeout: 60_000 }, async () => {
+  const saved = { ...process.env };
+  const root = await mkdtemp(join(tmpdir(), 'ai-hist-hook-guards-'));
+  try {
+    // Command-scope Git config from the broker must not leak into fixtures.
+    for (const key of Object.keys(process.env)) if (/^GIT_CONFIG(_|$)/.test(key)) delete process.env[key];
+    Object.assign(process.env, { HOME: root, USERPROFILE: root, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' });
+    const dbPath = join(root, 'history.db');
+    // installGitHooks resolves the session before touching Git, so the guards
+    // under test are only reachable once a real session is indexed.
+    const transcripts = join(root, '.claude', 'projects', 'fixture');
+    await mkdir(transcripts, { recursive: true });
+    await writeFile(join(transcripts, 'session-a.jsonl'), JSON.stringify({
+      type: 'user', uuid: 'u-0', sessionId: 'session-a',
+      timestamp: new Date(1_783_000_000_000).toISOString(),
+      message: { role: 'user', content: 'synthetic hook-guard prompt' },
+    }) + '\n');
+    await sync({ dbPath });
+
+    const repo = join(root, 'repo'); await mkdir(repo);
+    await run('git', ['init', '-q'], process.env, repo);
+    await run('git', ['config', 'user.email', 'test@example.com'], process.env, repo);
+    await run('git', ['config', 'user.name', 'SDK test'], process.env, repo);
+    await run('git', ['commit', '-q', '--allow-empty', '-m', 'init'], process.env, repo);
+
+    // A linked worktree shares the main worktree's hooks, but the hook body
+    // embeds one fixed sessionId; installing there would misattribute every
+    // other worktree's commits.
+    const linked = join(root, 'linked');
+    await run('git', ['worktree', 'add', '-q', linked, '-b', 'side'], process.env, repo);
+    await assert.rejects(
+      installGitHooks({ repo: linked, sessionId: 'session-a', source: 'claude', dbPath }),
+      /linked Git worktree/);
+
+    // `..` inside core.hooksPath must not satisfy the containment check by
+    // spelling alone; the resolved path is what has to stay inside the repo.
+    const outside = join(root, 'outside-hooks');
+    await run('git', ['config', 'core.hooksPath', '.git/hooks/../../../outside-hooks'], process.env, repo);
+    await assert.rejects(
+      installGitHooks({ repo, sessionId: 'session-a', source: 'claude', dbPath }),
+      /external shared core.hooksPath/);
+    await assert.rejects(stat(outside), 'the escaping hooks directory must not be created');
+
+    // A compiled or otherwise non-UTF-8 hook is still the user's hook: it must
+    // be backed up, not silently overwritten because decoding failed.
+    await run('git', ['config', 'core.hooksPath', '.git/hooks'], process.env, repo);
+    const opaque = Buffer.from([0xff, 0xfe, 0x00, 0x01, 0x02]);
+    await writeFile(join(repo, '.git', 'hooks', 'post-commit'), opaque, { mode: 0o755 });
+    const installed = await installGitHooks({ repo, sessionId: 'session-a', source: 'claude', dbPath });
+    const backup = await readFile(join(repo, '.git', 'hooks', 'post-commit.before-ai-hist'));
+    assert.deepEqual(backup, opaque, 'the original bytes survive verbatim');
+    assert.match(await readFile(installed.hookPath, 'utf8'), /post-commit.before-ai-hist/);
+  } finally {
+    for (const key of Object.keys(process.env)) if (!(key in saved)) delete process.env[key];
+    Object.assign(process.env, saved);
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/sdk-ts/src/cloud.test.ts
+++ b/sdk-ts/src/cloud.test.ts
@@ -6,7 +6,7 @@ import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
-import { enableCloud, installGitHooks, loadStoredRelayhistoryAuth, pushCloud, sync } from './index.js';
+import { createShareableTrace, enableCloud, installGitHooks, loadStoredRelayhistoryAuth, pushCloud, sync } from './index.js';
 
 async function run(bin: string, args: string[], env: NodeJS.ProcessEnv, cwd?: string) {
   const child = spawn(bin, args, { env, cwd, stdio: ['ignore', 'pipe', 'pipe'] });
@@ -38,6 +38,9 @@ test('npm command: fresh auth to 525-record push, refresh, stage isolation, SDK 
       res.end(JSON.stringify({ accessToken: acceptToken, refreshToken: 'rth_rt_rotated' }));
     } else if (req.headers.authorization !== `Bearer ${acceptToken}`) {
       res.statusCode = 401; res.end('{}');
+    } else if (req.url === '/v1/sessions/session-a/shares') {
+      assert.equal(data.visibility, 'direct-link');
+      res.end(JSON.stringify({ url: `http://127.0.0.1:${address.port}/s/fixture-share`, visibility: 'direct-link', eventCount: 525 }));
     } else if (req.url?.endsWith('/v1/ingest')) {
       if (rejectIngest) { res.statusCode = 500; res.end('{}'); return; }
       bodies.push(data);
@@ -89,6 +92,12 @@ test('npm command: fresh auth to 525-record push, refresh, stage isolation, SDK 
     await run('git', ['init', '-q'], process.env, repo);
     await run('git', ['config', 'user.email', 'test@example.com'], process.env, repo);
     await run('git', ['config', 'user.name', 'SDK test'], process.env, repo);
+    const sharedHooks = join(root, 'shared-hooks'); await mkdir(sharedHooks);
+    await writeFile(join(sharedHooks, 'post-commit'), '#!/bin/sh\necho shared\n');
+    await run('git', ['config', 'core.hooksPath', sharedHooks], process.env, repo);
+    await assert.rejects(installGitHooks({ repo, sessionId: 'session-a', source: 'claude', dbPath, prUrl: 'https://github.com/AgentWorkforce/relayhistory/pull/123' }), /external shared core.hooksPath/);
+    assert.equal(await readFile(join(sharedHooks, 'post-commit'), 'utf8'), '#!/bin/sh\necho shared\n');
+    await run('git', ['config', 'core.hooksPath', '.git/hooks'], process.env, repo);
     await writeFile(join(repo, '.git', 'hooks', 'post-commit'), '#!/bin/sh\necho old-hook > old-hook-ran\nexit 0\n', { mode: 0o755 });
     await run('git', ['config', 'ai-hist.pr-url', 'https://github.com/AgentWorkforce/relayhistory/pull/123'], process.env, repo);
     const hook = await installGitHooks({ repo, sessionId: 'session-a', source: 'claude', dbPath });
@@ -102,6 +111,9 @@ test('npm command: fresh auth to 525-record push, refresh, stage isolation, SDK 
     assert.match(await run('git', ['notes', '--ref=ai-hist', 'show', 'HEAD'], process.env, repo), /ai-hist:claude:session-a/);
     acceptToken = 'rth_at_rotated';
     await pushCloud({ dbPath, baseUrl });
+    const trace = await createShareableTrace('session-a', { visibility: 'direct-link', baseUrl });
+    assert.equal(trace.url, `${baseUrl}/s/fixture-share`);
+    assert.equal(trace.eventCount, 525);
     assert.equal(refreshes, 1);
     assert.equal((await loadStoredRelayhistoryAuth(baseUrl))?.accessToken, acceptToken);
     assert(bodies.flatMap((body) => body.records).some((row) => row.lens === 'github' && row.taskRef?.id === 'AgentWorkforce/relayhistory#123'));

--- a/sdk-ts/src/cloud.test.ts
+++ b/sdk-ts/src/cloud.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { once } from 'node:events';
+import { mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { enableCloud, installGitHooks, loadStoredRelayhistoryAuth, pushCloud, sync } from './index.js';
+
+async function run(bin: string, args: string[], env: NodeJS.ProcessEnv, cwd?: string) {
+  const child = spawn(bin, args, { env, cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+  let stdout = '', stderr = '';
+  child.stdout.on('data', (chunk) => { stdout += chunk; });
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+  const [code] = await once(child, 'close');
+  assert.equal(code, 0, stderr);
+  return stdout;
+}
+
+test('npm command: fresh auth to 525-record push, refresh, stage isolation, SDK auth and commit hook', { timeout: 120_000 }, async () => {
+  const root = await mkdtemp(join(tmpdir(), 'ai-hist-cloud-'));
+  const saved = { ...process.env };
+  const bodies: any[] = [];
+  let refreshes = 0;
+  let rejectIngest = false;
+  let acceptToken = 'rth_at_first';
+  const server = createServer(async (req, res) => {
+    let body = ''; for await (const chunk of req) body += chunk;
+    const data = body ? JSON.parse(body) : {};
+    res.setHeader('Content-Type', 'application/json');
+    if (req.url === '/v1/cli/login') {
+      assert.equal(data.mode, 'sync');
+      res.end(JSON.stringify({ accessToken: 'rth_at_first', refreshToken: 'rth_rt_first' }));
+    } else if (req.url === '/v1/auth/token/refresh') {
+      refreshes++;
+      assert.equal(data.refreshToken, 'rth_rt_first');
+      res.end(JSON.stringify({ accessToken: acceptToken, refreshToken: 'rth_rt_rotated' }));
+    } else if (req.headers.authorization !== `Bearer ${acceptToken}`) {
+      res.statusCode = 401; res.end('{}');
+    } else if (req.url?.endsWith('/v1/ingest')) {
+      if (rejectIngest) { res.statusCode = 500; res.end('{}'); return; }
+      bodies.push(data);
+      res.end(JSON.stringify({ batchId: data.batchId, received: data.records.length, accepted: data.records.length, cursors: data.cursors }));
+    } else { res.end(JSON.stringify({ accepted: data.turns?.length ?? 0 })); }
+  });
+  server.listen(0, '127.0.0.1'); await once(server, 'listening');
+  const address = server.address() as { port: number };
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const dbPath = join(root, 'history.db');
+  try {
+    process.env.HOME = root;
+    process.env.USERPROFILE = root;
+    process.env.RELAYHISTORY_HOME = join(root, 'auth');
+    process.env.AI_HIST_CONFIG_DIR = join(root, 'old-sdk');
+    process.env.CLAUDE_CONFIG_DIR = join(root, '.claude');
+    delete process.env.CODEX_HOME;
+    process.env.AI_HIST_DB = dbPath;
+    process.env.RELAYHISTORY_ALLOW_UNTRUSTED_CLOUD_BASE_URL = '1';
+    delete process.env.RELAYHISTORY_BASE_URL; delete process.env.AI_HIST_BASE_URL;
+    delete process.env.CLOUD_API_ACCESS_TOKEN;
+    const fixture = join(root, 'agent-relay');
+    // Exercise the real Rust session -> device-login -> session subprocess path.
+    await writeFile(fixture, `#!/bin/sh\nif [ "$2" = login ]; then touch '${root}/logged-in'; exit 0; fi\nif [ ! -f '${root}/logged-in' ]; then exit 1; fi\necho '{"accessToken":"fixture-cloud-token"}'\n`, { mode: 0o755 });
+    process.env.AGENT_RELAY_BIN = fixture;
+    const transcripts = join(root, '.claude', 'projects', 'fixture');
+    await mkdir(transcripts, { recursive: true });
+    await writeFile(join(transcripts, 'session-a.jsonl'), Array.from({ length: 525 }, (_, i) => JSON.stringify({ type: 'user', uuid: `u-${i}`, sessionId: 'session-a', timestamp: new Date(1_783_000_000_000 + i * 1000).toISOString(), message: { role: 'user', content: `synthetic cloud prompt ${i}` } })).join('\n'));
+    const cli = new URL('./cli.js', import.meta.url).pathname;
+    const stdout = await run(process.execPath, [cli, 'enable-cloud', '--base-url', baseUrl, '--db', dbPath, '--once', '--json'], process.env);
+    assert.equal(JSON.parse(stdout).sent, 525);
+    const prompts = bodies.flatMap((body) => body.records).map((row) => row.content);
+    assert.equal(new Set(prompts).size, 525);
+    for (let i = 0; i < 525; i++) assert(prompts.some((text) => text.includes(`synthetic cloud prompt ${i}`)));
+    const auth = await loadStoredRelayhistoryAuth(baseUrl);
+    assert.equal(auth?.accessToken, 'rth_at_first');
+    assert.equal(bodies.length, 2);
+    await mkdir(process.env.AI_HIST_CONFIG_DIR!, { recursive: true });
+    await writeFile(join(process.env.AI_HIST_CONFIG_DIR!, 'auth.json'), JSON.stringify({ baseUrl, accessToken: 'stale-sdk-token' }));
+    assert.equal((await loadStoredRelayhistoryAuth(baseUrl))?.accessToken, 'rth_at_first');
+
+    const repo = join(root, 'repo'); await mkdir(repo);
+    await run('git', ['init', '-q'], process.env, repo);
+    await run('git', ['config', 'user.email', 'test@example.com'], process.env, repo);
+    await run('git', ['config', 'user.name', 'SDK test'], process.env, repo);
+    await writeFile(join(repo, '.git', 'hooks', 'post-commit'), '#!/bin/sh\necho old-hook > old-hook-ran\nexit 0\n', { mode: 0o755 });
+    const hook = await installGitHooks({ repo, sessionId: 'session-a', source: 'claude', dbPath, prUrl: 'https://github.com/AgentWorkforce/relayhistory/pull/123' });
+    assert.equal((await stat(hook.hookPath)).mode & 0o111, 0o111);
+    await writeFile(join(repo, 'file.txt'), 'fixture');
+    await run('git', ['add', 'file.txt'], process.env, repo);
+    await run('git', ['commit', '-qm', 'fixture commit'], process.env, repo);
+    assert.equal((await readFile(join(repo, 'old-hook-ran'), 'utf8')).trim(), 'old-hook');
+    assert.match(await run('git', ['notes', '--ref=ai-hist', 'show', 'HEAD'], process.env, repo), /ai-hist:claude:session-a/);
+    acceptToken = 'rth_at_rotated';
+    await pushCloud({ dbPath, baseUrl });
+    assert.equal(refreshes, 1);
+    assert.equal((await loadStoredRelayhistoryAuth(baseUrl))?.accessToken, acceptToken);
+    assert(bodies.flatMap((body) => body.records).some((row) => row.lens === 'github' && row.taskRef?.id === 'AgentWorkforce/relayhistory#123'));
+    const files = await readdir(join(root, 'auth', 'stages'));
+    const cursorFile = files.find((file) => file.endsWith('.cursor.json'))!;
+    const before = await readFile(join(root, 'auth', 'stages', cursorFile), 'utf8');
+    const failingBase = `${baseUrl}/second-stage`;
+    // Seed a second stage through the legacy SDK migration; it must not borrow stage one's cursor.
+    await writeFile(join(process.env.AI_HIST_CONFIG_DIR!, 'auth.json'), JSON.stringify({ baseUrl: failingBase, accessToken: acceptToken }));
+    await loadStoredRelayhistoryAuth(failingBase);
+    await assert.rejects(loadStoredRelayhistoryAuth(), /Refusing to guess/);
+    rejectIngest = true;
+    // Change the fixture server to reject any ingest path for the second destination.
+    await assert.rejects(enableCloud({ dbPath, baseUrl: failingBase, watch: false }));
+    assert.equal(await readFile(join(root, 'auth', 'stages', cursorFile), 'utf8'), before);
+    const authFiles = (await readdir(join(root, 'auth', 'stages'))).filter((file) => file.endsWith('.auth.json'));
+    for (const file of authFiles) assert.equal((await stat(join(root, 'auth', 'stages', file))).mode & 0o777, 0o600);
+  } finally {
+    for (const key of Object.keys(process.env)) if (!(key in saved)) delete process.env[key];
+    Object.assign(process.env, saved);
+    server.closeAllConnections(); await new Promise<void>((resolve) => server.close(() => resolve()));
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -493,6 +493,9 @@ export interface SyncResult { databasePath: string; scope: SessionScope; complet
 type UnknownRecord = Record<string, unknown>;
 
 interface NativeBinding {
+  createShareableTrace(sessionId: string, visibility: string, source?: string, baseUrl?: string): Promise<string>;
+  installGitHooks(optionsJson: string, node: string, sdkUrl: string): Promise<string>;
+  linkGitCommit(optionsJson: string): Promise<string>;
   cloudLoadAuth(baseUrl?: string): Promise<RelayhistoryAuth | null>;
   cloudLogin(options: object): Promise<RelayhistoryAuth>;
   enableCloud(options: object): Promise<CloudPushResult>;
@@ -1576,4 +1579,23 @@ export async function enableCloud(options: EnableCloudOptions = {}): Promise<Clo
   };
   schedule();
   return { ...first, async stop() { stopped = true; clearTimeout(timer); await pending; } };
+}
+
+export interface GitHookOptions { repo: string; sessionId: string; source?: string; dbPath?: string; prUrl?: string }
+/** Install a local post-commit recorder for an explicit session. prUrl identifies
+ * an existing GitHub PR; linkage is uploaded by the next cloud push. */
+export async function installGitHooks(options: GitHookOptions): Promise<{ hookPath: string }> {
+  const hookPath = await nativeCall((native) => native.installGitHooks(JSON.stringify({ ...options, dbPath: options.dbPath ?? defaultDbPath() }), process.execPath, import.meta.url));
+  return { hookPath };
+}
+export async function linkGitCommit(options: GitHookOptions): Promise<{ commitSha: string }> {
+  const commitSha = await nativeCall((native) => native.linkGitCommit(JSON.stringify({ ...options, dbPath: options.dbPath ?? defaultDbPath() })));
+  return { commitSha };
+}
+
+export type TraceVisibility = 'public' | 'private' | 'direct-link';
+export interface ShareableTrace { url: string; visibility: TraceVisibility; eventCount: number }
+/** Share the already-pushed, frozen server snapshot of a session. */
+export async function createShareableTrace(sessionId: string, options: { visibility: TraceVisibility; source?: string; baseUrl?: string }): Promise<ShareableTrace> {
+  return nativeCall(async (native) => JSON.parse(await native.createShareableTrace(sessionId, options.visibility, options.source, options.baseUrl)) as ShareableTrace);
 }

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -9,7 +9,7 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-export const NATIVE_CONTRACT_VERSION = 7;
+export const NATIVE_CONTRACT_VERSION = 8;
 export const SESSION_CATALOG_CONTRACT_VERSION = 3;
 export const SESSION_HYDRATION_CONTRACT_VERSION = 2;
 export const SESSION_RELATIONSHIP_CONTRACT_VERSION = 1;
@@ -493,6 +493,10 @@ export interface SyncResult { databasePath: string; scope: SessionScope; complet
 type UnknownRecord = Record<string, unknown>;
 
 interface NativeBinding {
+  cloudLoadAuth(baseUrl?: string): Promise<RelayhistoryAuth | null>;
+  cloudLogin(options: object): Promise<RelayhistoryAuth>;
+  enableCloud(options: object): Promise<CloudPushResult>;
+  pushCloud(options: object): Promise<CloudPushResult>;
   nativeContractVersion(): number;
   nativeBuildProfile?(): string;
   search(query: string, options?: object): Promise<UnknownRecord[]>;
@@ -1511,4 +1515,65 @@ export function resumeCommand(entry: Pick<HistoryEntry, 'source' | 'sessionId' |
 
 function shellQuote(value: string): string {
   return /^[A-Za-z0-9._:/-]+$/.test(value) ? value : `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+export interface RelayhistoryAuth { baseUrl: string; accessToken: string; refreshToken?: string }
+export type LoginCloudResult = { ok: true; auth: RelayhistoryAuth } | { ok: false; error: string };
+export interface CloudPushResult { baseUrl: string; sent: number; accepted: number; syncSkipped: boolean }
+export interface CloudOptions { dbPath?: string; baseUrl?: string; relayAccessToken?: string; label?: string }
+export interface EnableCloudOptions extends CloudOptions {
+  /** Keep syncing until stop() is called. Defaults to true. */
+  watch?: boolean;
+  intervalMs?: number;
+  onPush?: (result: CloudPushResult) => void;
+  onError?: (error: unknown) => void;
+}
+export interface CloudHandle extends CloudPushResult { stop(): Promise<void> }
+
+/** Both SDK consumers and the engine use the same stage-scoped Rust auth store. */
+export async function loadStoredRelayhistoryAuth(baseUrl?: string): Promise<RelayhistoryAuth | null> {
+  return nativeCall((native) => native.cloudLoadAuth(baseUrl));
+}
+
+export async function loginCloud(relayAccessToken: string, options: { baseUrl?: string; label?: string } = {}): Promise<LoginCloudResult> {
+  try {
+    const auth = await nativeCall((native) => native.cloudLogin({ ...options, relayAccessToken }));
+    return { ok: true, auth };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function pushCloud(options: CloudOptions = {}): Promise<CloudPushResult> {
+  return nativeCall((native) => native.pushCloud(options));
+}
+
+/** Device login, service-token exchange and first push run in Rust. The optional
+ * loop is host orchestration only: no token, refresh, stage or cursor logic in JS.
+ * The loop remains in this process; await stop() before shutdown. */
+export async function enableCloud(options: EnableCloudOptions = {}): Promise<CloudHandle> {
+  const intervalMs = options.intervalMs ?? 60_000;
+  if (!Number.isSafeInteger(intervalMs) || intervalMs < 1_000 || intervalMs > 2_147_483_647) {
+    throw new InvalidArgumentError('intervalMs must be an integer between 1000 and 2147483647', 'INVALID_ARGUMENT');
+  }
+  const first = await nativeCall((native) => native.enableCloud(options));
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let pending: Promise<void> = Promise.resolve();
+  const schedule = () => {
+    if (stopped || options.watch === false) return;
+    timer = setTimeout(() => {
+      pending = (async () => {
+        try {
+          const result = await pushCloud({ dbPath: options.dbPath, baseUrl: first.baseUrl });
+          options.onPush?.(result);
+        } catch (error) {
+          if (options.onError) options.onError(error);
+          else process.stderr.write(`ai-hist cloud push failed: ${error instanceof Error ? error.message : String(error)}\n`);
+        } finally { schedule(); }
+      })();
+    }, intervalMs);
+  };
+  schedule();
+  return { ...first, async stop() { stopped = true; clearTimeout(timer); await pending; } };
 }

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -1584,9 +1584,9 @@ export async function enableCloud(options: EnableCloudOptions = {}): Promise<Clo
 export interface GitHookOptions { repo: string; sessionId: string; source?: string; dbPath?: string; prUrl?: string }
 /** Install a local post-commit recorder for an explicit session. prUrl identifies
  * an existing GitHub PR; linkage is uploaded by the next cloud push. */
-export async function installGitHooks(options: GitHookOptions): Promise<{ hookPath: string }> {
-  const hookPath = await nativeCall((native) => native.installGitHooks(JSON.stringify({ ...options, dbPath: options.dbPath ?? defaultDbPath() }), process.execPath, import.meta.url));
-  return { hookPath };
+export async function installGitHooks(options: GitHookOptions): Promise<{ hookPath: string; prUrl: string | null }> {
+  const result = await nativeCall((native) => native.installGitHooks(JSON.stringify({ ...options, dbPath: options.dbPath ?? defaultDbPath() }), process.execPath, import.meta.url));
+  return JSON.parse(result) as { hookPath: string; prUrl: string | null };
 }
 export async function linkGitCommit(options: GitHookOptions): Promise<{ commitSha: string }> {
   const commitSha = await nativeCall((native) => native.linkGitCommit(JSON.stringify({ ...options, dbPath: options.dbPath ?? defaultDbPath() })));

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -9,7 +9,7 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-export const NATIVE_CONTRACT_VERSION = 8;
+export const NATIVE_CONTRACT_VERSION = 9;
 export const SESSION_CATALOG_CONTRACT_VERSION = 3;
 export const SESSION_HYDRATION_CONTRACT_VERSION = 2;
 export const SESSION_RELATIONSHIP_CONTRACT_VERSION = 1;
@@ -493,6 +493,8 @@ export interface SyncResult { databasePath: string; scope: SessionScope; complet
 type UnknownRecord = Record<string, unknown>;
 
 interface NativeBinding {
+  accessToken(baseUrl?: string): Promise<string>;
+  replay(sessionId: string, options: ReplayOptions): Promise<ReplayResult>;
   createShareableTrace(sessionId: string, visibility: string, source?: string, baseUrl?: string): Promise<string>;
   installGitHooks(optionsJson: string, node: string, sdkUrl: string): Promise<string>;
   linkGitCommit(optionsJson: string): Promise<string>;
@@ -1523,6 +1525,36 @@ function shellQuote(value: string): string {
 export interface RelayhistoryAuth { baseUrl: string; accessToken: string; refreshToken?: string }
 export type LoginCloudResult = { ok: true; auth: RelayhistoryAuth } | { ok: false; error: string };
 export interface CloudPushResult { baseUrl: string; sent: number; accepted: number; syncSkipped: boolean }
+/** Return a secret service token with at least 60 seconds of validity. Rust
+ * selects the stage, refreshes if needed and atomically saves rotated tokens. */
+export async function accessToken(options: { baseUrl?: string } = {}): Promise<string> {
+  return nativeCall((native) => native.accessToken(options.baseUrl));
+}
+
+export interface ReplayOptions {
+  baseUrl?: string;
+  /** Page size, not a total cap; Rust fetches every page in server order. */
+  limit?: number;
+  maxContent?: number;
+  /** Return the raw event array serialized as JSON instead of readable text. */
+  json?: boolean;
+  /** Atomically save in Rust after all pages succeed; transcript is then null. */
+  out?: string;
+}
+export interface ReplayResult { eventCount: number; transcript: string | null; outputPath: string | null }
+
+/** Fetch a cloud transcript without opening or importing into the local DB. */
+export async function replay(sessionId: string, options: ReplayOptions = {}): Promise<ReplayResult> {
+  for (const key of ['limit', 'maxContent'] as const) {
+    const value = options[key];
+    if (value !== undefined && (!Number.isSafeInteger(value) || value < 0 || value > 0xffff_ffff)) {
+      throw new InvalidArgumentError(`${key} must be an integer between 0 and 4294967295`, 'INVALID_ARGUMENT');
+    }
+  }
+  const result = await nativeCall((native) => native.replay(sessionId, options));
+  return { eventCount: result.eventCount, transcript: result.transcript ?? null, outputPath: result.outputPath ?? null };
+}
+
 export interface CloudOptions { dbPath?: string; baseUrl?: string; relayAccessToken?: string; label?: string }
 export interface EnableCloudOptions extends CloudOptions {
   /** Keep syncing until stop() is called. Defaults to true. */


### PR DESCRIPTION
The published npm CLI cannot reach Rust-only `token` and `replay`, and cloud opt-in lacks a native SDK entrypoint. This exposes the existing Rust implementations through NAPI contract 9 and public async SDK methods: `accessToken()`, `replay()`, `enableCloud()` and `pushCloud()`. The npm CLI only parses arguments and dispatches to those methods. No standalone binary or TypeScript transport is introduced.

`token` reuses #111's stage selection, proactive refresh, atomic credential rotation and secret-safe errors. Piped stdout contains only the token and one newline. `replay` shares the existing Rust pagination, renderer and atomic output writer; it fetches all pages before replacing `--out` and never opens SQLite. This supplies the commands referenced by cloud PR #42, once the client is released.

Cloud enablement drains the backlog and optionally runs a foreground push loop pinned to its selected stage. The compatibility cloud import delegates to the canonical Rust auth store and migrates legacy SDK credentials without replacing newer tokens. Explicit-session Git hooks preserve prior hooks and Git notes, resolve an existing PR, emit the existing server PR-link contract, and reject shared external hook directories. The earlier native share client accompanies cloud PR #43; no additional sharing implementation was added for the token/replay scope.

## Rebased onto 0.15.1

The branch was based on `865a536` (release 0.15.0). It is now rebased onto `5188b13` (release 0.15.1), picking up the four changes that landed underneath it today: `2fd5bbc` (Rust `token`), `3d559ed` (first-run bootstrap), `5f3246b` (npx first-search verification and pretty session output) and `d56f64d` (native Linux glibc floor).

Both conflicts were in `sdk-ts/src/cli.ts` and both were unions, not competing edits: `BOOLEAN_FLAGS` now carries main's `pretty` alongside this branch's `once`, and the usage block lists both `enable-cloud` and `sessions list --pretty`.

The bootstrap seam was checked explicitly, because it is the one that could silently reintroduce the original bug: `bootstrapLocal` runs only on a bare `ai-hist` invocation with no command, so it cannot print to stdout ahead of `token`. `token` writes the token and nothing else to stdout; the secret-in-scrollback warning goes to stderr and only when stdout is a TTY.

## Verification, post-rebase

Local, darwin-arm64, mise Node 22.22.2. Exit codes captured directly rather than through a pipe.

| Check | Result |
| --- | --- |
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy --workspace --all-targets -- -A clippy::too_many_arguments -D warnings` | exit 0, zero warnings |
| `cargo test --workspace` | see below |
| `verify-native-contract.mjs` | contract 9 agrees across Rust source, TS SDK source and built addon |
| `git diff --exit-code -- crates/ai-hist-napi/index.d.ts` | clean; checked-in declarations match the regenerated ones |
| `sdk-ts` `tsc --noEmit` | exit 0 |
| `sdk-ts` `npm test` | exit 0, 73/73 |
| `node --test scripts/*.test.mjs` | exit 0, 10/10 |

## Verified against the artifact, not the source

The tarballs were packed and installed the way CI does — SDK, loader and the darwin-arm64 platform addon — into a scratch project, then the installed `./node_modules/.bin/ai-hist` was run.

- The installed CLI's usage block lists `ai-hist token [--base-url URL]` and `ai-hist replay SESSION_ID [--base-url URL] [--limit N] [--max-content N] [--json] [--out PATH]`.
- The same check against the **actually-published `ai-hist@0.15.1`** from the registry lists neither: zero matches for `token` or `replay`. This independently reproduces the QA report rather than taking it on trust.
- `cloud-commands.test.js` was rerun with `AI_HIST_TEST_PACKAGE_DIR` pointed at the installed package: exit 0. It covers token stdout exactness, proactive refresh with credential rotation, secret-safe failures, stage selection, replay pagination and atomic `--out` replacement.
- The specific failure QA reported — `$(ai-hist token)` silently yielding an empty string — was reproduced as a real shell command substitution against a fixture cloud using the installed binary. It captured a 27-character token identical to the one the fixture issued.

Full evidence, including the earlier dev-stage acceptance, is in `docs/ws12-validation.md`.

Limits: Agent Relay must be installed for device login; the push loop is foreground. Hooks need an indexed session and an existing PR. Shares freeze convergence events; private reads need an authenticated HTTP client. The live login used an existing Relay identity, not fresh browser approval. The registry commands stay blocked until this client is merged and released.

No merge, npm publication, or production deployment was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZCcjtYz9ioxEv4KGn8DqJ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes touch cloud authentication, token refresh, stage selection, and Git hook installation—areas where mistakes can leak credentials, target the wrong environment, or corrupt repository hooks.
> 
> **Overview**
> **Native contract 9** wires the npm CLI and async SDK to Rust for cloud work that previously lived only in the binary: **`accessToken`**, **`replay`**, **`enableCloud`/`pushCloud`**, auth load/login, **`installGitHooks`/`linkGitCommit`**, and **`createShareableTrace`**. The CLI adds **`token`**, **`replay`**, and **`enable-cloud`** as thin wrappers; CI smoke now runs **`cloud-commands.test.js`** against the installed tarball.
> 
> **Cloud auth** gains **`load_sdk_auth`** (canonical store plus one-time import from legacy **`~/.config/ai-hist/auth.json`**), shared **`resolve_stage` / `resolve_base_url`**, and stricter stage rules: malformed env selectors error instead of silently hitting production, multi-stage setups refuse to guess, and explicit **`--base-url`** wins over a broken env. **`token`** and **`replay`** use the SDK loader; the multi-stage ambiguity probe still goes through **`load_auth`**.
> 
> **Git linkage** adds **`git_sdk`**: opt-in post-commit hooks record an explicit session, optional GitHub PR evidence, and notes; the outbox can emit a separate **`github_pr`** event when commit evidence includes a PR. **`replay`** returns structured output for the SDK (no stdout side effects) while keeping atomic file writes in Rust.
> 
> Docs (**`enable-cloud.md`**, README/SDK README) and broad Rust/TS tests cover hooks (worktree, path escape, hook preservation), legacy migration, and installed-artifact behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a337b87744c1c44c08a795cebfaf41a1633d54a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->