### PR TITLE
Fix CLI --help and unknown command UX (#127)

### DIFF
--- a/sdk-ts/src/cli-output.test.ts
+++ b/sdk-ts/src/cli-output.test.ts
@@ -703,3 +703,42 @@ test('resume and pack reject flags the other commands accept but these do not', 
     (error: unknown) => isUsageFailure(error, 'pack does not accept --after-source'),
   );
 });
+
+test('--help flag works on root and replay commands with exit code 0', async () => {
+  for (const args of [['--help'], ['-h'], ['help']]) {
+    const rootHelp = await run(process.execPath, [cli, ...args]);
+    assert.equal(rootHelp.stderr, '');
+    assert.match(rootHelp.stdout, /Usage:/);
+    assert.match(rootHelp.stdout, /ai-hist \[--no-bootstrap\] \[--db PATH\] \[--json\] \[--help\]/);
+  }
+
+  const replayHelp = await run(process.execPath, [cli, 'replay', '--help']);
+  assert.equal(replayHelp.stderr, '');
+  assert.match(replayHelp.stdout, /Usage:/);
+  assert.match(replayHelp.stdout, /ai-hist replay SESSION_ID.*--help/);
+
+  const sessionsHelp = await run(process.execPath, [cli, 'sessions', '--help']);
+  assert.equal(sessionsHelp.stderr, '');
+  assert.match(sessionsHelp.stdout, /Usage:/);
+});
+
+test('--help is rejected on commands that do not advertise it', async () => {
+  await assert.rejects(
+    run(process.execPath, [cli, 'login', '--help', '--no-warning']),
+    (error: unknown) => isUsageFailure(error, 'login does not accept --help'),
+  );
+});
+
+test('unknown subcommands name what was unknown instead of generic parse error', async () => {
+  // Test unknown root command
+  await assert.rejects(
+    run(process.execPath, [cli, 'unknown-command', '--no-warning']),
+    (error: unknown) => isUsageFailure(error, "unknown command 'unknown-command'"),
+  );
+
+  // Test unknown sessions subcommand
+  await assert.rejects(
+    run(process.execPath, [cli, 'sessions', 'unknown-subcommand', '--no-warning']),
+    (error: unknown) => isUsageFailure(error, "unknown sessions subcommand 'unknown-subcommand'"),
+  );
+});

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -17,7 +17,7 @@ type Parsed = { positional: string[]; flags: Map<string, Array<string | true>> }
 
 type PackageMetadata = { version?: string };
 
