### PR TITLE
fix: lower native Linux glibc floor and gate releases on real CLI search

### DIFF
--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -131,6 +131,26 @@ jobs:
             npx napi build --platform --release --target "${{ matrix.target }}"
           fi
 
+      - name: Enforce GNU artifact glibc ceiling
+        if: matrix.test_glibc
+        shell: bash
+        env:
+          GLIBC_FLOOR: ${{ matrix.glibc }}
+        run: |
+          set -euo pipefail
+          # Inspect the produced ELF, so compiler/toolchain changes cannot
+          # silently raise the floor even when newer runtime tests pass.
+          readelf --version-info ./*.node > /tmp/addon-versions.txt
+          python3 - <<'PY'
+          import os, re
+          from pathlib import Path
+          versions = {tuple(map(int, v.split('.'))) for v in re.findall(r'GLIBC_(\d+\.\d+(?:\.\d+)?)', Path('/tmp/addon-versions.txt').read_text())}
+          floor = tuple(map(int, os.environ['GLIBC_FLOOR'].split('.')))
+          if not versions or max(versions) > floor:
+              raise SystemExit(f'Invalid glibc requirements: {sorted(versions)}; ceiling={floor}')
+          print(f'Maximum required glibc: {".".join(map(str, max(versions)))}')
+          PY
+
       - name: Execute native contract smoke test
         if: matrix.test_native
         shell: bash

--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -60,10 +60,18 @@ jobs:
             test_native: true
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            cross: true
+            glibc: '2.28'
             test_native: true
+            test_glibc: true
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+            cross: true
+            glibc: '2.28'
             test_native: true
+            test_glibc: true
+            # Zig 0.13 cannot link the Cortex-A53 flag emitted by Rust 1.98.
+            rust: 1.97.0
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             cross: true
@@ -114,7 +122,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ matrix.cross }}" = "true" ]; then
+          # Match the official Node 20/22 glibc baseline, independent of runner OS.
+          if [ -n "${{ matrix.glibc }}" ]; then
+            npx napi build --platform --release --target "${{ matrix.target }}" --zig --zig-abi-suffix "${{ matrix.glibc }}"
+          elif [ "${{ matrix.cross }}" = "true" ]; then
             npx napi build --platform --release --target "${{ matrix.target }}" --zig
           else
             npx napi build --platform --release --target "${{ matrix.target }}"

--- a/.github/workflows/publish-napi.yml
+++ b/.github/workflows/publish-napi.yml
@@ -141,6 +141,28 @@ jobs:
         shell: bash
         run: docker run --rm -v "$GITHUB_WORKSPACE:/work" -w /work/crates/ai-hist-napi node:22-alpine node ../../scripts/verify-native-contract.mjs ./index.js
 
+      - name: Build CLI for Linux runtime smoke tests
+        if: matrix.test_glibc || matrix.test_musl
+        working-directory: sdk-ts
+        run: npm ci --ignore-scripts && npm run build
+
+      - name: Execute GNU CLI smoke tests on supported Linux runtimes
+        if: matrix.test_glibc
+        working-directory: .
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Bookworm is explicit too: floating Node tags must not silently
+          # move the oldest Debian runtime covered by this gate.
+          for image in node:22-slim node:22 node:22-bookworm-slim ubuntu:22.04 ubuntu:24.04 node:22-trixie-slim; do
+            bash scripts/smoke-linux-native.sh "$image" local
+          done
+
+      - name: Execute musl CLI smoke test
+        if: matrix.test_musl
+        working-directory: .
+        run: bash scripts/smoke-linux-native.sh node:22-alpine local
+
       - uses: actions/upload-artifact@v4
         with:
           name: napi-${{ matrix.target }}
@@ -394,7 +416,7 @@ jobs:
           npm init -y
           node "$GITHUB_WORKSPACE/scripts/npm-install-with-registry-retry.mjs" \
             "ai-hist@$VERSION" "ai-hist-mcp@$VERSION"
-          ./node_modules/.bin/ai-hist sessions list --db "$SMOKE/empty.db" --json
+          node "$GITHUB_WORKSPACE/scripts/smoke-native-cli.mjs" ./node_modules/ai-hist/dist/cli.js --prove-rejection
           timeout 2 ./node_modules/.bin/ai-hist-mcp </dev/null || test $? -eq 124
 
           NO_OPTIONAL=$(mktemp -d)
@@ -414,6 +436,17 @@ jobs:
               },
             );
           '
+
+      - name: Registry CLI smoke test on older glibc
+        if: ${{ !inputs.dry_run }}
+        working-directory: .
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          for image in node:22-bookworm-slim ubuntu:22.04; do
+            bash scripts/smoke-linux-native.sh "$image" registry "$VERSION"
+          done
 
       # The branch only advances once every package is published and the
       # registry smoke tests pass, so a failed release never persists its

--- a/scripts/smoke-linux-native.sh
+++ b/scripts/smoke-linux-native.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Usage: smoke-linux-native.sh IMAGE local|registry [VERSION]
+# DOCKER_DEFAULT_PLATFORM can select amd64/arm64 for local QA.
+set -euo pipefail
+IMAGE=${1:?container image required}
+MODE=${2:?local or registry required}
+VERSION=${3:-}
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+[[ "$MODE" = local || "$MODE" = registry ]] || exit 2
+[[ "$MODE" != registry || -n "$VERSION" ]] || exit 2
+
+RUNTIME=$IMAGE
+if [[ "$IMAGE" = ubuntu:* ]]; then
+  # Install only runtime dependencies in the requested Ubuntu image. Copy the
+  # official Node binary without replacing Ubuntu's libc with Debian's libc.
+  RUNTIME="ai-hist-smoke-ubuntu-${IMAGE#ubuntu:}-$$"
+  trap 'docker image rm "$RUNTIME" >/dev/null' EXIT
+  docker build --quiet --build-arg "BASE=$IMAGE" -t "$RUNTIME" - <<'DOCKERFILE'
+ARG BASE
+FROM node:22-bookworm-slim AS node
+FROM ${BASE}
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libstdc++6 && rm -rf /var/lib/apt/lists/*
+COPY --from=node /usr/local/ /usr/local/
+DOCKERFILE
+fi
+
+docker run --rm -v "$ROOT:/work:ro" -e "SMOKE_MODE=$MODE" -e "SMOKE_VERSION=$VERSION" \
+  -e "SMOKE_IMAGE=$IMAGE" "$RUNTIME" sh -eu -c '
+  node -e '\''console.log(process.env.SMOKE_IMAGE, process.arch, "glibc=" + (process.report.getReport().header.glibcVersionRuntime || "musl"))'\''
+  mkdir -p /tmp/smoke
+  cd /tmp/smoke
+  if [ "$SMOKE_MODE" = registry ]; then
+    npm init -y >/dev/null
+    node /work/scripts/npm-install-with-registry-retry.mjs "ai-hist@$SMOKE_VERSION"
+    node /work/scripts/smoke-native-cli.mjs node_modules/ai-hist/dist/cli.js --prove-rejection
+  else
+    # A private writable copy keeps the negative control away from the build
+    # artifacts, and lets the SDK local native dependency resolve normally.
+    mkdir -p crates
+    cp -R /work/crates/ai-hist-napi crates/
+    cp -R /work/sdk-ts .
+    node /work/scripts/smoke-native-cli.mjs sdk-ts/dist/cli.js --prove-rejection
+  fi
+'

--- a/scripts/smoke-native-cli.mjs
+++ b/scripts/smoke-native-cli.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const cli = resolve(process.argv[2]);
+const temporary = mkdtempSync(join(tmpdir(), 'ai-hist-native-smoke-'));
+const env = { ...process.env, HOME: temporary };
+const args = ['search', 'anything', '--local', '--db', join(temporary, 'empty.db'), '--json'];
+
+function run(args) {
+  const result = spawnSync(process.execPath, [cli, ...args], {
+    env, encoding: 'utf8', timeout: 30_000,
+  });
+  if (result.error) throw result.error;
+  assert.equal(result.signal, null, `CLI killed by ${result.signal}`);
+  return result;
+}
+
+function search() {
+  const result = run(args);
+  assert.equal(result.status, 0, `ai-hist search anything failed:\n${result.stderr}`);
+  assert.deepEqual(JSON.parse(result.stdout), [], 'Fresh database should return no results');
+  console.log('PASS: ai-hist search anything (native addon loaded)');
+}
+
+try {
+  search();
+  if (process.argv.includes('--prove-rejection')) {
+    // Resolve the actual loaded binary in a child process so it is unloaded
+    // before corruption. Handles both local builds and npm platform packages.
+    const locate = spawnSync(process.execPath, ['--input-type=commonjs', '-e', `
+      const requireFromCLI = require('node:module').createRequire(process.argv[1]);
+      requireFromCLI('ai-hist-native');
+      const binaries = Object.keys(require.cache).filter(path => path.endsWith('.node'));
+      if (binaries.length !== 1) throw new Error('Expected exactly one native addon: ' + binaries);
+      process.stdout.write(binaries[0]);
+    `, cli], { env, encoding: 'utf8', timeout: 30_000 });
+    if (locate.error) throw locate.error;
+    assert.equal(locate.status, 0, locate.stderr);
+    const binary = locate.stdout;
+    const original = readFileSync(binary);
+    try {
+      writeFileSync(binary, 'deliberately broken native artifact\n');
+      assert.equal(run(['--version']).status, 0, '--version still succeeds without loading native');
+      const broken = run(args);
+      assert.notEqual(broken.status, 0, 'Smoke gate accepted a broken addon');
+      assert.match(broken.stderr, /NATIVE_LOAD_FAILED/, 'Failure must be a native load failure');
+      console.log(`PASS: broken artifact rejected (search exit ${broken.status}; --version exit 0)`);
+      console.log(broken.stderr.trim());
+    } finally {
+      writeFileSync(binary, original);
+    }
+    search();
+  }
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}


### PR DESCRIPTION
ai-hist 0.15.0 GNU addons inherited the Ubuntu 24.04 runners’ glibc 2.39 requirement, so real CLI commands fail on Debian 12, Ubuntu 22.04, Amazon Linux 2023, and RHEL 9.

Both GNU targets now use the existing Zig 0.13 mechanism with explicit `--zig-abi-suffix 2.28`. This matches the [official Node Linux baseline](https://github.com/nodejs/node/blob/v22.x/BUILDING.md), covers the affected distributions, and remains independent of runner image changes. ARM64 GNU uses the existing ARM64 musl Rust 1.97 workaround for Zig 0.13’s unsupported Cortex-A53 linker flag. An ELF version check rejects artifacts exceeding the chosen ceiling; both produced GNU artifacts report **maximum required glibc 2.28**.

The **2.28 floor** restores libc compatibility with Debian 12 (2.36), Ubuntu 22.04 (2.35), Amazon Linux 2023 (2.34), and RHEL/AlmaLinux 9 (2.34). Debian and Ubuntu have direct runtime evidence in the matrix below; the Amazon Linux and RHEL/Alma conclusion follows from their documented libc versions ([AWS](https://docs.aws.amazon.com/linux/al2023/ug/glibc-gcc-and-binutils.html), [Red Hat](https://people.redhat.com/mskinner/rhug/q1.2022/rhel9update.pdf), [AlmaLinux](https://wiki.almalinux.org/release-notes/9.0)).

Choosing **2.17** instead would extend the addon's libc compatibility to older systems such as RHEL/CentOS 7 (2.17) and Amazon Linux 2 (2.26). It would not make the official Node 20/22 binaries work on those systems: their own Linux glibc baseline is 2.28. Serving those environments would also require a compatible Node >=20 runtime and additional QA; Node maintains a separate [unofficial glibc-2.17 build effort](https://github.com/nodejs/unofficial-builds). Thus 2.28 buys back every distro affected by this incident that was named in the brief, matches the supported Node runtime baseline, and avoids expanding this hotfix's runtime support promise to legacy systems. [RHEL 7 libc reference](https://www.redhat.com/it/blog/upgrading-rhel-7-rhel-8-leapp-and-boom?source=bloglisting), [Amazon Linux 2 libc reference](https://docs.aws.amazon.com/linux/al2023/ug/glibc-gcc-and-binutils.html).

Before publishing, both architectures run `ai-hist search anything --local --db <fresh-db> --json` in containers. Registry smoke tests use the same search probe and add bookworm/Ubuntu 22.04 containers. Every probe asserts real empty-database results and includes a negative control: corrupt the resolved addon, show `--version` still exits 0, require search to exit nonzero with `NATIVE_LOAD_FAILED`, restore the addon, and require success again.

The [release workflow dry run](https://github.com/AgentWorkforce/relayhistory/actions/runs/34272974872) and [normal PR CI](https://github.com/AgentWorkforce/relayhistory/actions/runs/34272979342) both passed at `4bd0ae1`. All seven platform builds and package assembly passed. No packages, tags, releases, or version commits were published.

| Runtime image | libc | x64 search | ARM64 search | Broken-addon rejection, both arches |
|---|---|---|---|---|
| `node:22-slim` | glibc 2.36 | PASS | PASS | PASS |
| `node:22` | glibc 2.36 | PASS | PASS | PASS |
| `node:22-bookworm-slim` | glibc 2.36 | PASS | PASS | PASS |
| `ubuntu:22.04` | glibc 2.35 | PASS | PASS | PASS |
| `ubuntu:24.04` | glibc 2.39 | PASS | PASS | PASS |
| `node:22-trixie-slim` | glibc 2.41 | PASS | PASS | PASS |
| `node:22-alpine` | musl | PASS | PASS | PASS |

Evidence: [GNU x64 job](https://github.com/AgentWorkforce/relayhistory/actions/runs/34272974872/job/102218949345), [GNU ARM64 job](https://github.com/AgentWorkforce/relayhistory/actions/runs/34272974872/job/102218949436), [musl x64 job](https://github.com/AgentWorkforce/relayhistory/actions/runs/34272974872/job/102218949412), [musl ARM64 job](https://github.com/AgentWorkforce/relayhistory/actions/runs/34272974872/job/102218949200). Each runtime logged:

```text
PASS: ai-hist search anything (native addon loaded)
PASS: broken artifact rejected (search exit 1; --version exit 0)
ai-hist: NATIVE_LOAD_FAILED: ... file too short [GNU] / Exec format error [musl]
PASS: ai-hist search anything (native addon loaded)
```

The new registry-mode probe was also run against published `ai-hist@0.15.0` in `node:22-slim`: it exited **1**, reporting `GLIBC_2.39 not found`. This independently demonstrates that the new gate catches the incident artifact. Post-publish steps are intentionally skipped in the dry run because no hotfix version has been published.

Independent local verification of the downloaded CI artifacts also passed search, deliberate corruption, and restoration on `node:22-slim`, `ubuntu:22.04`, and `node:22-alpine`, on both x64 and ARM64. The registry-mode probe additionally passed on `ubuntu:24.04` ARM64 with published 0.15.0, including deliberate corruption of its installed npm platform addon and successful restoration. Together with rejection on slim, this covers both registry-mode success and failure.

Additional validation: actionlint, shell/Node syntax checks, SDK build. Changes are limited to the native release workflow and its two smoke-test scripts; no SDK/CLI behavior or version changes. Do not merge or publish; Khaliq owns both.

