### PR TITLE
fix(sdk): shared first-use bootstrap and ship login in npm CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,11 @@ jobs:
           echo "$out"
           test "$code" -eq 1
           echo "$out" | grep -q '"status":"unbuilt"'
-          ./node_modules/.bin/ai-hist login --token smoke --base-url http://127.0.0.1:9; test $? -ne 2
+          set +e
+          ./node_modules/.bin/ai-hist login --token smoke --base-url http://127.0.0.1:9
+          login_code=$?
+          set -e
+          test "$login_code" -ne 2
           node --input-type=module -e 'await import("ai-hist")'
           node -e 'require("ai-hist/package.json")'
           AI_HIST_TEST_PACKAGE_DIR="$SMOKE/node_modules/ai-hist" node --test "$GITHUB_WORKSPACE/sdk-ts/dist/cloud-commands.test.js"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,13 @@ jobs:
             "$PACK_DIR/ai-hist-native-linux-x64-gnu-$VERSION.tgz"
           export HOME="$SMOKE/home" USERPROFILE="$SMOKE/home" XDG_DATA_HOME="$SMOKE/share"
           mkdir -p "$HOME"
-          ./node_modules/.bin/ai-hist sessions list --db "$SMOKE/missing.db" --no-bootstrap --json
+          set +e
+          out=$(./node_modules/.bin/ai-hist sessions list --db "$SMOKE/missing.db" --no-bootstrap --json 2>&1)
+          code=$?
+          set -e
+          echo "$out"
+          test "$code" -eq 1
+          echo "$out" | grep -q '"status":"unbuilt"'
           ./node_modules/.bin/ai-hist login --token smoke --base-url http://127.0.0.1:9; test $? -ne 2
           node --input-type=module -e 'await import("ai-hist")'
           node -e 'require("ai-hist/package.json")'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,10 @@ jobs:
             "$PACK_DIR/ai-hist-$VERSION.tgz" \
             "$PACK_DIR/ai-hist-native-$VERSION.tgz" \
             "$PACK_DIR/ai-hist-native-linux-x64-gnu-$VERSION.tgz"
-          ./node_modules/.bin/ai-hist sessions list --db "$SMOKE/missing.db" --json
+          export HOME="$SMOKE/home" USERPROFILE="$SMOKE/home" XDG_DATA_HOME="$SMOKE/share"
+          mkdir -p "$HOME"
+          ./node_modules/.bin/ai-hist sessions list --db "$SMOKE/missing.db" --no-bootstrap --json
+          ./node_modules/.bin/ai-hist login --token smoke --base-url http://127.0.0.1:9; test $? -ne 2
           node --input-type=module -e 'await import("ai-hist")'
           node -e 'require("ai-hist/package.json")'
           AI_HIST_TEST_PACKAGE_DIR="$SMOKE/node_modules/ai-hist" node --test "$GITHUB_WORKSPACE/sdk-ts/dist/cloud-commands.test.js"