-const BOOLEAN_FLAGS = new Set(['all', 'fts', 'json', 'local', 'no-bootstrap', 'no-related', 'no-warning', 'once', 'pretty', 'remote', 'version']);
+const BOOLEAN_FLAGS = new Set(['all', 'fts', 'help', 'json', 'local', 'no-bootstrap', 'no-related', 'no-warning', 'once', 'pretty', 'remote', 'version']);
 const VALUE_FLAGS = new Set([
   'base-url', 'interval', 'label', 'max-content', 'out', 'after', 'after-ms', 'after-session-id', 'after-source', 'before-ms', 'db', 'limit',
   'max-depth', 'max-nodes', 'project', 'source', 'tag', 'token', 'tokens',
@@ -210,10 +210,9 @@ function output(value: unknown, json: boolean): void {
   }
 }
 
-function usage(message?: string): never {
-  if (message) process.stderr.write(`ai-hist: ${message}\n\n`);
-  process.stderr.write(`Usage:
-  ai-hist [--no-bootstrap] [--db PATH] [--json]
+function showHelp(): never {
+  process.stdout.write(`Usage:
+  ai-hist [--no-bootstrap] [--db PATH] [--json] [--help]
   ai-hist enable-cloud [--base-url URL] [--token TOKEN] [--db PATH] [--interval SECONDS] [--once] [--json]
   ai-hist sessions list [--pretty] [--local | --remote | --all] [--source SOURCE]... [--limit N] [--before-ms MS] [--after JSON | --after-source SOURCE --after-session-id ID [--after-ms MS]] [--json]
   ai-hist sessions discover [--local | --remote | --all] [--source SOURCE] [--limit N] [--json]
@@ -230,7 +229,37 @@ function usage(message?: string): never {
   ai-hist pack QUERY... [--local | --remote | --all] [--source SOURCE] [--project PATH] [--tag TAG] [--limit N] [--tokens N] [--db PATH] [--fts] [--json]
   ai-hist login [--base-url URL] [--token TOKEN] [--label LABEL] [--json]
   ai-hist token [--base-url URL]
-  ai-hist replay SESSION_ID [--base-url URL] [--limit N] [--max-content N] [--json] [--out PATH]
+  ai-hist replay SESSION_ID [--base-url URL] [--limit N] [--max-content N] [--json] [--out PATH] [--help]
+  ai-hist stats [--local | --remote | --all] [--json]
+  ai-hist sync [--local | --remote | --all] [--db PATH] [--json]
+
+Every command that reads local history indexes it on first use; pass
+--no-bootstrap to answer from the store exactly as it stands.
+`);
+  process.exit(0);
+}
+
+function usage(message?: string): never {
+  if (message) process.stderr.write(`ai-hist: ${message}\n\n`);
+  process.stderr.write(`Usage:
+  ai-hist [--no-bootstrap] [--db PATH] [--json] [--help]
+  ai-hist enable-cloud [--base-url URL] [--token TOKEN] [--db PATH] [--interval SECONDS] [--once] [--json]
+  ai-hist sessions list [--pretty] [--local | --remote | --all] [--source SOURCE]... [--limit N] [--before-ms MS] [--after JSON | --after-source SOURCE --after-session-id ID [--after-ms MS]] [--json]
+  ai-hist sessions discover [--local | --remote | --all] [--source SOURCE] [--limit N] [--json]
+  ai-hist sessions hydrate SOURCE SESSION_ID [--local | --remote | --all] [--no-related] [--db PATH] [--json]
+  ai-hist sessions relationships SOURCE SESSION_ID [--db PATH] [--json]
+  ai-hist sessions tree SOURCE SESSION_ID [--max-depth N] [--max-nodes N] [--db PATH] [--json]
+  ai-hist sessions tools SOURCE SESSION_ID [--limit N] [--after JSON] [--db PATH] [--json]
+  ai-hist sessions edits SOURCE SESSION_ID [--limit N] [--after JSON] [--db PATH] [--json]
+  ai-hist search QUERY... [--local | --remote | --all] [--source SOURCE] [--project PATH] [--limit N] [--json]
+  ai-hist recent [N] [--local | --remote | --all] [--source SOURCE] [--project PATH] [--json]
+  ai-hist session SESSION_ID [--source SOURCE] [--json]
+  ai-hist events SESSION_ID [--source SOURCE] [--limit N] [--after JSON] [--json]
+  ai-hist resume QUERY... [--local | --remote | --all] [--db PATH] [--fts] [--json]
+  ai-hist pack QUERY... [--local | --remote | --all] [--source SOURCE] [--project PATH] [--tag TAG] [--limit N] [--tokens N] [--db PATH] [--fts] [--json]
+  ai-hist login [--base-url URL] [--token TOKEN] [--label LABEL] [--json]
+  ai-hist token [--base-url URL]
+  ai-hist replay SESSION_ID [--base-url URL] [--limit N] [--max-content N] [--json] [--out PATH] [--help]
   ai-hist stats [--local | --remote | --all] [--json]
   ai-hist sync [--local | --remote | --all] [--db PATH] [--json]
 
@@ -554,7 +583,7 @@ function validateInterval(args: Parsed): void {
 // that used to live only in the bare-invocation branch: keeping it here is what
 // stops `search` and `ai-hist` disagreeing about whether a store exists.
 const COMMANDS = new Map<string, CommandSpec>([
-  ['', { name: 'ai-hist', positionals: [0, 0], allowed: ['db', 'json'], readsLocalStore: true }],
+  ['', { name: 'ai-hist', positionals: [0, 0], allowed: ['db', 'json', 'help'], readsLocalStore: true }],
   ['login', { name: 'login', positionals: [0, 0],
     allowed: ['base-url', 'json', 'label', 'token'],
     validate: (args: Parsed) => {
@@ -562,7 +591,7 @@ const COMMANDS = new Map<string, CommandSpec>([
     } }],
   ['token', { name: 'token', positionals: [0, 0], allowed: ['base-url'] }],
   ['replay', { name: 'replay', positionals: [1, 1], requires: 'replay requires SESSION_ID',
-    allowed: ['base-url', 'limit', 'max-content', 'json', 'out'] }],
+    allowed: ['base-url', 'limit', 'max-content', 'json', 'out', 'help'] }],
   ['enable-cloud', { name: 'enable-cloud', positionals: [0, 0], validate: validateInterval,
     allowed: ['base-url', 'db', 'interval', 'once', 'json', 'token'] }],
   ['sessions list', { name: 'sessions list', positionals: [0, 0], readsLocalStore: true,
@@ -628,6 +657,15 @@ function commandSpec(command: string | undefined, subcommand: string | undefined
   return COMMANDS.get(command);
 }
 
+function unknownCommandMessage(command: string | undefined, subcommand: string | undefined): string {
+  if (command === undefined) return 'invalid usage';
+  if (command === 'sessions') {
+    if (subcommand === undefined) return 'sessions requires a subcommand';
+    return `unknown sessions subcommand '${subcommand}'`;
+  }
+  return `unknown command '${command}'`;
+}
+
 // A store that was never built and a store holding no match are different
 // answers, and `No results.` is only true of the second. Wording and exit code
 // separate them; the query is not run against a store that cannot hold one.
@@ -651,12 +689,24 @@ async function main(): Promise<void> {
     await maybePrintUpdateNotice(version, rawArgs);
     return;
   }
-  const args = parse(rawArgs);
+  const args = parse(rawArgs.map((arg) => arg === '-h' ? '--help' : arg));
   const [command, subcommand, ...rest] = args.positional;
   const json = args.flags.has('json');
 
+  if ((args.flags.has('help') && command === undefined) || (command === 'help' && subcommand === undefined)) {
+    showHelp();
+  }
+  if (command === 'sessions' && subcommand === undefined && args.flags.has('help')) {
+    showHelp();
+  }
+
   const spec = commandSpec(command, subcommand);
-  if (!spec) usage();
+  if (!spec) usage(unknownCommandMessage(command, subcommand));
+
+  if (args.flags.has('help') && spec.allowed.includes('help')) {
+    showHelp();
+  }
+
   // The whole command line is checked before any work: a line that is going to
   // be rejected must not first spend a first-run bootstrap only to exit 2.
   validateFlags(args, spec.name, spec.readsLocalStore ? [...spec.allowed, 'no-bootstrap'] : spec.allowed);

--- a/sdk-ts/src/cli.ts
+++ b/sdk-ts/src/cli.ts
@@ -693,7 +693,11 @@ async function main(): Promise<void> {
   const [command, subcommand, ...rest] = args.positional;
   const json = args.flags.has('json');
 
-  if ((args.flags.has('help') && command === undefined) || (command === 'help' && subcommand === undefined)) {
+  // Handle help before command resolution to prevent unknown command errors
+  if (args.flags.has('help') && command === undefined) {
+    showHelp();
+  }
+  if (command === 'help' && subcommand === undefined && rest.length === 0) {
     showHelp();
   }
   if (command === 'sessions' && subcommand === undefined && args.flags.has('help')) {


### PR DESCRIPTION
## Summary

Fixes ai-hist --help and ai-hist replay --help to work properly (exit code 0 instead of 2/unknown option), and improves unknown subcommand error messages to name what was unknown instead of showing a generic parse error.

## Changes

- Add help flag to BOOLEAN_FLAGS and command specs for root and replay commands
- Create showHelp() function that writes to stdout and exits with code 0 (not 2)
- Add unknownCommandMessage() function to provide specific error messages
- Update usage() calls to show what unknown command/subcommand was attempted
- Add comprehensive tests for both --help functionality and unknown command error improvements

## Testing

All tests pass and functionality works as expected.

Fixes #127

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/AgentWorkforce/relayhistory/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential selection for `ai-hist token` and ambiguity detection; wrong behavior could pick the wrong cloud stage or block legitimate single-stage setups, but the change intentionally tightens parity with the SDK and adds tests.
> 
> **Overview**
> Aligns **`ai-hist token`** cloud session resolution with the TypeScript SDK’s **`resolveCloudSession()`**, fixing cases where the CLI disagreed with npm clients on which stage to use.
> 
> **Stage discovery:** Adds **`sdk_legacy_auth_path()`** for credentials under **`~/.config/ai-hist/auth.json`** (or **`AI_HIST_CONFIG_DIR`**) and **`refuse_ambiguous_stages()`**, which treats native staged auth, native legacy **`auth.json`**, and the SDK legacy file as one pool when no **`--base-url`** / env selector is set—refusing to guess if more than one distinct stage exists.
> 
> **`access_token`:** When nothing is selected, runs that ambiguity check instead of probing only via **`load_auth`**. Loads credentials through **`load_sdk_auth`** end-to-end (including migration from the SDK store) and derives the active **`base_url`** from the loaded session rather than defaulting to production before load. **Fixes #125:** a single non-prod stage (e.g. localhost) now resolves instead of **“not authenticated”**.
> 
> Shared **`ambiguous_stage_error`** text is reused from **`load_auth`**. Integration tests cover SDK+native multi-stage refusal and single-stage resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3262b4f81bc6891df85bc72b2bdbab271c23151a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->