--- a/sdk-ts/src/architecture.test.ts
+++ b/sdk-ts/src/architecture.test.ts
@@ -113,8 +113,9 @@ test('cloud compatibility entrypoint does not reimplement the native cloud opera
 
 test('token and replay SDK operations delegate to native code', async () => {
   const source = await readFile(join(sourceDir, 'index.ts'), 'utf8');
-  const cloudCommands = source.slice(source.indexOf('export async function accessToken('), source.indexOf('export interface CloudOptions'));
+  const cloudCommands = source.slice(source.indexOf('export async function accessToken('), source.indexOf('export async function pushCloud('));
   assert.match(cloudCommands, /native\.accessToken\(/);
   assert.match(cloudCommands, /native\.replay\(/);
+  assert.match(cloudCommands, /native\.cloudLogin\(/);
   assert.doesNotMatch(cloudCommands, /fetch\(|readFile|writeFile|auth\.json|nextCursor|refreshToken/);
 });

--- a/sdk-ts/src/cli-output.test.ts
+++ b/sdk-ts/src/cli-output.test.ts
@@ -398,11 +398,19 @@ test('topology commands require SOURCE and SESSION_ID and reject location scope'
 test('scope flags are boolean, default to local, and are mutually exclusive', async () => {
   const root = await mkdtemp(join(tmpdir(), 'relayhistory-cli-scope-'));
   const db = join(root, 'missing.db');
+  const env = { ...process.env, HOME: root, USERPROFILE: root, XDG_DATA_HOME: join(root, 'share') };
   try {
-    const implicit = await run(process.execPath, [cli, 'sessions', 'list', '--db', db, '--json', '--no-warning']);
-    const explicit = await run(process.execPath, [cli, '--json', 'sessions', 'list', '--local', '--db', db, '--no-warning']);
-    assert.deepEqual(JSON.parse(explicit.stdout), JSON.parse(implicit.stdout));
-    const remote = await run(process.execPath, [cli, 'sessions', 'list', '--remote', '--db', db, '--json', '--no-warning']);
+    const readEmpty = async (args: string[]) => {
+      try {
+        return await run(process.execPath, args, { env });
+      } catch (error) {
+        return error as NodeJS.ErrnoException & { stdout: string };
+      }
+    };
+    const implicit = await readEmpty([cli, 'sessions', 'list', '--db', db, '--json', '--no-warning']);
+    const explicit = await readEmpty([cli, '--json', 'sessions', 'list', '--local', '--db', db, '--no-warning']);
+    assert.deepEqual(JSON.parse(implicit.stdout), JSON.parse(explicit.stdout));
+    const remote = await run(process.execPath, [cli, 'sessions', 'list', '--remote', '--db', db, '--json', '--no-warning'], { env });
     assert.equal(JSON.parse(remote.stdout).scope, 'remote');
 
     await assert.rejects(
@@ -475,11 +483,15 @@ test('unknown, missing-value, and command-inapplicable flags fail with usage exi
 
 test('search preserves a multi-word positional query', async () => {
   const root = await mkdtemp(join(tmpdir(), 'relayhistory-cli-search-'));
+  const env = { ...process.env, HOME: root, USERPROFILE: root, XDG_DATA_HOME: join(root, 'share') };
   try {
-    const result = await run(process.execPath, [
-      cli, 'search', 'two', 'word query', '--db', join(root, 'missing.db'), '--json', '--no-warning',
-    ]);
-    assert.deepEqual(JSON.parse(result.stdout), []);
+    await assert.rejects(
+      run(process.execPath, [
+        cli, 'search', 'two', 'word query', '--db', join(root, 'missing.db'), '--json', '--no-warning',
+      ], { env }),
+      (error: unknown) => typeof error === 'object' && error !== null
+        && 'stdout' in error && JSON.parse(String(error.stdout)).status === 'empty',
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -531,9 +543,13 @@ test('resume rejects an unknown flag with a documented --db option', async () =>
 
 test('resume fails loudly when nothing matches', async () => {
   const root = await mkdtemp(join(tmpdir(), 'relayhistory-cli-resume-empty-'));
+  const home = join(root, 'home');
+  const db = join(root, 'history.db');
+  const env = { ...process.env, HOME: home, USERPROFILE: home, XDG_DATA_HOME: join(home, 'share') };
   try {
+    await seedCodexSession(root, home, db);
     await assert.rejects(
-      run(process.execPath, [cli, 'resume', 'no such session anywhere', '--db', join(root, 'missing.db'), '--no-warning']),
+      run(process.execPath, [cli, 'resume', 'no such session anywhere', '--db', db, '--no-warning'], { env }),
       (error: unknown) => typeof error === 'object' && error !== null
         && 'stderr' in error && String(error.stderr).includes('No session found'),
     );
@@ -662,9 +678,13 @@ test('pack rejects a negative or fractional --tokens instead of silently misinte
 
 test('pack reports no results distinctly from a match, and exits non-zero', async () => {
   const root = await mkdtemp(join(tmpdir(), 'relayhistory-cli-pack-empty-'));
+  const home = join(root, 'home');
+  const db = join(root, 'history.db');
+  const env = { ...process.env, HOME: home, USERPROFILE: home, XDG_DATA_HOME: join(home, 'share') };
   try {
+    await seedCodexSession(root, home, db);
     await assert.rejects(
-      run(process.execPath, [cli, 'pack', 'nothing matches this', '--db', join(root, 'missing.db'), '--no-warning']),
+      run(process.execPath, [cli, 'pack', 'nothing matches this', '--db', db, '--no-warning'], { env }),
       (error: unknown) => typeof error === 'object' && error !== null
         && 'stdout' in error && String(error.stdout).includes('No results.'),
     );

--- a/sdk-ts/src/cli-output.test.ts
+++ b/sdk-ts/src/cli-output.test.ts
@@ -74,11 +74,23 @@ test('sessions discover preserves repeated sources and emits JSONL', async () =>
 test('sessions list keeps human and JSON output contracts distinct', async () => {
   const root = await mkdtemp(join(tmpdir(), 'relayhistory-cli-empty-'));
   const db = join(root, 'missing.db');
+  const env = { ...process.env, HOME: root, USERPROFILE: root, XDG_DATA_HOME: join(root, 'share') };
   try {
-    const human = await run(process.execPath, [cli, 'sessions', 'list', '--db', db, '--no-warning']);
-    assert.match(human.stdout, /No sessions in the catalog/);
-    const json = await run(process.execPath, [cli, 'sessions', 'list', '--db', db, '--json', '--no-warning']);
-    assert.deepEqual(JSON.parse(json.stdout), { contract_version: 3, scope: 'local', sessions: [], next_cursor: null });
+    await assert.rejects(
+      run(process.execPath, [cli, 'sessions', 'list', '--db', db, '--no-warning'], { env }),
+      (error: unknown) => typeof error === 'object' && error !== null
+        && 'stdout' in error && String(error.stdout).includes('No searchable local sessions found'),
+    );
+    await assert.rejects(
+      run(process.execPath, [cli, 'sessions', 'list', '--db', db, '--json', '--no-warning'], { env }),
+      (error: unknown) => {
+        if (typeof error !== 'object' || error === null || !('stdout' in error)) return false;
+        return JSON.stringify(JSON.parse(String(error.stdout))) === JSON.stringify({
+          status: 'empty', indexed_prompts: 0,
+          message: 'No searchable local sessions found. Start a coding-agent session, then run ai-hist again.',
+        });
+      },
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -104,7 +116,8 @@ test('sessions hydrate uses the SDK contract and is idempotent', async () => {
     ], { env });
     const hydrated = JSON.parse(first.stdout) as Record<string, unknown>;
     assert.equal(hydrated.contract_version, 2);
-    assert.equal(hydrated.status, 'hydrated');
+    assert.ok(hydrated.status === 'hydrated' || hydrated.status === 'updated',
+      `expected hydrated or updated, got ${String(hydrated.status)}`);
     assert.equal(hydrated.capability, 'full');
     assert.equal(hydrated.discovery_state, 'full');
     assert.deepEqual(hydrated.evidence, {

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -3,12 +3,12 @@
 import { readFile } from 'node:fs/promises';
 
 import {
-  bootstrapLocal, discoverSessions, formatSessionRow, getSession, getSessionEventsPage, getSessionFileEditsPage,
+  discoverSessions, ensureLocalStore, formatSessionRow, getSession, getSessionEventsPage, getSessionFileEditsPage,
   getSessionRelationships, getSessionToolCallsPage, getSessionTree, hydrateSession,
-  listSessionCatalogPage, recent, resumeCommand, search, stats, sync,
+  listSessionCatalogPage, login, recent, resumeCommand, search, stats, sync,
   enableCloud, accessToken, replay,
-  type CatalogCursor, type EvidenceCursor, type HistoryEntry, type SessionFileEditsPage,
-  type SessionRelationship, type SessionScope, type SessionToolCallsPage,
+  type CatalogCursor, type EvidenceCursor, type HistoryEntry, type LocalStoreReadiness,
+  type SessionFileEditsPage, type SessionRelationship, type SessionScope, type SessionToolCallsPage,
 } from './index.js';
 
 type Parsed = { positional: string[]; flags: Map<string, Array<string | true>> };
@@ -17,8 +17,8 @@ type PackageMetadata = { version?: string };
 
 const BOOLEAN_FLAGS = new Set(['all', 'fts', 'json', 'local', 'no-bootstrap', 'no-related', 'no-warning', 'once', 'pretty', 'remote', 'version']);
 const VALUE_FLAGS = new Set([
-  'base-url', 'interval', 'max-content', 'out', 'after', 'after-ms', 'after-session-id', 'after-source', 'before-ms', 'db', 'limit',
-  'max-depth', 'max-nodes', 'project', 'source', 'tag', 'tokens',
+  'base-url', 'interval', 'label', 'max-content', 'out', 'after', 'after-ms', 'after-session-id', 'after-source', 'before-ms', 'db', 'limit',
+  'max-depth', 'max-nodes', 'project', 'source', 'tag', 'token', 'tokens',
 ]);
 const KNOWN_FLAGS = new Set([...BOOLEAN_FLAGS, ...VALUE_FLAGS]);
 
@@ -211,10 +211,14 @@ function usage(message?: string): never {
   ai-hist events SESSION_ID [--source SOURCE] [--limit N] [--after JSON] [--json]
   ai-hist resume QUERY... [--local | --remote | --all] [--db PATH] [--fts] [--json]
   ai-hist pack QUERY... [--local | --remote | --all] [--source SOURCE] [--project PATH] [--tag TAG] [--limit N] [--tokens N] [--db PATH] [--fts] [--json]
+  ai-hist login [--base-url URL] [--token TOKEN] [--label LABEL] [--json]
   ai-hist token [--base-url URL]
   ai-hist replay SESSION_ID [--base-url URL] [--limit N] [--max-content N] [--json] [--out PATH]
   ai-hist stats [--local | --remote | --all] [--json]
   ai-hist sync [--local | --remote | --all] [--db PATH] [--json]
+
+Every command that reads local history indexes it on first use; pass
+--no-bootstrap to answer from the store exactly as it stands.
 `);
   process.exit(2);
 }
@@ -374,7 +378,6 @@ function queryPositionals(subcommand: string | undefined, rest: string[], comman
 }
 
 async function runResume(args: Parsed, subcommand: string | undefined, rest: string[], json: boolean): Promise<void> {
-  validateFlags(args, 'resume', ['all', 'db', 'fts', 'json', 'local', 'remote']);
   const query = queryPositionals(subcommand, rest, 'resume');
   // Matches the Rust CLI: search is capped to the single best match, then that
   // one row is checked for a usable session id rather than scanning further.
@@ -429,9 +432,6 @@ function takeCodePoints(text: string, limit: number): { truncated: boolean; text
 }
 
 async function runPack(args: Parsed, subcommand: string | undefined, rest: string[], json: boolean): Promise<void> {
-  validateFlags(args, 'pack', [
-    'all', 'db', 'fts', 'json', 'limit', 'local', 'project', 'remote', 'source', 'tag', 'tokens',
-  ]);
   const query = queryPositionals(subcommand, rest, 'pack');
   const queryStr = query.join(' ');
   const tokens = nonNegativeIntFlag(args, 'tokens') ?? 0;
@@ -508,6 +508,123 @@ function outputTree(value: Awaited<ReturnType<typeof getSessionTree>>, json: boo
   if (value.truncated) process.stdout.write('truncated: node/depth budget reached\n');
 }
 
+interface CommandSpec {
+  /** Name used in flag- and argument-rejection messages. */
+  name: string;
+  allowed: readonly string[];
+  /** Positional arguments after the command words: [minimum, maximum]. */
+  positionals: readonly [number, number | null];
+  /** Named in the usage error when fewer than the minimum are given. */
+  requires?: string;
+  /** Answers from the local database, so it takes the shared first-use bootstrap. */
+  readsLocalStore?: boolean;
+  /** Addresses a session by identity; --local/--remote/--all are meaningless. */
+  rejectsScope?: boolean;
+  /** Remaining command-line checks, run before any store work. */
+  validate?: (args: Parsed) => void;
+}
+
+function validateInterval(args: Parsed): void {
+  // --interval is seconds; validate before converting so the error names the
+  // unit the caller actually typed rather than a millisecond bound.
+  const seconds = numberFlag(args, 'interval') ?? 60;
+  if (!Number.isSafeInteger(seconds) || seconds < 1 || seconds > 2_147_483) {
+    usage('--interval must be a whole number of seconds between 1 and 2147483');
+  }
+}
+
+// The whole dispatch surface in one table. `readsLocalStore` is the decision
+// that used to live only in the bare-invocation branch: keeping it here is what
+// stops `search` and `ai-hist` disagreeing about whether a store exists.
+const COMMANDS = new Map<string, CommandSpec>([
+  ['', { name: 'ai-hist', positionals: [0, 0], allowed: ['db', 'json'], readsLocalStore: true }],
+  ['login', { name: 'login', positionals: [0, 0],
+    allowed: ['base-url', 'json', 'label', 'token'],
+    validate: (args: Parsed) => {
+      if (textFlag(args, 'token') && !textFlag(args, 'base-url')) usage('login requires --base-url with --token');
+    } }],
+  ['token', { name: 'token', positionals: [0, 0], allowed: ['base-url'] }],
+  ['replay', { name: 'replay', positionals: [1, 1], requires: 'replay requires SESSION_ID',
+    allowed: ['base-url', 'limit', 'max-content', 'json', 'out'] }],
+  ['enable-cloud', { name: 'enable-cloud', positionals: [0, 0], validate: validateInterval,
+    allowed: ['base-url', 'db', 'interval', 'once', 'json'] }],
+  ['sessions list', { name: 'sessions list', positionals: [0, 0], readsLocalStore: true,
+    validate: (args) => {
+      if (args.flags.has('json') && args.flags.has('pretty')) usage('--pretty and --json are mutually exclusive');
+    },
+    allowed: [
+      'after', 'after-ms', 'after-session-id', 'after-source', 'all', 'before-ms', 'db',
+      'json', 'limit', 'local', 'pretty', 'remote', 'source',
+    ] }],
+  ['sessions discover', { name: 'sessions discover', positionals: [0, 0],
+    allowed: ['all', 'db', 'json', 'limit', 'local', 'remote', 'source'] }],
+  ['sessions hydrate', { name: 'sessions hydrate', positionals: [2, 2], readsLocalStore: true,
+    requires: 'sessions hydrate requires SOURCE and SESSION_ID',
+    allowed: ['all', 'db', 'json', 'local', 'no-related', 'remote'] }],
+  ['sessions relationships', { name: 'sessions relationships', positionals: [2, 2], readsLocalStore: true,
+    rejectsScope: true, requires: 'sessions relationships requires SOURCE and SESSION_ID',
+    allowed: ['all', 'db', 'json', 'local', 'remote'] }],
+  ['sessions tree', { name: 'sessions tree', positionals: [2, 2], readsLocalStore: true, rejectsScope: true,
+    requires: 'sessions tree requires SOURCE and SESSION_ID',
+    allowed: ['all', 'db', 'json', 'local', 'max-depth', 'max-nodes', 'remote'] }],
+  ['sessions tools', { name: 'sessions tools', positionals: [2, 2], readsLocalStore: true,
+    requires: 'sessions tools requires SOURCE and SESSION_ID', allowed: ['after', 'db', 'json', 'limit'] }],
+  ['sessions edits', { name: 'sessions edits', positionals: [2, 2], readsLocalStore: true,
+    requires: 'sessions edits requires SOURCE and SESSION_ID', allowed: ['after', 'db', 'json', 'limit'] }],
+  ['search', { name: 'search', positionals: [1, null], requires: 'search requires a query', readsLocalStore: true,
+    allowed: ['all', 'before-ms', 'db', 'fts', 'json', 'limit', 'local', 'project', 'remote', 'source', 'tag'] }],
+  ['recent', { name: 'recent', positionals: [0, 1], readsLocalStore: true,
+    validate: (args) => {
+      const count = args.positional[1];
+      if (count !== undefined && !Number.isFinite(Number(count))) {
+        usage(`recent count must be a number (got '${count}')`);
+      }
+    },
+    allowed: ['all', 'before-ms', 'db', 'json', 'limit', 'local', 'project', 'remote', 'source', 'tag'] }],
+  ['session', { name: 'session', positionals: [1, 1], requires: 'session requires SESSION_ID',
+    readsLocalStore: true, rejectsScope: true,
+    allowed: ['all', 'db', 'json', 'local', 'remote', 'source', 'tag'] }],
+  ['events', { name: 'events', positionals: [1, 1], requires: 'events requires SESSION_ID',
+    readsLocalStore: true, rejectsScope: true,
+    allowed: ['after', 'all', 'db', 'json', 'limit', 'local', 'remote', 'source'] }],
+  ['resume', { name: 'resume', positionals: [1, null], requires: 'resume requires a query', readsLocalStore: true,
+    allowed: ['all', 'db', 'fts', 'json', 'local', 'remote'] }],
+  ['pack', { name: 'pack', positionals: [1, null], requires: 'pack requires a query', readsLocalStore: true,
+    validate: (args) => { nonNegativeIntFlag(args, 'tokens'); },
+    allowed: ['all', 'db', 'fts', 'json', 'limit', 'local', 'project', 'remote', 'source', 'tag', 'tokens'] }],
+  ['stats', { name: 'stats', positionals: [0, 0], readsLocalStore: true,
+    allowed: ['all', 'db', 'json', 'local', 'remote', 'tag'] }],
+  // sync and `sessions discover` build the store rather than read it, so they
+  // do not bootstrap first; running them is itself the remedy for an empty one.
+  ['sync', { name: 'sync', positionals: [0, 0], allowed: ['all', 'db', 'json', 'local', 'remote'] }],
+]);
+
+/** Command words consumed before the positional arguments start. */
+function commandWords(command: string | undefined): number {
+  if (command === undefined) return 0;
+  return command === 'sessions' ? 2 : 1;
+}
+
+function commandSpec(command: string | undefined, subcommand: string | undefined): CommandSpec | undefined {
+  if (command === undefined) return COMMANDS.get('');
+  if (command === 'sessions') return subcommand ? COMMANDS.get(`sessions ${subcommand}`) : undefined;
+  return COMMANDS.get(command);
+}
+
+// A store that was never built and a store holding no match are different
+// answers, and `No results.` is only true of the second. Wording and exit code
+// separate them; the query is not run against a store that cannot hold one.
+function reportUnusableStore(readiness: LocalStoreReadiness, json: boolean): boolean {
+  if (readiness.status === 'ready' || readiness.status === 'skipped') return false;
+  const message = readiness.status === 'unbuilt'
+    ? 'No local index yet: run ai-hist (or ai-hist sync) to build one.'
+    : 'No searchable local sessions found. Start a coding-agent session, then run ai-hist again.';
+  if (json) output({ status: readiness.status, indexedPrompts: readiness.indexedPrompts, message }, true);
+  else process.stdout.write(`${message}\n`);
+  process.exitCode = 1;
+  return true;
+}
+
 async function main(): Promise<void> {
   const rawArgs = process.argv.slice(2);
   const versionArgs = rawArgs.filter((arg) => arg !== '--no-warning');
@@ -521,34 +638,67 @@ async function main(): Promise<void> {
   const [command, subcommand, ...rest] = args.positional;
   const json = args.flags.has('json');
 
+  const spec = commandSpec(command, subcommand);
+  if (!spec) usage();
+  // The whole command line is checked before any work: a line that is going to
+  // be rejected must not first spend a first-run bootstrap only to exit 2.
+  validateFlags(args, spec.name, spec.readsLocalStore ? [...spec.allowed, 'no-bootstrap'] : spec.allowed);
+  if (spec.rejectsScope) rejectScopeFlag(args, spec.name);
+  const tail = args.positional.slice(commandWords(command));
+  const [least, most] = spec.positionals;
+  if (tail.length < least) usage(spec.requires);
+  if (most !== null && tail.length > most) rejectSurplusPositionals(tail.slice(most), spec.name);
+  spec.validate?.(args);
+  const intervalSeconds = numberFlag(args, 'interval') ?? 60;
+  const sessionSource = command === 'sessions' ? tail[0] : undefined;
+  const sessionId = command === 'sessions' ? tail[1] : undefined;
+  const recentFallback = command === 'recent' && tail.length > 0 ? Number(tail[0]) : undefined;
+  let readiness: LocalStoreReadiness | null = null;
+  if (spec.readsLocalStore) {
+    readiness = await ensureLocalStore({
+      dbPath: textFlag(args, 'db'), scope: scopeFlag(args), bootstrap: !args.flags.has('no-bootstrap'),
+    });
+    if (readiness.bootstrap?.status === 'partial') {
+      process.stderr.write('Some local sessions could not be fully indexed; run ai-hist --json for diagnostics.\n');
+    }
+    // The bare invocation reports the store's condition as its result and
+    // succeeds either way. Every command that asks the store a question refuses
+    // to answer out of one that cannot hold an answer.
+    if (command !== undefined && reportUnusableStore(readiness, json)) return;
+  }
+
   if (command === undefined) {
-    validateFlags(args, 'ai-hist', ['db', 'json', 'no-bootstrap']);
-    if (args.flags.has('no-bootstrap')) {
+    // --no-bootstrap answers from the catalog as it stands; the bootstrap path
+    // reports what it just indexed.
+    if (!readiness?.bootstrap) {
       output(await listSessionCatalogPage({ dbPath: textFlag(args, 'db') }), json);
       return;
     }
-    const result = await bootstrapLocal({ dbPath: textFlag(args, 'db') });
-    if (json) output(result, true);
+    if (json) output(readiness.bootstrap, true);
     else {
-      process.stdout.write(result.indexedPrompts > 0
-        ? `Ready: ${result.indexedPrompts} indexed prompt(s). Search with: ai-hist search "your query"\n`
+      process.stdout.write(readiness.indexedPrompts > 0
+        ? `Ready: ${readiness.indexedPrompts} indexed prompt(s). Search with: ai-hist search "your query"\n`
         : 'No searchable local sessions found. Start a coding-agent session, then run ai-hist again.\n');
-      if (result.status === 'partial') process.stderr.write('Some local sessions could not be fully indexed; run ai-hist --json for diagnostics.\n');
     }
     return;
   }
+  if (command === 'login') {
+    const auth = await login({
+      baseUrl: textFlag(args, 'base-url'),
+      relayAccessToken: textFlag(args, 'token'),
+      label: textFlag(args, 'label'),
+    });
+    if (json) output({ ok: true, baseUrl: auth.baseUrl }, true);
+    else process.stdout.write(`Logged in to ${auth.baseUrl} (session stored).\n`);
+    return;
+  }
   if (command === 'token') {
-    validateFlags(args, 'token', ['base-url']);
-    rejectSurplusPositionals(args.positional.slice(1), 'token');
     const token = await accessToken({ baseUrl: textFlag(args, 'base-url') });
     if (process.stdout.isTTY) process.stderr.write('Warning: this access token is a secret and will remain in terminal scrollback.\n');
     process.stdout.write(`${token}\n`);
     return;
   }
   if (command === 'replay') {
-    validateFlags(args, 'replay', ['base-url', 'limit', 'max-content', 'json', 'out']);
-    if (!subcommand) usage('replay requires SESSION_ID');
-    rejectSurplusPositionals(rest, 'replay');
     const result = await replay(subcommand, {
       baseUrl: textFlag(args, 'base-url'), limit: nonNegativeIntFlag(args, 'limit'),
       maxContent: nonNegativeIntFlag(args, 'max-content'), json, out: textFlag(args, 'out'),
@@ -557,14 +707,6 @@ async function main(): Promise<void> {
     return;
   }
   if (command === 'enable-cloud') {
-    validateFlags(args, 'enable-cloud', ['base-url', 'db', 'interval', 'once', 'json']);
-    rejectSurplusPositionals(args.positional.slice(1), 'enable-cloud');
-    // --interval is seconds; validate before converting so the error names the
-    // unit the caller actually typed rather than a millisecond bound.
-    const intervalSeconds = numberFlag(args, 'interval') ?? 60;
-    if (!Number.isSafeInteger(intervalSeconds) || intervalSeconds < 1 || intervalSeconds > 2_147_483) {
-      usage('--interval must be a whole number of seconds between 1 and 2147483');
-    }
     const handle = await enableCloud({
       baseUrl: textFlag(args, 'base-url'), dbPath: textFlag(args, 'db'),
       intervalMs: intervalSeconds * 1000,
@@ -582,13 +724,7 @@ async function main(): Promise<void> {
   }
 
   if (command === 'sessions' && subcommand === 'list') {
-    validateFlags(args, 'sessions list', [
-      'after', 'after-ms', 'after-session-id', 'after-source', 'all', 'before-ms', 'db',
-      'json', 'limit', 'local', 'pretty', 'remote', 'source',
-    ]);
-    rejectSurplusPositionals(rest, 'sessions list');
     const sources = textFlags(args, 'source');
-    if (json && args.flags.has('pretty')) usage('--pretty and --json are mutually exclusive');
     const page = await listSessionCatalogPage({
       dbPath: textFlag(args, 'db'), scope: scopeFlag(args), sources: sources.length ? sources as never : undefined,
       limit: numberFlag(args, 'limit'), beforeMs: numberFlag(args, 'before-ms'),
@@ -604,8 +740,6 @@ async function main(): Promise<void> {
     return;
   }
   if (command === 'sessions' && subcommand === 'discover') {
-    validateFlags(args, 'sessions discover', ['all', 'db', 'json', 'limit', 'local', 'remote', 'source']);
-    rejectSurplusPositionals(rest, 'sessions discover');
     const sources = textFlags(args, 'source');
     outputDiscovery(await discoverSessions({
       dbPath: textFlag(args, 'db'), scope: scopeFlag(args), sources: sources.length ? sources as never : undefined,
@@ -614,13 +748,9 @@ async function main(): Promise<void> {
     return;
   }
   if (command === 'sessions' && subcommand === 'hydrate') {
-    validateFlags(args, 'sessions hydrate', ['all', 'db', 'json', 'local', 'no-related', 'remote']);
-    const [source, sessionId, ...surplus] = rest;
-    if (!source || !sessionId) usage('sessions hydrate requires SOURCE and SESSION_ID');
-    rejectSurplusPositionals(surplus, 'sessions hydrate');
     outputHydration(await hydrateSession({
-      source: source as never,
-      sessionId,
+      source: sessionSource as never,
+      sessionId: sessionId!,
       scope: scopeFlag(args),
       dbPath: textFlag(args, 'db'),
       includeRelated: !args.flags.has('no-related'),
@@ -628,77 +758,45 @@ async function main(): Promise<void> {
     return;
   }
   if (command === 'sessions' && subcommand === 'relationships') {
-    validateFlags(args, 'sessions relationships', ['all', 'db', 'json', 'local', 'remote']);
-    const [source, sessionId, ...surplus] = rest;
-    if (!source || !sessionId) usage('sessions relationships requires SOURCE and SESSION_ID');
-    rejectSurplusPositionals(surplus, 'sessions relationships');
-    rejectScopeFlag(args, 'sessions relationships');
     outputRelationships(await getSessionRelationships({
-      source: source as never, sessionId, dbPath: textFlag(args, 'db'),
+      source: sessionSource as never, sessionId: sessionId!, dbPath: textFlag(args, 'db'),
     }), json);
     return;
   }
   if (command === 'sessions' && subcommand === 'tree') {
-    validateFlags(args, 'sessions tree', ['all', 'db', 'json', 'local', 'max-depth', 'max-nodes', 'remote']);
-    const [source, sessionId, ...surplus] = rest;
-    if (!source || !sessionId) usage('sessions tree requires SOURCE and SESSION_ID');
-    rejectSurplusPositionals(surplus, 'sessions tree');
-    rejectScopeFlag(args, 'sessions tree');
     outputTree(await getSessionTree({
-      source: source as never, sessionId, dbPath: textFlag(args, 'db'),
+      source: sessionSource as never, sessionId: sessionId!, dbPath: textFlag(args, 'db'),
       maxDepth: numberFlag(args, 'max-depth'), maxNodes: numberFlag(args, 'max-nodes'),
     }), json);
     return;
   }
   if (command === 'sessions' && (subcommand === 'tools' || subcommand === 'edits')) {
     const name = `sessions ${subcommand}`;
-    validateFlags(args, name, ['after', 'db', 'json', 'limit']);
-    const [source, sessionId, ...surplus] = rest;
-    if (!source || !sessionId) usage(`${name} requires SOURCE and SESSION_ID`);
-    rejectSurplusPositionals(surplus, name);
     const options = {
       dbPath: textFlag(args, 'db'),
       limit: numberFlag(args, 'limit'),
       after: evidenceCursorFlag(args),
     };
     if (subcommand === 'tools') {
-      outputToolCalls(await getSessionToolCallsPage(source as never, sessionId, options), json);
+      outputToolCalls(await getSessionToolCallsPage(sessionSource as never, sessionId!, options), json);
     } else {
-      outputFileEdits(await getSessionFileEditsPage(source as never, sessionId, options), json);
+      outputFileEdits(await getSessionFileEditsPage(sessionSource as never, sessionId!, options), json);
     }
     return;
   }
   if (command === 'search') {
-    validateFlags(args, 'search', [
-      'all', 'before-ms', 'db', 'fts', 'json', 'limit', 'local', 'project', 'remote', 'source', 'tag',
-    ]);
-    if (!subcommand) usage();
     output(await search([subcommand, ...rest].join(' '), { ...common(args), rawFts: args.flags.has('fts') }), json);
     return;
   }
   if (command === 'recent') {
-    validateFlags(args, 'recent', [
-      'all', 'before-ms', 'db', 'json', 'limit', 'local', 'project', 'remote', 'source', 'tag',
-    ]);
-    rejectSurplusPositionals(rest, 'recent');
-    const fallback = subcommand ? Number(subcommand) : undefined;
-    if (fallback !== undefined && !Number.isFinite(fallback)) usage(`recent count must be a number (got '${subcommand}')`);
-    output(await recent({ ...common(args), limit: numberFlag(args, 'limit') ?? fallback }), json);
+    output(await recent({ ...common(args), limit: numberFlag(args, 'limit') ?? recentFallback }), json);
     return;
   }
   if (command === 'session') {
-    validateFlags(args, 'session', ['all', 'db', 'json', 'local', 'remote', 'source', 'tag']);
-    if (!subcommand) usage();
-    rejectSurplusPositionals(rest, 'session');
-    rejectScopeFlag(args, 'session');
     output(await getSession(subcommand, { dbPath: textFlag(args, 'db'), source: textFlag(args, 'source') as never, tag: textFlag(args, 'tag') }), json);
     return;
   }
   if (command === 'events') {
-    validateFlags(args, 'events', ['after', 'all', 'db', 'json', 'limit', 'local', 'remote', 'source']);
-    if (!subcommand) usage();
-    rejectSurplusPositionals(rest, 'events');
-    rejectScopeFlag(args, 'events');
     output(await getSessionEventsPage(subcommand, {
       dbPath: textFlag(args, 'db'), source: textFlag(args, 'source') as never,
       limit: numberFlag(args, 'limit'), after: cursorFlag(args),
@@ -714,14 +812,10 @@ async function main(): Promise<void> {
     return;
   }
   if (command === 'stats') {
-    validateFlags(args, 'stats', ['all', 'db', 'json', 'local', 'remote', 'tag']);
-    rejectSurplusPositionals([subcommand, ...rest].filter((value): value is string => value !== undefined), 'stats');
     output(await stats({ dbPath: textFlag(args, 'db'), scope: scopeFlag(args), tag: textFlag(args, 'tag') }), json);
     return;
   }
   if (command === 'sync') {
-    validateFlags(args, 'sync', ['all', 'db', 'json', 'local', 'remote']);
-    rejectSurplusPositionals([subcommand, ...rest].filter((value): value is string => value !== undefined), 'sync');
     output(await sync({ dbPath: textFlag(args, 'db'), scope: scopeFlag(args) }), json);
     return;
   }

--- a/sdk-ts/src/first-use.test.ts
+++ b/sdk-ts/src/first-use.test.ts
@@ -1,0 +1,145 @@
+// Runs the built CLI, not the SDK: the defect these guard survived to release
+// because bootstrap was wired into one entry point and asserted through the
+// library, so no test ever typed the command a new user types first.
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const cli = fileURLToPath(new URL('./cli.js', import.meta.url));
+
+type Run = { code: number; stdout: string; stderr: string };
+
+function run(args: string[], env: NodeJS.ProcessEnv): Promise<Run> {
+  return new Promise((resolve) => {
+    execFile(process.execPath, [cli, ...args], { env }, (error, stdout, stderr) => {
+      const code = error ? (error as NodeJS.ErrnoException & { code?: number }).code ?? 1 : 0;
+      resolve({ code: typeof code === 'number' ? code : 1, stdout, stderr });
+    });
+  });
+}
+
+async function emptyHome(): Promise<{ home: string; env: NodeJS.ProcessEnv }> {
+  const home = await mkdtemp(join(tmpdir(), 'ai-hist-first-use-'));
+  return {
+    home,
+    env: {
+      ...process.env, HOME: home, USERPROFILE: home,
+      XDG_DATA_HOME: join(home, '.local', 'share'), RELAYHISTORY_NO_UPDATE_CHECK: '1',
+    },
+  };
+}
+
+async function seedClaudeSession(home: string): Promise<void> {
+  const folder = join(home, '.claude', 'projects', '-work-demo');
+  await mkdir(folder, { recursive: true });
+  await writeFile(join(folder, 'session.jsonl'), `${JSON.stringify({
+    sessionId: '11111111-1111-1111-1111-555555555555', uuid: 'user-1', cwd: '/work/demo', type: 'user',
+    message: { role: 'user', content: 'please fix the zzqqmarker parser bug' },
+    timestamp: '2026-09-08T10:00:00Z',
+  })}\n`);
+}
+
+// The reported defect verbatim: five searches, no database, `No results.` each time.
+test('search is the first command typed and bootstraps like the bare invocation', async () => {
+  const { home, env } = await emptyHome();
+  try {
+    await seedClaudeSession(home);
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const found = await run(['search', 'zzqqmarker'], env);
+      assert.equal(found.code, 0, found.stderr);
+      assert.match(found.stdout, /zzqqmarker parser bug/);
+    }
+    assert.ok(existsSync(join(home, '.local', 'share', 'ai-hist', 'ai-history.db')));
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('every command that reads local history bootstraps, not only the bare one', async () => {
+  for (const command of [['recent'], ['stats'], ['sessions', 'list'], ['pack', 'zzqqmarker'], ['resume', 'zzqqmarker']]) {
+    const { home, env } = await emptyHome();
+    try {
+      await seedClaudeSession(home);
+      const result = await run(command, env);
+      assert.equal(result.code, 0, `${command.join(' ')}: ${result.stderr}`);
+      assert.ok(existsSync(join(home, '.local', 'share', 'ai-hist', 'ai-history.db')), command.join(' '));
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  }
+});
+
+// `No results.` is a claim about a store that was searched. A store that holds
+// nothing at all has to say something else, and say it with a failing status.
+test('an unindexed store and a store with no match are different answers', async () => {
+  const { home, env } = await emptyHome();
+  try {
+    const bare = await run(['search', 'zzqqmarker'], env);
+    assert.equal(bare.code, 1);
+    assert.match(bare.stdout, /No searchable local sessions found/);
+    assert.doesNotMatch(bare.stdout, /No results\./);
+
+    const asJson = await run(['search', 'zzqqmarker', '--json'], env);
+    assert.equal(asJson.code, 1);
+    assert.deepEqual(JSON.parse(asJson.stdout).status, 'empty');
+
+    await seedClaudeSession(home);
+    const miss = await run(['search', 'nothingmatchesthis'], env);
+    assert.equal(miss.code, 0, miss.stderr);
+    assert.equal(miss.stdout, 'No results.\n');
+    const hit = await run(['search', 'zzqqmarker'], env);
+    assert.equal(hit.code, 0, hit.stderr);
+    assert.match(hit.stdout, /zzqqmarker parser bug/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test('--no-bootstrap reports an unbuilt store instead of building or lying', async () => {
+  const { home, env } = await emptyHome();
+  try {
+    await seedClaudeSession(home);
+    const declined = await run(['search', 'zzqqmarker', '--no-bootstrap'], env);
+    assert.equal(declined.code, 1);
+    assert.match(declined.stdout, /No local index yet/);
+    const built = await run(['search', 'zzqqmarker'], env);
+    assert.equal(built.code, 0, built.stderr);
+    // Once the store answers, --no-bootstrap answers from it unchanged.
+    const reread = await run(['search', 'zzqqmarker', '--no-bootstrap'], env);
+    assert.equal(reread.code, 0, reread.stderr);
+    assert.match(reread.stdout, /zzqqmarker parser bug/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+// The usage block is what tells a user bootstrap is the default. Whatever it
+// documents as reading local history must actually accept the opt-out.
+test('the built npm CLI ships login so token/replay errors name a real remedy', async () => {
+  const shipped = await readFile(fileURLToPath(new URL('../dist/cli.js', import.meta.url)), 'utf8');
+  assert.match(shipped, /['"]login['"]/);
+  assert.doesNotMatch(shipped, /admin-mint/);
+  const missingToken = await run(['login', '--token', 'fixture-token'], process.env);
+  assert.equal(missingToken.code, 2);
+  assert.match(missingToken.stderr, /login requires --base-url with --token/);
+});
+
+test('every documented local-history command accepts --no-bootstrap', async () => {
+  const { home, env } = await emptyHome();
+  try {
+    await seedClaudeSession(home);
+    await run(['sync'], env);
+    for (const command of [[], ['search', 'zzqqmarker'], ['recent'], ['stats'], ['sessions', 'list'],
+      ['session', '11111111-1111-1111-1111-555555555555'], ['pack', 'zzqqmarker'], ['resume', 'zzqqmarker']]) {
+      const result = await run([...command, '--no-bootstrap'], env);
+      assert.notEqual(result.code, 2, `${command.join(' ') || 'ai-hist'} rejected --no-bootstrap: ${result.stderr}`);
+    }
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});

--- a/sdk-ts/src/index.ts
+++ b/sdk-ts/src/index.ts
@@ -1505,6 +1505,52 @@ export async function bootstrapLocal(options: BootstrapLocalOptions = {}): Promi
     alreadyIndexed: false, indexedPrompts: indexed.total, hydratedSessions, discovery, diagnostics };
 }
 
+/**
+ * `ready` — the store answers queries. `empty` — bootstrap ran and this machine
+ * has no local coding-agent history at all. `unbuilt` — bootstrap was declined,
+ * so nothing is indexed yet and that is not the same as having no history.
+ * `skipped` — the caller is not reading the local store.
+ */
+export type LocalStoreStatus = 'ready' | 'empty' | 'unbuilt' | 'skipped';
+
+export interface LocalStoreReadiness {
+  status: LocalStoreStatus;
+  indexedPrompts: number;
+  /** The bootstrap that ran on this call, or null when none did. */
+  bootstrap: BootstrapLocalResult | null;
+}
+
+export interface EnsureLocalStoreOptions {
+  dbPath?: string;
+  /** Only `local` and `all` read the local database; `remote` skips the check. */
+  scope?: SessionScope;
+  /** False for `--no-bootstrap`: report the store as it stands, build nothing. */
+  bootstrap?: boolean;
+}
+
+/**
+ * The single first-use decision behind every local read. Callers must not each
+ * choose whether to bootstrap: a fresh install has to answer the same way
+ * whichever command the user happens to type first, and a store that was never
+ * built has to be distinguishable from one that holds no match.
+ */
+export async function ensureLocalStore(options: EnsureLocalStoreOptions = {}): Promise<LocalStoreReadiness> {
+  const { dbPath, scope = 'local' } = options;
+  if (scope === 'remote') return { status: 'skipped', indexedPrompts: 0, bootstrap: null };
+  if (options.bootstrap === false) {
+    const existing = await stats({ dbPath, scope: 'local' });
+    return { status: existing.total > 0 ? 'ready' : 'unbuilt', indexedPrompts: existing.total, bootstrap: null };
+  }
+  const bootstrap = await bootstrapLocal({ dbPath });
+  // `partial` reports indexing diagnostics, not emptiness: whether the store can
+  // answer is decided by the prompt count alone.
+  return {
+    status: bootstrap.indexedPrompts > 0 ? 'ready' : 'empty',
+    indexedPrompts: bootstrap.indexedPrompts,
+    bootstrap,
+  };
+}
+
 export function resumeCommand(entry: Pick<HistoryEntry, 'source' | 'sessionId' | 'project' | 'locations'>): string | null {
   if (!entry.sessionId) return null;
   if (entry.locations.length > 0 && !entry.locations.includes('local')) return null;
@@ -1570,9 +1616,27 @@ export async function loadStoredRelayhistoryAuth(baseUrl?: string): Promise<Rela
   return nativeCall((native) => native.cloudLoadAuth(baseUrl));
 }
 
+export interface LoginOptions {
+  baseUrl?: string;
+  relayAccessToken?: string;
+  label?: string;
+}
+
+/** Authenticate to relayhistory-cloud via device login or a supplied bearer token. */
+export async function login(options: LoginOptions = {}): Promise<RelayhistoryAuth> {
+  if (options.relayAccessToken && !options.baseUrl) {
+    throw new InvalidArgumentError('`--base-url` is required with manual `--token` login', 'INVALID_ARGUMENT');
+  }
+  return nativeCall((native) => native.cloudLogin({
+    baseUrl: options.baseUrl,
+    relayAccessToken: options.relayAccessToken,
+    label: options.label,
+  }));
+}
+
 export async function loginCloud(relayAccessToken: string, options: { baseUrl?: string; label?: string } = {}): Promise<LoginCloudResult> {
   try {
-    const auth = await nativeCall((native) => native.cloudLogin({ ...options, relayAccessToken }));
+    const auth = await login({ ...options, relayAccessToken });
     return { ok: true, auth };
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : String(error) };


### PR DESCRIPTION
## Summary
- **#122:** Every command that reads local history now routes through `ensureLocalStore()` — `ai-hist search <term>` bootstraps the same way bare `ai-hist` does. Unbuilt stores and no-match searches return distinct messages and exit codes.
- **#123:** `ai-hist login` is reachable from the npm CLI via the native napi bridge (same path as `token`/`replay`). Errors that name `ai-hist login` now point at a command that exists in the shipped artifact.
- Adds `first-use.test.ts` exercising the built CLI against clean `$HOME` fixtures.

## Test plan
- [x] `npm run build` in `sdk-ts`
- [x] `node --test dist/first-use.test.js dist/architecture.test.js dist/cli-output.test.js`
- [ ] CI green
- [ ] Khaliq merge (mergePolicy: never)

Closes #122, closes #123

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

